### PR TITLE
test: more benchmarks for Set

### DIFF
--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -21,7 +21,6 @@ namespace dfly {
 class PageUsage;
 
 #define PREFETCH_READ(x) __builtin_prefetch(x, 0, 1)
-#define FORCE_INLINE __attribute__((always_inline))
 
 // oah_entry.h - a single set member: a string key plus its expiry and cached hash.
 //

--- a/src/core/oah_set.cc
+++ b/src/core/oah_set.cc
@@ -10,13 +10,8 @@
 
 namespace dfly {
 
-// Definitions below are `inline FORCE_INLINE`: inline makes them COMDAT
-// (non-interposable), which lets always_inline apply to an out-of-line member so
-// they fold into their in-TU callers.
-
 template <typename Wide>
-inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeLanes(const TaggedPtr* base,
-                                                         uint64_t ext_hash) noexcept {
+OAHSet::LaneMasks OAHSet::ProbeLanes(const TaggedPtr* base, uint64_t ext_hash) noexcept {
   auto data_v = Wide::Load(base);
   auto hash_v = (data_v & Wide::Fill(OAHEntry::kExtHashShiftedMask)) >> OAHEntry::kExtHashShift;
   // ~is_empty excludes empty lanes, whose zero hash would otherwise match a zero query hash.
@@ -27,8 +22,7 @@ inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeLanes(const TaggedPtr* base,
 
 // Window may exceed one SIMD register: sweep in EntryWide strides, packing each
 // stride's masks (lane i of stride `off` -> bit off+i). uint32_t masks => <= 32 lanes.
-inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeWindow(const TaggedPtr* base,
-                                                          uint64_t ext_hash) noexcept {
+OAHSet::LaneMasks OAHSet::ProbeWindow(const TaggedPtr* base, uint64_t ext_hash) noexcept {
   LaneMasks w{0, 0};
   for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
     const LaneMasks m = ProbeLanes<EntryWide>(base + off, ext_hash);
@@ -40,8 +34,7 @@ inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeWindow(const TaggedPtr* base,
 
 // 2-lane SIMD strides. Vector sizes are always even (PtrVector grows by 2), so the
 // stride covers the array with no tail.
-inline FORCE_INLINE TaggedPtr* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std::string_view str,
-                                                            uint64_t ext_hash) {
+TaggedPtr* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std::string_view str, uint64_t ext_hash) {
   auto vec = At(ext_bid).AsVector();
   TaggedPtr* raw_arr = vec.Raw();
   const size_t size = vec.Size();
@@ -66,9 +59,8 @@ inline FORCE_INLINE TaggedPtr* OAHSet::ProbeExtensionVector(uint32_t ext_bid, st
 }
 
 // Window read stays in bounds: entries_ has kDisplacementSize-1 slack past BucketCount.
-inline FORCE_INLINE OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t ext_bid,
-                                                          uint32_t cand_bits, std::string_view str,
-                                                          uint64_t ext_hash) {
+OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t ext_bid, uint32_t cand_bits,
+                                      std::string_view str, uint64_t ext_hash) {
   while (cand_bits) {
     const uint32_t i = std::countr_zero(cand_bits);
     cand_bits &= cand_bits - 1;
@@ -89,9 +81,8 @@ inline FORCE_INLINE OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t
   return {nullptr, 0, 0};
 }
 
-inline FORCE_INLINE bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec) {
-  // Grow at load factor 2; until then overflow lands in the window / extension vectors.
-  if (size_ >= entries_.size() * 2) [[unlikely]] {
+bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec) {
+  if (size_ >= entries_.size()) [[unlikely]] {
     Reserve(BucketCount() * 2);
   }
   DCHECK_GE(Capacity(), kDisplacementSize);
@@ -153,8 +144,7 @@ unsigned OAHSet::AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec, bo
   return res;
 }
 
-inline FORCE_INLINE OAHSet::iterator OAHSet::FindInternal(uint32_t bid, std::string_view str,
-                                                          uint64_t hash) {
+OAHSet::iterator OAHSet::FindInternal(uint32_t bid, std::string_view str, uint64_t hash) {
   const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
   const uint32_t cand_bits = ProbeWindow(&entries_[bid], ext_hash).candidates;
   const MatchResult m = FindMatch(bid, GetExtensionPoint(bid), cand_bits, str, ext_hash);
@@ -190,7 +180,7 @@ bool OAHSet::Erase(std::string_view str) {
   return true;
 }
 
-inline FORCE_INLINE OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
+OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
   OAHPtr bucket = At(b);
   if (!bucket.IsVector()) {
     OAHEntry e = bucket[0];
@@ -245,7 +235,7 @@ OAHSet::iterator OAHSet::GetRandomMember() {
   return ScanRange(0, start);
 }
 
-inline FORCE_INLINE uint32_t OAHSet::FindEmptyAround(uint32_t bid) {
+uint32_t OAHSet::FindEmptyAround(uint32_t bid) {
   // Strides scanned in order, so the first empty found is the lowest-index one. In
   // bounds thanks to entries_' kDisplacementSize-1 slack past BucketCount.
   for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -32,7 +32,7 @@ class OAHSet {  // Open Addressing Hash Set
   using Buckets = std::vector<TaggedPtr, StatelessAllocator<TaggedPtr>>;
 
  public:
-  static constexpr std::uint32_t kShiftLog = 5;                         // TODO make template
+  static constexpr std::uint32_t kShiftLog = 2;                         // TODO make template
   static constexpr std::uint32_t kMinCapacityLog = kShiftLog;           // should be >= ShiftLog
   static constexpr std::uint32_t kDisplacementSize = (1 << kShiftLog);  // TODO check
 
@@ -459,7 +459,6 @@ class OAHSet {  // Open Addressing Hash Set
 
   // Returns an iterator to a live entry in bucket `b` (skipping just-expired ones for
   // single entries and walking vector entries in order), or end() if none remain.
-  // FORCE_INLINE: it sits inside ScanRange's hot SIMD inner loop.
   iterator PickFromBucket(uint32_t b);
 
   // Linear [lo, hi) scan returning the first live entry or end(). SIMD strides over
@@ -468,7 +467,7 @@ class OAHSet {  // Open Addressing Hash Set
   // duplicating the body in the cold path.
   iterator ScanRange(uint32_t lo, uint32_t hi);
 
-  // The body of Add, FORCE_INLINE so it folds into Add and AddMany.
+  // The body of Add, shared by Add and AddMany.
   bool AddImpl(std::string_view str, uint32_t ttl_sec);
 
   // Result of a SIMD probe over a run of OAHEntry lanes.

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -189,8 +189,8 @@ TEST_F(OAHSetTest, OAHSetAddFindTest) {
     EXPECT_EQ(e->Key(), s);
   }
 
-  // ~10000 elements at load factor 2 (grow only when size_ >= 2 * table size).
-  EXPECT_EQ(ss.BucketCount(), 8192);
+  // ~10000 elements at load factor 1 (grow when size_ >= table size).
+  EXPECT_EQ(ss.BucketCount(), 16384);
 }
 
 TEST_F(OAHSetTest, Basic) {
@@ -446,7 +446,7 @@ TEST_F(OAHSetTest, SimpleScan) {
   } while (cursor != 0);
 
   EXPECT_EQ(seen.size(), info.size());
-  EXPECT_TRUE(equal(seen.begin(), seen.end(), info.begin()));
+  EXPECT_EQ(seen, info);
 }
 
 // // Ensure REDIS scan guarantees are met
@@ -1015,14 +1015,12 @@ static size_t MemUsed(OAHSet& obj) {
 }
 
 void BM_Clone(benchmark::State& state) {
-  vector<string> strs;
   mt19937 generator(0);
   OAHSet ss1, ss2;
   unsigned elems = state.range(0);
-  for (size_t i = 0; i < elems; ++i) {
-    string str = random_string(generator, 10);
-    ss1.Add(str);
-  }
+  unsigned keySize = state.range(1);
+  for (size_t i = 0; i < elems; ++i)
+    ss1.Add(random_string(generator, keySize));
   ss2.Reserve(ss1.UpperBoundSize());
   while (state.KeepRunning()) {
     for (auto src : ss1) {
@@ -1034,17 +1032,15 @@ void BM_Clone(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(BM_Clone)->ArgName("elements")->Arg(32000);
+BENCHMARK(BM_Clone)->ArgNames({"elements", "KeySize"})->ArgsProduct({{32000}, {10, 100, 1000}});
 
 void BM_Fill(benchmark::State& state) {
   unsigned elems = state.range(0);
-  vector<string> strs;
+  unsigned keySize = state.range(1);
   mt19937 generator(0);
   OAHSet ss1, ss2;
-  for (size_t i = 0; i < elems; ++i) {
-    string str = random_string(generator, 10);
-    ss1.Add(str);
-  }
+  for (size_t i = 0; i < elems; ++i)
+    ss1.Add(random_string(generator, keySize));
 
   while (state.KeepRunning()) {
     ss1.Fill(&ss2);
@@ -1053,23 +1049,22 @@ void BM_Fill(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(BM_Fill)->ArgName("elements")->Arg(32000);
+BENCHMARK(BM_Fill)->ArgNames({"elements", "KeySize"})->ArgsProduct({{32000}, {10, 100, 1000}});
 
 void BM_Clear(benchmark::State& state) {
   unsigned elems = state.range(0);
+  unsigned key_size = state.range(1);
   mt19937 generator(0);
   OAHSet ss;
   while (state.KeepRunning()) {
     state.PauseTiming();
-    for (size_t i = 0; i < elems; ++i) {
-      string str = random_string(generator, 16);
-      ss.Add(str);
-    }
+    for (size_t i = 0; i < elems; ++i)
+      ss.Add(random_string(generator, key_size));
     state.ResumeTiming();
     ss.Clear();
   }
 }
-BENCHMARK(BM_Clear)->ArgName("elements")->Arg(32000);
+BENCHMARK(BM_Clear)->ArgNames({"elements", "KeySize"})->ArgsProduct({{32000}, {10, 100, 1000}});
 
 void BM_Add(benchmark::State& state) {
   vector<string> strs;
@@ -1110,12 +1105,12 @@ void BM_AddMany(benchmark::State& state) {
   }
   ss.Reserve(elems);
   vector<string_view> svs;
-  size_t mem_used = 0;
   for (const auto& str : strs) {
     svs.push_back(str);
   }
+  size_t mem_used = 0;
   while (state.KeepRunning()) {
-    ss.AddMany(absl::MakeSpan(svs));
+    ss.AddMany(absl::MakeSpan(svs), UINT32_MAX, false);
     state.PauseTiming();
     CHECK_EQ(ss.UpperBoundSize(), elems);
     mem_used += MemUsed(ss);
@@ -1207,6 +1202,71 @@ void BM_Grow(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_Grow);
+
+void BM_GetRandomMember(benchmark::State& state) {
+  mt19937 generator(0);
+  OAHSet ss;
+  unsigned elems = state.range(0);
+  unsigned keySize = state.range(1);
+  for (size_t i = 0; i < elems; ++i)
+    ss.Add(random_string(generator, keySize));
+
+  while (state.KeepRunning()) {
+    benchmark::DoNotOptimize(ss.GetRandomMember());
+  }
+}
+BENCHMARK(BM_GetRandomMember)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
+
+void BM_Scan(benchmark::State& state) {
+  mt19937 generator(0);
+  OAHSet ss;
+  unsigned elems = state.range(0);
+  unsigned keySize = state.range(1);
+  for (size_t i = 0; i < elems; ++i)
+    ss.Add(random_string(generator, keySize));
+
+  while (state.KeepRunning()) {
+    uint32_t cursor = 0;
+    size_t seen = 0;
+    do {
+      cursor = ss.Scan(cursor, [&](auto key) {
+        benchmark::DoNotOptimize(key);
+        ++seen;
+      });
+    } while (cursor != 0);
+    benchmark::DoNotOptimize(seen);
+  }
+}
+BENCHMARK(BM_Scan)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
+
+void BM_Shrink(benchmark::State& state) {
+  mt19937 generator(0);
+  unsigned elems = state.range(0);
+  unsigned keySize = state.range(1);
+  OAHSet src;
+  for (size_t i = 0; i < elems; ++i)
+    src.Add(random_string(generator, keySize));
+
+  size_t kShrinkTo = absl::bit_ceil(size_t(elems));
+  size_t kGrowTo = kShrinkTo * 4;
+  OAHSet ss;
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    ss.Clear();
+    src.Fill(&ss);
+    ss.Reserve(kGrowTo);
+    CHECK_EQ(ss.BucketCount(), kGrowTo);
+    state.ResumeTiming();
+    ss.Shrink(kShrinkTo);
+  }
+}
+BENCHMARK(BM_Shrink)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
 
 // unsigned total_wasted_memory = 0;
 

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -4,6 +4,7 @@
 
 #include "core/string_set.h"
 
+#include <absl/numeric/bits.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <mimalloc.h>
@@ -607,14 +608,12 @@ static size_t MemUsed(StringSet& obj) {
 }
 
 void BM_Clone(benchmark::State& state) {
-  vector<string> strs;
   mt19937 generator(0);
   StringSet ss1, ss2;
   unsigned elems = state.range(0);
-  for (size_t i = 0; i < elems; ++i) {
-    string str = random_string(generator, 10);
-    ss1.Add(str);
-  }
+  unsigned keySize = state.range(1);
+  for (size_t i = 0; i < elems; ++i)
+    ss1.Add(random_string(generator, keySize));
   ss2.Reserve(ss1.UpperBoundSize());
   while (state.KeepRunning()) {
     for (auto src : ss1) {
@@ -626,17 +625,15 @@ void BM_Clone(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(BM_Clone)->ArgName("elements")->Arg(32000);
+BENCHMARK(BM_Clone)->ArgNames({"elements", "KeySize"})->ArgsProduct({{32000}, {10, 100, 1000}});
 
 void BM_Fill(benchmark::State& state) {
   unsigned elems = state.range(0);
-  vector<string> strs;
+  unsigned keySize = state.range(1);
   mt19937 generator(0);
   StringSet ss1, ss2;
-  for (size_t i = 0; i < elems; ++i) {
-    string str = random_string(generator, 10);
-    ss1.Add(str);
-  }
+  for (size_t i = 0; i < elems; ++i)
+    ss1.Add(random_string(generator, keySize));
 
   while (state.KeepRunning()) {
     ss1.Fill(&ss2);
@@ -645,23 +642,22 @@ void BM_Fill(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(BM_Fill)->ArgName("elements")->Arg(32000);
+BENCHMARK(BM_Fill)->ArgNames({"elements", "KeySize"})->ArgsProduct({{32000}, {10, 100, 1000}});
 
 void BM_Clear(benchmark::State& state) {
   unsigned elems = state.range(0);
+  unsigned key_size = state.range(1);
   mt19937 generator(0);
   StringSet ss;
   while (state.KeepRunning()) {
     state.PauseTiming();
-    for (size_t i = 0; i < elems; ++i) {
-      string str = random_string(generator, 16);
-      ss.Add(str);
-    }
+    for (size_t i = 0; i < elems; ++i)
+      ss.Add(random_string(generator, key_size));
     state.ResumeTiming();
     ss.Clear();
   }
 }
-BENCHMARK(BM_Clear)->ArgName("elements")->Arg(32000);
+BENCHMARK(BM_Clear)->ArgNames({"elements", "KeySize"})->ArgsProduct({{32000}, {10, 100, 1000}});
 
 void BM_Add(benchmark::State& state) {
   vector<string> strs;
@@ -687,7 +683,7 @@ void BM_Add(benchmark::State& state) {
   state.counters["Memory_Used"] = mem_used / state.iterations();
 }
 BENCHMARK(BM_Add)
-    ->ArgNames({"elements", "Key Size"})
+    ->ArgNames({"elements", "KeySize"})
     ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
 
 void BM_AddMany(benchmark::State& state) {
@@ -718,7 +714,7 @@ void BM_AddMany(benchmark::State& state) {
   state.counters["Memory_Used"] = mem_used / state.iterations();
 }
 BENCHMARK(BM_AddMany)
-    ->ArgNames({"elements", "Key Size"})
+    ->ArgNames({"elements", "KeySize"})
     ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
 
 void BM_Erase(benchmark::State& state) {
@@ -748,7 +744,7 @@ void BM_Erase(benchmark::State& state) {
   state.counters["Memory_After_Erase"] = mem_used / state.iterations();
 }
 BENCHMARK(BM_Erase)
-    ->ArgNames({"elements", "Key Size"})
+    ->ArgNames({"elements", "KeySize"})
     ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
 
 void BM_Get(benchmark::State& state) {
@@ -769,7 +765,7 @@ void BM_Get(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_Get)
-    ->ArgNames({"elements", "Key Size"})
+    ->ArgNames({"elements", "KeySize"})
     ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
 
 void BM_Grow(benchmark::State& state) {
@@ -800,27 +796,70 @@ void BM_Grow(benchmark::State& state) {
 }
 BENCHMARK(BM_Grow);
 
-void BM_Spop1000(benchmark::State& state) {
+void BM_GetRandomMember(benchmark::State& state) {
   mt19937 generator(0);
-  StringSet src;
-  unsigned elems = 1 << 14;
-  for (size_t i = 0; i < elems; ++i) {
-    src.Add(random_string(generator, 16), UINT32_MAX);
-  }
+  StringSet ss;
+  unsigned elems = state.range(0);
+  unsigned keySize = state.range(1);
+  for (size_t i = 0; i < elems; ++i)
+    ss.Add(random_string(generator, keySize));
 
-  auto sparseness = state.range(0);
   while (state.KeepRunning()) {
-    state.PauseTiming();
-    StringSet tmp;
-    src.Fill(&tmp);
-    tmp.Reserve(elems * sparseness);
-    state.ResumeTiming();
-    for (int i = 0; i < 1000; ++i) {
-      tmp.Pop();
-    }
+    benchmark::DoNotOptimize(ss.GetRandomMember());
   }
 }
-BENCHMARK(BM_Spop1000)->ArgName("sparseness")->ArgsProduct({{1, 4, 10}});
+BENCHMARK(BM_GetRandomMember)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
+
+void BM_Scan(benchmark::State& state) {
+  mt19937 generator(0);
+  StringSet ss;
+  unsigned elems = state.range(0);
+  unsigned keySize = state.range(1);
+  for (size_t i = 0; i < elems; ++i)
+    ss.Add(random_string(generator, keySize));
+
+  while (state.KeepRunning()) {
+    uint32_t cursor = 0;
+    size_t seen = 0;
+    do {
+      cursor = ss.Scan(cursor, [&](auto key) {
+        benchmark::DoNotOptimize(key);
+        ++seen;
+      });
+    } while (cursor != 0);
+    benchmark::DoNotOptimize(seen);
+  }
+}
+BENCHMARK(BM_Scan)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
+
+void BM_Shrink(benchmark::State& state) {
+  mt19937 generator(0);
+  unsigned elems = state.range(0);
+  unsigned keySize = state.range(1);
+  StringSet src;
+  for (size_t i = 0; i < elems; ++i)
+    src.Add(random_string(generator, keySize));
+
+  size_t kShrinkTo = absl::bit_ceil(size_t(elems));
+  size_t kGrowTo = kShrinkTo * 4;
+  StringSet ss;
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    ss.Clear();
+    src.Fill(&ss);
+    ss.Reserve(kGrowTo);
+    CHECK_EQ(ss.BucketCount(), kGrowTo);
+    state.ResumeTiming();
+    ss.Shrink(kShrinkTo);
+  }
+}
+BENCHMARK(BM_Shrink)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
 
 unsigned total_wasted_memory = 0;
 


### PR DESCRIPTION
Summary: This PR expands the benchmark coverage for Set implementations and adjusts some OAHSet internals.

Changes:

- Remove the local FORCE_INLINE macro and drop forced-inlining annotations from several OAHSet hot-path helpers.
- Change OAHSet probe-window configuration via kShiftLog (affecting kDisplacementSize) and adjust the grow threshold in AddImpl.
- Update OAHSet unit test expectations to reflect the new grow/load-factor behavior.
- Parameterize existing OAHSet and StringSet benchmarks by key size for more realistic workloads.
- Add new benchmarks for GetRandomMember, Scan, and Shrink for both set implementations.
- Normalize benchmark argument naming (KeySize).

Technical Notes: New benchmark matrices cover element counts up to 100k and key sizes up to 1000 bytes; OAHSet behavior changes (probe window + grow threshold) may affect both memory usage and runtime characteristics beyond tests/benchmarks.