### PR TITLE
fix(helm): use fullname helper for PVC and serviceName

### DIFF
--- a/contrib/charts/dragonfly/ci/persistence-and-existing-secret.golden.yaml
+++ b/contrib/charts/dragonfly/ci/persistence-and-existing-secret.golden.yaml
@@ -53,7 +53,7 @@ metadata:
     app.kubernetes.io/version: "v1.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
-  serviceName: test
+  serviceName: test-dragonfly
   replicas: 1
   selector:
     matchLabels:
@@ -102,7 +102,7 @@ spec:
             requests: {}
           volumeMounts:
             - mountPath: /data
-              name: "test-data"
+              name: "test-dragonfly-data"
           env:
             - name: DFLY_requirepass
               valueFrom:
@@ -111,7 +111,7 @@ spec:
                   key: password
   volumeClaimTemplates:
     - metadata:
-        name: "test-data"
+        name: "test-dragonfly-data"
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: standard

--- a/contrib/charts/dragonfly/ci/persistent-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/persistent-values.golden.yaml
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/version: "v1.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
-  serviceName: test
+  serviceName: test-dragonfly
   replicas: 1
   selector:
     matchLabels:
@@ -94,10 +94,10 @@ spec:
             requests: {}
           volumeMounts:
             - mountPath: /data
-              name: "test-data"
+              name: "test-dragonfly-data"
   volumeClaimTemplates:
     - metadata:
-        name: "test-data"
+        name: "test-dragonfly-data"
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: standard

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -3,7 +3,7 @@
 volumeMounts:
   {{- if .Values.storage.enabled }}
   - mountPath: /data
-    name: "{{ .Release.Name }}-data"
+    name: "{{ include "dragonfly.fullname" . }}-data"
   {{- end }}
   {{- if and .Values.tls .Values.tls.enabled }}
   - mountPath: /etc/dragonfly/tls

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ .Release.Name }}
+  serviceName: {{ include "dragonfly.fullname" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -30,7 +30,7 @@ spec:
       {{- include "dragonfly.pod" . | trim | nindent 6 }}
   volumeClaimTemplates:
     - metadata:
-        name: "{{ .Release.Name }}-data"
+        name: "{{ include "dragonfly.fullname" . }}-data"
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.storage.storageClassName }}


### PR DESCRIPTION
## Summary
StatefulSet's `serviceName` and PVC/volumeMount names used raw `.Release.Name` instead of the `dragonfly.fullname` helper used elsewhere in the chart, causing name collisions when the chart is used as a subchart dependency.

Fixes #7381