### PR TITLE
feat:extend CmdArgParser functionality

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -36,7 +36,10 @@ namespace facade {
 //   auto f  = parser.Next<FInt<1, 99>>("bad f");                // FInt with a custom out-of-range
 //                                                               // / non-integer error message
 //   auto s  = parser.Next<Validated<double, NotNan<kMsg>>>();   // parse + custom-error rule check
+//   auto u  = parser.Next(ParseUnit);                           // token parser fn: (sv, err) -> T
+//   auto n  = parser.Next(Number<int>);                         // full parser fn: (parser) -> T
 //   auto count = parser.NextOrDefault<size_t>(10);              // read optional with default
+//   auto conv  = parser.NextOrDefault(ParseUnit, 1.0);          // optional arg via a parser fn
 //   Range fields = parser.NextRange();                         // [N, e1..eN] counted list
 //   Range pairs  = parser.NextRange(2);                        // [N, f1,v1,..] N field/value pairs
 //   Range fs     = parser.NextRange(1, mismatch, true);        // consume-all variant
@@ -62,7 +65,8 @@ namespace facade {
 //       Map(&dir, "ASC", Dir::ASC, "DESC", Dir::DESC),   // tag -> fixed value mapping
 //       Tag("ATTR", Map(&mask, "v", Mask::Volatile,      // nested: outer tag + inner Map
 //                       "p", Mask::Permanent)),          //   (inner keyword required on match)
-//       OneOf(Exist("NX", &nx), Exist("XX", &xx)),       // mutex — at most one may match
+//       OneOf(Exist("NX", &nx), Exist("XX", &xx))       // mutex — at most one may match
+//           .Err("NX and XX are incompatible"),        //   custom conflict message (optional)
 //       If(!read_only, Tag("STORE", &store_key)));    // runtime-gated option
 //
 // Strict vs lenient dispatch:
@@ -80,6 +84,7 @@ namespace facade {
 // Error surfacing (at the end of parse):
 //   if (!parser.Finalize())                                     // also reports UNPROCESSED on
 //     return cmd_cntx->SendError(parser.TakeError().MakeReply()); // trailing args
+//   parser.Finalize("Unsupported option: ");                    // report "<prefix><leftover arg>"
 //   // or: if (parser.HasError()) ...
 //   parser.ReportCustom("bad option");                          // inject a custom error (no-op if
 //                                                               // one is already set)
@@ -97,6 +102,32 @@ concept as_vnum = requires(T t) {
   { T::validate(t.value) } -> std::same_as<RuleError>;
 };
 
+struct CmdArgParser;
+
+// A parser callable for Next(fn), taking either fn(CmdArgParser*) (drives the parser, may consume
+// several args) or fn(std::string_view, RuleError&) (converts the next arg, sets err on failure).
+template <class F>
+concept ParserFn =
+    std::is_invocable_v<F, CmdArgParser*> || std::is_invocable_v<F, std::string_view, RuleError&>;
+
+// Numeric conversion core shared by Num and Number; false if `arg` isn't a round-trippable T.
+template <class T> bool TryParseNum(std::string_view arg, T* out) {
+  if constexpr (std::is_same_v<T, float>) {
+    return absl::SimpleAtof(arg, out);
+  } else if constexpr (std::is_same_v<T, double>) {
+    return absl::SimpleAtod(arg, out);
+  } else if constexpr (std::is_integral_v<T> && sizeof(T) >= sizeof(int32_t)) {
+    return absl::SimpleAtoi(arg, out);
+  } else {
+    static_assert(std::is_integral_v<T> && sizeof(T) < sizeof(int32_t));
+    int32_t tmp;
+    if (!absl::SimpleAtoi(arg, &tmp))
+      return false;
+    *out = static_cast<T>(tmp);
+    return tmp == *out;  // reject values that don't fit T
+  }
+}
+
 // Base for validated numbers: holds the parsed value and converts back to it.
 template <class T> struct VNum {
   T value = {};
@@ -106,8 +137,7 @@ template <class T> struct VNum {
 };
 
 // Validation rules for Next<Validated<T, Rules...>>(): free functions `RuleError rule(T)`. Reusable
-// ones take the message as a reference-to-constexpr NTTP. They also validate values from elsewhere:
-//   if (auto e = SomeRule<...>(v); e.failed) parser.ReportCustom(std::string{e.msg});
+// ones take the message as a reference-to-constexpr NTTP.
 
 // Out of [min, max] -> generic type error (FInt is the idiomatic spelling).
 template <auto min, auto max> RuleError InRange(decltype(min) v) {
@@ -115,8 +145,7 @@ template <auto min, auto max> RuleError InRange(decltype(min) v) {
   return {v < min || v > max, {}};
 }
 
-// Out of [min, max] -> custom Msg. Integer bounds only (floating-point NTTPs need clang 18+; use a
-// dedicated rule for float ranges).
+// Out of [min, max] -> custom Msg. Integer bounds only (float NTTPs need clang 18+).
 template <auto min, auto max, const auto& Msg> RuleError Bounded(decltype(min) v) {
   static_assert(std::is_same_v<decltype(min), decltype(max)>, "inconsistent types");
   return {!(v >= min && v <= max), Msg};
@@ -140,8 +169,7 @@ template <auto Bad, const auto& Msg> RuleError NotEq(decltype(Bad) v) {
   return {v == Bad, Msg};
 }
 
-// Accepts a value only if every rule accepts it; first rejection wins. Each rule is a function
-// T -> RuleError, e.g. Validated<int, Bounded<0, 9, kMsg>>.
+// Accepts a value only if every rule accepts it; first rejection wins.
 template <class T, RuleError (*... Rules)(T)> struct Validated : VNum<T> {
   static RuleError validate(T v) {
     RuleError e;
@@ -289,6 +317,30 @@ struct CmdArgParser {
     }
   }
 
+  // Runs a parser callable (see ParserFn): a fn(CmdArgParser*) drives the parser; a
+  // fn(std::string_view, RuleError&) converts the next arg, its RuleError becoming a report.
+  template <class F>
+  requires ParserFn<F>
+  auto Next(F&& fn) {
+    if constexpr (std::is_invocable_v<F, CmdArgParser*>) {
+      return std::forward<F>(fn)(this);
+    } else {
+      using R = std::invoke_result_t<F, std::string_view, RuleError&>;
+      static_assert(std::is_default_constructible_v<R> && !std::is_reference_v<R>,
+                    "token parser must return a default-constructible value type");
+      if (cur_i_ >= args_.size()) {
+        Report(OUT_OF_BOUNDS, cur_i_);
+        return R{};
+      }
+      size_t idx = cur_i_++;
+      RuleError e;
+      R val = std::forward<F>(fn)(SafeSV(idx), e);
+      if (e.failed)
+        Report(e.msg.empty() ? INVALID_CASES : CUSTOM_ERROR, idx, std::string{e.msg});
+      return e.failed ? R{} : val;
+    }
+  }
+
   // Like Next<T>(), but replaces any read failure (bad value, missing arg, ...) with a caller-
   // supplied CUSTOM_ERROR message. A rule's own message from a Validated<T, Rules...> passes
   // through unchanged, so parser.Next<Timeout>(kNotAFloat) reports kNotAFloat for a non-float but
@@ -336,6 +388,13 @@ struct CmdArgParser {
 
   template <class T = std::string_view> auto NextOrDefault(T default_value = {}) {
     return HasNext() ? Next<T>() : default_value;
+  }
+
+  // Runs a parser callable (see ParserFn) if an arg remains, else returns default_value.
+  template <class F, class D>
+  requires ParserFn<F>
+  auto NextOrDefault(F&& fn, D default_value) {
+    return HasNext() ? Next(std::forward<F>(fn)) : default_value;
   }
 
   // Consumes the next arg; reports INVALID_NEXT if it doesn't match (case-insensitive).
@@ -441,10 +500,18 @@ struct CmdArgParser {
     return *this;
   }
 
-  // Requires no leftover args and no prior errors. Reports UNPROCESSED if args remain.
-  bool Finalize() {
+  // Requires all args consumed and no prior error. If args remain, reports the generic UNPROCESSED
+  // (syntax) error, or "<unexpected_prefix><first leftover arg>" when a prefix is given (built only
+  // on failure). Returns true only if everything was consumed without error.
+  bool Finalize(std::string_view unexpected_prefix = {}) {
     if (HasNext()) {
-      Report(UNPROCESSED, cur_i_);
+      if (unexpected_prefix.empty()) {
+        Report(UNPROCESSED, cur_i_);
+      } else {
+        std::string msg{unexpected_prefix};
+        msg.append(Peek());
+        Report(CUSTOM_ERROR, cur_i_, std::move(msg));
+      }
       return false;
     }
     return !HasError();
@@ -544,31 +611,10 @@ struct CmdArgParser {
   }
 
   template <typename T> T Num(size_t idx) {
-    auto arg = SafeSV(idx);
-    T out;
-    if constexpr (std::is_same_v<T, float>) {
-      if (absl::SimpleAtof(arg, &out))
-        return out;
-    } else if constexpr (std::is_same_v<T, double>) {
-      if (absl::SimpleAtod(arg, &out))
-        return out;
-    } else if constexpr (std::is_integral_v<T> && sizeof(T) >= sizeof(int32_t)) {
-      if (absl::SimpleAtoi(arg, &out))
-        return out;
-    } else if constexpr (std::is_integral_v<T> && sizeof(T) < sizeof(int32_t)) {
-      int32_t tmp;
-      if (absl::SimpleAtoi(arg, &tmp)) {
-        out = tmp;  // out can not store the whole tmp
-        if (tmp == out)
-          return out;
-      }
-    }
-
-    if constexpr (std::is_floating_point_v<T>) {
-      Report(INVALID_FLOAT, idx);
-    } else {
-      Report(INVALID_INT, idx);
-    }
+    T out{};
+    if (TryParseNum(SafeSV(idx), &out))
+      return out;
+    Report(std::is_floating_point_v<T> ? INVALID_FLOAT : INVALID_INT, idx);
     return {};
   }
 
@@ -579,9 +625,34 @@ struct CmdArgParser {
   ErrorInfo error_;
 };
 
+// Default parser callable for arithmetic types: Next(Number<int>) behaves like Next<int>().
+template <class T> T Number(CmdArgParser* parser) {
+  return parser->Next<T>();
+}
+
 namespace detail {
 
-struct ExistOpt {
+// CRTP base for Apply() options: adds a fluent .Err(msg) whose message ReportErr() surfaces on
+// failure (OneOf conflict, nested Tag mismatch), else the generic INVALID_CASES syntax error. The
+// message is owned (copied) so temporaries like absl::StrCat(...) are safe.
+template <class Derived> struct OptBase {
+  std::string err = {};
+
+  Derived&& Err(std::string msg) && {
+    err = std::move(msg);
+    return std::move(static_cast<Derived&>(*this));
+  }
+
+ protected:
+  void ReportErr(CmdArgParser* parser) const {
+    if (err.empty())
+      parser->Report(CmdArgParser::INVALID_CASES);
+    else
+      parser->ReportCustom(err);
+  }
+};
+
+struct ExistOpt : OptBase<ExistOpt> {
   std::string_view tag;
   bool* field;
 
@@ -594,7 +665,7 @@ struct ExistOpt {
   }
 };
 
-template <class... Args> struct TagOpt {
+template <class... Args> struct TagOpt : OptBase<TagOpt<Args...>> {
   std::string_view tag;
   std::tuple<Args*...> args;
 
@@ -612,7 +683,7 @@ template <class... Args> struct TagOpt {
   }
 };
 
-template <class Func> struct LambdaOpt {
+template <class Func> struct LambdaOpt : OptBase<LambdaOpt<Func>> {
   std::string_view tag;
   Func func;
 
@@ -625,7 +696,7 @@ template <class Func> struct LambdaOpt {
   }
 };
 
-template <class T, class... Cases> struct MapOpt {
+template <class T, class... Cases> struct MapOpt : OptBase<MapOpt<T, Cases...>> {
   static_assert(sizeof...(Cases) % 2 == 0, "Map expects alternating tag/value pairs");
 
   T* field;
@@ -648,7 +719,7 @@ template <class T, class... Cases> struct MapOpt {
   }
 };
 
-template <class Inner> struct IfOpt {
+template <class Inner> struct IfOpt : OptBase<IfOpt<Inner>> {
   bool cond;
   Inner inner;
 
@@ -657,7 +728,7 @@ template <class Inner> struct IfOpt {
   }
 };
 
-template <class... Opts> struct OneOfOpt {
+template <class... Opts> struct OneOfOpt : OptBase<OneOfOpt<Opts...>> {
   std::tuple<Opts...> opts;
   mutable bool matched = false;
 
@@ -666,15 +737,15 @@ template <class... Opts> struct OneOfOpt {
     if (!any)
       return false;
     if (matched)
-      parser->Report(CmdArgParser::INVALID_CASES);
+      this->ReportErr(parser);
     matched = true;
     return true;
   }
 };
 
-// Nested: outer tag consumes one arg, then inner option runs against the next arg. If the inner
-// doesn't match, reports INVALID_CASES (the inner keyword is required once the outer matched).
-template <class Inner> struct TagNestedOpt {
+// Outer tag consumes one arg, then the inner option must match the next; otherwise reports
+// .Err(msg) or INVALID_CASES.
+template <class Inner> struct TagNestedOpt : OptBase<TagNestedOpt<Inner>> {
   std::string_view tag;
   Inner inner;
 
@@ -682,7 +753,7 @@ template <class Inner> struct TagNestedOpt {
     if (!parser->Check(tag))
       return false;
     if (!inner.TryApply(parser))
-      parser->Report(CmdArgParser::INVALID_CASES);
+      this->ReportErr(parser);
     return true;
   }
 };
@@ -696,36 +767,36 @@ concept ParseOption = requires(const T& t, CmdArgParser* p) {
 }  // namespace detail
 
 inline detail::ExistOpt Exist(std::string_view tag, bool* field) {
-  return {tag, field};
+  return {{}, tag, field};
 }
 
 template <class... Args> detail::TagOpt<Args...> Tag(std::string_view tag, Args*... args) {
-  return detail::TagOpt<Args...>{tag, std::make_tuple(args...)};
+  return {{}, tag, std::make_tuple(args...)};
 }
 
 template <class Func>
 requires std::is_invocable_v<Func, CmdArgParser*> detail::LambdaOpt<Func> Tag(std::string_view tag,
                                                                               Func func) {
-  return {tag, std::move(func)};
+  return {{}, tag, std::move(func)};
 }
 
 // Nested option: outer tag + inner sub-option (e.g. Map). After outer matches, inner must match
 // the following arg or INVALID_CASES is reported.
 template <detail::ParseOption Inner>
 detail::TagNestedOpt<Inner> Tag(std::string_view tag, Inner inner) {
-  return {tag, std::move(inner)};
+  return {{}, tag, std::move(inner)};
 }
 
 template <class T, class... Cases> detail::MapOpt<T, Cases...> Map(T* field, Cases... cases) {
-  return {field, std::make_tuple(std::move(cases)...)};
+  return {{}, field, std::make_tuple(std::move(cases)...)};
 }
 
 template <class Inner> detail::IfOpt<Inner> If(bool cond, Inner inner) {
-  return {cond, std::move(inner)};
+  return {{}, cond, std::move(inner)};
 }
 
 template <class... Opts> detail::OneOfOpt<Opts...> OneOf(Opts... opts) {
-  return {{std::move(opts)...}, false};
+  return {{}, {std::move(opts)...}};
 }
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -490,6 +490,29 @@ TEST_F(CmdArgParserTest, ApplyOneOf) {
     EXPECT_EQ(count, 5u);
     EXPECT_FALSE(parser.HasError());
   }
+
+  // .Err(msg) reports a custom conflict message instead of the generic syntax error.
+  {
+    auto parser = Make({"NX", "XX"});
+    bool nx = false, xx = false;
+    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)).Err("NX and XX are incompatible"));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
+    EXPECT_EQ(err.MakeReply().ToSv(), "NX and XX are incompatible");
+  }
+
+  // .Err() owns the message: a temporary/short-lived source may be destroyed before Apply runs.
+  {
+    bool nx = false, xx = false;
+    auto opt = [&] {
+      std::string tmp = "dynamic conflict";  // destroyed when this lambda returns
+      return OneOf(Exist("NX", &nx), Exist("XX", &xx)).Err(tmp);
+    }();
+    auto parser = Make({"NX", "XX"});
+    parser.Apply(opt);
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "dynamic conflict");
+  }
 }
 
 TEST_F(CmdArgParserTest, ApplyOptional) {
@@ -712,6 +735,71 @@ TEST_F(CmdArgParserTest, ValidatedDouble) {
   }
 }
 
+// A token parser callable (string_view, RuleError&): converts one arg, custom error on miss.
+constexpr char kBadUnit[] = "bad unit";
+double ParseUnit(std::string_view sv, RuleError& err) {
+  if (sv == "M")
+    return 1.0;
+  if (sv == "KM")
+    return 1000.0;
+  err = {true, kBadUnit};
+  return -1.0;
+}
+
+TEST_F(CmdArgParserTest, ParserFunction) {
+  {  // token form: fn(string_view, RuleError&) converts the next arg
+    auto parser = Make({"KM", "M"});
+    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 1000.0);
+    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 1.0);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {
+    auto parser = Make({"YARD"});
+    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 0.0);  // value-initialized on failure
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
+    EXPECT_EQ(err.MakeReply().ToSv(), kBadUnit);
+  }
+  {
+    auto parser = Make({});  // framework surfaces OUT_OF_BOUNDS before calling fn
+    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 0.0);
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::OUT_OF_BOUNDS);
+  }
+  {  // full form: fn(CmdArgParser*) can consume several args and return a compound type
+    auto parser = Make({"3", "4"});
+    auto point = [](CmdArgParser* p) {
+      int x =
+          p->Next<int>();  // sequence reads explicitly; argument evaluation order is unspecified
+      return std::make_pair(x, p->Next<int>());
+    };
+    auto [x, y] = parser.Next(point);
+    EXPECT_EQ(x, 3);
+    EXPECT_EQ(y, 4);
+    EXPECT_FALSE(parser.HasError());
+  }
+}
+
+TEST_F(CmdArgParserTest, NumberParser) {
+  // The Number<> default parser callable matches the built-in Next<T>() behavior and error kinds.
+  {
+    auto parser = Make({"42", "3.5"});
+    EXPECT_EQ(parser.Next(Number<int>), 42);
+    EXPECT_DOUBLE_EQ(parser.Next(Number<double>), 3.5);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {
+    auto parser = Make({"notanint"});
+    EXPECT_EQ(parser.Next(Number<int>), 0);
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
+  }
+  {
+    auto parser = Make({"notafloat"});
+    EXPECT_DOUBLE_EQ(parser.Next(Number<double>), 0.0);
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_FLOAT);
+  }
+}
+
 TEST_F(CmdArgParserTest, RangeList) {
   using Range = CmdArgParser::Range;
   // NextRange reads [count, e1..eN] and returns a bounded Range; a terminal Range converts to
@@ -850,6 +938,29 @@ TEST_F(CmdArgParserTest, BackedArguments) {
     EXPECT_FALSE(parser.HasAtLeast(3));
     parser.Skip(2);
     EXPECT_TRUE(parser.Finalize());
+  }
+}
+
+TEST_F(CmdArgParserTest, FinalizeUnexpected) {
+  {  // all consumed -> success
+    auto parser = Make({"NX"});
+    EXPECT_TRUE(parser.Check("NX"));
+    EXPECT_TRUE(parser.Finalize("Unsupported option: "));
+    EXPECT_FALSE(parser.HasError());
+  }
+  {  // leftover + empty prefix -> generic UNPROCESSED
+    auto parser = Make({"FOO"});
+    EXPECT_FALSE(parser.Finalize());
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::UNPROCESSED);
+  }
+  {  // leftover + prefix -> custom "<prefix><arg>" (raw case, first leftover arg)
+    auto parser = Make({"a", "foo", "bar"});
+    EXPECT_EQ(parser.Next(), "a");
+    EXPECT_FALSE(parser.Finalize("Unsupported option: "));
+    auto err = parser.TakeError();
+    EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
+    EXPECT_EQ(err.MakeReply().ToSv(), "Unsupported option: foo");
+    EXPECT_EQ(err.index, 1u);  // points at the first leftover arg, not the consumed one
   }
 }
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1124,29 +1124,19 @@ void TtlGeneric(string_view key, TimeUnit unit, CommandContext* cmd_cntx) {
   }
 }
 
-io::Result<int32_t, string> ParseExpireOptionsOrReply(const facade::ParsedArgs& args) {
+int32_t ParseExpireOptions(CmdArgParser* parser) {
   int32_t flags = ExpireFlags::EXPIRE_ALWAYS;
-  for (auto arg : args) {
-    string arg_sv = absl::AsciiStrToUpper(ToSV(arg));
-    if (arg_sv == "NX") {
-      flags |= ExpireFlags::EXPIRE_NX;
-    } else if (arg_sv == "XX") {
-      flags |= ExpireFlags::EXPIRE_XX;
-    } else if (arg_sv == "GT") {
-      flags |= ExpireFlags::EXPIRE_GT;
-    } else if (arg_sv == "LT") {
-      flags |= ExpireFlags::EXPIRE_LT;
-    } else {
-      return nonstd::make_unexpected(absl::StrCat("Unsupported option: ", arg_sv));
-    }
-  }
+  parser->Apply(Tag("NX", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_NX; }),
+                Tag("XX", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_XX; }),
+                Tag("GT", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_GT; }),
+                Tag("LT", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_LT; }));
+  parser->Finalize("Unsupported option: ");
 
-  if ((flags & ExpireFlags::EXPIRE_NX) && (flags & ExpireFlags::EXPIRE_XX)) {
-    return nonstd::make_unexpected("NX and XX options at the same time are not compatible");
-  }
-  if ((flags & ExpireFlags::EXPIRE_GT) && (flags & ExpireFlags::EXPIRE_LT)) {
-    return nonstd::make_unexpected("GT and LT options at the same time are not compatible");
-  }
+  // NX/XX and GT/LT are mutually exclusive; duplicate flags (e.g. NX NX) are tolerated like Redis.
+  if ((flags & ExpireFlags::EXPIRE_NX) && (flags & ExpireFlags::EXPIRE_XX))
+    parser->ReportCustom("NX and XX options at the same time are not compatible");
+  if ((flags & ExpireFlags::EXPIRE_GT) && (flags & ExpireFlags::EXPIRE_LT))
+    parser->ReportCustom("GT and LT options at the same time are not compatible");
   return flags;
 }
 
@@ -1399,20 +1389,16 @@ void GenericFamily::Persist(facade::CmdArgParser parser, CommandContext* cmd_cnt
 
 void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  int32_t expire_options = parser.Next(ParseExpireOptions);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
-  }
-
-  auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
-  if (!expire_options) {
-    return cmd_cntx->SendError(expire_options.error());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     auto op_args = t->GetOpArgs(shard);
     DbSlice::ExpireParams params{TimeUnit::SEC, int_arg, op_args.db_cntx.time_now_ms,
                                  /*cap=*/true};
-    params.expire_options = expire_options.value();
+    params.expire_options = expire_options;
     return OpExpire(op_args, key, params);
   };
 
@@ -1422,17 +1408,14 @@ void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx
 
 void GenericFamily::ExpireAt(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  int32_t expire_options = parser.Next(ParseExpireOptions);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
 
-  auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
-  if (!expire_options) {
-    return cmd_cntx->SendError(expire_options.error());
-  }
   // ExpireParams normalizes 0/negative inputs internally.
   DbSlice::ExpireParams params{TimeUnit::SEC, int_arg};
-  params.expire_options = expire_options.value();
+  params.expire_options = expire_options;
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);
@@ -1470,17 +1453,14 @@ void GenericFamily::Keys(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
 
 void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  int32_t expire_options = parser.Next(ParseExpireOptions);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
 
-  auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
-  if (!expire_options) {
-    return cmd_cntx->SendError(expire_options.error());
-  }
   // ExpireParams normalizes 0/negative inputs internally.
   DbSlice::ExpireParams params{TimeUnit::MSEC, int_arg};
-  params.expire_options = expire_options.value();
+  params.expire_options = expire_options;
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);
@@ -1496,20 +1476,16 @@ void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_c
 
 void GenericFamily::Pexpire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  int32_t expire_options = parser.Next(ParseExpireOptions);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
-  }
-
-  auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
-  if (!expire_options) {
-    return cmd_cntx->SendError(expire_options.error());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     auto op_args = t->GetOpArgs(shard);
     DbSlice::ExpireParams params{TimeUnit::MSEC, int_arg, op_args.db_cntx.time_now_ms,
                                  /*cap=*/true};
-    params.expire_options = expire_options.value();
+    params.expire_options = expire_options;
     return OpExpire(op_args, key, params);
   };
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
@@ -2292,7 +2268,7 @@ void GenericFamily::FieldExpire(facade::CmdArgParser parser, CommandContext* cmd
     return cmd_cntx->SendError(err.MakeReply());
   }
   facade::CmdArgVec fields;
-  auto field_args = cmd_cntx->tail_args().Tail(parser.UnparsedStart());
+  auto field_args = parser.RemainingRange();
   fields.assign(field_args.begin(), field_args.end());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -2315,8 +2291,8 @@ void GenericFamily::FieldExpire(facade::CmdArgParser parser, CommandContext* cmd
 // -1 if the field does not have associated TTL on it, and -3 if field is not found.
 void GenericFamily::FieldTtl(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, field] = parser.Next<string_view, string_view>();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) { return OpFieldTtl(t, shard, key, field); };
@@ -2333,8 +2309,8 @@ void GenericFamily::FieldTtl(facade::CmdArgParser parser, CommandContext* cmd_cn
 
 void GenericFamily::Move(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, target_db] = parser.Next<string_view, int32_t>();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
 
   if (target_db < 0 || uint32_t(target_db) >= absl::GetFlag(FLAGS_dbnum)) {
@@ -2371,8 +2347,8 @@ void GenericFamily::Move(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
 
 void GenericFamily::Rename(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [src_key, dest_key] = parser.Next<string_view, string_view>();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
   auto reply = RenameGeneric(src_key, dest_key, false, cmd_cntx->tx());
   cmd_cntx->SendError(reply);
@@ -2380,8 +2356,8 @@ void GenericFamily::Rename(facade::CmdArgParser parser, CommandContext* cmd_cntx
 
 void GenericFamily::RenameNx(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [src_key, dest_key] = parser.Next<string_view, string_view>();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
   auto reply = RenameGeneric(src_key, dest_key, true, cmd_cntx->tx());
   if (!reply.status) {
@@ -2430,32 +2406,32 @@ void GenericFamily::Copy(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
 
 void GenericFamily::ExpireTime(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
   ExpireTimeGeneric(key, TimeUnit::SEC, cmd_cntx);
 }
 
 void GenericFamily::PExpireTime(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
   ExpireTimeGeneric(key, TimeUnit::MSEC, cmd_cntx);
 }
 
 void GenericFamily::Ttl(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
   TtlGeneric(key, TimeUnit::SEC, cmd_cntx);
 }
 
 void GenericFamily::Pttl(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize()) {
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
   TtlGeneric(key, TimeUnit::MSEC, cmd_cntx);
 }

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -152,6 +152,15 @@ TEST_F(GenericFamilyTest, ExpireOptions) {
   resp = Run({"expire", "key", "3600", "GT", "LT"});
   ASSERT_THAT(resp, ErrArg("GT and LT options at the same time are not compatible"));
 
+  // Duplicate flags are tolerated (idempotent), like Redis.
+  resp = Run({"expire", "key", "3600", "NX", "NX"});
+  ASSERT_THAT(resp, IntArg(1));
+  Run({"persist", "key"});
+
+  // Unknown option -> error naming the offending token.
+  resp = Run({"expire", "key", "3600", "FOO"});
+  ASSERT_THAT(resp, ErrArg("Unsupported option: FOO"));
+
   // NX option should be added since there is no expiry
   resp = Run({"expire", "key", "3600", "NX"});
   EXPECT_THAT(resp, IntArg(1));

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -33,14 +33,12 @@ namespace dfly {
 
 using namespace std;
 using namespace facade;
-using absl::SimpleAtoi;
 namespace {
 
 using CI = CommandId;
 
 enum Errors {
-  INVALID_LONG_LAT = CmdArgParser::ErrorType::CUSTOM_ERROR,
-  INVALID_UNIT = INVALID_LONG_LAT + 1,
+  INVALID_LONG_LAT = CmdArgParser::CUSTOM_ERROR,
 };
 
 const char kNxXxErr[] = "XX and NX options at the same time are not compatible";
@@ -58,22 +56,6 @@ const char kMemberNotFound[] = "could not decode requested zset member";
 const char kInvalidUnit[] = "unsupported unit provided. please use M, KM, FT, MI";
 const char kCountError[] = "ERR COUNT must be > 0";
 constexpr string_view kGeoAlphabet = "0123456789bcdefghjkmnpqrstuvwxyz"sv;
-
-enum class Type {
-  FROMMEMBER,
-  FROMLONLAT,
-  BYRADIUS,
-  BYBOX,
-  ASC,
-  DESC,
-  COUNT,
-  WITHCOORD,
-  WITHDIST,
-  WITHHASH,
-
-  STORE,
-  STOREDIST
-};
 
 using MScoreResponse = std::vector<std::optional<double>>;
 
@@ -186,26 +168,25 @@ bool ToAsciiGeoHash(const std::optional<double>& val, array<char, 12>* buf) {
   return true;
 }
 
-double ExtractUnit(CmdArgParser* parser) {
-  auto unit = parser->TryMapNext("M", 1.0, "KM", 1000.0, "FT", 0.3048, "MI", 1609.34);
-  if (!unit)
-    parser->Report(Errors::INVALID_UNIT);
-  return unit.value_or(-1);
+// Unit token (M/KM/FT/MI) -> meters-per-unit factor.
+double ParseGeoUnit(std::string_view arg, facade::RuleError& err) {
+  const string unit = absl::AsciiStrToUpper(arg);
+  if (unit == "M")
+    return 1;
+  if (unit == "KM")
+    return 1000;
+  if (unit == "FT")
+    return 0.3048;
+  if (unit == "MI")
+    return 1609.34;
+  err = {true, kInvalidUnit};
+  return -1;
 }
 
-double ExtractUnit(std::string_view arg) {
-  const string unit = absl::AsciiStrToUpper(arg);
-  if (unit == "M") {
-    return 1;
-  } else if (unit == "KM") {
-    return 1000;
-  } else if (unit == "FT") {
-    return 0.3048;
-  } else if (unit == "MI") {
-    return 1609.34;
-  } else {
-    return -1;
-  }
+void ParseCircularShape(CmdArgParser* parser, GeoShape* shape, GeoSearchOpts* geo_ops) {
+  shape->t.radius = parser->Next<double>();
+  geo_ops->conversion = shape->conversion = parser->Next(ParseGeoUnit);
+  shape->type = CIRCULAR_TYPE;
 }
 
 bool HandleGeoParserFinalize(const GeoShape& shape, CmdArgParser* parser,
@@ -215,22 +196,47 @@ bool HandleGeoParserFinalize(const GeoShape& shape, CmdArgParser* parser,
   }
 
   auto error = parser->TakeError();
-  switch (error.type) {
-    case Errors::INVALID_LONG_LAT: {
-      string err =
-          absl::StrCat("-ERR invalid longitude,latitude pair ", shape.xy[0], ",", shape.xy[1]);
-      cmd_cntx->SendError(err, kSyntaxErrType);
-      break;
-    }
-    case Errors::INVALID_UNIT:
-      cmd_cntx->SendError("Unsupported unit provided. please use M, KM, FT, MI", kSyntaxErrType);
-      break;
-    default:
-      cmd_cntx->SendError(error.MakeReply());
-      break;
+  // INVALID_LONG_LAT is a geo-specific code reported without a message (it aliases CUSTOM_ERROR);
+  // a real custom message (e.g. from a parser or ReportCustom) is surfaced verbatim via
+  // MakeReply().
+  if (error.custom_msg.empty() && error.type == Errors::INVALID_LONG_LAT) {
+    string err =
+        absl::StrCat("-ERR invalid longitude,latitude pair ", shape.xy[0], ",", shape.xy[1]);
+    cmd_cntx->SendError(err, kSyntaxErrType);
+    return true;
   }
-
+  cmd_cntx->SendError(error.MakeReply());
   return true;
+}
+
+void SetSorting(GeoSearchOpts* geo_ops, Sorting sorting) {
+  geo_ops->sorting = geo_ops->sorting == Sorting::kUnsorted ? sorting : Sorting::kError;
+}
+
+void ParseCount(CmdArgParser* parser, GeoSearchOpts* geo_ops, string_view err_msg = {}) {
+  geo_ops->count = parser->Next<uint64_t>(err_msg);
+  geo_ops->any = parser->Check("ANY");
+}
+
+void SetStore(GeoSearchOpts* geo_ops, GeoStoreType store, string_view key) {
+  geo_ops->store_key = key;
+  geo_ops->store = geo_ops->store == GeoStoreType::kNoStore ? store : GeoStoreType::kError;
+}
+
+void ParseGeoResultOptions(CmdArgParser* parser, GeoSearchOpts* geo_ops, bool allow_store,
+                           string_view count_err = {}) {
+  parser->Apply(Tag("ASC", [&](CmdArgParser*) { SetSorting(geo_ops, Sorting::kAsc); }),
+                Tag("DESC", [&](CmdArgParser*) { SetSorting(geo_ops, Sorting::kDesc); }),
+                Tag("COUNT", [&](CmdArgParser* p) { ParseCount(p, geo_ops, count_err); }),
+                Exist("WITHCOORD", &geo_ops->withcoord), Exist("WITHDIST", &geo_ops->withdist),
+                Exist("WITHHASH", &geo_ops->withhash),
+                If(allow_store, Tag("STORE",
+                                    [&](CmdArgParser* p) {
+                                      SetStore(geo_ops, GeoStoreType::kStoreHash, p->Next());
+                                    })),
+                If(allow_store, Tag("STOREDIST", [&](CmdArgParser* p) {
+                     SetStore(geo_ops, GeoStoreType::kStoreDist, p->Next());
+                   })));
 }
 
 void CmdGeoAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
@@ -250,10 +256,7 @@ void CmdGeoAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   }
 
   auto* builder = cmd_cntx->rb();
-  vector<string_view> args;
-  while (parser.HasNext()) {
-    args.push_back(parser.Next());
-  }
+  auto args = parser.RemainingRange();
   if (args.empty() || args.size() % 3 != 0) {
     builder->SendError(kSyntaxErr);
     return;
@@ -337,7 +340,6 @@ void CmdGeoPos(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdGeoDist(CmdArgParser parser, CommandContext* cmd_cntx) {
-  double distance_multiplier = 1;
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   // GEODIST key member1 member2 [unit]. The unit is trailing/optional, so it can't be part of the
@@ -347,16 +349,9 @@ void CmdGeoDist(CmdArgParser parser, CommandContext* cmd_cntx) {
     arg = parser.Next();
 
   // Optional trailing unit; Finalize() rejects both a missing required arg and any trailing args.
-  std::string_view unit = parser.NextOrDefault();
+  double distance_multiplier = parser.NextOrDefault(ParseGeoUnit, 1.0);
   if (!parser.Finalize()) {
     return rb->SendError(parser.TakeError().MakeReply());
-  }
-
-  if (!unit.empty()) {
-    distance_multiplier = ExtractUnit(unit);
-    if (distance_multiplier < 0) {
-      return rb->SendError(kInvalidUnit);
-    }
   }
 
   OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(
@@ -625,81 +620,48 @@ void CmdGeoSearch(CmdArgParser parser, CommandContext* cmd_cntx) {
   GeoShape shape = {};
   GeoSearchOpts geo_ops;
   string_view member;
-
-  // FROMMEMBER or FROMLONLAT is set
-  int from_set = 0;
-  // BYRADIUS or BYBOX is set
-  int by_set = 0;
+  bool from_set = false, by_set = false;
   auto* builder = cmd_cntx->rb();
 
   string_view key = parser.Next();
 
-  while (parser.HasNext()) {
-    auto type = parser.MapNext(
-        "FROMMEMBER", Type::FROMMEMBER, "FROMLONLAT", Type::FROMLONLAT, "BYRADIUS", Type::BYRADIUS,
-        "BYBOX", Type::BYBOX, "ASC", Type::ASC, "DESC", Type::DESC, "COUNT", Type::COUNT,
-        "WITHCOORD", Type::WITHCOORD, "WITHDIST", Type::WITHDIST, "WITHHASH", Type::WITHHASH);
-
-    switch (type) {
-      case Type::FROMMEMBER:
-        ++from_set;
-        member = parser.Next();
-        break;
-      case Type::FROMLONLAT: {
-        ++from_set;
-        ParseLongLat(&parser, shape.xy);
-        break;
-      }
-      case Type::BYRADIUS:
-        ++by_set;
-        shape.t.radius = parser.Next<double>();
-        shape.conversion = ExtractUnit(&parser);
-        geo_ops.conversion = shape.conversion;
-        shape.type = CIRCULAR_TYPE;
-        break;
-      case Type::BYBOX: {
-        ++by_set;
-        std::tie(shape.t.r.width, shape.t.r.height) = parser.Next<double, double>();
-        shape.conversion = ExtractUnit(&parser);
-        geo_ops.conversion = shape.conversion;
-        shape.type = RECTANGLE_TYPE;
-        break;
-      }
-      case Type::ASC:
-        geo_ops.sorting = geo_ops.sorting == Sorting::kUnsorted ? Sorting::kAsc : Sorting::kError;
-        break;
-      case Type::DESC:
-        geo_ops.sorting = geo_ops.sorting == Sorting::kUnsorted ? Sorting::kDesc : Sorting::kError;
-        break;
-      case Type::COUNT:
-        geo_ops.count = parser.Next<uint64_t>();
-        geo_ops.any = parser.Check("ANY");
-        break;
-      case Type::WITHCOORD:
-        geo_ops.withcoord = true;
-        break;
-      case Type::WITHDIST:
-        geo_ops.withdist = true;
-        break;
-      case Type::WITHHASH:
-        geo_ops.withhash = true;
-        break;
-      default:
-        return builder->SendError(kSyntaxErr);
-    }
-  }
+  parser.Apply(OneOf(Tag("FROMMEMBER",
+                         [&](CmdArgParser* p) {
+                           from_set = true;
+                           member = p->Next();
+                         }),
+                     Tag("FROMLONLAT",
+                         [&](CmdArgParser* p) {
+                           from_set = true;
+                           ParseLongLat(p, shape.xy);
+                         }))
+                   .Err(kFromMemberLonglatErr),
+               OneOf(Tag("BYRADIUS",
+                         [&](CmdArgParser* p) {
+                           by_set = true;
+                           ParseCircularShape(p, &shape, &geo_ops);
+                         }),
+                     Tag("BYBOX",
+                         [&](CmdArgParser* p) {
+                           by_set = true;
+                           std::tie(shape.t.r.width, shape.t.r.height) = p->Next<double, double>();
+                           geo_ops.conversion = shape.conversion = p->Next(ParseGeoUnit);
+                           shape.type = RECTANGLE_TYPE;
+                         }))
+                   .Err(kByRadiusBoxErr),
+               Tag("ASC", [&](CmdArgParser*) { SetSorting(&geo_ops, Sorting::kAsc); }),
+               Tag("DESC", [&](CmdArgParser*) { SetSorting(&geo_ops, Sorting::kDesc); }),
+               Tag("COUNT", [&](CmdArgParser* p) { ParseCount(p, &geo_ops); }),
+               Exist("WITHCOORD", &geo_ops.withcoord), Exist("WITHDIST", &geo_ops.withdist),
+               Exist("WITHHASH", &geo_ops.withhash));
 
   if (HandleGeoParserFinalize(shape, &parser, cmd_cntx)) {
     return;
   }
 
   // check mandatory options
-  if (from_set == 0 || by_set == 0) {
+  if (!from_set || !by_set) {
     return builder->SendError(kSyntaxErr);
-  } else if (from_set > 1) {
-    return builder->SendError(kFromMemberLonglatErr);
-  } else if (by_set > 1) {
-    return builder->SendError(kByRadiusBoxErr);
   } else if (geo_ops.sorting == Sorting::kError) {
     return builder->SendError(kAscDescErr);
   } else if (geo_ops.count == 0) {
@@ -719,73 +681,21 @@ void GeoRadiusByMemberGeneric(CmdArgParser parser, CommandContext* cmd_cntx, boo
   string_view member = parser.Next();
 
   auto* builder = cmd_cntx->rb();
-  if (!ParseDouble(parser.Next(), &shape.t.radius)) {
-    return builder->SendError(kInvalidFloatErr);
-  }
-  shape.conversion = ExtractUnit(parser.Next());
-  geo_ops.conversion = shape.conversion;
-  if (shape.conversion == -1) {
-    return builder->SendError("unsupported unit provided. please use M, KM, FT, MI");
-  }
-  shape.type = CIRCULAR_TYPE;
+  ParseCircularShape(&parser, &shape, &geo_ops);
 
-  while (parser.HasNext()) {
-    string cur_arg = absl::AsciiStrToUpper(parser.Next());
+  ParseGeoResultOptions(&parser, &geo_ops, !read_only, kSyntaxErr);
 
-    if (cur_arg == "ASC") {
-      if (geo_ops.sorting != Sorting::kUnsorted) {
-        return builder->SendError(kAscDescErr);
-      }
-      geo_ops.sorting = Sorting::kAsc;
-    } else if (cur_arg == "DESC") {
-      if (geo_ops.sorting != Sorting::kUnsorted) {
-        return builder->SendError(kAscDescErr);
-      }
-      geo_ops.sorting = Sorting::kDesc;
-    } else if (cur_arg == "COUNT") {
-      if (!parser.HasNext() || !absl::SimpleAtoi(parser.Next(), &geo_ops.count)) {
-        return builder->SendError(kSyntaxErr);
-      }
-      if (geo_ops.count == 0) {
-        return builder->SendError(kCountError);
-      }
-      if (parser.HasNext() && parser.Peek() == "ANY") {
-        geo_ops.any = true;
-        parser.Skip(1);
-      }
-    } else if (cur_arg == "WITHCOORD") {
-      geo_ops.withcoord = true;
-    } else if (cur_arg == "WITHDIST") {
-      geo_ops.withdist = true;
-    } else if (cur_arg == "WITHHASH") {
-      geo_ops.withhash = true;
-    } else if (cur_arg == "STORE" && !read_only) {
-      if (geo_ops.store != GeoStoreType::kNoStore) {
-        return builder->SendError(kStoreTypeErr);
-      }
-      if (parser.HasNext()) {
-        geo_ops.store_key = parser.Next();
-        geo_ops.store = GeoStoreType::kStoreHash;
-      } else {
-        return builder->SendError(kSyntaxErr);
-      }
-    } else if (cur_arg == "STOREDIST" && !read_only) {
-      if (geo_ops.store != GeoStoreType::kNoStore) {
-        return builder->SendError(kStoreTypeErr);
-      }
-      if (parser.HasNext()) {
-        geo_ops.store_key = parser.Next();
-        geo_ops.store = GeoStoreType::kStoreDist;
-      } else {
-        return builder->SendError(kSyntaxErr);
-      }
-    } else {
-      return builder->SendError(kSyntaxErr);
-    }
+  if (HandleGeoParserFinalize(shape, &parser, cmd_cntx)) {
+    return;
   }
 
-  if ((geo_ops.withcoord || geo_ops.withdist || geo_ops.withhash) &&
-      geo_ops.store != GeoStoreType::kNoStore) {
+  if (geo_ops.sorting == Sorting::kError) {
+    return builder->SendError(kAscDescErr);
+  } else if (geo_ops.store == GeoStoreType::kError) {
+    return builder->SendError(kStoreTypeErr);
+  } else if (geo_ops.count == 0) {
+    return builder->SendError(kCountError);
+  } else if (geo_ops.HasWithStatement() && geo_ops.store != GeoStoreType::kNoStore) {
     return builder->SendError(kStoreCompatByMemberErr);
   }
 
@@ -801,64 +711,9 @@ void GeoRadiusGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool read_o
 
   string_view key = parser.Next();
   ParseLongLat(&parser, shape.xy);
-  shape.t.radius = parser.Next<double>();
-  shape.conversion = ExtractUnit(&parser);
-  geo_ops.conversion = shape.conversion;
-  shape.type = CIRCULAR_TYPE;
+  ParseCircularShape(&parser, &shape, &geo_ops);
 
-  while (parser.HasNext()) {
-    // try and parse for only RO options first
-    auto type =
-        parser.TryMapNext("ASC", Type::ASC, "DESC", Type::DESC, "COUNT", Type::COUNT, "WITHCOORD",
-                          Type::WITHCOORD, "WITHDIST", Type::WITHDIST, "WITHHASH", Type::WITHHASH);
-    // if writing variant and there there was a mapping failure test for write variant arguments
-    if (!type && !read_only) {
-      type = parser.MapNext("STORE", Type::STORE, "STOREDIST", Type::STOREDIST);
-    }
-
-    // could not map the argument to an argument for RO or write GEORADIUS
-    if (!type) {
-      return builder->SendError("syntax error", kSyntaxErrType);
-    }
-
-    switch (*type) {
-      case Type::STORE:
-        geo_ops.store_key = parser.Next();
-        geo_ops.store = geo_ops.store == GeoStoreType::kNoStore ? GeoStoreType::kStoreHash
-                                                                : GeoStoreType::kError;
-        break;
-      case Type::STOREDIST:
-        geo_ops.store_key = parser.Next();
-        geo_ops.store = geo_ops.store == GeoStoreType::kNoStore ? GeoStoreType::kStoreDist
-                                                                : GeoStoreType::kError;
-        break;
-      case Type::ASC:
-        geo_ops.sorting = geo_ops.sorting == Sorting::kUnsorted ? Sorting::kAsc : Sorting::kError;
-        break;
-      case Type::DESC:
-        geo_ops.sorting = geo_ops.sorting == Sorting::kUnsorted ? Sorting::kDesc : Sorting::kError;
-        break;
-      case Type::COUNT:
-        geo_ops.count = parser.Next<uint64_t>();
-        geo_ops.any = parser.Check("ANY");
-        break;
-      case Type::WITHCOORD:
-        geo_ops.withcoord = true;
-        break;
-      case Type::WITHDIST:
-        geo_ops.withdist = true;
-        break;
-      case Type::WITHHASH:
-        geo_ops.withhash = true;
-        break;
-      default:
-        // If MapNext failed, it means an unknown option was provided or
-        // an option requiring an argument was missing its argument.
-        // The parser has already recorded the error.
-        DCHECK(parser.HasError());
-        break;
-    }
-  }
+  ParseGeoResultOptions(&parser, &geo_ops, !read_only);
 
   if (HandleGeoParserFinalize(shape, &parser, cmd_cntx)) {
     return;
@@ -872,8 +727,7 @@ void GeoRadiusGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool read_o
     return builder->SendError(kCountError);
   }
 
-  if ((geo_ops.withcoord || geo_ops.withdist || geo_ops.withhash) &&
-      geo_ops.store != GeoStoreType::kNoStore) {
+  if (geo_ops.HasWithStatement() && geo_ops.store != GeoStoreType::kNoStore) {
     return builder->SendError(kStoreCompatRadErr);
   }
 

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -255,6 +255,14 @@ TEST_F(GeoFamilyTest, GeoRadiusByMember) {
   resp = Run("GEOADD t 13.361389 38.115556 a 13.3619 38.1159 b 13.3608 38.1152 c");
   resp = Run("GEOSEARCH t FROMLONLAT 13.361389 38.115556 BYRADIUS 1 KM COUNT 0");
   EXPECT_THAT(resp, ErrArg("ERR COUNT must be > 0"));
+
+  // A non-numeric COUNT must report a syntax error, not be misrendered as an invalid lon/lat pair
+  // (the geo-specific error codes alias CmdArgParser::CUSTOM_ERROR).
+  resp = Run("GEORADIUSBYMEMBER Sicily Agrigento 100 km COUNT notanumber");
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run("GEORADIUSBYMEMBER Sicily Agrigento 100 badunit");
+  EXPECT_THAT(resp, ErrArg("unsupported unit provided. please use M, KM, FT, MI"));
 }
 
 TEST_F(GeoFamilyTest, GeoRadiusByMemberRO) {

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -396,12 +396,9 @@ std::optional<JsonGetParams> ParseJsonGetParams(CmdArgParser* parser, SinkReplyB
   while (parser->HasNext()) {
     if (parser->Check("NOESCAPE")) {
       parsed_args.no_escape = true;
-    } else if (parser->Check("SPACE")) {
-      parsed_args.space = parser->Next();
-    } else if (parser->Check("NEWLINE")) {
-      parsed_args.new_line = parser->Next();
-    } else if (parser->Check("INDENT")) {
-      parsed_args.indent = parser->Next();
+    } else if (parser->Check("SPACE", &parsed_args.space) ||
+               parser->Check("NEWLINE", &parsed_args.new_line) ||
+               parser->Check("INDENT", &parsed_args.indent)) {
     } else {
       std::string_view path_str = parser->Next();
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -122,8 +122,7 @@ search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
     } else if (parser->Check("EF_CONSTRUCTION", &params.hnsw_ef_construction)) {
     } else if (parser->Check("TYPE")) {
       params.data_type = absl::AsciiStrToUpper(parser->Next<string_view>());
-    } else if (parser->Check("EF_RUNTIME")) {
-      params.hnsw_ef_runtime = parser->Next<uint32_t>();
+    } else if (parser->Check("EF_RUNTIME", &params.hnsw_ef_runtime)) {
     } else if (parser->Check("EPSILON")) {
       double epsilon = parser->Next<double>("Invalid EPSILON value");
       if (!params.use_hnsw) {
@@ -192,29 +191,14 @@ void ParseTextWeight(CmdArgParser* parser, search::SchemaField::TextParams* para
 
 ParseResult<search::SchemaField::TextParams> ParseTextParams(CmdArgParser* parser) {
   search::SchemaField::TextParams params{};
-  while (parser->HasNext()) {
-    if (parser->Check("WITHSUFFIXTRIE")) {
-      params.with_suffixtrie = true;
-      continue;
-    }
-    if (parser->Check("NOSTEM")) {
-      params.no_stem = true;
-      continue;
-    }
-    if (parser->Check("WEIGHT")) {
-      ParseTextWeight(parser, &params);
-      continue;
-    }
-    break;
-  }
+  parser->Apply(Exist("WITHSUFFIXTRIE", &params.with_suffixtrie), Exist("NOSTEM", &params.no_stem),
+                Tag("WEIGHT", [&](CmdArgParser* p) { ParseTextWeight(p, &params); }));
   return params;
 }
 
 search::SchemaField::NumericParams ParseNumericParams(CmdArgParser* parser) {
   search::SchemaField::NumericParams params{};
-  if (parser->Check("BLOCKSIZE")) {
-    params.block_size = parser->Next<size_t>();
-  }
+  parser->Check("BLOCKSIZE", &params.block_size);
   return params;
 }
 
@@ -390,7 +374,7 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
           absl::StrCat("Field type "sv, parser->Next(), " is not supported"sv));
     }
 
-    auto parsed_params = params_parser.value()(parser);
+    auto parsed_params = parser->Next(params_parser.value());
     if (!parsed_params) {
       return make_unexpected(parsed_params.error());
     }
@@ -564,9 +548,7 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
 
   while (parser->HasNext()) {
     // [LIMIT offset total]
-    if (parser->Check("LIMIT")) {
-      params.limit_offset = parser->Next<size_t>();
-      params.limit_total = parser->Next<size_t>();
+    if (parser->Check("LIMIT", &params.limit_offset, &params.limit_total)) {
       if (params.limit_total > max_results) {
         return CreateSyntaxError(absl::StrFormat("LIMIT exceeds maximum of %d", max_results));
       }
@@ -603,8 +585,8 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
       params.scorer = *scorer;
     } else if (parser->Check("BM25STD_TANH_FACTOR")) {
       tanh_factor = ParseBM25StdTanhFactor(parser);
-    } else if (parser->Check("DIALECT")) {
-      parser->Skip(1);  // Accepted and ignored — DF always behaves as dialect 2
+    } else if (std::string_view ignored; parser->Check("DIALECT", &ignored)) {
+      // Accepted and ignored — DF always behaves as dialect 2.
     } else {
       // Unsupported parameters are ignored for now
       parser->Skip(1);
@@ -826,9 +808,9 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
     }
 
     // LIMIT
-    if (parser->Check("LIMIT")) {
+    size_t offset = 0, num = 0;
+    if (parser->Check("LIMIT", &offset, &num)) {
       has_pipeline_step = true;
-      auto [offset, num] = parser->Next<size_t, size_t>();
       if (params.joins.empty() || params.join_agg_params.HasLimit()) {
         params.steps.push_back(aggregate::MakeLimitStep(offset, num));
       } else {
@@ -839,10 +821,10 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
     }
 
     // FILTER "expr"
-    if (parser->Check("FILTER")) {
+    std::string_view filter_expr;
+    if (parser->Check("FILTER", &filter_expr)) {
       has_pipeline_step = true;
-      std::string filter_expr{parser->Next<std::string_view>()};
-      auto step_or_err = aggregate::MakeFilterStep(filter_expr);
+      auto step_or_err = aggregate::MakeFilterStep(std::string{filter_expr});
       if (std::holds_alternative<std::string>(step_or_err)) {
         return CreateSyntaxError(
             absl::StrCat("FILTER expression error: ", std::get<std::string>(step_or_err)));
@@ -863,18 +845,18 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
     }
 
     // DIALECT (accepted and ignored — DF always behaves as dialect 2)
-    if (parser->Check("DIALECT")) {
-      parser->Skip(1);
+    std::string_view ignored_dialect;
+    if (parser->Check("DIALECT", &ignored_dialect)) {
       continue;
     }
 
     // APPLY "expr" AS alias
-    if (parser->Check("APPLY")) {
+    std::string_view expr;
+    if (parser->Check("APPLY", &expr)) {
       has_pipeline_step = true;
-      string expr{parser->Next<string_view>()};
       parser->ExpectTag("AS");
       string alias = parser->Next<string>();
-      auto step_or_err = aggregate::MakeApplyStep(expr, std::move(alias));
+      auto step_or_err = aggregate::MakeApplyStep(std::string{expr}, std::move(alias));
       if (std::holds_alternative<std::string>(step_or_err)) {
         return CreateSyntaxError(
             absl::StrCat("APPLY expression error: ", std::get<std::string>(step_or_err)));

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3613,46 +3613,42 @@ void ServerFamily::Latency(facade::CmdArgParser parser, CommandContext* cmd_cntx
 void ServerFamily::ShutdownCmd(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // Supported options (case-insensitive):
   // SAVE | NOSAVE, NOW, FORCE, ABORT, SAFE (Valkey-specific, the same as SAVE in Dragonfly)
-  enum ShutBits : uint32_t {
-    SB_SAVE = 1u << 0,
-    SB_NOSAVE = 1u << 1,
-    SB_NOW = 1u << 2,
-    SB_FORCE = 1u << 3,
-    SB_ABORT = 1u << 4,
-  };
+  struct ShutdownOpts {
+    bool save = false;
+    bool no_save = false;
+    bool now = false;
+    bool force = false;
+    bool abort = false;
+  } opts;
 
-  uint32_t sb = 0;
-  while (parser.HasNext()) {
-    // Map SAFE to SAVE directly (fallthrough behavior)
-    ShutBits opt = parser.MapNext("SAVE", SB_SAVE, "NOSAVE", SB_NOSAVE, "NOW", SB_NOW, "FORCE",
-                                  SB_FORCE, "ABORT", SB_ABORT, "SAFE", SB_SAVE);
-    sb |= static_cast<uint32_t>(opt);
-  }
+  parser.Apply(Exist("SAVE", &opts.save), Exist("SAFE", &opts.save), Exist("NOSAVE", &opts.no_save),
+               Exist("NOW", &opts.now), Exist("FORCE", &opts.force), Exist("ABORT", &opts.abort));
 
-  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  if (!parser.Finalize())
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
 
-  // Conflicting toggles
-  if ((sb & SB_SAVE) && (sb & SB_NOSAVE)) {
+  // SAVE/SAFE (synonyms) and NOSAVE are mutually exclusive.
+  if (opts.save && opts.no_save) {
     return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  if (sb & SB_ABORT) {
+  if (opts.abort) {
     // We currently do not support aborting an in-progress shutdown sequence.
     return cmd_cntx->SendError("SHUTDOWN ABORT is not supported");
   }
 
   // Configure save behavior on shutdown according to options.
-  if (sb & SB_FORCE) {
+  if (opts.force) {
     // FORCE implies no snapshot on shutdown regardless of SAVE/SAFE
     save_on_shutdown_ = false;
-  } else if (sb & SB_NOSAVE) {
+  } else if (opts.no_save) {
     save_on_shutdown_ = false;
-  } else if (sb & SB_SAVE) {
+  } else if (opts.save) {
     save_on_shutdown_ = true;
   }
 
   // Wire NOW/FORCE to a single fast-shutdown flag for listeners.
-  facade::g_shutdown_fast.store((sb & (SB_NOW | SB_FORCE)) != 0, std::memory_order_seq_cst);
+  facade::g_shutdown_fast.store(opts.now || opts.force, std::memory_order_seq_cst);
 
   CHECK_NOTNULL(acceptor_)->Stop();
   cmd_cntx->rb()->SendOk();

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -56,6 +56,8 @@ using namespace util;
 
 using CI = CommandId;
 
+constexpr char kOffsetOutOfRange[] = "offset is out of range";
+
 // Either immediately available value or tiering future + result
 template <typename T> using TResultOrT = variant<T, TieredStorage::TResult<T>>;
 
@@ -1070,9 +1072,7 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
         return NegativeExpire{};
 
       tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
-    } else if (parser.Check("_MCFLAGS")) {
-      sparams.memcache_flags = parser.Next<uint32_t>();
-    } else {
+    } else if (!parser.Check("_MCFLAGS", &sparams.memcache_flags)) {
       uint16_t flag = parser.MapNext(  //
           "GET", SetCmd::SET_GET, "STICK", SetCmd::SET_STICK, "KEEPTTL", SetCmd::SET_KEEP_EXPIRE,
           "XX", SetCmd::SET_IF_EXISTS, "NX", SetCmd::SET_IF_NOTEXIST);
@@ -1189,12 +1189,11 @@ cmd::CmdR CmdSet(CmdArgParser parser, CommandContext* cmd_cntx) {
 cmd::CmdR CmdSetExGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view cmd_name = cmd_cntx->cid()->name();
   auto [key, exp_int, value] = parser.Next<string_view, int64_t, string_view>();
+  if (exp_int < 1)
+    parser.ReportCustom(InvalidExpireTime(cmd_name));
 
   if (auto err = parser.TakeError(); err)
     co_return err.MakeReply();
-
-  if (exp_int < 1)
-    co_return facade::ErrorReply{InvalidExpireTime(cmd_name)};
 
   const ExpT type = cmd_name.front() == 'P' ? ExpT::PX : ExpT::EX;
   const uint64_t now_ms = GetCurrentTimeMs();
@@ -1660,15 +1659,13 @@ cmd::CmdR CmdGetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 cmd::CmdR CmdSetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, start, value] = parser.Next<string_view, int32_t, string_view>();
+  using SetRangeOffset = Validated<int32_t, NonNegative<kOffsetOutOfRange>>;
+  auto [key, offset, value] = parser.Next<string_view, SetRangeOffset, string_view>();
 
   if (auto err = parser.TakeError(); err)
     co_return err.MakeReply();
 
-  if (start < 0) {
-    co_return facade::ErrorReply{"offset is out of range"};
-  }
-
+  size_t start = offset;
   if (size_t min_size = start + value.size(); min_size > kMaxStrLen) {
     co_return facade::ErrorReply{"string exceeds maximum allowed size"};
   }

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1777,42 +1777,26 @@ void ZRangeGeneric(facade::ParsedArgs args, ZSetFamily::RangeParams range_params
   facade::CmdArgParser parser{args.Tail().Tail().Tail()};
   using RP = ZSetFamily::RangeParams;
 
-  while (true) {
-    RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  auto set_interval = [&](RP::IntervalType interval) {
+    return [&, interval](CmdArgParser* p) {
+      if (exchange(range_params.interval_type, interval) ==
+          (interval == RP::SCORE ? RP::LEX : RP::SCORE)) {
+        p->ReportCustom("BYSCORE and BYLEX options are not compatible");
+      }
+    };
+  };
 
-    if (!parser.HasNext())
-      break;
+  parser.Apply(Tag("BYSCORE", set_interval(RP::SCORE)), Tag("BYLEX", set_interval(RP::LEX)),
+               Exist("REV", &range_params.reverse), Exist("WITHSCORES", &range_params.with_scores),
+               Tag("LIMIT", [&](CmdArgParser* p) {
+                 auto [offset, limit] = p->Next<int32_t, int32_t>();
+                 range_params.limit = limit < 0 ? UINT32_MAX : static_cast<uint32_t>(limit);
+                 range_params.offset = offset < 0 ? UINT32_MAX : static_cast<uint32_t>(offset);
+               }));
 
-    if (parser.Check("BYSCORE")) {
-      if (exchange(range_params.interval_type, RP::SCORE) == RP::LEX)
-        return cmd_cntx->SendError("BYSCORE and BYLEX options are not compatible");
-      continue;
-    }
+  parser.Finalize("unsupported option ");
 
-    if (parser.Check("BYLEX")) {
-      if (exchange(range_params.interval_type, RP::LEX) == RP::SCORE)
-        return cmd_cntx->SendError("BYSCORE and BYLEX options are not compatible");
-      continue;
-    }
-    if (parser.Check("REV")) {
-      range_params.reverse = true;
-      continue;
-    }
-    if (parser.Check("WITHSCORES")) {
-      range_params.with_scores = true;
-      continue;
-    }
-
-    if (parser.Check("LIMIT")) {
-      auto [offset, limit] = parser.Next<int32_t, int32_t>();
-
-      range_params.limit = limit < 0 ? UINT32_MAX : static_cast<uint32_t>(limit);
-      range_params.offset = offset < 0 ? UINT32_MAX : static_cast<uint32_t>(offset);
-      continue;
-    }
-
-    return cmd_cntx->SendError(absl::StrCat("unsupported option ", parser.Peek()));
-  }
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   if (range_params.offset == UINT32_MAX) {
     auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());


### PR DESCRIPTION
Summary: This PR extends facade::CmdArgParser with callable-based parsing and richer error reporting, then migrates several command families to the new APIs for more consistent option handling.

Changes:

- Add Next(fn) / NextOrDefault(fn, default) for parser callables (either token-converters or full parser-driven functions).
- Refactor numeric parsing with TryParseNum and introduce Number<T> as a default callable for numeric types.
- Enhance Finalize() with an optional unexpected-arg prefix, and add RemainingRange() for consuming tail arguments.
- Introduce option-level .Err(msg) (owned string) to surface custom conflict/mismatch errors from OneOf and nested tags.
- Update unit tests for .Err(), parser callables, Number<>, and Finalize(prefix).
- Migrate option parsing in Generic/Geo/JSON/Search/Server/String/ZSet families to use Apply, Check(tag, &out...), and callable parsing.

Technical Notes: Several commands now rely on Finalize() to reject trailing args and on parser-surfaced CUSTOM_ERROR messages for unsupported options and conflicts.