### PR TITLE
fix(helm): remove .Release.Name to resolve name collisions

### DIFF
--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -88,6 +88,7 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 | storage.enabled | bool | `false` | If /data should persist. This will provision a StatefulSet instead. |
 | storage.requests | string | `"128Mi"` | Volume size to request for the PVC |
 | storage.storageClassName | string | `""` | Global StorageClass for Persistent Volume(s) |
+| storage.useFullnameForVolumes | bool | `false` | Use the chart's fullname (instead of the release name) for the StatefulSet's serviceName and the data volume/claim name. This avoids name collisions when the chart is installed as a subchart dependency. Do not enable this on an existing storage-enabled release: Kubernetes does not allow changing serviceName or renaming volumeClaimTemplates in place, so it only applies cleanly to new installs. |
 | tls.cert | string | `""` | TLS certificate |
 | tls.createCerts | bool | `false` | use cert-manager to automatically create the certificate |
 | tls.duration | string | `"87600h0m0s"` | duration or ttl of the validity of the created certificate |

--- a/contrib/charts/dragonfly/ci/persistent-fullname-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/persistent-fullname-values.golden.yaml
@@ -1,0 +1,106 @@
+---
+# Source: dragonfly/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.39.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: dragonfly/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.39.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: dragonfly
+      protocol: TCP
+      name: dragonfly
+  selector:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+---
+# Source: dragonfly/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.39.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: test-dragonfly
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: dragonfly
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-dragonfly
+      containers:
+        - name: dragonfly
+          image: "docker.dragonflydb.io/dragonflydb/dragonfly:v1.39.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: dragonfly
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          args:
+            - "--alsologtostderr"
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - mountPath: /data
+              name: "test-dragonfly-data"
+  volumeClaimTemplates:
+    - metadata:
+        name: "test-dragonfly-data"
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 128Mi

--- a/contrib/charts/dragonfly/ci/persistent-fullname-values.yaml
+++ b/contrib/charts/dragonfly/ci/persistent-fullname-values.yaml
@@ -1,0 +1,5 @@
+storage:
+  enabled: true
+  storageClassName: "standard"
+  requests: 128Mi
+  useFullnameForVolumes: true

--- a/contrib/charts/dragonfly/templates/_helpers.tpl
+++ b/contrib/charts/dragonfly/templates/_helpers.tpl
@@ -24,6 +24,39 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+StatefulSet serviceName. Defaults to the release name, matching this chart's
+historical behavior so existing storage-enabled releases are unaffected on
+upgrade (Kubernetes does not allow changing serviceName in place). Set
+storage.useFullnameForVolumes to base it on the fullname instead, which
+avoids name collisions when this chart is installed as a subchart dependency.
+*/}}
+{{- define "dragonfly.serviceName" -}}
+{{- if .Values.storage.useFullnameForVolumes }}
+{{- include "dragonfly.fullname" . }}
+{{- else }}
+{{- .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Data volume / PVC name. Defaults to "<release-name>-data", matching this
+chart's historical behavior so existing storage-enabled releases are
+unaffected on upgrade (Kubernetes does not allow renaming
+volumeClaimTemplates in place). Set storage.useFullnameForVolumes to base it
+on the fullname instead, which avoids name collisions when this chart is
+installed as a subchart dependency. Truncates the combined string (rather
+than truncating fullname alone and appending "-data") to respect the 63 char
+Kubernetes name limit.
+*/}}
+{{- define "dragonfly.dataVolumeName" -}}
+{{- if .Values.storage.useFullnameForVolumes }}
+{{- printf "%s-data" (include "dragonfly.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-data" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "dragonfly.chart" -}}

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -3,7 +3,7 @@
 volumeMounts:
   {{- if .Values.storage.enabled }}
   - mountPath: /data
-    name: "{{ .Release.Name }}-data"
+    name: "{{ include "dragonfly.dataVolumeName" . }}"
   {{- end }}
   {{- if and .Values.tls .Values.tls.enabled }}
   - mountPath: /etc/dragonfly/tls

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ .Release.Name }}
+  serviceName: {{ include "dragonfly.serviceName" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -30,7 +30,7 @@ spec:
       {{- include "dragonfly.pod" . | trim | nindent 6 }}
   volumeClaimTemplates:
     - metadata:
-        name: "{{ .Release.Name }}-data"
+        name: "{{ include "dragonfly.dataVolumeName" . }}"
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.storage.storageClassName }}

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -100,6 +100,13 @@ storage:
   storageClassName: ""
   # -- Volume size to request for the PVC
   requests: 128Mi
+  # -- Use the chart's fullname (instead of the release name) for the
+  # StatefulSet's serviceName and the data volume/claim name. This avoids
+  # name collisions when the chart is installed as a subchart dependency.
+  # Do not enable this on an existing storage-enabled release: Kubernetes
+  # does not allow changing serviceName or renaming volumeClaimTemplates in
+  # place, so it only applies cleanly to new installs.
+  useFullnameForVolumes: false
 
 tls:
   # -- enable TLS


### PR DESCRIPTION
## Summary
StatefulSet's `serviceName` and PVC/volumeMount names used raw `.Release.Name` instead of the `dragonfly.fullname` helper, causing name collisions when the chart is used as a subchart dependency. Fixed as opt-in via `storage.useFullnameForVolumes` so existing storage-enabled releases render unchanged on upgrade (Kubernetes forbids changing `serviceName`/renaming `volumeClaimTemplates` in place). Also fixes truncation order so the combined `<fullname>-data` string respects the 63 char limit.

Fixes #7381