### PR TITLE
perf: prefetch squashed command contexts

### DIFF
--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -220,43 +220,61 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     sinfo.reply_size_total_ptr->fetch_add(sz, std::memory_order_relaxed);
   };
 
-  for (auto& dispatched : sinfo.dispatched) {
-    auto* ctx = &local_cntx;
-    crb.SetReplyMode(dispatched.reply_mode);
+  const size_t dispatched_sz = sinfo.dispatched.size();
+  for (size_t batch_start = 0; batch_start < dispatched_sz; batch_start += 8) {
+    size_t batch_end = batch_start + 8;
+    if (batch_end > dispatched_sz)
+      batch_end = dispatched_sz;
 
-    // Allow captured replies to be stored in argument storage.
-    // Some commands might include arguments in replies, so we have a limited set
-    if (dispatched.cmd_cntx && dispatched.cid->SupportsAsync())
-      crb.ProvideInlineBuffer(dispatched.cmd_cntx->GetInlineBuffer());
-    else
-      crb.ProvideInlineBuffer({});  // reset buffer
-
-    // With tiered storage enabled, it makes sense to dispatch async commands concurrently
-    // to allow concurrent disk operations. Tiered futures are only blocked on during replies
-    bool do_async = es->tiered_storage() && !IsAtomic() && opts_.pipeline_mode &&
-                    dispatched.cid->SupportsAsync();
-    if (do_async) {
-      ctx = dispatched.cmd_cntx;
-      ctx->SetDeferredReply();
+    // We are in the context of a shard thread, so prefetching allows faster access
+    // to the command arguments.
+    for (size_t i = batch_start; i < batch_end; ++i) {
+      auto& dispatched = sinfo.dispatched[i];
+      if (dispatched.cmd_cntx) {
+        __builtin_prefetch(dispatched.cmd_cntx, 0, 3);
+      }
     }
 
-    ctx->SetupTx(dispatched.cid, local_cntx.tx());
-    ctx->tx()->MultiSwitchCmd(dispatched.cid);
+    for (size_t i = batch_start; i < batch_end; ++i) {
+      auto& dispatched = sinfo.dispatched[i];
+      auto* ctx = &local_cntx;
+      crb.SetReplyMode(dispatched.reply_mode);
 
-    auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, dispatched.args,
-                                        dispatched.key_index);
-    if (status != OpStatus::OK) {
-      ctx->SendError(status);  // Calls Resolve() in async, routes to crb in non async
-    } else {
-      ctx->UpdateCid(dispatched.cid);
-      ctx->SetTailArgs(dispatched.args);
-      service_->InvokeCmd(dispatched.args, ctx);
-    }
+      // Allow captured replies to be stored in argument storage.
+      // Some commands might include arguments in replies, so we have a limited set
+      if (dispatched.cmd_cntx && dispatched.cid->SupportsAsync())
+        crb.ProvideInlineBuffer(dispatched.cmd_cntx->GetInlineBuffer());
+      else
+        crb.ProvideInlineBuffer({});  // reset buffer
 
-    if (!do_async) {
-      move_reply(&dispatched);  // Async commands resolve the context directly
-    } else if (!ctx->CanReply()) {
-      ctx->Blocker()->Wait();  // Transaction didn't finish inline (likely locked key), wait for it
+      // With tiered storage enabled, it makes sense to dispatch async commands concurrently
+      // to allow concurrent disk operations. Tiered futures are only blocked on during replies
+      bool do_async = es->tiered_storage() && !IsAtomic() && opts_.pipeline_mode &&
+                      dispatched.cid->SupportsAsync();
+      if (do_async) {
+        ctx = dispatched.cmd_cntx;
+        ctx->SetDeferredReply();
+      }
+
+      ctx->SetupTx(dispatched.cid, local_cntx.tx());
+      ctx->tx()->MultiSwitchCmd(dispatched.cid);
+
+      auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, dispatched.args,
+                                          dispatched.key_index);
+      if (status != OpStatus::OK) {
+        ctx->SendError(status);  // Calls Resolve() in async, routes to crb in non async
+      } else {
+        ctx->UpdateCid(dispatched.cid);
+        ctx->SetTailArgs(dispatched.args);
+        service_->InvokeCmd(dispatched.args, ctx);
+      }
+
+      if (!do_async) {
+        move_reply(&dispatched);  // Async commands resolve the context directly
+      } else if (!ctx->CanReply()) {
+        ctx->Blocker()
+            ->Wait();  // Transaction didn't finish inline (likely locked key), wait for it
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Prefetch command contexts in `MultiCommandSquasher::SquashedHopCb` in small
batches before executing the commands on the shard thread.

The squashed commands hold pointers to `CommandContext` objects allocated on the
IO thread, and the shard thread immediately dereferences those contexts while
initializing and executing pipelined commands. Prefetching the contexts reduces
cold pointer chasing on the shard hot path without walking into
`BackedArguments`.

## Benchmark setup

- Server: `c6g.8xlarge`.
- Client/load generator: `c7gn.4xlarge`.
- Workload: RESP GET-only, pipeline depth 200, 10 connections per thread,
  unlimited QPS, 4M requests per run.

```bash
./dfly_bench -p 6380 -h <server> -c 10 --pipeline=200 \
  --ratio=0:1 -n 4000000 --qps=0
```

## Profiling setup

Captured user-space CPU cycles on a single shard-thread CPU to avoid I/O thread
noise:

```bash
sudo perf record -o <filename> -e cycles:u -F99 -C 14 -- <dragonfly command>
```

Reports were generated with:

```bash
perf report -i <file> --stdio --no-children -n --percent-limit=0.3
```

Compared `build-opt/perf.data.main` (`dragonfly.main`) against
`build-opt/perf.data.pref` (`dragonfly`).

## Profile results

- Total sampled cycles dropped from 64.34B to 59.31B (-7.8%).
- `StoreKeysInArgs` dropped from 10.62% to 2.28%.
- `InitByKeys` changed from 3.33% to 4.40%.
- `StoreKeysInArgs + InitByKeys` dropped from 13.95% to 6.68%.
- `SquashedHopCb` changed from 3.62% to 4.83%.
- `StoreKeysInArgs + InitByKeys + SquashedHopCb` dropped from 17.57% to
  11.51%.
- The remaining top hotspot in the prefetch build is
  `MultiCommandSquasher::SquashedHopCb` at 4.83%, followed by `InitByKeys` at
  4.40% and `ParsedCommand::Resolve` at 4.22%.
- Source-line attribution shows `ParsedCommand::Resolve` mostly at
  `parsed_command.cc:106`:

```cpp
reply_ = std::move(pl);
```