### PR TITLE
feat(ubsan): add UBSan CI suite and tooling

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -28,9 +28,24 @@ inputs:
     default: '-no-pie'
     type: string
   sanitizers:
-    description: "Enable sanitizers (NoSanitizers or Sanitizers)"
+    description: "Enable sanitizers (NoSanitizers or Sanitizers). Master toggle for all sanitizers."
     required: false
     default: 'NoSanitizers'
+    type: string
+  with-asan:
+    description: "Override ASan independently: 'ON'/'OFF'. Empty inherits from `sanitizers`."
+    required: false
+    default: ''
+    type: string
+  with-ubsan:
+    description: "Override UBSan independently: 'ON'/'OFF'. Empty inherits from `sanitizers`."
+    required: false
+    default: ''
+    type: string
+  ubsan-strict:
+    description: "Enable extended UBSan checks (WITH_UBSAN_STRICT). Off by default."
+    required: false
+    default: 'OFF'
     type: string
   with-aws:
     description: "Build with AWS support"
@@ -49,14 +64,23 @@ runs:
     - name: Configure CMake
       shell: bash
       run: |
-        # Set sanitizer flags
+        # Set sanitizer flags. `sanitizers` is the master toggle (both on/off);
+        # with-asan / with-ubsan optionally override each independently.
         ASAN="OFF"
-        USAN="OFF"
+        UBSAN="OFF"
         if [ '${{ inputs.sanitizers }}' = 'Sanitizers' ]; then
-          echo "Enabling ASAN/USAN"
+          echo "Enabling ASAN/UBSAN"
           ASAN="ON"
-          USAN="ON"
+          UBSAN="ON"
         fi
