### PR TITLE
refactor: improve CmdArgParser usage

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -46,7 +46,7 @@ namespace facade {
 // Tag matching:
 //   parser.ExpectTag("LOAD");                                   // required literal keyword
 //   if (parser.Check("NX")) { ... }                             // consume tag only if matched
-//   if (parser.Check("COUNT", &count)) { ... }                 // ...also read following args
+//   if (parser.Check("COUNT", &count)) { ... }                 // ...also read args (check errors)
 //   auto mode = parser.MapNext("EX", Mode::EX, "PX", Mode::PX); // tag -> enum mapping
 //   auto maybe_mode = parser.TryMapNext("ASC", Dir::ASC,        // like MapNext but returns
 //                                       "DESC", Dir::DESC);     // nullopt (no error) on miss
@@ -400,18 +400,18 @@ struct CmdArgParser {
     return res;
   }
 
-  // If the next arg matches `tag`, consume it and the following args-into-pointers; else no-op.
+  // Consumes `tag` if next and reads the following args-into-pointers; no-op otherwise. The result
+  // is the tag match only: a bad/missing value still returns true but latches an error (check it).
   template <class... Args> bool Check(std::string_view tag, Args*... args) {
-    if (cur_i_ + sizeof...(Args) >= args_.size())
+    if (cur_i_ >= args_.size())
       return false;
 
     std::string_view arg = SafeSV(cur_i_);
     if (!absl::EqualsIgnoreCase(arg, tag))
       return false;
 
-    ((*args = Convert<Args>(++cur_i_)), ...);
-
     ++cur_i_;
+    ((*args = Next<Args>()), ...);
 
     return true;
   }

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -96,17 +96,44 @@ TEST_F(CmdArgParserTest, NextStatement) {
 }
 
 TEST_F(CmdArgParserTest, CheckTailFail) {
-  auto parser = Make({"TAG", "11", "22", "TAG", "text"});
+  {
+    auto parser = Make({"TAG", "11", "22", "TAG", "text"});
 
-  int first;
-  string_view second;
-  EXPECT_TRUE(parser.Check("TAG", &first, &second));
-  EXPECT_EQ(first, 11);
-  EXPECT_EQ(second, "22");
+    int first;
+    string_view second;
+    EXPECT_TRUE(parser.Check("TAG", &first, &second));
+    EXPECT_EQ(first, 11);
+    EXPECT_EQ(second, "22");
 
-  EXPECT_FALSE(parser.Check("TAG", &first, &second));
-  EXPECT_TRUE(parser.Check("TAG", &first));
-  EXPECT_TRUE(parser.TakeError());
+    EXPECT_TRUE(parser.Check("TAG", &first, &second));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+    EXPECT_EQ(err.index, 4);
+  }
+  {
+    auto parser = Make({"TAG", "11"});
+
+    int first;
+    string_view second;
+    EXPECT_TRUE(parser.Check("TAG", &first, &second));
+
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+    EXPECT_EQ(err.index, 2);
+  }
+  {
+    auto parser = Make({"TAG"});
+
+    int first;
+    EXPECT_TRUE(parser.Check("TAG", &first));
+
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+    EXPECT_EQ(err.index, 1);
+  }
 }
 
 TEST_F(CmdArgParserTest, Map) {

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -141,7 +141,7 @@ void AclFamily::SetUser(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto reg = registry_->GetRegistryWithWriteLock();
   const bool exists = reg.registry.contains(username);
   const bool has_all_keys = exists ? reg.registry.find(username)->second.Keys().all_keys : false;
-  auto req = ParseAclSetUser(parser.UnparsedArgs(), false, has_all_keys);
+  auto req = ParseAclSetUser(parser.RemainingRange(), false, has_all_keys);
 
   auto error_case = [cmd_cntx](ErrorReply&& error) { cmd_cntx->SendError(error); };
 
@@ -198,7 +198,7 @@ void AclFamily::DelUser(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto& registry = *registry_;
   absl::flat_hash_set<string_view> users;
 
-  for (string_view username : parser.UnparsedArgs()) {
+  for (string_view username : parser.RemainingRange()) {
     if (username == "default") {
       continue;
     }
@@ -451,16 +451,12 @@ void AclFamily::Users(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void AclFamily::Cat(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto args = parser.UnparsedArgs();
   auto* rb = static_cast<facade::RedisReplyBuilder*>(cmd_cntx->rb());
 
-  if (args.size() > 1) {
-    rb->SendError(facade::OpStatus::SYNTAX_ERR);
-    return;
-  }
-
-  if (args.size() == 1) {
-    string category = absl::AsciiStrToUpper(args[0]);
+  if (parser.HasNext()) {
+    string category = absl::AsciiStrToUpper(parser.Next());
+    if (!parser.Finalize())
+      return rb->SendError(parser.TakeError().MakeReply());
 
     if (!cat_table_.contains(category)) {
       auto error = absl::StrCat("Unknown category: ", category);
@@ -555,22 +551,18 @@ void AclFamily::GetUser(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void AclFamily::GenPass(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto args = parser.UnparsedArgs();
   auto* builder = cmd_cntx->rb();
-  if (args.size() > 1) {
-    builder->SendError(facade::UnknownSubCmd("GENPASS", "ACL"));
-    return;
-  }
-  uint32_t random_bits = 256;
-  if (args.size() == 1) {
-    auto requested_bits = args[0];
 
-    if (!absl::SimpleAtoi(requested_bits, &random_bits) || random_bits == 0 || random_bits > 4096) {
-      return builder->SendError(
-          "ACL GENPASS argument must be the number of bits for the output password, a positive "
-          "number up to 4096");
-    }
+  using GenPassBits = facade::FInt<uint32_t{1}, uint32_t{4096}>;
+  uint32_t random_bits = parser.NextOrDefault<GenPassBits>(GenPassBits{256});
+  if (!parser.Finalize()) {
+    if (parser.TakeError().type == facade::CmdArgParser::UNPROCESSED)
+      return builder->SendError(facade::UnknownSubCmd("GENPASS", "ACL"));
+    return builder->SendError(
+        "ACL GENPASS argument must be the number of bits for the output password, a positive "
+        "number up to 4096");
   }
+
   std::random_device urandom("/dev/urandom");
   const size_t result_length = (random_bits + 3) / 4;
   constexpr size_t step_size = sizeof(decltype(std::random_device::max()));

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -172,7 +172,8 @@ void CmdReserve(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs items = parser.UnparsedArgs();
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpAdd(t->GetOpArgs(shard), key, items);
@@ -192,7 +193,9 @@ void CmdAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdExists(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs items = parser.UnparsedArgs();
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExists(t->GetOpArgs(shard), key, items);
   };
@@ -207,7 +210,8 @@ void CmdExists(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdMAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs items = parser.UnparsedArgs();
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpAdd(t->GetOpArgs(shard), key, items);
@@ -284,7 +288,8 @@ void CmdLoadChunk(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdMExists(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs items = parser.UnparsedArgs();
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExists(t->GetOpArgs(shard), key, items);

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -31,9 +31,14 @@ constexpr char kCmsNotFound[] = "CMS: key does not exist";
 constexpr char kCmsWrongNumKeys[] = "CMS: wrong number of keys";
 constexpr char kCmsWrongNumKeysWeights[] = "CMS: wrong number of keys/weights";
 constexpr char kCmsCannotParseNumber[] = "CMS: Cannot parse number";
+constexpr char kCmsPositiveIncrement[] = "CMS: increment must be a positive integer";
 
 constexpr uint32_t kMaxCmsWidth = 1'000'000;
 constexpr uint32_t kMaxCmsDepth = 100;
+
+RuleError PositiveCmsIncrement(int64_t v) {
+  return {v <= 0, kCmsPositiveIncrement};
+}
 
 bool ValidateCmsDimensions(uint32_t width, uint32_t depth, RedisReplyBuilder* rb) {
   if (width == 0 || depth == 0) {
@@ -192,33 +197,26 @@ void CmdInitByProb(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-
-  // Parse item/increment pairs. tail_args() includes the key, so subtract it.
-  size_t num_pair_args = cmd_cntx->tail_args().size() - 1;
-  if (num_pair_args < 2 || num_pair_args % 2 != 0) {
-    return cmd_cntx->SendError(kSyntaxErr);
-  }
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   vector<pair<string_view, int64_t>> items;
-  items.reserve(num_pair_args / 2);
+  items.reserve(parser.UnparsedArgs().size() / 2);
 
+  using CmsIncrement = Validated<int64_t, PositiveCmsIncrement>;
   while (parser.HasNext()) {
-    string_view item = parser.Next();
-    int64_t incr;
-    if (!absl::SimpleAtoi(parser.Next(), &incr)) {
-      return cmd_cntx->SendError(kCmsCannotParseNumber);
-    }
-    if (incr <= 0) {
-      return cmd_cntx->SendError("CMS: increment must be a positive integer");
-    }
+    auto [item, incr] = parser.Next<string_view, CmsIncrement>();
     items.emplace_back(item, incr);
+  }
+  if (auto err = parser.TakeError()) {
+    if (err.type == CmdArgParser::INVALID_INT)
+      return rb->SendError(kCmsCannotParseNumber);
+    return rb->SendError(err.MakeReply());
   }
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpIncrBy(t->GetOpArgs(shard), key, items);
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   OpResult<vector<int64_t>> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (!res) {
     if (res.status() == OpStatus::KEY_NOTFOUND) {

--- a/src/server/cms_family_test.cc
+++ b/src/server/cms_family_test.cc
@@ -77,6 +77,12 @@ TEST_F(CmsFamilyTest, IncrBy) {
   // Should fail with invalid number
   resp = Run("cms.incrby cms foo notanumber");
   EXPECT_THAT(resp, ErrArg("CMS: Cannot parse number"));
+
+  resp = Run({"cms.incrby", "cms", "foo", "0"});
+  EXPECT_THAT(resp, ErrArg("CMS: increment must be a positive integer"));
+
+  resp = Run({"cms.incrby", "cms", "foo", "1", "bar"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
 TEST_F(CmsFamilyTest, Query) {

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -166,41 +166,34 @@ OpResult<ScanOpts> ScanOpts::TryFrom(const facade::ParsedArgs& args, bool allow_
   ScanOpts scan_opts;
   facade::CmdArgParser parser{args};
 
-  while (parser.HasNext()) {
-    std::string_view pattern;
-    std::string_view type_str;
+  parser.Apply(
+      facade::If(allow_novalues, facade::Exist("NOVALUES", &scan_opts.novalues)),
+      facade::Tag(
+          "COUNT",
+          [&](facade::CmdArgParser* p) { scan_opts.limit = max(size_t{1}, p->Next<size_t>()); }),
+      facade::Tag("MATCH",
+                  [&](facade::CmdArgParser* p) {
+                    std::string_view pattern = p->Next();
+                    if (pattern != "*")
+                      scan_opts.matcher.reset(new GlobMatcher{pattern, true});
+                  }),
+      facade::Tag("TYPE",
+                  [&](facade::CmdArgParser* p) {
+                    CompactObjType obj_type = ObjTypeFromString(p->Next());
+                    if (obj_type == kInvalidCompactObjType) {
+                      p->Report(facade::CmdArgParser::INVALID_CASES);
+                      return;
+                    }
+                    scan_opts.type_filter = obj_type;
+                  }),
+      facade::Tag("BUCKET", &scan_opts.bucket_id),
+      facade::Tag("ATTR", facade::Map(&scan_opts.mask, "v", ScanOpts::Mask::Volatile, "p",
+                                      ScanOpts::Mask::Permanent, "a", ScanOpts::Mask::Accessed, "u",
+                                      ScanOpts::Mask::Untouched)),
+      facade::Tag("MINMSZ", &scan_opts.min_malloc_size));
 
-    if (parser.Check("NOVALUES")) {
-      if (!allow_novalues) {
-        return facade::OpStatus::SYNTAX_ERR;
-      }
-      scan_opts.novalues = true;
-    } else if (parser.Check("COUNT", &scan_opts.limit)) {
-      if (scan_opts.limit == 0)
-        scan_opts.limit = 1;
-    } else if (parser.Check("MATCH", &pattern)) {
-      if (pattern != "*")
-        scan_opts.matcher.reset(new GlobMatcher{pattern, true});
-    } else if (parser.Check("TYPE", &type_str)) {
-      CompactObjType obj_type = ObjTypeFromString(type_str);
-      if (obj_type == kInvalidCompactObjType) {
-        return facade::OpStatus::SYNTAX_ERR;
-      }
-      scan_opts.type_filter = obj_type;
-    } else if (parser.Check("BUCKET", &scan_opts.bucket_id)) {
-      // no-op
-    } else if (parser.Check("ATTR")) {
-      scan_opts.mask =
-          parser.MapNext("v", ScanOpts::Mask::Volatile, "p", ScanOpts::Mask::Permanent, "a",
-                         ScanOpts::Mask::Accessed, "u", ScanOpts::Mask::Untouched);
-    } else if (parser.Check("MINMSZ", &scan_opts.min_malloc_size)) {
-      // no-op
-    } else
-      return facade::OpStatus::SYNTAX_ERR;
-  }  // while
-
-  // Check for parsing errors (e.g. missing values or invalid integers)
-  if (auto err = parser.TakeError()) {
+  if (!parser.Finalize()) {
+    auto err = parser.TakeError();
     if (err.type == facade::CmdArgParser::INVALID_INT) {
       return facade::OpStatus::INVALID_INT;
     }

--- a/src/server/cuckoo_filter_family.cc
+++ b/src/server/cuckoo_filter_family.cc
@@ -261,7 +261,8 @@ OpResult<vector<bool>> RunExists(CommandContext* cmd_cntx, string_view key, Pars
 
 void CmdExists(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs items = parser.UnparsedArgs();
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   OpResult<vector<bool>> res = RunExists(cmd_cntx, key, items);
   if (!res && res.status() != OpStatus::KEY_NOTFOUND && res.status() != OpStatus::WRONG_TYPE)
@@ -271,7 +272,8 @@ void CmdExists(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdMExists(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs items = parser.UnparsedArgs();
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   OpResult<vector<bool>> res = RunExists(cmd_cntx, key, items);
   if (!res && res.status() != OpStatus::KEY_NOTFOUND && res.status() != OpStatus::WRONG_TYPE)

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -802,21 +802,16 @@ void DebugCmd::Shutdown() {
 }
 
 void DebugCmd::Reload(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  bool save = true;
+  bool no_save = false;
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  while (parser.HasNext()) {
-    string opt = absl::AsciiStrToUpper(parser.Next());
-    VLOG(1) << "opt " << opt;
-
-    if (opt == "NOSAVE") {
-      save = false;
-    } else {
-      return cmd_cntx->SendError("DEBUG RELOAD only supports the NOSAVE options.");
-    }
+  parser.Apply(Exist("NOSAVE", &no_save));
+  if (!parser.Finalize()) {
+    (void)parser.TakeError();
+    return cmd_cntx->SendError("DEBUG RELOAD only supports the NOSAVE options.");
   }
 
-  if (save) {
+  if (!no_save) {
     string err_details;
     VLOG(1) << "Performing save";
 
@@ -1568,6 +1563,8 @@ void DebugCmd::Compression(CmdArgParser parser, CommandContext* cmd_cntx) {
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (parser.Check("SET", &bintable)) {
+    RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
     // SET <bintable> [type]
     string raw;
     atomic_bool succeed = absl::Base64Unescape(bintable, &raw);
@@ -1593,6 +1590,8 @@ void DebugCmd::Compression(CmdArgParser parser, CommandContext* cmd_cntx) {
   if (parser.Check("EXPORT")) {
     print_bintable = true;
   } else if (parser.Check("IMPORT", &bintable)) {
+    RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
     string raw;
     bool succeed = absl::Base64Unescape(bintable, &raw);
     if (succeed) {

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -727,6 +727,15 @@ TEST_F(GenericFamilyTest, Scan) {
   EXPECT_EQ(10, vec.size());
   EXPECT_THAT(vec, Each(StartsWith("zset")));
 
+  EXPECT_THAT(Run({"scan", "0", "count"}), ErrArg("syntax error"));
+  EXPECT_THAT(Run({"scan", "0", "count", "not-a-number"}), ErrArg("value is not an integer"));
+  EXPECT_THAT(Run({"scan", "0", "type", "not-a-type"}), ErrArg("syntax error"));
+  EXPECT_THAT(Run({"scan", "0", "NOVALUES"}), ErrArg("syntax error"));
+
+  // COUNT is a size_t hint: values above UINT32_MAX must still parse.
+  resp = Run({"scan", "0", "count", "5000000000"});
+  EXPECT_THAT(resp, ArrLen(2));
+
   Run({"flushdb"});
 
   Run({"set", "", "foo"});

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -132,10 +132,10 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
 
 void PFAdd(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  facade::CmdArgVec values;
-  while (parser.HasNext()) {
-    values.push_back(parser.Next());
-  }
+  CmdArgParser::Range value_range = parser.RemainingRange();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
+  facade::CmdArgVec values{value_range.begin(), value_range.end()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return AddToHll(t->GetOpArgs(shard), key, values);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -832,7 +832,9 @@ struct HSetReplies {
 void CmdHDel(CmdArgParser parser, CommandContext* cmd_cntx) {
   parser.Next();  // skip key
   // Collect field names for HNSW data preservation.
-  ParsedArgs fields_span = parser.UnparsedArgs();
+  ParsedArgs fields_span = parser.RemainingRange(WrongNumArgsError("HDEL"));
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
   absl::InlinedVector<std::string_view, 4> field_names;
   for (auto f : fields_span)
     field_names.push_back(f);
@@ -1285,7 +1287,9 @@ void CmdHSet(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdHSetNx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
-  ParsedArgs values = parser.UnparsedArgs();
+  ParsedArgs values = parser.RemainingRange(WrongNumArgsError("HSETNX"));
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
   auto cb = [&, values](Transaction* t, EngineShard* shard) {
     return OpSet(t->GetOpArgs(shard), key, values, OpSetParams{.mode = OpSetParams::Mode::kNX});
   };

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1913,23 +1913,11 @@ void CmdArrIndex(CmdArgParser parser, CommandContext* cmd_cntx) {
 
   string_view search_value = parser.Next();
 
-  int start_index = 0;
-  if (parser.HasNext()) {
-    if (!absl::SimpleAtoi(parser.Next(), &start_index)) {
-      VLOG(1) << "Failed to convert the start index to numeric";
-      builder->SendError(kInvalidIntErr);
-      return;
-    }
-  }
+  int start_index = parser.NextOrDefault<int>(0);
+  RETURN_ON_PARSE_ERROR(parser, builder);
 
-  int end_index = 0;
-  if (parser.HasNext()) {
-    if (!absl::SimpleAtoi(parser.Next(), &end_index)) {
-      VLOG(1) << "Failed to convert the stop index to numeric";
-      builder->SendError(kInvalidIntErr);
-      return;
-    }
-  }
+  int end_index = parser.NextOrDefault<int>(0);
+  RETURN_ON_PARSE_ERROR(parser, builder);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpArrIndex(t->GetOpArgs(shard), key, json_path, search_value, start_index, end_index);
@@ -1942,22 +1930,15 @@ void CmdArrIndex(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdArrInsert(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.Next();
-  int index = -1;
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  string_view index_sv = parser.Next();
-  if (!absl::SimpleAtoi(index_sv, &index)) {
-    VLOG(1) << "Failed to convert the following value to numeric: " << index_sv;
-    builder->SendError(kInvalidIntErr);
-    return;
-  }
+  int index = parser.Next<int>();
+  RETURN_ON_PARSE_ERROR(parser, builder);
 
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
-  vector<string_view> new_values;
-  while (parser.HasNext()) {
-    new_values.emplace_back(parser.Next());
-  }
+  CmdArgParser::Range new_value_range = parser.RemainingRange();
+  vector<string_view> new_values{new_value_range.begin(), new_value_range.end()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpArrInsert(t->GetOpArgs(shard), key, json_path, index, new_values);
@@ -1974,10 +1955,8 @@ void CmdArrAppend(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
-  vector<string_view> append_values;
-  while (parser.HasNext()) {
-    append_values.emplace_back(parser.Next());
-  }
+  CmdArgParser::Range append_value_range = parser.RemainingRange();
+  vector<string_view> append_values{append_value_range.begin(), append_value_range.end()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpArrAppend(t->GetOpArgs(shard), key, json_path, append_values);
@@ -1990,21 +1969,10 @@ void CmdArrAppend(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdArrTrim(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.Next();
-  int start_index;
-  int stop_index;
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (!absl::SimpleAtoi(parser.Next(), &start_index)) {
-    VLOG(1) << "Failed to parse array start index";
-    builder->SendError(kInvalidIntErr);
-    return;
-  }
-
-  if (!absl::SimpleAtoi(parser.Next(), &stop_index)) {
-    VLOG(1) << "Failed to parse array stop index";
-    builder->SendError(kInvalidIntErr);
-    return;
-  }
+  auto [start_index, stop_index] = parser.Next<int, int>();
+  RETURN_ON_PARSE_ERROR(parser, builder);
 
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
@@ -2264,7 +2232,7 @@ void RegisterJsonFamily(CommandRegistry* registry) {
   *registry << CI{"JSON.CLEAR", CO::JOURNALED | CO::FAST, -2, 1, 1, acl::JSON}.HFUNC(Clear);
   *registry << CI{"JSON.ARRPOP", CO::JOURNALED | CO::FAST, -2, 1, 1, acl::JSON}.HFUNC(ArrPop);
   *registry << CI{"JSON.ARRTRIM", CO::JOURNALED | CO::FAST, 5, 1, 1, acl::JSON}.HFUNC(ArrTrim);
-  *registry << CI{"JSON.ARRINSERT", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::JSON}
+  *registry << CI{"JSON.ARRINSERT", CO::JOURNALED | CO::DENYOOM | CO::FAST, -5, 1, 1, acl::JSON}
                    .HFUNC(ArrInsert);
   *registry << CI{"JSON.ARRAPPEND", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::JSON}
                    .HFUNC(ArrAppend);

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -2240,6 +2240,10 @@ TEST_F(JsonFamilyTest, ArrInsert) {
 
   resp = Run({"JSON.ARRINSERT", "json", "$.a", "0", R"("c")"});
   EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
+
+  // Missing value -> wrong number of arguments (like Redis).
+  resp = Run({"JSON.ARRINSERT", "json", "$", "0"});
+  EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
 }
 
 TEST_F(JsonFamilyTest, ArrInsertLegacy) {

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1264,11 +1264,15 @@ void CmdBLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdLPush(CmdArgParser parser, CommandContext* cmd_cntx) {
-  return PushGeneric(ListDir::LEFT, false, parser.UnparsedArgs(), cmd_cntx);
+  ParsedArgs args = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  return PushGeneric(ListDir::LEFT, false, args, cmd_cntx);
 }
 
 void CmdLPushX(CmdArgParser parser, CommandContext* cmd_cntx) {
-  return PushGeneric(ListDir::LEFT, true, parser.UnparsedArgs(), cmd_cntx);
+  ParsedArgs args = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  return PushGeneric(ListDir::LEFT, true, args, cmd_cntx);
 }
 
 void CmdLPop(CmdArgParser parser, CommandContext* cmd_cntx) {
@@ -1276,11 +1280,15 @@ void CmdLPop(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdRPush(CmdArgParser parser, CommandContext* cmd_cntx) {
-  return PushGeneric(ListDir::RIGHT, false, parser.UnparsedArgs(), cmd_cntx);
+  ParsedArgs args = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  return PushGeneric(ListDir::RIGHT, false, args, cmd_cntx);
 }
 
 void CmdRPushX(CmdArgParser parser, CommandContext* cmd_cntx) {
-  return PushGeneric(ListDir::RIGHT, true, parser.UnparsedArgs(), cmd_cntx);
+  ParsedArgs args = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  return PushGeneric(ListDir::RIGHT, true, args, cmd_cntx);
 }
 
 void CmdRPop(CmdArgParser parser, CommandContext* cmd_cntx) {
@@ -1340,15 +1348,10 @@ void CmdLPos(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdLIndex(CmdArgParser parser, CommandContext* cmd_cntx) {
-  std::string_view key = parser.Next();
-  std::string_view index_str = parser.Next();
-  int32_t index;
+  auto [key, index] = parser.Next<string_view, int32_t>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  if (!absl::SimpleAtoi(index_str, &index)) {
-    rb->SendError(kInvalidIntErr);
-    return;
-  }
+  RETURN_ON_PARSE_ERROR(parser, rb);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpIndex(t->GetOpArgs(shard), key, index);
@@ -1388,15 +1391,8 @@ void CmdLInsert(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdLTrim(CmdArgParser parser, CommandContext* cmd_cntx) {
-  string_view key = parser.Next();
-  string_view s_str = parser.Next();
-  string_view e_str = parser.Next();
-  int32_t start, end;
-
-  if (!absl::SimpleAtoi(s_str, &start) || !absl::SimpleAtoi(e_str, &end)) {
-    cmd_cntx->SendError(kInvalidIntErr);
-    return;
-  }
+  auto [key, start, end] = parser.Next<string_view, int32_t, int32_t>();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpTrim(t->GetOpArgs(shard), key, start, end);
@@ -1408,16 +1404,9 @@ void CmdLTrim(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdLRange(CmdArgParser parser, CommandContext* cmd_cntx) {
-  std::string_view key = parser.Next();
-  std::string_view s_str = parser.Next();
-  std::string_view e_str = parser.Next();
-  int32_t start, end;
-
+  auto [key, start, end] = parser.Next<string_view, int32_t, int32_t>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (!absl::SimpleAtoi(s_str, &start) || !absl::SimpleAtoi(e_str, &end)) {
-    rb->SendError(kInvalidIntErr);
-    return;
-  }
+  RETURN_ON_PARSE_ERROR(parser, rb);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpRange(t->GetOpArgs(shard), key, start, end);
@@ -1433,15 +1422,8 @@ void CmdLRange(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 // lrem key 5 foo, will remove foo elements from the list if exists at most 5 times.
 void CmdLRem(CmdArgParser parser, CommandContext* cmd_cntx) {
-  std::string_view key = parser.Next();
-  std::string_view index_str = parser.Next();
-  std::string_view elem = parser.Next();
-  int32_t count;
-
-  if (!absl::SimpleAtoi(index_str, &count)) {
-    cmd_cntx->SendError(kInvalidIntErr);
-    return;
-  }
+  auto [key, count, elem] = parser.Next<string_view, int32_t, string_view>();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpRem(t->GetOpArgs(shard), key, elem, count);
@@ -1454,15 +1436,8 @@ void CmdLRem(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdLSet(CmdArgParser parser, CommandContext* cmd_cntx) {
-  std::string_view key = parser.Next();
-  std::string_view index_str = parser.Next();
-  std::string_view elem = parser.Next();
-  int32_t count;
-
-  if (!absl::SimpleAtoi(index_str, &count)) {
-    cmd_cntx->SendError(kInvalidIntErr);
-    return;
-  }
+  auto [key, count, elem] = parser.Next<string_view, int32_t, string_view>();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpSet(t->GetOpArgs(shard), key, elem, count);

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -129,9 +129,10 @@ void ScriptMgr::Run(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* buil
 }
 
 void ScriptMgr::ExistsCmd(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* builder) const {
+  CmdArgParser::Range shas = parser.RemainingRange();
   vector<uint8_t> res;
-  while (parser.HasNext()) {
-    string_view sha = parser.Next<string_view>();
+  res.reserve(shas.size());
+  for (string_view sha : shas) {
     res.push_back(Find(sha) ? 1 : 0);
   }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -458,20 +458,15 @@ optional<ClientListFilter> ParseClientListFilter(CmdArgParser parser, CommandCon
       return nullopt;
     }
     while (parser.HasNext()) {
-      uint32_t id;
-      if (!absl::SimpleAtoi(parser.Next<string_view>(), &id)) {
-        cmd_cntx->SendError("Invalid client ID");
-        return nullopt;
-      }
-      filter.ids.insert(id);
+      filter.ids.insert(parser.Next<uint32_t>("Invalid client ID"));
     }
   } else {
     cmd_cntx->SendError(facade::kSyntaxErr);
     return nullopt;
   }
 
-  if (parser.HasNext() || parser.HasError()) {
-    cmd_cntx->SendError(facade::kSyntaxErr);
+  if (!parser.Finalize()) {
+    cmd_cntx->SendError(parser.TakeError().MakeReply());
     return nullopt;
   }
   return filter;
@@ -3092,9 +3087,10 @@ void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   MetricsCollectOpts opts{.replication_memory = false, .cmd_stats = false, .cmd_latency = false};
   Metrics metrics;
 
-  sections.reserve(parser.UnparsedArgs().size());
-  while (parser.HasNext()) {
-    sections.emplace_back(absl::AsciiStrToUpper(parser.Next<string_view>()));
+  CmdArgParser::Range section_range = parser.RemainingRange();
+  sections.reserve(section_range.size());
+  for (string_view section_arg : section_range) {
+    sections.emplace_back(absl::AsciiStrToUpper(section_arg));
     const auto& section = sections.back();
     need_metrics |= (section != "SERVER") && (section != "REPLICATION");
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1130,7 +1130,8 @@ struct SetReplies {
 
 void CmdSAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs values = parser.UnparsedArgs();
+  ParsedArgs values = parser.RemainingRange(WrongNumArgsError("SADD"));
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [key, values](Transaction* t, EngineShard* shard) {
     return OpAdd(t->GetOpArgs(shard), key, values, false, false);
@@ -1169,7 +1170,8 @@ void CmdSIsMember(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdSMIsMember(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs members = parser.UnparsedArgs();
+  ParsedArgs members = parser.RemainingRange(WrongNumArgsError("SMISMEMBER"));
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   vector<int32_t> memberships(members.size());
 
@@ -1219,7 +1221,8 @@ void CmdSMove(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdSRem(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  ParsedArgs vals = parser.UnparsedArgs();
+  ParsedArgs vals = parser.RemainingRange(WrongNumArgsError("SREM"));
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [key, vals](Transaction* t, EngineShard* shard) {
     return OpRem(t->GetOpArgs(shard), key, vals, false);
@@ -1476,13 +1479,15 @@ void CmdSInterCard(CmdArgParser parser, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(OpStatus::AT_LEAST_ONE_KEY);
 
   unsigned limit = 0;
-  // num_keys has already been consumed, so args holds only the keys and an optional LIMIT clause.
-  auto args = parser.UnparsedArgs();
-  if (args.size() == (num_keys + 2) && args[num_keys] == "LIMIT") {
-    if (!absl::SimpleAtoi(args[num_keys + 1], &limit))
+  parser.Skip(num_keys);  // keys are handled by the command key spec.
+  parser.Check("LIMIT", &limit);
+
+  if (!parser.Finalize()) {
+    auto err = parser.TakeError();
+    if (err.type == CmdArgParser::INVALID_INT)
       return cmd_cntx->SendError("limit can't be negative");
-  } else if (args.size() > num_keys)
-    return cmd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(err.MakeReply());
+  }
 
   ResultStringVec result_set(shard_set->size(), OpStatus::SKIPPED);
   auto cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/topk_family.cc
+++ b/src/server/topk_family.cc
@@ -217,9 +217,8 @@ void TopkFamily::Reserve(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
     }
   }
 
-  if (parser.HasNext()) {
-    return rb->SendError(kSyntaxErr);
-  }
+  if (!parser.Finalize())
+    return rb->SendError(parser.TakeError().MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpReserve(t->GetOpArgs(shard), key, k, width, depth, decay);
@@ -233,14 +232,12 @@ void TopkFamily::Reserve(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
 
 void TopkFamily::Add(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  vector<string_view> items;
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  while (parser.HasNext()) {
-    items.push_back(parser.Next());
-  }
-  if (items.empty()) {
-    return cmd_cntx->SendError(kSyntaxErr);
-  }
+  CmdArgParser::Range item_range = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, rb);
+
+  vector<string_view> items{item_range.begin(), item_range.end()};
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpAdd(t->GetOpArgs(shard), key, items);
   };
@@ -250,7 +247,6 @@ void TopkFamily::Add(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
 
   // Build array response
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   {
     SinkReplyBuilder::ReplyScope scope(rb);
     rb->StartArray(result->size());
@@ -269,20 +265,19 @@ void TopkFamily::IncrBy(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   vector<pair<string_view, uint32_t>> items;
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
+  items.reserve(parser.UnparsedArgs().size() / 2);
   while (parser.HasNext()) {
-    string_view item = parser.Next();
-    if (!parser.HasNext()) {
-      return cmd_cntx->SendError(kSyntaxErr);
-    }
-    uint32_t incr =
-        parser.Next<Validated<uint32_t, Bounded<uint32_t{1}, uint32_t{100000}, kIncrRangeErr>>>();
-    RETURN_ON_PARSE_ERROR(parser, rb);
+    auto [item, incr] =
+        parser.Next<string_view,
+                    Validated<uint32_t, Bounded<uint32_t{1}, uint32_t{100000}, kIncrRangeErr>>>();
     items.emplace_back(item, incr);
   }
+  RETURN_ON_PARSE_ERROR(parser, rb);
 
   if (items.empty()) {
     return cmd_cntx->SendError(kSyntaxErr);
   }
+
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpIncrBy(t->GetOpArgs(shard), key, items);
   };
@@ -306,14 +301,12 @@ void TopkFamily::IncrBy(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void TopkFamily::Query(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  vector<string_view> items;
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  while (parser.HasNext()) {
-    items.push_back(parser.Next());
-  }
-  if (items.empty()) {
-    return cmd_cntx->SendError(kSyntaxErr);
-  }
+  CmdArgParser::Range item_range = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, rb);
+
+  vector<string_view> items{item_range.begin(), item_range.end()};
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpQuery(t->GetOpArgs(shard), key, items);
   };
@@ -322,7 +315,6 @@ void TopkFamily::Query(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
 
   // Build array response
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   {
     SinkReplyBuilder::ReplyScope scope(rb);
     rb->StartArray(result->size());
@@ -334,14 +326,12 @@ void TopkFamily::Query(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void TopkFamily::Count(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  vector<string_view> items;
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  while (parser.HasNext()) {
-    items.push_back(parser.Next());
-  }
-  if (items.empty()) {
-    return cmd_cntx->SendError(kSyntaxErr);
-  }
+  CmdArgParser::Range item_range = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, rb);
+
+  vector<string_view> items{item_range.begin(), item_range.end()};
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpCount(t->GetOpArgs(shard), key, items);
   };
@@ -350,7 +340,6 @@ void TopkFamily::Count(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
 
   // Build array response
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   {
     SinkReplyBuilder::ReplyScope scope(rb);
     rb->StartArray(result->size());
@@ -362,21 +351,13 @@ void TopkFamily::Count(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void TopkFamily::List(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   bool with_count = false;
 
-  if (parser.HasNext()) {
-    string_view flag = parser.Next();
-    if (absl::EqualsIgnoreCase(flag, "WITHCOUNT")) {
-      with_count = true;
-    } else {
-      return cmd_cntx->SendError(kSyntaxErr);
-    }
-  }
+  parser.Apply(OneOf(Exist("WITHCOUNT", &with_count)));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (parser.HasNext()) {
-    return rb->SendError(kSyntaxErr);
-  }
+  if (!parser.Finalize())
+    return rb->SendError(parser.TakeError().MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) { return OpList(t->GetOpArgs(shard), key); };
   auto result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
@@ -401,9 +382,8 @@ void TopkFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  if (parser.HasNext()) {
-    return rb->SendError(kSyntaxErr);
-  }
+  if (!parser.Finalize())
+    return rb->SendError(parser.TakeError().MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) { return OpInfo(t->GetOpArgs(shard), key); };
   auto result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -55,12 +55,7 @@ using ScoredArray = ZSetFamily::ScoredArray;
 using ScoredMemberView = ZSetFamily::ScoredMemberView;
 using ScoredMemberSpan = ZSetFamily::ScoredMemberSpan;
 
-struct ValidateZMPopResult {
-  uint32_t num_keys;
-  bool is_max;
-  int pop_count;
-  float timeout;
-};
+using ZPopTimeout = Validated<float, NonNegative<kTimeoutNegativeErr>>;
 
 inline zrangespec GetZrangeSpec(bool reverse, const ZSetFamily::ScoreInterval& si) {
   auto interval = si;
@@ -1900,61 +1895,6 @@ std::optional<std::string_view> GetFirstNonEmptyKeyFound(EngineShard* shard, Tra
   return std::nullopt;
 }
 
-// Validates the ZMPop and BZMPop command arguments and extracts the values to the output params.
-// If the arguments are invalid sends the appropiate error to builder and returns false.
-bool ValidateZMPopCommand(CmdArgParser parser, bool is_blocking, CommandContext* cmd_cntx,
-                          ValidateZMPopResult* result) {
-  if (is_blocking) {
-    if (!absl::SimpleAtof(parser.Next(), &result->timeout)) {
-      cmd_cntx->SendError("timeout is not a float or out of range");
-      return false;
-    }
-    if (result->timeout < 0) {
-      cmd_cntx->SendError("timeout is negative");
-      return false;
-    }
-  }
-
-  if (!SimpleAtoi(parser.Next(), &(result->num_keys))) {
-    cmd_cntx->SendError(kUintErr);
-    return false;
-  }
-
-  if (result->num_keys <= 0 || !parser.HasAtLeast(result->num_keys + 1)) {
-    // We should have at least num_keys keys + a MIN/MAX arg.
-    cmd_cntx->SendError(kSyntaxErr);
-    return false;
-  }
-  // Skip over the keys themselves.
-  parser.Skip(result->num_keys);
-
-  // We know we have at least one more arg (we checked above).
-  if (parser.Check("MAX")) {
-    result->is_max = true;
-  } else if (parser.Check("MIN")) {
-    result->is_max = false;
-  } else {
-    cmd_cntx->SendError(kSyntaxErr);
-    return false;
-  }
-
-  result->pop_count = 1;
-  // Check if we have additional COUNT argument.
-  if (parser.HasNext()) {
-    if (!parser.Check("COUNT", &result->pop_count)) {
-      cmd_cntx->SendError(kSyntaxErr);
-      return false;
-    }
-  }
-
-  if (!parser.Finalize()) {
-    cmd_cntx->SendError(parser.TakeError().MakeReply());
-    return false;
-  }
-
-  return true;
-}
-
 }  // namespace
 
 void ZSetFamily::ZAddGeneric(string_view key, const ZParams& zparams, ScoredMemberSpan memb_sp,
@@ -2482,22 +2422,16 @@ void CmdZInterStore(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdZInterCard(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* builder = cmd_cntx->rb();
 
-  unsigned num_keys = parser.Next<unsigned>();
-  if (parser.TakeError()) {
-    return cmd_cntx->SendError(OpStatus::SYNTAX_ERR);
-  }
-
-  // After numkeys is consumed, the remaining args are the keys followed by an optional LIMIT
-  // clause.
-  facade::ParsedArgs args = parser.UnparsedArgs();
+  parser.NextRange(1, kSyntaxErr);  // numkeys + keys, handled by the command key spec.
 
   uint64_t limit = 0;
-  if (args.size() == (num_keys + 2) && args[num_keys] == "LIMIT") {
-    if (!absl::SimpleAtoi(args[num_keys + 1], &limit)) {
+  parser.Check("LIMIT", &limit);
+
+  if (!parser.Finalize()) {
+    auto err = parser.TakeError();
+    if (err.type == CmdArgParser::INVALID_INT)
       return builder->SendError("limit value is not a positive integer", kSyntaxErrType);
-    }
-  } else if (args.size() != num_keys) {
-    return builder->SendError(kSyntaxErr);
+    return builder->SendError(err.MakeReply());
   }
 
   vector<OpResult<ScoredMap>> maps(shard_set->size(), OpStatus::SKIPPED);
@@ -2521,12 +2455,22 @@ void CmdZInterCard(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 // Generic function for ZMPop and BZMPop commands
 void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blocking) {
-  ValidateZMPopResult zmpop_args;
-  // Validate on a copy so `parser` stays positioned at the start for reading the keys below.
-  if (!ValidateZMPopCommand(parser, is_blocking, cmd_cntx, &zmpop_args)) {
+  auto* response_builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  float timeout = 0;
+  if (is_blocking)
+    timeout = parser.Next<ZPopTimeout>(kTimeoutNotFloatErr);
+
+  CmdArgParser::Range keys = parser.NextRange();  // numkeys + keys, handled by the key spec.
+  bool is_max = parser.MapNext("MAX", true, "MIN", false);
+
+  int pop_count = 1;
+  parser.Check("COUNT", &pop_count);
+
+  if (!parser.Finalize()) {
+    cmd_cntx->SendError(parser.TakeError().MakeReply());
     return;
   }
-  auto* response_builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   // From the list of input keys, keep the first (in the order of keys in the command) key found
   // in the current shard.
@@ -2546,7 +2490,7 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
   // Keep all the keys found (first only for each shard) in a set for fast lookups.
   absl::flat_hash_set<std::string_view> first_found_keys_for_shard;
   // We can have at most one result from each shard.
-  first_found_keys_for_shard.reserve(std::min(shard_set->size(), zmpop_args.num_keys));
+  first_found_keys_for_shard.reserve(std::min<size_t>(shard_set->size(), keys.size()));
   for (const auto& key : first_found_key_per_shard_vec) {
     if (!key.has_value()) {
       continue;
@@ -2557,12 +2501,9 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
   // Now that we have the first non empty key from each shard, find the first overall first key
   // and pop elements from it.
   std::optional<std::string_view> key_to_pop = std::nullopt;
-  // Skip the leading [timeout] (BZMPOP only) and numkeys args to reach the key list, then find the
-  // first key (in command order) that exists and is non-empty on some shard. The string_views point
-  // into the command's backing args, which outlive this call.
-  parser.Skip(1 + is_blocking);
-  for (size_t i = 0; i < zmpop_args.num_keys; ++i) {
-    std::string_view key = parser.Next();
+  // Find the first key (in command order) that exists and is non-empty on some shard. The
+  // string_views point into the command's backing args, which outlive this call.
+  for (std::string_view key : keys) {
     if (first_found_keys_for_shard.contains(key)) {
       key_to_pop = key;
       break;
@@ -2581,7 +2522,7 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
     auto* ns = &trans->GetNamespace();
 
     auto limit_tp = Transaction::time_point::max();
-    auto limit_ms = (unsigned)(zmpop_args.timeout * 1000);
+    auto limit_ms = (unsigned)(timeout * 1000);
     if (limit_ms > 0) {
       using namespace std::chrono;
       limit_tp = steady_clock::now() + milliseconds(limit_ms);
@@ -2618,8 +2559,8 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
   DCHECK(key_to_pop.has_value());
 
   // Pop elements from relevant set.
-  OpResult<ScoredArray> pop_result = ZPopMinMaxInternal(
-      *key_to_pop, FilterShards::YES, zmpop_args.pop_count, zmpop_args.is_max, cmd_cntx->tx());
+  OpResult<ScoredArray> pop_result =
+      ZPopMinMaxInternal(*key_to_pop, FilterShards::YES, pop_count, is_max, cmd_cntx->tx());
 
   if (pop_result.status() == OpStatus::WRONG_TYPE) {
     return response_builder->SendError(kWrongTypeErr);


### PR DESCRIPTION
Summary: This PR refactors command handlers to use facade::CmdArgParser more consistently, improving how missing/invalid arguments are detected and surfaced to clients.

Changes:

- Update CmdArgParser::Check() to consume the tag and then read values via Next<>(), latching errors instead of pre-checking tail length.
- Migrate many handlers from manual loops/size checks to RemainingRange(), NextRange(), and Apply()/Finalize()-based parsing.
- Standardize error handling with early returns (e.g., RETURN_ON_PARSE_ERROR) after range/typed reads.
- Tighten arity for JSON.ARRINSERT (now requires at least one inserted value) to match Redis behavior.
- Improve numeric validation in some module commands (e.g., CMS increments) using Validated<> rules.
- Add/extend unit tests covering new error cases (SCAN option errors, CMS.INCRBY edge cases, JSON.ARRINSERT missing value).

Technical Notes: The refactor leans on the parser’s “latch first error, finalize once” model; call sites now generally consume all args and rely on Finalize()/TakeError() for Redis-compatible replies.