+        # Per-sanitizer overrides (empty = inherit from `sanitizers`).
+        if [ -n '${{ inputs.with-asan }}' ]; then
+          ASAN='${{ inputs.with-asan }}'
+        fi
+        if [ -n '${{ inputs.with-ubsan }}' ]; then
+          UBSAN='${{ inputs.with-ubsan }}'
+        fi
+        echo "Sanitizers resolved: ASAN=${ASAN} UBSAN=${UBSAN}"
 
         # Build cmake command array
         CMAKE_CMD=(cmake
@@ -84,7 +108,8 @@ runs:
           -DWITH_UNWIND=OFF
           -DWITH_GPERF=OFF
           -DWITH_ASAN="${ASAN}"
-          -DWITH_USAN="${USAN}"
+          -DWITH_UBSAN="${UBSAN}"
+          -DWITH_UBSAN_STRICT="${{ inputs.ubsan-strict }}"
           -DLEGACY_GLOG=OFF
         )
 

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -1,0 +1,275 @@
+name: ubsan
+
+# UndefinedBehaviorSanitizer run.
+#
+# Runs on x86_64 and aarch64: some findings differ by arch (char signedness, long
+# width), so both are checked.
+#
+# Two phases:
+#   1. Self-test (required): inject RunUbsanSelfTest() into dragonfly, build with
+#      UBSan, and check that every check fires - proof the flags are live.
+#   2. Run (informational): revert the patch, rebuild, and run the pytest suite
+#      under UBSan, saving findings as artifacts and a summary.
+#
+# Full details live in tools/sanitizers/ubsan/README.md.
+
+on:
+  schedule:
+    - cron: '0 4 * * 6' # Saturdays 04:00 UTC
+  workflow_dispatch: # manual run, any branch
+    inputs:
+      enable_helio:
+        description: "Enable Helio Instrumentation"
+        type: boolean
+        default: true
+      compare:
+        description: "Diff-run (Show newly-added issues vs a baseline run)"
+        type: boolean
+        default: true
+      compare_ref:
+        description: "Diff-run baseline: a git ref or a run number to compare to. Relevant only if Diff-run enabled. Empty = last successful scheduled run; else a git ref (sha/branch/tag) OR R<run-number> e.g. R3. Must be green + an ancestor of HEAD."
+        type: string
+        default: ""
+      fail_on_new:
+        description: "Fail the job on NEW real-UB + implicit-conversion findings vs baseline (default: informational)"
+        type: boolean
+        default: false
+      ubsan_runtime_options:
+        description: "Extra UBSAN_OPTIONS appended as colon-separated key=value pairs, e.g. 'silence_unsigned_overflow=1' (not a build option)."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  actions: read   # download-artifact fetches artifacts from other workflow runs
+
+jobs:
+  ubsan:
+    name: UBSan (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-24.04
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
+    env:
+      # Base UBSAN_OPTIONS shared by both runs; each step adds its own log_path.
+      # UBSAN_EXTRA_RUNTIME_OPTS (the manual input) is added only to phase 2.
+      UBSAN_COMMON_RUNTIME_OPTS: "print_stacktrace=1:report_error_type=1"
+      UBSAN_EXTRA_RUNTIME_OPTS: ${{ inputs.ubsan_runtime_options }}
+      # Sourced step library used by the run steps below (source "$CI_STEPS").
+      CI_STEPS: ${{ github.workspace }}/tools/sanitizers/ubsan/ci_steps.sh
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: ghcr.io/romange/ubuntu-dev:24
+      options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
+      volumes:
+        - /:/hostroot
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Show toolchain
+        run: |
+          echo "=== arch ==="; uname -m
+          echo "=== clang ==="; clang++ --version
+          echo "=== cmake ==="; cmake --version
+
+      # Defensive: the UBSan build is large; free host disk like the main CI does.
+      # The host root is mounted at /hostroot (see the job's volumes).
+      - name: Free disk space
+        run: |
+          source "$CI_STEPS"
+          step_free_disk_space
+
+      # Read + validate inputs (they default to their listed value on scheduled
+      # runs) and write the config banner for the summary. enable_helio toggles the
+      # ignore-list at build time, so it affects both builds.
+      - name: Resolve run configuration
+        id: runcfg
+        env:
+          ENABLE_HELIO: ${{ inputs.enable_helio }}
+          COMPARE: ${{ inputs.compare }}
+          COMPARE_REF: ${{ inputs.compare_ref }}
+          FAIL_ON_NEW: ${{ inputs.fail_on_new }}
+          UBSAN_RUNTIME_OPTIONS: ${{ inputs.ubsan_runtime_options }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          source "$CI_STEPS"
+          step_resolve_run_configuration
+
+      # Validate compare_ref before the build (the artifact is fetched later), so a
+      # bad value fails fast. Empty = last successful scheduled run; otherwise the
+      # ref/run must be green and an ancestor of HEAD.
+      - name: Resolve findings baseline
+        id: baseline
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.compare }}
+        env:
+          COMPARE_REF: ${{ inputs.compare_ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          source "$CI_STEPS"
+          step_resolve_findings_baseline
+
+      # ----------------------------------------------------------------------
+      # Phase 1: self-test -- prove every enabled UBSan check is actually live.
+      # ----------------------------------------------------------------------
+      - name: Inject UBSan self-test into dragonfly
+        run: |
+          git apply --whitespace=nowarn tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+          echo "Applied inject_ubsan_selftest.patch"
+
+      - name: Build dragonfly (UBSan, strict, -O1)
+        uses: ./.github/actions/builder
+        with:
+          build-type: Debug
+          c-compiler: clang
+          cxx-compiler: clang++
+          sanitizers: Sanitizers
+          with-asan: 'OFF'   # UBSan-only run: ASan would abort on the self-test's memory cases.
+          ubsan-strict: 'ON'
+          with-aws: 'OFF'
+          targets: dragonfly
+
+      - name: Run self-test and assert every check fires
+        run: |
+          source "$CI_STEPS"
+          step_run_self_test
+
+      # Make sure that the runtime options actually change behavior (not separate
+      # code - same binary, different UBSAN_OPTIONS).
+      - name: Assert runtime options take effect
+        run: |
+          source "$CI_STEPS"
+          step_assert_runtime_options
+
+      - name: Revert self-test injection
+        run: |
+          git apply -R --whitespace=nowarn tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+          echo "Reverted inject_ubsan_selftest.patch"
+
+      # ----------------------------------------------------------------------
+      # Phase 2: run the whole pytest suite (minus 'large') under UBSan. Findings
+      # and timings go to ubsan-logs and the summary; they don't fail the job.
+      # ----------------------------------------------------------------------
+      - name: Finalize sanitized dragonfly (incremental, patch reverted)
+        uses: ./.github/actions/builder
+        with:
+          build-type: Debug
+          c-compiler: clang
+          cxx-compiler: clang++
+          sanitizers: Sanitizers
+          with-asan: 'OFF'   # UBSan-only run.
+          ubsan-strict: 'ON'
+          with-aws: 'OFF'
+          # Same build dir as phase 1 -- ninja only recompiles dfly_main.cc and
+          # relinks dragonfly (the self-test source is gone). No clean rebuild.
+          targets: dragonfly
+
+      - name: Install Python test requirements
+        run: ${GITHUB_WORKSPACE}/.github/scripts/install-pytest-requirements.sh
+
+      # Test pass/fail is intentionally NOT a gate here (handled separately).
+      # continue-on-error lets the run proceed so we can evaluate UBSan findings.
+      - name: Run tests under UBSan
+        id: run_tests
+        continue-on-error: true
+        run: |
+          source "$CI_STEPS"
+          step_run_tests
+
+      # Download the baseline artifact for the run resolved above (empty run_id =
+      # no baseline, so the step is skipped). A miss only warns for the default
+      # baseline (continue-on-error); an explicit ref/run fails.
+      - name: Fetch findings baseline
+        if: ${{ steps.baseline.outputs.run_id != '' && steps.run_tests.outputs.ran == 'true' }}
+        continue-on-error: ${{ steps.baseline.outputs.lenient == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ubsan-logs-${{ matrix.arch }}
+          path: ${{ github.workspace }}/build/ubsan-baseline
+          run-id: ${{ steps.baseline.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish UBSan findings to job summary
+        # Only when phase 2 actually ran; skip the empty "0 findings" report if the
+        # job bailed out earlier (bad input, or a build / self-test failure).
+        if: ${{ !cancelled() && steps.run_tests.outputs.ran == 'true' }}
+        env:
+          CFG_SUMMARY: ${{ steps.runcfg.outputs.cfg_summary }}
+          CFG_REPRO: ${{ steps.runcfg.outputs.cfg_repro }}
+        run: |
+          source "$CI_STEPS"
+          step_publish_findings "${{ matrix.arch }}" "${{ steps.baseline.outputs.desc }}"
+
+      # Opt-in gate: fail on NEW findings vs the baseline, limited to real UB +
+      # implicit-conversion (the #7562 class). Off by default until the diff is steady.
+      - name: Enforce fail_on_new
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.fail_on_new && steps.run_tests.outputs.ran == 'true' }}
+        run: |
+          source "$CI_STEPS"
+          step_enforce_fail_on_new
+
+      # Best-effort timing baseline: pull the latest regression-tests JUnit so the
+      # report can flag tests that ran suspiciously fast under UBSan (likely bailed
+      # early). Non-fatal: if it can't be fetched, the comparison is skipped.
+      - name: Resolve regression timing baseline
+        id: regbase
+        if: ${{ !cancelled() && steps.run_tests.outputs.ran == 'true' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          source "$CI_STEPS"
+          step_resolve_regression_baseline
+
+      - name: Fetch regression JUnit timing baseline
+        if: ${{ steps.regbase.outputs.run_id != '' }}
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: junit-regression-*
+          merge-multiple: true
+          path: ${{ github.workspace }}/build/regression-baseline
+          run-id: ${{ steps.regbase.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish test timings & failures to job summary
+        if: ${{ !cancelled() && steps.run_tests.outputs.ran == 'true' }}
+        run: |
+          source "$CI_STEPS"
+          step_publish_timings "${{ matrix.arch }}"
+
+      - name: Upload UBSan logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ubsan-logs-${{ matrix.arch }}
+          path: ${{ github.workspace }}/build/ubsan-logs
+          if-no-files-found: ignore
+
+      # Leave the runner clean: kill any leftover dragonfly and drop the local logs
+      # (already uploaded). Mostly for self-hosted / local runners.
+      - name: Clean up
+        if: always()
+        run: |
+          pkill -9 -x dragonfly 2>/dev/null || true
+          rm -rf "${GITHUB_WORKSPACE}/build/ubsan-logs" || true
+
+      - name: Notify on failure
+        if: failure() && github.ref == 'refs/heads/main'
+        run: |
+          job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "UBSan run (${{ matrix.arch }}) failed: ${job_link}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,7 +356,7 @@ Pass options to `helio/blaze.sh` with `-D` prefix:
 ```
 
 **Most useful options**:
-- `WITH_ASAN=ON` / `WITH_USAN=ON` - Enable sanitizers for debugging
+- `WITH_ASAN=ON` / `WITH_UBSAN=ON` - Enable sanitizers for debugging
 - `WITH_SEARCH=OFF` - Disable search module for faster builds
 - `WITH_AWS=OFF` / `WITH_GCP=OFF` - Disable cloud libraries
 - `WITH_TIERING=OFF` - Disable disk storage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
 check_cxx_source_compiles("int main() { return 0; }" SUPPORT_ASAN)
 
 set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
-check_cxx_source_compiles("int main() { return 0; }" SUPPORT_USAN)
+check_cxx_source_compiles("int main() { return 0; }" SUPPORT_UBSAN)
 set(CMAKE_REQUIRED_FLAGS "")
 
 # We must define all the required variables from the root cmakefile, otherwise
@@ -76,7 +76,7 @@ if(USE_AFL)
   # Force disable sanitizers when fuzzing (AFL++ incompatible with ASAN/UBSAN)
   message(STATUS "Disabling sanitizers (incompatible with AFL++ fuzzing)")
   set(WITH_ASAN OFF CACHE BOOL "Disable ASAN for fuzzing" FORCE)
-  set(WITH_USAN OFF CACHE BOOL "Disable UBSAN for fuzzing" FORCE)
+  set(WITH_UBSAN OFF CACHE BOOL "Disable UBSAN for fuzzing" FORCE)
 
   # Disable AWS and GCP for fuzzing builds (not needed, reduces build time)
   message(STATUS "Disabling AWS and GCP integrations for fuzzing")
@@ -90,10 +90,68 @@ if (SUPPORT_ASAN AND WITH_ASAN)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
 endif()
 
-option(WITH_USAN "Enable -fsanitize=undefined" OFF)
-if (SUPPORT_USAN AND WITH_USAN)
-  message(STATUS "ub sanitizer enabled")
+# UndefinedBehaviorSanitizer (UBSan). Check reference:
+# WITH_UBSAN        -> set `-fsanitize=undefined` checks only.
+# WITH_UBSAN_STRICT -> additional Clang-only checks:
+# 1) implicit integer conversions (truncation, sign-change)
+# 2) integer overflow (signed and unsigned)
+# 3) indirect call type mismatches (function)
+# 4) vtable type confusion (vptr)
+# 5) out-of-bounds object access (object-size).
+option(WITH_UBSAN "Enable -fsanitize=undefined" OFF)
+
+# Extended UBSan checks. Relevant only if WITH_UBSAN is also ON. Clang only -- GCC
+# implements none of these.
+option(WITH_UBSAN_STRICT "Enable extended UBSan checks (implicit-conversion, integer, function, vptr, object-size). Clang only." ON)
+
+if (SUPPORT_UBSAN AND WITH_UBSAN)
+  message(STATUS "UndefinedBehaviorSanitizer enabled (-fsanitize=undefined)")
+  # -fsanitize=undefined: the default UBSan umbrella (~18 true-UB checks)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined")
+  set(ubsan_compile_flags "-fsanitize=undefined")
+
+  if (WITH_UBSAN_STRICT)
+    if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      message(FATAL_ERROR
+        "WITH_UBSAN_STRICT requires Clang, but CMAKE_CXX_COMPILER_ID is "
+        "'${CMAKE_CXX_COMPILER_ID}'. Build with clang/clang++, or pass "
+        "-DWITH_UBSAN_STRICT=OFF to use base -fsanitize=undefined only.")
+    endif()
+    message(STATUS "UndefinedBehaviorSanitizer STRICT enabled (extended checks)")
+    # Instrumenting 'object-size' (below) wont work with with -O0, so the strict build forces -O1. -O1 plus
+    # the sanitizer flags make clang tag some link-step arguments as unused, so -Wno-error keeps that from
+    # failing a -Werror build.
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1 -Wno-error=unused-command-line-argument")
+    # Exclude third-party code from instrumentation (see tools/sanitizers/ubsan/ubsan-ignorelist.txt).
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize-ignorelist=${CMAKE_SOURCE_DIR}/tools/sanitizers/ubsan/ubsan-ignorelist.txt")
+    # lossy/sign-changing implicit integer conversions:
+    # implicit-conversion = implicit-unsigned-integer-truncation + implicit-signed-integer-truncation +
+    # implicit-integer-sign-change. Not UB, but caught the PR #7562 bug (1ULL<<32 silently truncated to 0).
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=implicit-conversion")
+    # nullability: catches a null pointer used where the code explicitly promised it
+    # can't be null (a pointer marked with Clang's _Nonnull annotation). Low-noise:
+    # only fires on pointers carrying that annotation.
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=nullability")
+    # float-divide-by-zero: floating-point division by zero (usually a bug).
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=float-divide-by-zero")
+    # integer: flags integer overflow, bad bit-shifts, and divide-by-zero.
+    # Noisy: unsigned "wraparound" is legal and used on purpose (hashing, size math).
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=integer")
+    # function: indirect call through a function pointer of the WRONG type (needs RTTI,
+    #   which Dragonfly already builds with). Catches ABI / type-confusion bugs.
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=function")
+    # vptr: use of an object whose vptr indicates the wrong dynamic type, or whose
+    #   lifetime has not begun / has ended (needs RTTI, link with clang++).
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=vptr")
+    # object-size: catches reads/writes past the end of an object whose size the
+    # compiler knows (e.g. a fixed-size buffer). Needs -O1+; does nothing at -O0.
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=object-size")
+    # Extend the summary with the strict checks (for the recap line below).
+    set(ubsan_compile_flags "${ubsan_compile_flags},implicit-conversion,nullability,float-divide-by-zero,integer,function,vptr,object-size")
+  endif()
+
+  # One-line recap of every UBSan flag added, printed to the configure log.
+  message(STATUS "UBSan compile flags: ${ubsan_compile_flags}")
 endif()
 
 # Split debug info into .dwo files so the linker handles much less data.

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -65,12 +65,22 @@ cd build-opt && ninja dragonfly
 | WITH_COLLECTION_CMDS | Include commands for collections (SET, HSET, ZSET)                                                                                                                                                                                       |
 | WITH_EXTENSION_CMDS  | Include extension commands (Bloom, HLL, JSON, ...)                                                                                                                                                                                       |
 | USE_MOLD             | Uses the mold linker to reduce link time overhead while enabling Link Time Optimization (LTO) for improved runtime performance. Recommended for benchmarking and production. |
+| WITH_ASAN            | Enable AddressSanitizer (`-fsanitize=address`). Debug builds only. Clang and GCC. |
+| WITH_UBSAN            | Enable UndefinedBehaviorSanitizer. Adds the stock `-fsanitize=undefined` check group (alignment, array-bounds, null, shift, signed-integer-overflow, ...). Debug builds only. Clang and GCC. |
+| WITH_UBSAN_STRICT    | Extends `WITH_UBSAN` with Clang-only checks: `implicit-conversion` (silent integer truncation / sign-change, e.g. the bug class from PR #7562), `nullability`, `float-divide-by-zero`, `integer` (unsigned overflow + shift), `function`, `vptr`, and `object-size` (effective only at `-O1+`). Default `ON`, but only relevant with `WITH_UBSAN` is also `ON`. Excludes third-party / vendored code via `tools/sanitizers/ubsan/ubsan-ignorelist.txt`. Noisy on code that intentionally uses unsigned wrap-around (hashing, length math). |
 
 Minimal debug build:
 
 ```bash
 ./helio/blaze.sh -DWITH_GPERF=OFF -DWITH_AWS=OFF -DWITH_GCP=OFF -DWITH_TIERING=OFF -DWITH_SEARCH=OFF -DWITH_COLLECTION_CMDS=OFF -DWITH_EXTENSION_CMDS=OFF
 ```
+
+### Running UBSan locally
+
+Dragonfly has a full UBSan setup - a self-test that proves the checks are live, a
+whole-suite CI run, and triage tooling. For how to configure and build a UBSan
+binary, the full `UBSAN_OPTIONS` reference, and how to read the findings, see
+[tools/sanitizers/ubsan/README.md](../tools/sanitizers/ubsan/README.md).
 
 ## Step 4 - voilà
 

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -594,6 +594,18 @@ def pytest_runtest_makereport(item, call):
             if call_outcome and call_outcome.failed:
                 copy_failed_logs(log_dir, call_outcome)
 
+        # UBSan-only: locate the failure with its findings. Imported and run only when actually under UBSan.
+        failed = (
+            report
+            if report.failed
+            else (call_outcome if call_outcome and call_outcome.failed else None)
+        )
+        if failed is not None:
+            from . import ubsan_helper
+
+            if ubsan_helper.is_active():
+                ubsan_helper.collect_failure(item, failed, log_dir)
+
 
 @pytest.fixture(scope="function")
 def redis_server(port_picker, df_log_dir) -> RedisServer:

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -17,6 +17,8 @@ from prometheus_client.parser import text_string_to_metric_families
 from redis.asyncio import Redis as RedisClient
 from redis.asyncio import RedisCluster as RedisCluster
 
+from . import ubsan_helper
+
 START_DELAY = 0.8
 START_GDB_DELAY = 5.0
 
@@ -296,6 +298,9 @@ class DflyInstance:
             cwd=self.params.cwd,
             stdout=None if self.params.direct_output else subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            # Under UBSan, give the child its own per-test log_path so findings land
+            # in a per-test folder. Returns None otherwise -> inherit ubsan env.
+            env=ubsan_helper.child_env(),
         )
         logging.info(f"Starting {real_path} {' '.join(all_args)}, pid {self.proc.pid}")
 

--- a/tests/dragonfly/ubsan_helper.py
+++ b/tests/dragonfly/ubsan_helper.py
@@ -1,0 +1,88 @@
+"""UBSan-only test helpers: per-test log layout and failure collection.
+
+Everything here is a no-op unless the process runs under UBSan (detected via
+`UBSAN_OPTIONS` carrying a `log_path=`). Kept out of conftest.py / instance.py so
+the normal, non-sanitized test path never touches it.
+"""
+
+import os
+import shutil
+
+
+def is_active() -> bool:
+    """True when running under UBSan with per-test logging configured."""
+    return "log_path=" in os.environ.get("UBSAN_OPTIONS", "")
+
+
+def logs_base():
+    """Base dir UBSan writes to (dirname of the UBSAN_OPTIONS log_path), or None."""
+    for part in os.environ.get("UBSAN_OPTIONS", "").split(":"):
+        if part.startswith("log_path="):
+            return os.path.dirname(part[len("log_path=") :]) or "."
+    return None
+
+
+def _sanitize(s):
+    s = "".join(c if c.isalnum() or c in "._-" else "_" for c in s).strip("_")
+    return s or "unknown"
+
+
+def log_subdir(base_dir, test_id):
+    """`<base_dir>/<suite>/<case>` for a PYTEST_CURRENT_TEST / nodeid style id."""
+    raw = test_id.split(" (")[0]
+    file_part, _, case_part = raw.partition("::")
+    suite = os.path.basename(file_part)
+    if suite.endswith(".py"):
+        suite = suite[:-3]
+    return os.path.join(base_dir, _sanitize(suite)[:80], _sanitize(case_part)[:120])
+
+
+def child_env():
+    """Child env with a per-test UBSAN_OPTIONS log_path, or None if not under UBSan.
+
+    Points log_path at `<base>/<suite>/<case>/ubsan` so each test gets its own
+    folder of `ubsan.<pid>` files (no cross-test PID clobber). None lets Popen
+    inherit os.environ unchanged.
+    """
+    opts = os.environ.get("UBSAN_OPTIONS", "")
+    if "log_path=" not in opts:
+        return None
+
+    test_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown")
+    parts = opts.split(":")
+    for i, part in enumerate(parts):
+        if part.startswith("log_path="):
+            base_dir = os.path.dirname(part[len("log_path=") :]) or "."
+            sub_dir = log_subdir(base_dir, test_id)
+            os.makedirs(sub_dir, exist_ok=True)
+            parts[i] = f"log_path={os.path.join(sub_dir, 'ubsan')}"
+    env = os.environ.copy()
+    env["UBSAN_OPTIONS"] = ":".join(parts)
+    return env
+
+
+def collect_failure(item, report, log_dir):
+    """Co-locate a failed test's report + server logs with its ubsan.<pid> findings."""
+    base = logs_base()
+    if not base:
+        return
+    sub_dir = log_subdir(base, item.nodeid)
+    os.makedirs(sub_dir, exist_ok=True)
+    with open(os.path.join(sub_dir, "test-failure.log"), "a") as fh:
+        fh.write(f"\n===== {report.when} {report.outcome}: {report.nodeid} =====\n")
+        fh.write((report.longreprtext or "") + "\n")
+        for label, text in (
+            ("captured stdout", report.capstdout),
+            ("captured stderr", report.capstderr),
+            ("captured log", report.caplog),
+        ):
+            if text:
+                fh.write(f"----- {label} -----\n{text}\n")
+    if log_dir and os.path.isdir(log_dir):
+        for f in os.listdir(log_dir):
+            src = os.path.join(log_dir, f)
+            if os.path.isfile(src):
+                try:
+                    shutil.copy(src, sub_dir)
+                except OSError:
+                    pass

--- a/tools/sanitizers/ubsan/README.md
+++ b/tools/sanitizers/ubsan/README.md
@@ -1,0 +1,236 @@
+# UBSan tooling
+
+This directory holds everything for running Dragonfly under Clang's
+**UndefinedBehaviorSanitizer (UBSan)**: a self-test that proves the checks are
+live, the ignore/suppression lists, and the scripts that turn a run into a
+report. A scheduled CI job ([`.github/workflows/ubsan.yml`](../../../.github/workflows/ubsan.yml))
+builds Dragonfly with UBSan and runs the whole test suite under it on both
+`x86_64` and `aarch64`.
+
+UBSan is used here in two tiers:
+
+- **Base** (`WITH_UBSAN`): the stock `-fsanitize=undefined` group (~18 real-UB
+  checks: alignment, array-bounds, null, shift, signed-integer-overflow, ...).
+  Works on Clang and GCC.
+- **Strict** (`WITH_UBSAN_STRICT`, default ON, **Clang only**): extra checks that
+  are not always UB but catch real bugs - `implicit-conversion` (silent integer
+  truncation / sign-change, the PR #7562 class), `integer` (unsigned overflow and
+  shift), `nullability`, `float-divide-by-zero`, `function`, `vptr`, and
+  `object-size` (needs `-O1`).
+
+## Build and run locally
+
+**Use Clang.** UBSan (and sanitizers in general) are developed against Clang, so it
+runs cleaner and reports more precisely than GCC, and the **strict** tier is
+Clang-only. GCC works for the **base** tier but is not recommended; if you must use
+it, pass `-DWITH_UBSAN_STRICT=OFF` (otherwise configure fails with a clear error).
+The strict build sets `-O1` itself, which the `object-size` check needs. Findings can
+vary slightly by Clang version, so match CI's compiler - the job's **Show toolchain**
+step prints the exact `clang++ --version` from the `ubuntu-dev:24` container.
+
+```bash
+# configure a debug UBSan build (WITH_UBSAN_STRICT is ON by default)
+./helio/blaze.sh -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+  -DWITH_UBSAN=ON -DWITH_UBSAN_STRICT=ON -DWITH_AWS=OFF -DWITH_GCP=OFF
+
+cd build-dbg && ninja dragonfly
+```
+
+Run the server (or any binary) with `UBSAN_OPTIONS` to control reporting:
+
+```bash
+UBSAN_OPTIONS="print_stacktrace=1:report_error_type=1:halt_on_error=0:\
+log_path=$(pwd)/ubsan-logs/dfly:\
+suppressions=$(git rev-parse --show-toplevel)/tools/sanitizers/ubsan/ubsan-suppressions.txt" \
+  ./build-dbg/dragonfly --alsologtostderr
+```
+
+| `UBSAN_OPTIONS` | Effect |
+| --- | --- |
+| `print_stacktrace=1` | Print a symbolized stack for every finding. |
+| `report_error_type=1` | Name the exact check (e.g. `implicit-integer-sign-change`) in the SUMMARY line. |
+| `halt_on_error=0` | Keep running after each finding (default). Set `1` to stop at the first one. |
+| `log_path=DIR/PREFIX` | Write findings to `PREFIX.<pid>` instead of stderr. Keep them inside the build dir, not `/tmp`. |
+| `strip_path_prefix=PATH` | Trim `PATH` from file names so locations read as `src/...` / `helio/...`. |
+| `suppressions=FILE` | Skip findings listed in `ubsan-suppressions.txt` (recoverable checks only). |
+| `silence_unsigned_overflow=1` | Mute the (often intentional) unsigned-overflow check. |
+
+The table above is only what we use; UBSan has many more runtime options. To see
+the complete list (more detailed than the official docs), run any UBSan-linked
+binary with `help=1` - it prints them at startup:
+
+```bash
+UBSAN_OPTIONS=help=1 ./build-dbg/dragonfly   # prints the option list, then starts the server
+```
+
+## Run the pytest (regression) tests under UBSan
+
+These are the normal Python integration tests, just run against a UBSan build with
+`UBSAN_OPTIONS` set - that env var is the only UBSan-specific part. Activate your
+pytest virtualenv first (assumed already set up; it needs the deps from
+`tests/dragonfly/requirements.txt`), then point `DRAGONFLY_PATH` at the UBSan
+`dragonfly` and export `UBSAN_OPTIONS`.
+
+Run one test file (drop the path for the whole suite):
+
+```bash
+ROOT="$(pwd)"
+mkdir -p build-dbg/ubsan-logs
+DRAGONFLY_PATH="$ROOT/build-dbg/dragonfly" \
+UBSAN_OPTIONS="halt_on_error=0:print_stacktrace=1:report_error_type=1:\
+strip_path_prefix=$ROOT/:\
+suppressions=$ROOT/tools/sanitizers/ubsan/ubsan-suppressions.txt:\
+log_path=$ROOT/build-dbg/ubsan-logs/ubsan" \
+  python3 -m pytest -m "not large" tests/dragonfly/connection_test.py
+```
+
+For a **single test case**, add `-k` (and the asyncio loop-scope flag pytest wants
+for a lone async test):
+
+```bash
+DRAGONFLY_PATH="$ROOT/build-dbg/dragonfly" \
+UBSAN_OPTIONS="halt_on_error=0:print_stacktrace=1:report_error_type=1:log_path=$ROOT/build-dbg/ubsan-logs/ubsan" \
+  python3 -m pytest -xvs tests/dragonfly/connection_test.py \
+    -o asyncio_default_fixture_loop_scope=function -k "test_reply_count"
+```
+
+Findings land in **one folder per test**:
+`build-dbg/ubsan-logs/<suite>/<case>/ubsan.<pid>`. The test harness
+([`tests/dragonfly/ubsan_helper.py`](../../../tests/dragonfly/ubsan_helper.py))
+rewrites `log_path` for each Dragonfly instance so tests never overwrite each
+other's findings. A failing test also drops a `test-failure.log` (its traceback
+plus the server logs) in the same folder.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `ubsan_selftest.cc` | `RunUbsanSelfTest()` - one example of every enabled check. Not built into dragonfly by default. |
+| `inject_ubsan_selftest.patch` | Adds `ubsan_selftest.cc` to the dragonfly target and makes `main()` run `RunUbsanSelfTest()` at startup, then exit. Apply, run, revert. |
+| `ubsan-ignorelist.txt` | Compile-time `-fsanitize-ignorelist`: which code is NOT instrumented (third-party, toolchain). |
+| `ubsan-suppressions.txt` | Runtime `UBSAN_OPTIONS=suppressions=`: hides specific findings at run time. |
+| `ubsan_summarize_findings.sh` | Turns a logs folder into the markdown findings report (the CI job summary). |
+| `ubsan_test_report.py` | Turns the pytest JUnit into a timings + failures report, and flags tests that bailed out early. |
+| `ubsan_trace.sh` | Triage helper: from an unzipped artifact, list which tests hit a `file:line` and print its stack. |
+| `ci_steps.sh` | Step bodies for the CI job. Each big workflow step sources this and calls one `step_*` function. |
+
+## Verify UBSan is live (self-test)
+
+Phase 1 of the CI job proves every enabled check actually fires - a build with
+broken flags would otherwise report a falsely "clean" run.
+
+```bash
+# 1. inject the self-test into the real binary
+git apply --whitespace=nowarn tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+
+# 2. build (clang, strict; the strict build sets -O1 for object-size itself)
+./helio/blaze.sh -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+  -DWITH_UBSAN=ON -DWITH_UBSAN_STRICT=ON -DWITH_AWS=OFF -DWITH_GCP=OFF
+cd build-dbg && ninja dragonfly && cd ..
+
+# 3. run it: the patched binary runs the self-test at startup and exits (no flag)
+UBSAN_OPTIONS="print_stacktrace=1:report_error_type=1" ./build-dbg/dragonfly
+
+# 4. revert the injection
+git apply -R --whitespace=nowarn tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+```
+
+Expect **one `runtime error:` finding per case** in `ubsan_selftest.cc` (one row of
+the table below - 12 at the time of writing). The CI job derives the expected count
+from the case table in `ubsan_selftest.cc` and fails if any check is missing.
+
+## Checks covered
+
+| # | Check | Tier | Notes |
+| --- | --- | --- | --- |
+| 1 | implicit-unsigned-integer-truncation | strict | the PR #7562 pattern |
+| 2 | implicit-signed-integer-truncation | strict | |
+| 3 | implicit-integer-sign-change | strict | |
+| 4 | array-bounds | base | `local-bounds` is deliberately off - it traps and cannot be recoverable |
+| 5 | nullability | strict | |
+| 6 | float-divide-by-zero | strict | |
+| 7 | signed-integer-overflow | base | true UB |
+| 8 | unsigned-integer-overflow | strict (`integer`) | legal wrap, still flagged |
+| 9 | unsigned-shift-base | strict (`integer`) | |
+| 10 | function | strict | needs RTTI |
+| 11 | vptr | strict | needs RTTI |
+| 12 | object-size | strict | only at `-O1+` |
+
+"base" = stock `-fsanitize=undefined`; "strict" = `WITH_UBSAN_STRICT` (Clang only).
+
+## Suppressions vs ignore-list
+
+Two different tools - pick by what you want to happen:
+
+- **Ignore-list** (`ubsan-ignorelist.txt`, compile-time): the code is **not
+  instrumented at all**. Use it to skip whole vendored / toolchain files, or to
+  mute one noisy check for a file or function permanently. Needs a rebuild. This
+  is the preferred, durable choice.
+- **Suppressions** (`ubsan-suppressions.txt`, runtime): the code is instrumented
+  but the **report is hidden**. Use it to silence one confirmed-benign
+  *recoverable* finding quickly, with no rebuild. Keep it empty by default.
+
+"Recoverable" means the check prints and lets the program keep running (this run
+keeps everything recoverable). A suppression only works on recoverable checks; the
+ignore-list works on everything.
+
+## The CI job (`ubsan.yml`)
+
+Runs on a schedule and on demand (**Actions -> Run workflow**), on `x86_64` and
+`aarch64`. Two phases: **(1)** the self-test above, then **(2)** revert the patch,
+rebuild incrementally, and run the whole suite (minus `large`) under UBSan.
+Findings and timings go to the job summary and to an `ubsan-logs-<arch>` artifact.
+Findings are informational - they do not fail the job unless `fail_on_new` is on.
+
+Manual-run inputs:
+
+| Input | Meaning |
+| --- | --- |
+| `enable_helio` | Instrument the helio submodule too (default ON). Off excludes it via the ignore-list. |
+| `compare` | Show a "new vs existing" diff against a baseline run (default ON). |
+| `compare_ref` | Baseline to diff against: empty = last successful scheduled run; a git ref; or `R<run-number>` (e.g. `R3`). Must be green and an ancestor of HEAD. |
+| `fail_on_new` | Fail the job on NEW real-UB / implicit-conversion findings vs the baseline (default OFF). |
+| `ubsan_runtime_options` | Extra **runtime** `UBSAN_OPTIONS`, colon-separated, appended to the phase-2 defaults (later keys win). Example: `halt_on_error=1:silence_unsigned_overflow=1`. |
+
+> **Sanity-check the input** with a harmless, obvious effect:
+> `ubsan_runtime_options=silence_unsigned_overflow=1` - the large
+> unsigned-integer-overflow group vanishes from the summary.
+
+## Read the results
+
+The **job summary** starts with a Notes banner (run config + totals + how-to),
+then lists the findings split into **undefined behavior** (real C++ violations)
+and **suspicious / defined-but-flagged** (the noisy integer / implicit-conversion
+checks), each grouped by check type with locations deduplicated by
+`file:line:column`. With a baseline it also shows what is newly added.
+
+Render the findings report yourself:
+
+```bash
+# from a local run
+bash tools/sanitizers/ubsan/ubsan_summarize_findings.sh build-dbg/ubsan-logs local | less
+
+# or from a downloaded ubsan-logs-<arch> artifact
+bash tools/sanitizers/ubsan/ubsan_summarize_findings.sh ./ubsan-logs-x86_64 x86_64 > findings.md
+```
+
+The summary shows `file:line:column` only. For the **full stack and which test hit
+it**, use the bundled `ubsan_trace.sh` helper on the per-test `ubsan.<pid>` logs.
+Give it a `file:line` from the summary; point it at the logs folder with a 2nd
+argument (or run it from inside that folder, where it defaults to `.`).
+
+```bash
+# from a downloaded artifact: unzip ubsan-logs-<arch>, then pass its path
+bash tools/sanitizers/ubsan/ubsan_trace.sh 'src/core/dense_set.cc:494' ~/Downloads/ubsan-logs-aarch64
+
+# the helper is also bundled INSIDE the artifact, so from its unzipped root you can run
+cd ~/Downloads/ubsan-logs-aarch64 && bash ubsan_trace.sh 'src/core/dense_set.cc:494'
+
+# from a local run
+bash tools/sanitizers/ubsan/ubsan_trace.sh 'src/core/dense_set.cc:494' build-dbg/ubsan-logs
+```
+
+`ubsan_test_report.py` adds a timings + failures section and, when a regression
+timing baseline is available, flags failing tests that finished far faster than
+normal - under UBSan (which is slower) that usually means they crashed or bailed
+out early and covered less code.

--- a/tools/sanitizers/ubsan/ci_steps.sh
+++ b/tools/sanitizers/ubsan/ci_steps.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+#
+# Step bodies for .github/workflows/ubsan.yml. Each workflow step longer than a
+# couple of lines sources this file and calls one step_* function:
+#
+#   source "${GITHUB_WORKSPACE}/tools/sanitizers/ubsan/ci_steps.sh"
+#   step_<name>
+#
+# Contract:
+#   - Sourced (not executed), so functions run in the step's own shell and
+#     inherit its environment: the step `env:` block, plus GitHub's own vars
+#     ($GITHUB_WORKSPACE, $GITHUB_OUTPUT, $GITHUB_STEP_SUMMARY, ...).
+#   - GitHub ${{ ... }} expressions are NOT visible here (they are substituted
+#     into the YAML). Values that come from ${{ }} (e.g. matrix.arch) are passed
+#     in as function arguments.
+#   - set -eo pipefail below makes any failing command abort the function, which
+#     fails the step (the function call is the step's last command).
+set -eo pipefail
+
+# Guard: these functions rely on the GitHub Actions environment (GITHUB_WORKSPACE,
+# GITHUB_OUTPUT, ...). The runner always sets GITHUB_ACTIONS=true; bail out early
+# with a clear error if it is missing (we are not in a job).
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  echo "Error: ci_steps.sh must run inside GitHub Actions (GITHUB_ACTIONS is unset)." >&2
+  echo "       step_* functions need GITHUB_WORKSPACE / GITHUB_OUTPUT / ... and will fail here." >&2
+  exit 1
+fi
+
+# Free host disk before the large UBSan build (host root is mounted at /hostroot).
+step_free_disk_space() {
+  echo "=== disk before ==="; df -h
+  rm -rf /hostroot/usr/share/dotnet || true
+  rm -rf /hostroot/usr/local/share/boost || true
+  rm -rf /hostroot/usr/local/lib/android || true
+  rm -rf /hostroot/opt/ghc || true
+  echo "=== disk after ==="; df -h
+}
+
+# Read + validate inputs and write the config banner to $GITHUB_OUTPUT.
+# Reads the ENABLE_HELIO / COMPARE / ... env vars set on the step.
+step_resolve_run_configuration() {
+  helio="${ENABLE_HELIO:-true}"          # empty on scheduled runs -> default ON
+  compare="${COMPARE:-true}"
+  ref="${COMPARE_REF:-}"
+  fail_on_new="${FAIL_ON_NEW:-false}"
+  supp_file="tools/sanitizers/ubsan/ubsan-suppressions.txt"
+
+  # Validate the runtime options before the build, so a typo fails fast.
+  # Each colon-separated token must be key=value, with no spaces.
+  rt_opts="${UBSAN_RUNTIME_OPTIONS:-}"
+  if [[ -n "${rt_opts}" ]]; then
+    IFS=':' read -ra _rt <<< "${rt_opts}"
+    for tok in "${_rt[@]}"; do
+      [[ "${tok}" =~ ^[A-Za-z0-9_]+=[^[:space:]]+$ ]] \
+        || { echo "::error::ubsan_runtime_options: invalid token '${tok}' (expected key=value, colon-separated, no spaces)."; exit 1; }
+    done
+    echo "runtime options: ${rt_opts}"
+  fi
+
+  if [[ "${helio}" == "false" ]]; then
+    # Enable the ignore-list rule so helio is NOT instrumented.
+    sed -i 's|^#[[:space:]]*src:\*/helio/\*|src:*/helio/*|' \
+      tools/sanitizers/ubsan/ubsan-ignorelist.txt
+    echo "helio instrumentation: DISABLED"
+  else
+    echo "helio instrumentation: ENABLED (default)"
+  fi
+
+  # Suppressions: the phase-2 run applies the committed suppressions file
+  # (may be empty, which suppresses nothing).
+  real_entries() { grep -cvE '^[[:space:]]*(#|$)' "$1" 2>/dev/null || true; }
+  supp_src="repo default ($(real_entries "${supp_file}") entries)"
+  echo "Using ${supp_src}."
+  echo "::group::effective ${supp_file}"
+  cat "${supp_file}"
+  echo "::endgroup::"
+
+  on_off() { [[ "$1" == "$2" ]] && echo OFF || echo ON; }
+  fail_on_new_str="$([[ "${fail_on_new}" == true ]] && echo ON || echo OFF)"
+  # Build the config banner + repro command. Each must be ONE line for
+  # $GITHUB_OUTPUT; the summary step shows them in the "Notes" banner.
+  cfg="helio: **$(on_off "${helio}" false)** | compare: **$(on_off "${compare}" false)**"
+  cfg+=" | baseline: **${ref:-last successful scheduled run}**"
+  cfg+=" | fail_on_new: **${fail_on_new_str}** | suppressions: **${supp_src}**"
+  repro="gh workflow run ubsan.yml --ref ${REF_NAME}"
+  repro+=" -f enable_helio=${helio} -f compare=${compare}"
+  repro+=" -f compare_ref='${ref}' -f fail_on_new=${fail_on_new}"
+  {
+    echo "cfg_summary=${cfg}"
+    echo "cfg_repro=${repro}"
+  } >> "$GITHUB_OUTPUT"
+}
+
+# Validate compare_ref and resolve the baseline to a concrete run_id (empty if
+# none). Emits run_id / lenient / desc to $GITHUB_OUTPUT for the download step.
+# Reads COMPARE_REF + GH_TOKEN from the step env.
+step_resolve_findings_baseline() {
+  fail() { echo "::error::$1"; exit 1; }
+  api="${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}"
+  gh_get() { curl -sS -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$1"; }
+  emit() { printf '%s\n' "$@" >> "$GITHUB_OUTPUT"; }
+  # base is an ancestor of HEAD if the compare API status is ahead/identical
+  # (works even on a shallow checkout, where git merge-base would fail).
+  ensure_ancestor() {
+    local base="$1" msg="$2" st
+    st="$(gh_get "${api}/compare/${base}...${GITHUB_SHA}" | jq -r '.status // "error"')" || st="error"
+    case "${st}" in
+      ahead|identical) return 0 ;;
+      behind|diverged) fail "${msg}" ;;
+      *) fail "${msg} (GitHub compare API returned status=${st})" ;;
+    esac
+  }
+
+  ref="${COMPARE_REF:-}"
+
+  # Default: the latest successful SCHEDULED run of this workflow (lenient - if
+  # there is none yet, emit an empty run_id and the download step is skipped).
+  if [[ -z "${ref}" ]]; then
+    run_id="$(gh_get "${api}/actions/workflows/ubsan.yml/runs?event=schedule&status=success&per_page=1" \
+              | jq -r '.workflow_runs[0].id // ""')" || run_id=""
+    [[ -n "${run_id}" ]] || echo "No successful scheduled run yet - skipping the baseline diff."
+    emit "run_id=${run_id}" "lenient=true" "desc=the last successful scheduled run"
+    exit 0
+  fi
+
+  # R<run-number> (e.g. R3): that specific run, must be GREEN + an ancestor.
+  if [[ "${ref}" =~ ^[Rr][0-9]+$ ]]; then
+    num="${ref#[Rr]}"
+    row="$(gh_get "${api}/actions/workflows/ubsan.yml/runs?per_page=100" \
+           | jq -c --argjson n "${num}" 'first(.workflow_runs[] | select(.run_number==$n))')" || true
+    [[ -n "${row}" && "${row}" != "null" ]] || fail "compare_ref '${ref}': no run #${num} for ubsan.yml (or beyond the latest 100 runs)."
+    conclusion="$(printf '%s' "${row}" | jq -r '.conclusion')"
+    sha="$(printf '%s' "${row}" | jq -r '.head_sha')"
+    run_id="$(printf '%s' "${row}" | jq -r '.id')"
+    [[ "${conclusion}" == "success" ]] || fail "compare_ref '${ref}': run #${num} is not green (conclusion=${conclusion})."
+    ensure_ancestor "${sha}" "compare_ref '${ref}': run #${num} commit ${sha} is not an ancestor of HEAD."
+    emit "run_id=${run_id}" "lenient=false" "desc=run #${num} (${sha:0:12})"
+    exit 0
+  fi
+
+  # A git ref (sha / branch / tag): resolve to a sha, confirm ancestry, then find
+  # the most recent successful ubsan.yml run for that commit.
+  sha="$(git rev-parse --verify "${ref}^{commit}" 2>/dev/null)" || true
+  [[ -n "${sha}" ]] || sha="$(git rev-parse --verify "origin/${ref}^{commit}" 2>/dev/null)" || true
+  [[ -n "${sha}" || ! "${ref}" =~ ^[0-9a-fA-F]{7,40}$ ]] || sha="${ref}"
+  [[ -n "${sha}" ]] || fail "compare_ref '${ref}' is not a valid git ref."
+  ensure_ancestor "${sha}" "compare_ref '${ref}' (${sha}) is not an ancestor of HEAD (must be on the current branch history)."
+  run_id="$(gh_get "${api}/actions/workflows/ubsan.yml/runs?head_sha=${sha}&status=success&per_page=1" \
+            | jq -r '.workflow_runs[0].id // ""')" || run_id=""
+  [[ -n "${run_id}" ]] || fail "compare_ref '${ref}' (${sha}): no successful ubsan.yml run for that commit."
+  emit "run_id=${run_id}" "lenient=false" "desc=${ref} (${sha:0:12})"
+}
+
+# Resolve the latest successful regression-tests run on main to a run_id (empty if
+# none) for the timing-baseline download. Best-effort; reads GH_TOKEN from env.
+step_resolve_regression_baseline() {
+  api="${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}"
+  run_id="$(curl -sS -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" \
+            "${api}/actions/workflows/regression-tests.yml/runs?branch=main&status=success&per_page=1" \
+            | jq -r '.workflow_runs[0].id // ""')" || run_id=""
+  [[ -n "${run_id}" ]] || echo "No successful regression-tests run on main - skipping the timing baseline."
+  printf 'run_id=%s\n' "${run_id}" >> "$GITHUB_OUTPUT"
+}
+
+# Run the injected self-test and assert every UBSan check fired.
+step_run_self_test() {
+  cd "${GITHUB_WORKSPACE}/build"
+  mkdir -p ubsan-logs
+  # No halt_on_error -> UBSan prints and continues, so one run exercises all cases.
+  export UBSAN_OPTIONS="${UBSAN_COMMON_RUNTIME_OPTS}:log_path=${PWD}/ubsan-logs/selftest"
+  ./dragonfly || true
+  # UBSan writes to <log_path>.<pid>; gather them all.
+  cat ubsan-logs/selftest.* > selftest.ubsan 2>/dev/null || true
+  echo "================ self-test UBSan output ================"
+  cat selftest.ubsan || true
+  echo "======================================================="
+
+  # Each enabled check must appear at least once. Substrings are matched
+  # against UBSan's "runtime error:" / SUMMARY lines (report_error_type=1).
+  declare -A checks=(
+    ["implicit-conversion"]="implicit conversion"
+    ["implicit-integer-sign-change"]="implicit-integer-sign-change"
+    ["array-bounds"]="out of bounds"
+    ["nullability"]="null pointer passed as argument"
+    ["float-divide-by-zero"]="division by zero"
+    ["signed-integer-overflow"]="signed integer overflow"
+    ["unsigned-integer-overflow"]="unsigned integer overflow"
+    ["shift"]="shift"
+    ["function"]="incorrect function type"
+    ["vptr"]="member call on address"
+    ["object-size"]="object-size"
+  )
+  missing=0
+  for name in "${!checks[@]}"; do
+    if grep -qiF "${checks[$name]}" selftest.ubsan; then
+      echo "  PASS  $name"
+    else
+      echo "  MISS  $name  (expected substring: '${checks[$name]}')"
+      missing=$((missing + 1))
+    fi
+  done
+  if [[ $missing -gt 0 ]]; then
+    echo "::error::UBSan self-test: $missing expected check(s) did not fire -- toolchain/flags may be broken."
+    exit 1
+  fi
+  echo "All expected UBSan checks fired."
+
+  # Each case should produce exactly one finding. Read the expected count from
+  # the case table in ubsan_selftest.cc so it updates itself when cases change.
+  # Match on the source path to skip startup / third-party noise.
+  selftest_src="${GITHUB_WORKSPACE}/tools/sanitizers/ubsan/ubsan_selftest.cc"
+  expected=$(grep -cE '\{[0-9]+, "(base|strict)", &Case_' "${selftest_src}")
+  selftest_count=$(grep "runtime error" selftest.ubsan | grep -c "ubsan_selftest.cc" || true)
+  echo "self-test produced ${selftest_count} finding(s) in ubsan_selftest.cc (expected ${expected})"
+  if [[ "${selftest_count}" -ne "${expected}" ]]; then
+    echo "::error::UBSan self-test expected exactly ${expected} findings, got ${selftest_count}"
+    exit 1
+  fi
+}
+
+# Sanity-check that UBSAN_OPTIONS actually change behavior (same binary).
+step_assert_runtime_options() {
+  cd "${GITHUB_WORKSPACE}/build"
+  # halt_on_error=1 stops at the first finding (fewer "runtime error" lines).
+  all=$(UBSAN_OPTIONS="report_error_type=1" ./dragonfly 2>&1 | grep -c "runtime error" || true)
+  one=$(UBSAN_OPTIONS="halt_on_error=1" ./dragonfly 2>&1 | grep -c "runtime error" || true)
+  echo "findings without halt_on_error=$all, with halt_on_error=1=$one"
+  if [[ "$one" -ge "$all" || "$all" -lt 2 ]]; then
+    echo "::warning::halt_on_error did not reduce the number of findings as expected"
+  fi
+  # silence_unsigned_overflow=1 must drop the unsigned-overflow finding.
+  noisy=$(UBSAN_OPTIONS="report_error_type=1" ./dragonfly 2>&1 | grep -c "unsigned integer overflow" || true)
+  quiet=$(UBSAN_OPTIONS="report_error_type=1:silence_unsigned_overflow=1" ./dragonfly 2>&1 | grep -c "unsigned integer overflow" || true)
+  echo "unsigned-overflow findings: noisy=$noisy silenced=$quiet"
+}
+
+# Run the whole pytest suite (minus 'large') under UBSan. Ends with exit $rc so
+# the step outcome reflects pytest pass/fail; the step is continue-on-error.
+step_run_tests() {
+  cd "${GITHUB_WORKSPACE}/tests"
+  mkdir -p "${GITHUB_WORKSPACE}/build/ubsan-logs"
+
+  # Bundle the triage helper into the artifact root so it runs directly
+  # from the unzipped download (see the summary's INFO note).
+  cp "${GITHUB_WORKSPACE}/tools/sanitizers/ubsan/ubsan_trace.sh" \
+    "${GITHUB_WORKSPACE}/build/ubsan-logs/"
+
+  export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/build/dragonfly"
+
+  # halt_on_error=0 keeps dragonfly alive so one run logs every finding.
+  # strip_path_prefix shortens paths to src/... / helio/...; instance.py gives
+  # each test its own log_path (build/ubsan-logs/<suite>/<case>/ubsan.<pid>).
+  opts="halt_on_error=0:${UBSAN_COMMON_RUNTIME_OPTS}:strip_path_prefix=${GITHUB_WORKSPACE}/"
+  opts+=":suppressions=${GITHUB_WORKSPACE}/tools/sanitizers/ubsan/ubsan-suppressions.txt"
+  opts+=":log_path=${GITHUB_WORKSPACE}/build/ubsan-logs/ubsan"
+  # Append operator-supplied options (workflow_dispatch); later keys override ours.
+  [[ -n "${UBSAN_EXTRA_RUNTIME_OPTS:-}" ]] && opts+=":${UBSAN_EXTRA_RUNTIME_OPTS}"
+  export UBSAN_OPTIONS="${opts}"
+
+  # Run the whole suite except 'large' tests and valkey_search (needs setup).
+  # --continue-on-collection-errors: one bad import must not abort the session.
+  # --junitxml records per-test time + failure for the timing report.
+  # -rfE + tee save the full console (with failure logs) to pytest-console.log.
+  # The timeout is generous: the suite is much slower under UBSan.
+  rc=0
+  timeout 110m pytest -m "not large" \
+    --ignore=dragonfly/valkey_search --timeout=600 --color=yes -rfE \
+    --continue-on-collection-errors \
+    --junitxml="${GITHUB_WORKSPACE}/build/ubsan-logs/ubsan-junit.xml" \
+    dragonfly/ 2>&1 | tee "${GITHUB_WORKSPACE}/build/ubsan-logs/pytest-console.log" || rc=$?
+
+  # Mark that phase 2 ran (pass or fail) so the report steps below gate on one
+  # flag. Keep pytest's exit code so the step outcome still shows pass/fail.
+  echo "ran=true" >> "$GITHUB_OUTPUT"
+  exit $rc
+}
+
+# Render the findings report into the job summary. Args: <arch> <baseline-desc>.
+step_publish_findings() {
+  local arch="$1" desc="$2"
+  bash "${GITHUB_WORKSPACE}/tools/sanitizers/ubsan/ubsan_summarize_findings.sh" \
+    "${GITHUB_WORKSPACE}/build/ubsan-logs" "${arch}" \
+    "${GITHUB_WORKSPACE}/build/ubsan-baseline" "${desc}" \
+    >> "$GITHUB_STEP_SUMMARY"
+}
+
+# Opt-in gate: fail on NEW real-UB / implicit-conversion findings vs the baseline.
+step_enforce_fail_on_new() {
+  f="${GITHUB_WORKSPACE}/build/ubsan-logs/new-findings.txt"
+  if [[ ! -s "$f" ]]; then
+    echo "No new findings vs baseline (or no baseline available)."
+    exit 0
+  fi
+  # new-findings.txt rows are BUCKET<TAB>KIND<TAB>file:line:col<TAB>example-test.
+  gated="$(awk -F'\t' '$1=="UB" || $2=="implicit-conversion"' "$f")"
+  n="$(printf '%s\n' "${gated}" | grep -c . || true)"
+  if [[ "$n" -gt 0 ]]; then
+    echo "::error::fail_on_new: ${n} new gated finding(s) vs baseline (UB + implicit-conversion)."
+    printf '%s\n' "${gated}" | awk -F'\t' '{ print "  + "$2"  "$3"  (e.g. "$4")" }'
+    exit 1
+  fi
+  echo "No new gated findings (UB / implicit-conversion) vs baseline."
+}
+
+# Render the timings + failures report into the job summary. Args: <arch>.
+step_publish_timings() {
+  local arch="$1"
+  python3 "${GITHUB_WORKSPACE}/tools/sanitizers/ubsan/ubsan_test_report.py" \
+    "${GITHUB_WORKSPACE}/build/ubsan-logs/ubsan-junit.xml" \
+    "${arch}" \
+    "${GITHUB_WORKSPACE}/build/regression-baseline" >> "$GITHUB_STEP_SUMMARY" || true
+}

--- a/tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+++ b/tools/sanitizers/ubsan/inject_ubsan_selftest.patch
@@ -1,0 +1,44 @@
+UBSan self-test injection patch.
+
+Apply this patch to a sanitized dragonfly build to run RunUbsanSelfTest() at
+startup -- it triggers one example of every enabled UBSan check, then exits.
+Use it to verify that UBSan is live before trusting a clean run result.
+
+This patch is NOT meant to be committed to the tree.
+
+Apply:   git apply --whitespace=nowarn tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+Revert:  git apply -R --whitespace=nowarn tools/sanitizers/ubsan/inject_ubsan_selftest.patch
+
+diff --git a/src/server/dfly_main.cc b/src/server/dfly_main.cc
+--- a/src/server/dfly_main.cc
++++ b/src/server/dfly_main.cc
+@@ -124,6 +124,8 @@
+           "Relevant only for modern kernels with io_uring enabled");
+
+ ABSL_FLAG(bool, omit_basic_usage, false, "Omit printing basic usage info.");
++
++extern "C" void RunUbsanSelfTest();  // defined in tools/sanitizers/ubsan/ubsan_selftest.cc
+
+ #ifdef USE_AFL
+ ABSL_FLAG(uint32_t, afl_loop_limit, UINT_MAX,
+@@ -1082,5 +1082,9 @@ int main(int argc, char* argv[]) {
+   MainInitGuard guard(&argc, &argv);
+
+   ParseFlagsFromEnv();
++
++  // UBSan self-test build: run the checks and exit before starting the server.
++  RunUbsanSelfTest();
++  return 0;
+
+ #ifdef USE_ABSL_LOG
+diff --git a/src/server/CMakeLists.txt b/src/server/CMakeLists.txt
+--- a/src/server/CMakeLists.txt
++++ b/src/server/CMakeLists.txt
+@@ -13,4 +13,7 @@
+ add_custom_target(check_dfly WORKING_DIRECTORY .. COMMAND ctest -L DFLY)
+ cxx_link(dragonfly base dragonfly_lib)
++# UBSan self-test: compile the extra case file into the existing dragonfly target.
++# Separate statement (not part of add_executable) so edits to the source list never conflict.
++target_sources(dragonfly PRIVATE ${CMAKE_SOURCE_DIR}/tools/sanitizers/ubsan/ubsan_selftest.cc)
+
+ if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/tools/sanitizers/ubsan/ubsan-ignorelist.txt
+++ b/tools/sanitizers/ubsan/ubsan-ignorelist.txt
@@ -1,0 +1,24 @@
+# Clang SanitizerSpecialCaseList -- passed to the compiler via
+# -fsanitize-ignorelist (wired in the WITH_UBSAN_STRICT block of CMakeLists.txt).
+#
+# Files matched here are NOT instrumented by UBSan, so findings always point at
+# first-party Dragonfly code instead of vendored dependencies.
+#
+# Format reference: https://clang.llvm.org/docs/SanitizerSpecialCaseList.html
+#   src:<glob>       match by source file path
+#   fun:<glob>       match by (mangled) function name
+#   mainfile:<glob>  match by main translation unit
+# A leading '!' re-includes a previously excluded entry.
+
+# --- Vendored / third-party sources built in-tree ---------------------------
+src:*/third_party/*
+src:*/_deps/*
+
+# --- The helio framework (git submodule).
+# Uncomments the rule below (via sed) so helio is excluded from instrumentation.
+# src:*/helio/*
+
+# --- System toolchain headers (libstdc++ / gcc) and Boost -------------------
+src:*/usr/lib/gcc/*
+src:*/include/c++/*
+src:*/usr/include/*

--- a/tools/sanitizers/ubsan/ubsan-suppressions.txt
+++ b/tools/sanitizers/ubsan/ubsan-suppressions.txt
@@ -1,0 +1,43 @@
+# UndefinedBehaviorSanitizer suppression file for Dragonfly.
+#
+#
+#   UBSAN_OPTIONS="suppressions=$(pwd)/tools/sanitizers/ubsan/ubsan-suppressions.txt" ./build-dbg/dragonfly
+#
+# -----------------------------------------------------------------------------
+# Format
+# -----------------------------------------------------------------------------
+# One rule per line:
+#
+#   <check>:<pattern>
+#
+#   <check>   The UBSan check that produced the report, e.g.:
+#               alignment, signed-integer-overflow, unsigned-integer-overflow,
+#               implicit-conversion, shift, vptr, function, null, ...
+#             Use the token from the report's "runtime error:" / SUMMARY line.
+#             (Run with UBSAN_OPTIONS=report_error_type=1 to print the exact token.)
+#
+#   <pattern> A substring/regex matched against the symbolized function name OR
+#             the source file path of the top frame. Module-name matching uses
+#             the mangled/demangled symbol; file matching uses the file path.
+#
+# Examples:
+#   unsigned-integer-overflow:MurmurHash*       # silence intentional hash wrap
+#   implicit-conversion:*/third_party/*         # ignore vendored code
+#   vptr:absl::*                                 # known abseil false positive
+#
+# Notes:
+#   * Suppressions only apply to checks compiled in "recoverable" mode. Checks
+#     that abort (the default for some groups) are not suppressible at runtime;
+#     use -fno-sanitize-recover= / -fsanitize-recover= at compile time to control
+#     that, and prefer keeping everything recoverable for the run.
+#   * Keep this list EMPTY by default. Only add an entry with a one-line comment
+#     explaining (a) why the finding is benign and (b) a tracking issue link.
+#   * A growing suppression list is a smell: prefer fixing the narrowing/overflow
+#     or annotating intent (e.g. explicit static_cast) over suppressing.
+#   * When to use ubsan-suppressions.txt and not ubsan-ignorelist.txt: use this file
+#     (runtime, no rebuild) to silence a single confirmed-benign recoverable finding
+#     during triage; use the ignore-list (compile-time) to skip whole vendored/toolchain
+#     files or to mute a noisy check per file/function permanently.
+# -----------------------------------------------------------------------------
+
+# (no suppressions yet)

--- a/tools/sanitizers/ubsan/ubsan_selftest.cc
+++ b/tools/sanitizers/ubsan/ubsan_selftest.cc
@@ -1,0 +1,236 @@
+// UBSan self-test for Dragonfly.
+//
+// PURPOSE
+//   Prove that every UBSan check enabled in the build is actually live.
+//   Each case deliberately triggers ONE compile-time check. Run this against
+//   any sanitized dragonfly binary to verify the toolchain + flags are working
+//   before trusting a clean run result.
+//
+//   Usage: apply tools/sanitizers/ubsan/inject_ubsan_selftest.patch, build
+//   dragonfly, then run ./dragonfly -- the patched binary runs RunUbsanSelfTest()
+//   at startup and exits before serving traffic.
+//
+//   Build/run with UBSAN_OPTIONS=halt_on_error=0 (UBSan's default) so that every
+//   case reports and the process keeps going; otherwise it stops at the first
+//   finding.
+//
+// CHECK TIERS: each case is tagged "base" or "strict".
+//   base   -> fires with stock `-fsanitize=undefined` (WITH_UBSAN): the
+//             array-bounds and signed-integer-overflow cases.
+//   strict -> fires only with the extended checks (WITH_UBSAN_STRICT): the
+//             implicit-conversion class, integer, function, vptr, object-size,
+//             nullability. These are Clang-only.
+//   A WITH_UBSAN-only build triggers just the base case(s); the other cases run
+//   but produce no diagnostic. There is no per-check compile-time macro, so the
+//   tier tags are informational -- the CI builds with WITH_UBSAN_STRICT=ON and
+//   asserts that every case fired.
+//
+// RUNTIME-OPTION COVERAGE (not separate code cases - re-run this binary with
+//   different UBSAN_OPTIONS to exercise each):
+//     report_error_type=1         names the exact check in the SUMMARY line
+//     halt_on_error=1             aborts on the first finding
+//     log_path=<dir>/prefix       writes diagnostics to <dir>/prefix.<pid>
+//     print_stacktrace=1          full symbolized stack per finding
+//     silence_unsigned_overflow=1 mutes case 8 (unsigned wrap)
+//     suppressions=<file>         skips entries in tools/sanitizers/ubsan/ubsan-suppressions.txt
+//
+// This file is NOT compiled into dragonfly by default. It is intentionally
+// full of undefined / lossy operations and must only ever be built with UBSan.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+// This translation unit is *meant* to contain UB / lossy conversions. Silence
+// the corresponding -W warnings so it compiles even under -Werror.
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wconversion"
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wint-conversion"
+#pragma clang diagnostic ignored "-Wcast-function-type"
+#pragma clang diagnostic ignored "-Warray-bounds"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wreturn-type"
+#endif
+
+namespace {
+
+// volatile sink prevents the optimizer from eliding our intentional UB at -O1.
+volatile uint64_t g_sink = 0;
+
+// optnone (keeps the UB from being optimized away at -O1) is Clang-only. Degrade to
+// plain noinline on GCC so the patched self-test still compiles under -Werror.
+#if defined(__clang__)
+#define UBSAN_CASE __attribute__((noinline, optnone))
+#else
+#define UBSAN_CASE __attribute__((noinline))
+#endif
+
+// Compile-time check #1: implicit-unsigned-integer-truncation.
+// PR #7562 pattern: 1ULL<<32 narrowed to unsigned silently becomes 0.
+UBSAN_CASE void Case_ImplicitUnsignedTruncation() {
+  volatile uint64_t big = 1ULL << 32;  // 4294967296
+  unsigned narrowed = big;             // truncates to 0
+  g_sink = narrowed;
+  std::printf("[1] implicit-unsigned-integer-truncation: %llu -> %u\n",
+              static_cast<unsigned long long>(big), narrowed);
+}
+
+// Compile-time check #2: implicit-signed-integer-truncation
+UBSAN_CASE void Case_ImplicitSignedTruncation() {
+  volatile int64_t big = 0x1'0000'0001LL;  // does not fit in int32
+  int narrowed = big;
+  g_sink = static_cast<uint64_t>(narrowed);
+  std::printf("[2] implicit-signed-integer-truncation\n");
+}
+
+// Compile-time check #3: implicit-integer-sign-change
+UBSAN_CASE void Case_ImplicitSignChange() {
+  volatile int neg = -1;
+  unsigned u = neg;  // sign change -1 -> UINT_MAX
+  g_sink = u;
+  std::printf("[3] implicit-integer-sign-change\n");
+}
+
+// Compile-time check #4: array-bounds (base: -fsanitize=undefined).
+// Indexing past an array's declared extent. Caught recoverably by array-bounds.
+// (local-bounds is intentionally NOT enabled: it traps with SIGILL and cannot be
+// made recoverable, which would abort the rest of the run.)
+UBSAN_CASE void Case_ArrayBounds() {
+  int arr[4] = {0, 1, 2, 3};
+  volatile int idx = 7;  // out of [0,4)
+  g_sink = static_cast<uint64_t>(arr[idx]);
+  std::printf("[4] array-bounds\n");
+}
+
+// Compile-time check #5: nullability.
+UBSAN_CASE static void TakesNonNull(int* _Nonnull p) {
+  g_sink = reinterpret_cast<uintptr_t>(p);
+}
+UBSAN_CASE void Case_Nullability() {
+  int* volatile p = nullptr;
+  TakesNonNull(p);  // null passed where _Nonnull expected
+  std::printf("[5] nullability\n");
+}
+
+// Compile-time check #6: float-divide-by-zero
+UBSAN_CASE void Case_FloatDivByZero() {
+  volatile double num = 1.0;
+  volatile double den = 0.0;
+  volatile double r = num / den;  // +inf, flagged
+  g_sink = static_cast<uint64_t>(r != r);
+  std::printf("[6] float-divide-by-zero\n");
+}
+
+// Compile-time check #7: signed-integer-overflow (in -fsanitize=undefined)
+UBSAN_CASE void Case_SignedOverflow() {
+  volatile int32_t a = 0x7fffffff;  // INT_MAX
+  int32_t b = a + 1;                // signed overflow == UB
+  g_sink = static_cast<uint64_t>(b);
+  std::printf("[7] signed-integer-overflow\n");
+}
+
+// Compile-time check #8: unsigned-integer-overflow (STRICT: integer)
+UBSAN_CASE void Case_UnsignedOverflow() {
+  volatile uint32_t a = 0xffffffffu;  // UINT_MAX
+  uint32_t b = a + 1;                 // wraps to 0 (well-defined, but flagged)
+  g_sink = b;
+  std::printf("[8] unsigned-integer-overflow\n");
+}
+
+// Compile-time check #9: unsigned-shift-base (STRICT: integer)
+UBSAN_CASE void Case_UnsignedShiftBase() {
+  volatile uint32_t a = 0xff000000u;
+  uint32_t b = a << 8;  // shifts bits out of a 32-bit value
+  g_sink = b;
+  std::printf("[9] unsigned-shift-base\n");
+}
+
+// Compile-time check #10: function (STRICT)
+UBSAN_CASE static void RealTakesInt(int x) {
+  g_sink = static_cast<uint64_t>(x);
+}
+UBSAN_CASE void Case_FunctionType() {
+  using WrongFn = void (*)(const char*);
+  WrongFn fp = reinterpret_cast<WrongFn>(&RealTakesInt);
+  fp("hello");  // indirect call through wrong function-pointer type
+  std::printf("[10] function\n");
+}
+
+// Compile-time check #11: vptr (STRICT)
+struct VBase {
+  virtual ~VBase() = default;
+  virtual void f() {
+    g_sink = 0xB;
+  }
+};
+
+struct VDerived : VBase {
+  void f() override {
+    g_sink = 0xD;
+  }
+  int extra = 0;
+};
+
+UBSAN_CASE void Case_Vptr() {
+  VBase base;
+  // 'base' is really a VBase, but we access it as VDerived and make a virtual
+  // call. -fsanitize=vptr reports the type mismatch here. In recoverable mode it
+  // reports and then dispatches through base's real vtable (VBase::f), so it is
+  // safe to continue.
+  VDerived* d = reinterpret_cast<VDerived*>(&base);
+  d->f();
+  std::printf("[11] vptr\n");
+}
+
+// Compile-time check #12: object-size (STRICT; needs -O1).
+// object-size is the one check that needs the optimizer: __builtin_object_size is
+// "unknown" under -O0/optnone. So this case must NOT use UBSAN_CASE (it adds
+// optnone) -- plain noinline keeps the build's -O1 and still gives a clean frame.
+// Store through a pointer, not memset: object-size instruments scalar stores, not
+// the memset libcall.
+__attribute__((noinline)) void Case_ObjectSize() {
+  char buf[4] = {};
+  char* p = buf;  // pointer, not array: array-bounds ignores p[]; object-size checks it.
+  // Offset must be a compile-time constant: objectsize(p + off) only folds to a
+  // known size (0 here, past the 4-byte buf) for a constant off -- a runtime/volatile
+  // index folds to "unknown" and never fires. The dead store survives because the
+  // check itself is a call with side effects.
+  p[8] = 7;  // store past buf; objectsize(p + 8) == 0 -> flagged at -O1+
+  g_sink = static_cast<uint64_t>(buf[0]);
+  std::printf("[12] object-size (effective only at -O1+)\n");
+}
+
+}  // namespace
+
+// Runs every UBSan self-test case. Declared (not in a header) in dfly_main.cc by
+// the inject patch (tools/sanitizers/ubsan/inject_ubsan_selftest.patch).
+extern "C" void RunUbsanSelfTest() {
+  std::printf("=== Dragonfly UBSan self-test ===\n");
+  struct {
+    int id;
+    const char* tier;  // "base" = -fsanitize=undefined, "strict" = WITH_UBSAN_STRICT
+    void (*fn)();
+  } cases[] = {
+      {1, "strict", &Case_ImplicitUnsignedTruncation},
+      {2, "strict", &Case_ImplicitSignedTruncation},
+      {3, "strict", &Case_ImplicitSignChange},
+      {4, "base", &Case_ArrayBounds},
+      {5, "strict", &Case_Nullability},
+      {6, "strict", &Case_FloatDivByZero},
+      {7, "base", &Case_SignedOverflow},
+      {8, "strict", &Case_UnsignedOverflow},
+      {9, "strict", &Case_UnsignedShiftBase},
+      {10, "strict", &Case_FunctionType},
+      {11, "strict", &Case_Vptr},
+      {12, "strict", &Case_ObjectSize},
+  };
+  for (auto& c : cases) {
+    std::printf("-- case %d [%s] --\n", c.id, c.tier);
+    c.fn();
+  }
+  std::printf("=== UBSan self-test done (sink=%llu) ===\n",
+              static_cast<unsigned long long>(g_sink));
+}

--- a/tools/sanitizers/ubsan/ubsan_summarize_findings.sh
+++ b/tools/sanitizers/ubsan/ubsan_summarize_findings.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# Summarize UBSan findings into GitHub-flavored markdown on stdout. The workflow
+# appends it to the job summary:
+#
+#   bash ubsan_summarize_findings.sh <ubsan-logs-dir> <arch> >> "$GITHUB_STEP_SUMMARY"
+#
+# Run it locally too -- see tools/sanitizers/ubsan/README.md ("Summarizing
+# findings"). Example after a local sanitized run that wrote logs with
+# UBSAN_OPTIONS=...:log_path=build-dbg/ubsan-logs/pytest :
+#
+#   bash tools/sanitizers/ubsan/ubsan_summarize_findings.sh build-dbg/ubsan-logs local | less
+#
+# Color in job summaries: GitHub strips inline CSS, so we colorize via
+#   - GitHub "alerts" (blockquote callouts): [!CAUTION] = red, [!WARNING] = amber.
+#     (Alerts only color the icon/border/heading; body text stays theme-readable.)
+#   - ```diff fences: lines beginning with '+' render green.
+#
+set -euo pipefail
+
+logs_dir="${1:?usage: ubsan_summarize_findings.sh <logs-dir> [arch] [baseline-logs-dir] [baseline-desc]}"
+arch="${2:-local}"   # display label only; defaults to "local" for ad-hoc local runs
+# Optional baseline: a previous run's ubsan-logs dir. When present and non-empty,
+# a "Newly added" section at the top lists only locations here-but-not-in-baseline.
+baseline_dir="${3:-}"
+baseline_desc="${4:-the last successful scheduled run}"
+
+UB_LINK="https://en.cppreference.com/w/cpp/language/ub"
+# Official list of every UBSan check name (unsigned-integer-overflow, implicit-
+# conversion, vptr, ...) with a one-line definition of each.
+UBSAN_CHECKS_DOC="https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks"
+
+# grep -rH keeps the source filename on every line so each finding can be
+# attributed to an example test. Logs live at <suite>/<case>/ubsan.<pid> (one
+# folder per test); we recurse and match only the ubsan.* files.
+# (Full symbolized stacks stay in the uploaded artifact; here we keep headlines.)
+raw="$(grep -rH -i "runtime error:" --include='ubsan.*' "${logs_dir}" 2>/dev/null || true)"
+
+# Classify each finding: UB (real bugs) vs SUSP (defined-but-flagged by the extra
+# integer / implicit-conversion checks). The operand TYPE in the message tells
+# unsigned wrap/shift/negation (defined) apart from the signed counterpart (UB).
+# Output: BUCKET<TAB>KIND<TAB>file:line:col<TAB>example-test
+classify() {
+  awk '
+    # Only real findings carry "runtime error:". Skipping everything else keeps
+    # empty / blank input from being miscounted as a bogus "other" finding.
+    !/runtime error:/ { next }
+    {
+      # grep -rH prefixed "<path>/<suite>/<case>/ubsan.<pid>:" -- split it off the
+      # finding text at the first colon (log paths contain no colon).
+      ci = index($0, ":");
+      fname = substr($0, 1, ci - 1);
+      rest  = substr($0, ci + 1);
+      # The last two path components are the suite (file) and case (name + params)
+      # -- that is the example test we attribute this location to.
+      nseg = split(fname, seg, "/");
+      test = (nseg >= 3) ? seg[nseg-2] "/" seg[nseg-1] : seg[nseg];
+
+      loc=rest; sub(/ runtime error:.*/, "", loc); sub(/^[ \t]+/, "", loc);
+      low=tolower(rest); b="UB"; k="other";
+      if (low ~ /implicit conversion/)                       { b="SUSP"; k="implicit-conversion" }
+      else if (low ~ /unsigned integer overflow/)            { b="SUSP"; k="unsigned-overflow" }
+      else if (low ~ /negation of/) {
+        if (low ~ /type .(unsigned|uint|size_t|size_type|value_type)/) { b="SUSP"; k="unsigned-negation" }
+        else { b="UB"; k="signed-negation" } }
+      else if (low ~ /left shift of/) {
+        if (low ~ /type .(unsigned|uint)/) { b="SUSP"; k="unsigned-shift-base" }
+        else { b="UB"; k="signed-shift-base" } }
+      else if (low ~ /shift exponent/)                       { b="UB"; k="shift-exponent" }
+      else if (low ~ /misaligned address/)                   { b="UB"; k="misaligned-load" }
+      else if (low ~ /member call on address|does not point to an object/) { b="UB"; k="vptr" }
+      else if (low ~ /out of bounds/)                        { b="UB"; k="out-of-bounds" }
+      else if (low ~ /null pointer/)                         { b="UB"; k="null-argument" }
+      else if (low ~ /incorrect function type/)              { b="UB"; k="function-type" }
+      else if (low ~ /signed integer overflow/)              { b="UB"; k="signed-overflow" }
+      else if (low ~ /division by zero/)                     { b="UB"; k="divide-by-zero" }
+      print b "\t" k "\t" loc "\t" test;
+    }'
+}
+
+# Sorted-unique file:line:col of every finding under a logs dir (for baseline diff).
+extract_locs() {
+  grep -rh -i "runtime error:" --include='ubsan.*' "$1" 2>/dev/null \
+    | sed -E 's/ runtime error:.*//; s/^[[:space:]]+//' | sort -u
+}
+
+tagged="$(printf '%s\n' "${raw}" | classify)"
+
+# Baseline (a previous run's ubsan-logs). When present + non-empty, findings are
+# split into New (not in baseline) vs Existing, and the new ones are written to
+# new-findings.txt for the optional fail_on_new gate.
+base_locs=""
+has_baseline=0
+if [[ -n "${baseline_dir}" && -d "${baseline_dir}" ]]; then
+  base_locs="$(extract_locs "${baseline_dir}")"
+  [[ -n "${base_locs}" ]] && has_baseline=1
+fi
+
+new_findings_file="${logs_dir}/new-findings.txt"
+rm -f "${new_findings_file}" 2>/dev/null || true
+if [[ "${has_baseline}" -eq 1 ]]; then
+  # Unique-by-location rows (BUCKET<TAB>KIND<TAB>loc<TAB>example-test) new vs baseline.
+  printf '%s\n' "${tagged}" \
+    | awk -F'\t' 'NR==FNR { seen[$0]=1; next }
+                  NF && !($3 in seen) && !($3 in done) { done[$3]=1; print }' \
+        <(printf '%s\n' "${base_locs}") - \
+    > "${new_findings_file}" 2>/dev/null || true
+fi
+
+# Occurrence totals (for the footer). Location counts are computed per section.
+count_bucket() { printf '%s\n' "${tagged}" | awk -F'\t' -v b="$1" '$1==b' | grep -c . || true; }
+count_locs()   { printf '%s\n' "$1" | awk -F'\t' 'NF{print $3}' | sort -u | grep -c . || true; }
+count_rows()   { printf '%s\n' "$1" | grep -c . || true; }  # occurrences (one per finding)
+bucket_rows()  { printf '%s\n' "${tagged}" | awk -F'\t' -v b="$1" '$1==b'; }
+split_new()      { printf '%s\n' "$1" | awk -F'\t' 'NR==FNR{seen[$0]=1;next} NF && !($3 in seen)' <(printf '%s\n' "${base_locs}") -; }
+split_existing() { printf '%s\n' "$1" | awk -F'\t' 'NR==FNR{seen[$0]=1;next} NF &&  ($3 in seen)' <(printf '%s\n' "${base_locs}") -; }
+emit_types_of()  { printf '%s\n' "$1" | awk -F'\t' 'NF{print $2}' | sort | uniq -c | sort -rn | awk 'NF{printf "+ %s\n", $0}'; }
+emit_locs_of()   { printf '%s\n' "$1" \
+                     | awk -F'\t' 'NF { c[$3]++; kind[$3]=$2; if (!($3 in ex)) ex[$3]=$4 }
+                                   END { for (l in c) printf "%d\t%s\t%s\t%s\n", c[l], kind[l], l, ex[l] }' \
+                     | sort -rn | head -300 \
+                     | awk -F'\t' '{ printf "%7d  %-18s %s  (e.g. %s)\n", $1, $2, $3, $4 }'; }
+
+ub_total="$(count_bucket UB)"
+susp_total="$(count_bucket SUSP)"
+total=$(( ub_total + susp_total ))
+
+# --- One findings block: check-type breakdown + expandable locations --------
+emit_findings_block() {
+  local rows="$1" label="$2"
+  echo "By check type:"
+  echo '```diff'
+  emit_types_of "${rows}"
+  echo '```'
+  echo ""
+  echo "<details><summary>${label} Locations (count &middot; type &middot; file:line:column &middot; example test) - Press the arrow to expand</summary>"
+  echo ""
+  echo '```'
+  emit_locs_of "${rows}"
+  echo '```'
+  echo ""
+  echo "</details>"
+  echo ""
+}
+
+# --- One bucket (UB or SUSP), FULL list (no New/Existing split here -- the diff
+# is shown separately, above, by emit_diff).
+emit_section() {
+  local bucket="$1" label
+  [[ "${bucket}" == "UB" ]] && label="Undefined Behaviors" || label="Suspicious Behaviors"
+  local rows; rows="$(bucket_rows "${bucket}")"
+  local total_locs; total_locs="$(count_locs "${rows}")"
+  local total_occ; total_occ="$(count_rows "${rows}")"
+  if [[ "${bucket}" == "UB" ]]; then
+    echo "## Undefined behaviors - ${total_locs} location(s), ${total_occ} occurrence(s) · ${arch}"
+    echo ""
+    echo "> [!CAUTION]"
+    echo "> These are **real C++ undefined behavior**: the program violates the C++"
+    echo "> standard, so the standard imposes **no requirements** on the result - the"
+    echo "> compiler may miscompile, crash, or silently corrupt data. These should be fixed."
+  else
+    echo "## Suspicious / defined-but-flagged - ${total_locs} location(s), ${total_occ} occurrence(s) · ${arch}"
+    echo ""
+    echo "> [!WARNING]"
+    echo "> Well-defined behavior surfaced by the extra integer & implicit-conversion"
+    echo "> checks (unsigned wrap/shift/negation, narrowing conversions). Not C++"
+    echo "> standard violations, but worth a look for unintended truncation / sign bugs."
+  fi
+  echo ""
+  if [[ "${total_locs}" -eq 0 ]]; then
+    echo "_none_"
+    echo ""
+    return
+  fi
+  emit_findings_block "${rows}" "${label}"
+}
+
+# --- Diff area: the NEWLY ADDED findings (both buckets) shown BEFORE the full
+# report. Only when a baseline is available. Same findings also appear in full.
+emit_diff() {
+  [[ "${has_baseline}" -eq 1 ]] || return 0
+  local ub_new susp_new ubn suspn
+  ub_new="$(split_new "$(bucket_rows UB)")"
+  susp_new="$(split_new "$(bucket_rows SUSP)")"
+  ubn="$(count_locs "${ub_new}")"
+  suspn="$(count_locs "${susp_new}")"
+  echo "> [!CAUTION]"
+  echo "> **Newly added since ${baseline_desc}:** **${ubn}** undefined behavior +"
+  echo "> **${suspn}** suspicious location(s). Each also appears in the full report further down."
+  echo ""
+  echo "## New undefined behaviors - ${ubn} location(s) · ${arch}"
+  echo ""
+  if [[ "${ubn}" -eq 0 ]]; then echo "_none_"; echo ""; else emit_findings_block "${ub_new}" "New Undefined Behaviors"; fi
+  echo "## New suspicious / defined-but-flagged - ${suspn} location(s) · ${arch}"
+  echo ""
+  if [[ "${suspn}" -eq 0 ]]; then echo "_none_"; echo ""; else emit_findings_block "${susp_new}" "New Suspicious Behaviors"; fi
+  echo "---"
+  echo ""
+  echo "# Full report · ${arch}"
+  echo ""
+}
+
+# Single blue INFO banner at the very top, combining (1) the run configuration,
+# (2) the occurrence totals, and (3) how to read the report + reach the artifact.
+# CFG_SUMMARY / CFG_REPRO are passed in by the workflow (absent for local runs).
+emit_notes() {
+  local i=0
+  echo "> [!NOTE]"
+  echo "> "
+  if [[ -n "${CFG_SUMMARY:-}" ]]; then
+    i=$((i + 1))
+    echo "> **${i}. Run configuration:** ${CFG_SUMMARY}"
+    if [[ -n "${CFG_REPRO:-}" ]]; then
+      echo "> Re-run with these settings: **Actions -> Run workflow** (pick the same"
+      echo "> values), or with the GitHub CLI: \`${CFG_REPRO}\`"
+    fi
+    echo "> "
+  fi
+  i=$((i + 1))
+  echo "> **${i}. Totals (${arch}):** **${total}** finding occurrence(s) -"
+  echo "> **${ub_total}** undefined behavior, **${susp_total}** suspicious /"
+  echo "> defined-but-flagged. Locations are deduplicated by file:line:column."
+  echo "> Full symbolized stack traces: download the \`ubsan-logs-${arch}\` artifact."
+  echo "> "
+  i=$((i + 1))
+  echo "> **${i}. How to read:** each row below is one UBSan diagnostic"
+  echo "> (\`file:line:column\`), deduplicated and counted. **These findings do NOT"
+  echo "> fail the job** - UBSan here is *recoverable*: it prints the diagnostic and"
+  echo "> lets the program keep running. The summary tells you **what / where**; the"
+  echo "> uploaded \`ubsan-logs-${arch}\` artifact tells you **who / why** - the exact"
+  echo "> test and the full call stack. Each location lists **one example test**"
+  echo "> (\`suite/case\`). References: [what is C++ undefined behavior](${UB_LINK}) ·"
+  echo "> [what each UBSan check means](${UBSAN_CHECKS_DOC})."
+  echo ""
+  echo "Triage a \`file:line:column\` from the unzipped \`ubsan-logs-${arch}\` artifact root - list the tests that hit it, open the full stack, or let the helper do both:"
+  echo ""
+  echo '```bash'
+  echo "# which tests hit this location (each match is <suite>/<case>/ubsan.<pid>):"
+  echo "> grep -rl 'src/core/dense_set.cc:494:17' ."
+  echo "# print ONLY that finding's stack (its error line through its SUMMARY line):"
+  echo "> sed -n '\\%src/core/dense_set.cc:494:17%,/^SUMMARY/p' <suite>/<case>/ubsan.*"
+  echo "# ...or let the bundled helper do both (it takes any grep pattern):"
+  echo "> bash ubsan_trace.sh 'src/core/dense_set.cc:494:17'"
+  echo '```'
+  echo ""
+}
+
+# --- Suppression help: how to silence a confirmed false positive (once) -----
+emit_suppress_help() {
+  echo "> [!TIP]"
+  echo "> **Suppressing a confirmed false positive (suspicious list):** These extra"
+  echo "> checks (implicit-conversion, unsigned wrap/shift/negation) are well-defined"
+  echo "> and often intentional. After you REVIEW a finding and confirm it is benign,"
+  echo "> exclude just that check for its file or function by adding a per-check section"
+  echo "> to \`tools/sanitizers/ubsan/ubsan-ignorelist.txt\`, then rebuild. The section"
+  echo "> header scopes it to ONE check, so real UB elsewhere in that file is still"
+  echo "> caught. Granularity is file/function, not line - document WHY it is safe, and"
+  echo "> prefer fixing the code when practical."
+  echo ""
+  echo '```'
+  echo "# tools/sanitizers/ubsan/ubsan-ignorelist.txt"
+  echo "[implicit-conversion]                 # only this check is suppressed"
+  echo "fun:*YourFunctionName*                # or  src:src/path/to/file.cc"
+  echo '```'
+  echo ""
+}
+
+emit_notes
+emit_suppress_help
+emit_diff
+emit_section UB
+emit_section SUSP
+echo ""

--- a/tools/sanitizers/ubsan/ubsan_test_report.py
+++ b/tools/sanitizers/ubsan/ubsan_test_report.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Summarize a pytest JUnit XML from the UBSan run as GitHub-flavored markdown.
+
+Usage:
+    ubsan_test_report.py <ubsan-junit.xml> <arch> [baseline-junit-path]
+
+Generates (to stdout, meant to be appended to $GITHUB_STEP_SUMMARY):
+  * an outcome line (passed / failed / errored / skipped, total wall time);
+  * every failure/error with its reason (first message line);
+  * a `slowest-tests.txt` file (full per-test timings) written into the artifact;
+  * if a baseline is given, "reduced-coverage suspects": tests that failed or
+    errored AND finished much faster than their regression baseline. UBSan is
+    strictly slower than a normal run, so a test that finishes far quicker than
+    baseline almost certainly bailed out early -> it exercised less code.
+
+The baseline path may be a single JUnit file or a directory; every *.xml under a
+directory is parsed and merged (regression uploads e.g. pytest-iouring.xml).
+Missing inputs degrade gracefully -- the relevant section is simply omitted.
+"""
+
+import os
+import sys
+import glob
+import xml.etree.ElementTree as ET
+
+# A test that finishes below this fraction of its baseline time under UBSan (which
+# is always slower) most likely exited early and covered less code.
+EARLY_EXIT_RATIO = 0.8
+
+
+def _key(case):
+    """Stable join key across runs: pytest classname + test name (with params)."""
+    cls = case.get("classname", "")
+    name = case.get("name", "")
+    return f"{cls}::{name}" if cls else name
+
+
+def _outcome(case):
+    child = case.find("failure")
+    if child is not None:
+        return "failed", child
+    child = case.find("error")
+    if child is not None:
+        return "errored", child
+    if case.find("skipped") is not None:
+        return "skipped", None
+    return "passed", None
+
+
+def _reason(node):
+    """First meaningful line of a failure/error message."""
+    if node is None:
+        return ""
+    msg = (node.get("message") or "").strip()
+    if not msg:
+        msg = (node.text or "").strip()
+    for line in msg.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _parse(path):
+    """Return {key: (time, outcome, reason)} for one JUnit file."""
+    out = {}
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return out
+    for case in root.iter("testcase"):
+        try:
+            t = float(case.get("time", "0") or 0)
+        except ValueError:
+            t = 0.0
+        outcome, node = _outcome(case)
+        out[_key(case)] = (t, outcome, _reason(node))
+    return out
+
+
+def _parse_baseline(path):
+    """Merge every JUnit under `path` (file or dir) into {key: time}."""
+    files = []
+    if os.path.isdir(path):
+        files = sorted(glob.glob(os.path.join(path, "**", "*.xml"), recursive=True))
+    elif os.path.isfile(path):
+        files = [path]
+    times = {}
+    for f in files:
+        for key, (t, _outcome, _reason) in _parse(f).items():
+            # Keep the largest observed baseline time (most coverage) per test.
+            if t > times.get(key, 0.0):
+                times[key] = t
+    return times
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.stderr.write(__doc__)
+        return 2
+    junit_path, arch = sys.argv[1], sys.argv[2]
+    baseline_path = sys.argv[3] if len(sys.argv) > 3 else ""
+
+    print(f"## Test timings & failures ({arch})\n")
+
+    if not os.path.isfile(junit_path):
+        print("> [!NOTE]")
+        print("> No JUnit report was produced (pytest may not have started).")
+        return 0
+
+    cases = _parse(junit_path)
+    if not cases:
+        print("> [!NOTE]")
+        print("> JUnit report contained no test cases.")
+        return 0
+
+    counts = {"passed": 0, "failed": 0, "errored": 0, "skipped": 0}
+    total_time = 0.0
+    for _t, outcome, _r in cases.values():
+        counts[outcome] = counts.get(outcome, 0) + 1
+        total_time += _t
+
+    print(
+        f"**{len(cases)} tests** — "
+        f"{counts['passed']} passed, "
+        f"{counts['failed']} failed, "
+        f"{counts['errored']} errored, "
+        f"{counts['skipped']} skipped. "
+        f"Total test time: {total_time:.1f}s.\n"
+    )
+
+    # ---- Failures / errors with reasons -----------------------------------
+    problems = [(k, t, o, r) for k, (t, o, r) in cases.items() if o in ("failed", "errored")]
+    if problems:
+        print("> [!CAUTION]")
+        print(f"> {len(problems)} test(s) failed or errored under UBSan.\n")
+        print("```")
+        for key, t, outcome, reason in sorted(problems, key=lambda x: x[0]):
+            print(f"[{outcome}] {key}  ({t:.1f}s)")
+            if reason:
+                print(f"    {reason}")
+        print("```\n")
+
+    # ---- Slowest tests: written to a file in the artifact, not the summary ---
+    slowest = sorted(cases.items(), key=lambda kv: kv[1][0], reverse=True)
+    slowest_path = os.path.join(os.path.dirname(os.path.abspath(junit_path)), "slowest-tests.txt")
+    try:
+        with open(slowest_path, "w") as fh:
+            fh.write(f"# Tests by wall time, slowest first ({arch}) — {len(slowest)} tests\n")
+            for key, (t, _o, _r) in slowest:
+                fh.write(f"{t:8.1f}s  {key}\n")
+        print(
+            f"⏱️ Full per-test timings (slowest first) are in "
+            f"`{os.path.basename(slowest_path)}` at the root of the `ubsan-logs-{arch}` artifact.\n"
+        )
+    except OSError:
+        pass
+
+    # ---- Reduced-coverage suspects vs regression baseline -----------------
+    if baseline_path:
+        baseline = _parse_baseline(baseline_path)
+        if not baseline:
+            print("> [!NOTE]")
+            print("> No regression baseline was available for a timing comparison.")
+            return 0
+        suspects = []
+        for key, t, outcome, _r in problems:
+            b = baseline.get(key)
+            if b and b > 0 and t < EARLY_EXIT_RATIO * b:
+                suspects.append((key, t, b))
+        if suspects:
+            print("> [!WARNING]")
+            print(
+                "> These failing/erroring tests finished far faster than their "
+                "regression baseline — under UBSan (slower than normal) that means "
+                "they likely bailed out early and covered less code:\n"
+            )
+            print("```")
+            for key, t, b in sorted(suspects, key=lambda x: x[1]):
+                print(f"ubsan={t:.1f}s  baseline={b:.1f}s  ({t / b:.0%})  {key}")
+            print("```\n")
+        else:
+            print("> [!TIP]")
+            print(
+                "> No reduced-coverage suspects: every failing/erroring test ran "
+                "at least as long as its regression baseline."
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sanitizers/ubsan/ubsan_trace.sh
+++ b/tools/sanitizers/ubsan/ubsan_trace.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# UBSan artifact helper script: run it from the root of an unzipped
+# `ubsan-logs-<arch>` artifact (or pass the folder as the 2nd argument).
+#
+#   ./ubsan_trace.sh <grep-pattern> [logs-dir]
+#
+# Examples:
+#   ./ubsan_trace.sh 'src/core/dense_set.cc:494'      # a file:line from the summary
+#   ./ubsan_trace.sh 'member call on address'         # any substring works
+#   ./ubsan_trace.sh 'histogram.cc:318' ~/Downloads/ubsan-logs-x86_64
+#
+# UBSan logs are laid out one folder per test: <suite>/<case>/ubsan.<pid>.
+# This lists every test (suite/case) whose log matched the pattern, then prints
+# the first full symbolized stack for it. The pattern is matched literally (-F).
+#
+set -euo pipefail
+
+pat="${1:?usage: ubsan_trace.sh <grep-pattern> [logs-dir]}"
+dir="${2:-.}"
+
+# Blue section headers on a terminal; no color codes when piped/redirected.
+if [[ -t 1 ]]; then B=$'\033[1;34m'; R=$'\033[0m'; else B=""; R=""; fi
+
+echo "${B}== tests that hit: ${pat} ==${R}"
+mapfile -t hits < <(grep -rlF --include='ubsan.*' -- "${pat}" "${dir}" 2>/dev/null || true)
+if [[ "${#hits[@]}" -eq 0 ]]; then
+  echo "(no matches under ${dir})"
+  exit 0
+fi
+# <suite>/<case> is the parent folder of each matching ubsan.<pid> file. Strip the
+# logs-dir prefix with bash string ops (not a sed regex) so paths with metacharacters work.
+prefix="${dir%/}/"
+for f in "${hits[@]}"; do
+  d="$(dirname "${f}")"
+  printf '%s\n' "${d#"$prefix"}"
+done | sort -u
+
+echo ""
+echo "${B}== first full stack (${hits[0]}) ==${R}"
+# Print from the matching "runtime error:" line through its SUMMARY line.
+awk -v p="${pat}" 'index($0, p) { f = 1 } f { print } f && /^SUMMARY/ { exit }' "${hits[0]}"


### PR DESCRIPTION
- Add a scheduled workflow that builds under UBSan and runs the whole test suite on x86_64 and aarch64
- Add strict UBSan build support with extended Clang-only checks (WITH_UBSAN_STRICT); rename WITH_USAN to WITH_UBSAN. All tokens with the name 'USan' renamed to 'UBSan' (the correct name).
- Add a self-test that proves every check is live before trusting a clean run
- Integrate with pytest: per-test findings folders plus failure logs
- Generate a findings report and summary, with a baseline diff (new vs existing) and an opt-in fail-on-new gate
- Add triage tooling and docs

See tools/sanitizers/ubsan/README.md for the full setup, UBSAN_OPTIONS reference, and how to read the findings.

Note: this PR is large, due to lots of boilerplate code and documentation.

