### PR TITLE
feat(tiered): add --tiered_writes_cooling_bypass to keep write bursts out of the cool pool

### DIFF
--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -13,6 +13,7 @@
 #include <variant>
 
 #include "absl/cleanup/cleanup.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/flags/internal/flag.h"
 #include "absl/functional/bind_front.h"
 #include "absl/functional/overload.h"
@@ -63,6 +64,12 @@ ABSL_FLAG(float, tiered_upload_threshold, 0.1,
 ABSL_FLAG(bool, tiered_experimental_hash_support, false, "Experimental hash datatype offloading");
 
 ABSL_FLAG(bool, tiered_experimental_list_support, false, "Experimental list node offloading");
+
+ABSL_FLAG(bool, tiered_writes_cooling_bypass, false,
+          "If true, values offloaded as a result of a write/overwrite are externalized straight "
+          "to disk instead of being retained in the in-RAM cooling pool. Prevents write-heavy "
+          "bursts from evicting genuinely read-hot entries out of the cool pool; reads still "
+          "upload values back into RAM. Only takes effect when tiered_experimental_cooling is on");
 
 ABSL_FLAG(uint32, tiered_min_ttl_to_offload_ms, 5000,
           "Min remaining TTL in ms for a value to be eligible for offloading");
@@ -154,9 +161,18 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       : tiering::OpManager{max_size}, ts_{ts}, db_slice_{*db_slice} {
   }
 
+  // Records that the stash for (dbid, key) should bypass the cooling pool and go disk-only. The
+  // intent must survive the async stash gap (write path -> async stash -> SetExternal), so it is
+  // kept in a per-shard set instead of a PrimeValue state bit. Only populated when bypass is set,
+  // so it stays empty in the common case.
+  void MarkCoolingBypass(DbIndex dbid, std::string_view key) {
+    cooling_bypass_pending_.emplace(dbid, key);
+  }
+
   // Clear Stash pending flag for entry
   void ClearStashPending(OpManager::KeyRef key) {
     UnblockBackpressure(key, false);
+    cooling_bypass_pending_.erase(key);
     if (auto pv = Find(key.first, key.second); pv) {
       pv->SetStashPending(false);
       stats_.total_cancels++;
@@ -181,6 +197,10 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   void CancelStash(tiering::KeyRef id, size_t size) {
     UnblockBackpressure(id, false);
+    // A cancelled stash never reaches SetExternal/ClearStashPending, so drop any bypass marker
+    // here to avoid a stale entry (which could wrongly bypass cooling on a later stash of the
+    // same key, or leak). Covers both the own-page and small-bin sub-cases below.
+    cooling_bypass_pending_.erase(id);
     // TODO: Don't recompute size estimate, try-delete bin first
     if (OccupiesWholePages(size)) {
       CancelPending(id);
@@ -269,7 +289,13 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       stats_.total_stashes++;
 
       StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
-      if (ts_->config_.experimental_cooling) {
+
+      // A write/overwrite driven stash bypasses the cooling pool (see
+      // --tiered_writes_cooling_bypass) and goes disk-only, so write bursts don't evict read-hot
+      // entries. The intent is carried in cooling_bypass_pending_ across the async stash gap.
+      bool bypass = cooling_bypass_pending_.erase(key) > 0;
+
+      if (ts_->config_.experimental_cooling && !bypass) {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
       } else {
@@ -322,6 +348,12 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   // When we don't have memory to upload a page for defragmentation, we save it here to do it later
   std::deque<uint32_t /* page index (kPageSize) */> delayed_defrag_queue_;
+
+  // Keys whose in-flight stash should bypass the cooling pool (see --tiered_writes_cooling_bypass).
+  // Stored as owning DbKeyId with heterogeneous lookup, so we can probe with an OpManager::KeyRef
+  // (which holds a string_view) without allocating. Populated only when bypass is requested.
+  absl::flat_hash_set<tiering::DbKeyId, tiering::detail::Hasher, tiering::detail::Eq>
+      cooling_bypass_pending_;
 
   TieredStorage* ts_;
   DbSlice& db_slice_;
@@ -523,6 +555,11 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
   tiering::OpManager::PendingId id;
   error_code ec;
 
+  // Carry the cooling-bypass intent per-key across the async stash gap. Done per-key (not per-bin)
+  // so small-bin batching keeps per-key granularity. Cleaned up in ClearStashPending on abort.
+  if (blobs.bypass_cooling)
+    op_manager_->MarkCoolingBypass(dbid, key);
+
   if (OccupiesWholePages(est_size)) {  // large enough for own page
     id = KeyRef(dbid, key);
     auto serialize = absl::bind_front(&StashDescriptor::Serialize, &blobs);
@@ -638,6 +675,7 @@ void TieredStorage::UpdateFromFlags() {
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
       .experimental_list_offload = absl::GetFlag(FLAGS_tiered_experimental_list_support),
+      .writes_cooling_bypass = absl::GetFlag(FLAGS_tiered_writes_cooling_bypass),
       .min_ttl_to_offload_ms = absl::GetFlag(FLAGS_tiered_min_ttl_to_offload_ms),
   };
 
@@ -651,7 +689,7 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
                             FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
                             FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
                             FLAGS_tiered_experimental_list_support,
-                            FLAGS_tiered_min_ttl_to_offload_ms);
+                            FLAGS_tiered_writes_cooling_bypass, FLAGS_tiered_min_ttl_to_offload_ms);
 }
 
 bool TieredStorage::ShouldOffload() const {
@@ -862,6 +900,11 @@ void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, Pri
           ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk.GetExpireTime()});
       blobs) {
     pv->SetStashPending(true);
+    // This is the write path (proactive offload driven by an edit). Request cooling-pool bypass so
+    // the value is externalized straight to disk. Background/scan-driven offload (RunOffloading)
+    // does not go through here and keeps the normal cooling behavior. The intent is carried on the
+    // StashDescriptor (not a PrimeValue bit) and recorded per-key inside StashPrimeValue.
+    blobs->bypass_cooling = ts->BypassCoolingForWrites();
     ts->StashPrimeValue(dbid, key, *blobs, backpressure);
   }
 }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -13,7 +13,6 @@
 #include <variant>
 
 #include "absl/cleanup/cleanup.h"
-#include "absl/container/flat_hash_set.h"
 #include "absl/flags/internal/flag.h"
 #include "absl/functional/bind_front.h"
 #include "absl/functional/overload.h"
@@ -161,18 +160,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       : tiering::OpManager{max_size}, ts_{ts}, db_slice_{*db_slice} {
   }
 
-  // Records that the stash for (dbid, key) should bypass the cooling pool and go disk-only. The
-  // intent must survive the async stash gap (write path -> async stash -> SetExternal), so it is
-  // kept in a per-shard set instead of a PrimeValue state bit. Only populated when bypass is set,
-  // so it stays empty in the common case.
-  void MarkCoolingBypass(DbIndex dbid, std::string_view key) {
-    cooling_bypass_pending_.emplace(dbid, key);
-  }
-
   // Clear Stash pending flag for entry
   void ClearStashPending(OpManager::KeyRef key) {
     UnblockBackpressure(key, false);
-    cooling_bypass_pending_.erase(key);
     if (auto pv = Find(key.first, key.second); pv) {
       pv->SetStashPending(false);
       stats_.total_cancels++;
@@ -197,10 +187,6 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   void CancelStash(tiering::KeyRef id, size_t size) {
     UnblockBackpressure(id, false);
-    // A cancelled stash never reaches SetExternal/ClearStashPending, so drop any bypass marker
-    // here to avoid a stale entry (which could wrongly bypass cooling on a later stash of the
-    // same key, or leak). Covers both the own-page and small-bin sub-cases below.
-    cooling_bypass_pending_.erase(id);
     // TODO: Don't recompute size estimate, try-delete bin first
     if (OccupiesWholePages(size)) {
       CancelPending(id);
@@ -232,14 +218,21 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   // Load all values from bin by their hashes
   void Defragment(tiering::DiskSegment segment, string_view value);
 
-  void NotifyStashed(const OwnedEntryId& id,
+  void NotifyStashed(const OwnedEntryId& id, bool bypass_cooling,
                      const io::Result<tiering::DiskSegment>& segment) override {
     if (!segment) {
       VLOG(1) << "Stash failed " << segment.error().message();
       visit([this](auto id) { ClearStashPending(id); }, id);
-    } else {
-      visit([this, segment](auto id) { SetExternal(id, *segment); }, id);
+      return;
     }
+    // Only the own-page (single PrimeValue) stash can carry a cooling-bypass decision. Small bins
+    // record it per-key and consume it via ReportStashed; list nodes never enter the cooling pool.
+    visit(absl::Overload{
+              [&](const tiering::DbKeyId& key) { SetExternal(key, bypass_cooling, *segment); },
+              [&](uintptr_t bin_id) { SetExternal(tiering::SmallBins::BinId(bin_id), *segment); },
+              [&](const tiering::ListNodeId& node) { SetExternal(node, *segment); },
+          },
+          id);
   }
 
   bool NotifyFetched(const OwnedEntryId& id, tiering::DiskSegment segment,
@@ -277,8 +270,11 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   // Find entry by key in db_slice and store external segment in place of original value.
-  // Update memory stats
-  void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment) {
+  // Update memory stats. When bypass_cooling is set (a write/overwrite driven stash, see
+  // --tiered_writes_cooling_bypass), the value goes disk-only instead of into the cooling pool, so
+  // write bursts don't evict read-hot entries. The intent is carried on the stash across the async
+  // gap (own-page: OpManager stash flag; small-bin: per-key in SmallBins), not a PrimeValue bit.
+  void SetExternal(OpManager::KeyRef key, bool bypass_cooling, tiering::DiskSegment segment) {
     UnblockBackpressure(key, true);
     if (auto* pv = Find(key.first, key.second); pv) {
       auto* stats = GetDbTableStats(key.first);
@@ -290,12 +286,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
       StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
 
-      // A write/overwrite driven stash bypasses the cooling pool (see
-      // --tiered_writes_cooling_bypass) and goes disk-only, so write bursts don't evict read-hot
-      // entries. The intent is carried in cooling_bypass_pending_ across the async stash gap.
-      bool bypass = cooling_bypass_pending_.erase(key) > 0;
-
-      if (ts_->config_.experimental_cooling && !bypass) {
+      if (ts_->config_.experimental_cooling && !bypass_cooling) {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
       } else {
@@ -307,13 +298,15 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     }
   }
 
-  // Find bin by id and call SetExternal for all contained entries
+  // Find bin by id and call SetExternal for all contained entries, each with its own per-key
+  // cooling-bypass flag recorded in SmallBins (a bin may mix write-path and background entries).
   void SetExternal(tiering::SmallBins::BinId id, tiering::DiskSegment segment) {
-    for (const auto& [sub_dbid, sub_key, sub_segment] : ts_->bins_->ReportStashed(id, segment))
-      SetExternal({sub_dbid, sub_key}, sub_segment);
+    for (const auto& [sub_dbid, sub_key, sub_bypass, sub_segment] :
+         ts_->bins_->ReportStashed(id, segment))
+      SetExternal({sub_dbid, sub_key}, sub_bypass, sub_segment);
   }
 
-  // Finalize stash for a fragments identified by pointer
+  // Finalize stash for a fragments identified by pointer. List nodes never enter the cooling pool.
   void SetExternal(tiering::ListNodeId id, tiering::DiskSegment segment) {
     auto* stats = GetDbTableStats(std::get<0>(id));
 
@@ -348,12 +341,6 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   // When we don't have memory to upload a page for defragmentation, we save it here to do it later
   std::deque<uint32_t /* page index (kPageSize) */> delayed_defrag_queue_;
-
-  // Keys whose in-flight stash should bypass the cooling pool (see --tiered_writes_cooling_bypass).
-  // Stored as owning DbKeyId with heterogeneous lookup, so we can probe with an OpManager::KeyRef
-  // (which holds a string_view) without allocating. Populated only when bypass is requested.
-  absl::flat_hash_set<tiering::DbKeyId, tiering::detail::Hasher, tiering::detail::Eq>
-      cooling_bypass_pending_;
 
   TieredStorage* ts_;
   DbSlice& db_slice_;
@@ -555,19 +542,20 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
   tiering::OpManager::PendingId id;
   error_code ec;
 
-  // Carry the cooling-bypass intent per-key across the async stash gap. Done per-key (not per-bin)
-  // so small-bin batching keeps per-key granularity. Cleaned up in ClearStashPending on abort.
-  if (blobs.bypass_cooling)
-    op_manager_->MarkCoolingBypass(dbid, key);
-
+  // Carry the cooling-bypass intent across the async stash gap without a side table. For an
+  // own-page stash it rides the OpManager stash flag; for a small-bin stash it is recorded per-key
+  // inside SmallBins (a bin may mix write-path and background entries) and echoed via
+  // ReportStashed.
   if (OccupiesWholePages(est_size)) {  // large enough for own page
     id = KeyRef(dbid, key);
     auto serialize = absl::bind_front(&StashDescriptor::Serialize, &blobs);
-    ec = op_manager_->PrepareAndStash(id, est_size, serialize);
-  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs)); bin) {
+    ec = op_manager_->PrepareAndStash(id, est_size, serialize, blobs.bypass_cooling);
+  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs), blobs.bypass_cooling);
+             bin) {
     id = bin->id;
     auto serialize = absl::bind_front(&tiering::SmallBins::SerializeBin, bins_.get(), &*bin);
-    ec = op_manager_->PrepareAndStash(id, 4_KB, serialize);
+    // Bin-level flag is unused: the per-key bypass is recorded inside SmallBins (above).
+    ec = op_manager_->PrepareAndStash(id, 4_KB, serialize, /*bypass_cooling=*/false);
   } else {
     return;  // added to bin, no operations pending
   }
@@ -928,7 +916,8 @@ void TieredStorage::StashPartialValue(tiering::PendingId id, const StashDescript
 
   auto serialize = absl::bind_front(&StashDescriptor::Serialize, &blobs);
 
-  error_code ec = op_manager_->PrepareAndStash(id, est_size, serialize);
+  // List nodes never enter the cooling pool, so cooling bypass does not apply.
+  error_code ec = op_manager_->PrepareAndStash(id, est_size, serialize, /*bypass_cooling=*/false);
   if (ec) {
     bool to_log = ec != errc::file_too_large && ec != errc::operation_would_block &&
                   ec != errc::operation_in_progress;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -37,6 +37,10 @@ struct TieredStorageBase {
         : tiering::FragmentRef::SerializationDescr(params) {
     }
 
+    // When true, this stash bypasses the in-RAM cooling pool and is externalized straight to disk
+    // (see --tiered_writes_cooling_bypass).
+    bool bypass_cooling = false;
+
     size_t EstimatedSerializedSize() const;
     size_t Serialize(io::MutableBytes buffer) const;
   };
@@ -130,6 +134,12 @@ class TieredStorage : public TieredStorageBase {
     return is_closed_;
   }
 
+  // True if write/overwrite driven stashes should bypass the cooling pool and be externalized
+  // straight to disk. Only meaningful when the cooling pool is enabled.
+  bool BypassCoolingForWrites() const {
+    return config_.writes_cooling_bypass && config_.experimental_cooling;
+  }
+
  private:
   void ReadInternal(tiering::ReadId, const tiering::DiskSegment& segment,
                     const tiering::Decoder& decoder,
@@ -165,6 +175,7 @@ class TieredStorage : public TieredStorageBase {
     float upload_threshold;
     bool experimental_hash_offload;
     bool experimental_list_offload;
+    bool writes_cooling_bypass;
     uint32_t min_ttl_to_offload_ms;
   } config_;
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -31,6 +31,7 @@ ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
 ABSL_DECLARE_FLAG(uint64_t, registered_buffer_size);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_hash_support);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_list_support);
+ABSL_DECLARE_FLAG(bool, tiered_writes_cooling_bypass);
 ABSL_DECLARE_FLAG(unsigned, list_tiering_threshold);
 ABSL_DECLARE_FLAG(int32_t, list_max_listpack_size);
 
@@ -151,6 +152,41 @@ TEST_P(LatentCoolingTSTest, SimpleGetSet) {
   metrics = GetMetrics();
   EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0);
   EXPECT_EQ(metrics.db_stats[0].tiered_used_bytes, 0);
+}
+
+// With cooling enabled, a written+stashed value normally lands in the in-RAM cooling pool. When
+// --tiered_writes_cooling_bypass is on, the write path requests a cooling-pool bypass so the stash
+// goes straight to disk, leaving the cool pool (and thus read-hot entries) untouched.
+TEST_F(TieredStorageTest, WritesCoolingBypass) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);     // force offloading
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);  // stashes land in the cooling pool
+  UpdateFromFlags();
+
+  const int kLen = 4000;
+
+  // Baseline: cold overwrites disabled -> the stashed value is retained in the cooling pool, so
+  // cold_storage_bytes grows.
+  SetFlag(&FLAGS_tiered_writes_cooling_bypass, false);
+  UpdateFromFlags();
+  Run({"SET", "hot", BuildString(kLen)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  size_t cool_baseline = GetMetrics().tiered_stats.cold_storage_bytes;
+  EXPECT_GT(cool_baseline, 0u);
+
+  // Cold overwrites enabled -> the stashed value bypasses the cooling pool and goes disk-only, so
+  // cold_storage_bytes does not grow for it.
+  SetFlag(&FLAGS_tiered_writes_cooling_bypass, true);
+  UpdateFromFlags();
+  Run({"SET", "cold", BuildString(kLen)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 2; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.tiered_stats.cold_storage_bytes, cool_baseline);  // unchanged by the cold SET
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 2);
+
+  // The cold value is still readable (uploaded back from disk on access).
+  EXPECT_EQ(Run({"GET", "cold"}), BuildString(kLen));
 }
 
 TEST_P(LatentCoolingTSTest, StrLen) {

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -106,13 +106,13 @@ void OpManager::DeleteOffloaded(DiskSegment segment) {
 }
 
 void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
-                      util::fb2::RegisteredSlice buf) {
+                      util::fb2::RegisteredSlice buf, bool bypass_cooling) {
   auto id = ToOwned(id_ref);
   unsigned version = ++pending_stash_counter_;
   pending_stash_ver_[id] = version;
 
-  auto io_cb = [this, version, id = std::move(id), segment](std::error_code ec) {
-    ProcessStashed(id, version,
+  auto io_cb = [this, version, id = std::move(id), segment, bypass_cooling](std::error_code ec) {
+    ProcessStashed(id, version, bypass_cooling,
                    ec ? nonstd::make_unexpected(ec) : io::Result<DiskSegment>(segment));
   };
 
@@ -121,13 +121,14 @@ void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
 }
 
 std::error_code OpManager::PrepareAndStash(PendingId id, size_t length,
-                                           const std::function<size_t(io::MutableBytes)>& writer) {
+                                           const std::function<size_t(io::MutableBytes)>& writer,
+                                           bool bypass_cooling) {
   auto buf = PrepareStash(length);
   if (!buf.has_value())
     return buf.error();
 
   size_t written = writer(buf->second.bytes);
-  Stash(id, {buf->first, written}, buf->second);
+  Stash(id, {buf->first, written}, buf->second, bypass_cooling);
   return {};
 }
 
@@ -145,12 +146,12 @@ OpManager::ReadOp& OpManager::PrepareRead(DiskSegment aligned_segment) {
   return it->second;
 }
 
-void OpManager::ProcessStashed(const OwnedEntryId& id, unsigned version,
+void OpManager::ProcessStashed(const OwnedEntryId& id, unsigned version, bool bypass_cooling,
                                const io::Result<DiskSegment>& segment) {
   if (auto it = pending_stash_ver_.find(id);
       it != pending_stash_ver_.end() && it->second == version) {
     pending_stash_ver_.erase(it);
-    NotifyStashed(id, segment);
+    NotifyStashed(id, bypass_cooling, segment);
   } else if (segment) {
     // Throw away the value because it's no longer up-to-date even if no error occured
     VLOG(1) << "Releasing segment " << *segment << ", id: " << ToString(id);

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -70,13 +70,15 @@ class OpManager {
     return storage_.PrepareStash(length);
   }
 
-  // Stash value to be offloaded. It is opaque to OpManager.
-  void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::RegisteredSlice buf);
+  // Stash value to be offloaded. It is opaque to OpManager. bypass_cooling is carried across the
+  // async stash and handed back verbatim to NotifyStashed; OpManager itself never acts on it.
+  void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::RegisteredSlice buf,
+             bool bypass_cooling);
 
   // PrepareStash + Stash via function
   std::error_code PrepareAndStash(
       PendingId id, size_t length,
-      const std::function<size_t /*written*/ (io::MutableBytes)>& writer);
+      const std::function<size_t /*written*/ (io::MutableBytes)>& writer, bool bypass_cooling);
 
   Stats GetStats() const;
 
@@ -84,8 +86,9 @@ class OpManager {
   using OwnedEntryId = std::variant<uintptr_t, DbKeyId, ListNodeId>;
 
   // Notify that a stash succeeded and the entry was stored at the provided segment or failed with
-  // given error
-  virtual void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment) = 0;
+  // given error. bypass_cooling is the bit passed to Stash/PrepareAndStash, echoed back here.
+  virtual void NotifyStashed(const OwnedEntryId& id, bool bypass_cooling,
+                             const io::Result<DiskSegment>& segment) = 0;
 
   // Notify that an entry was successfully fetched. Includes whether entry was modified.
   // Returns true if value needs to be deleted from the storage.
@@ -138,7 +141,7 @@ class OpManager {
   void ProcessRead(size_t offset, io::Result<std::string_view> value);
 
   // Called once Stash finished
-  void ProcessStashed(const OwnedEntryId& id, unsigned version,
+  void ProcessStashed(const OwnedEntryId& id, unsigned version, bool bypass_cooling,
                       const io::Result<DiskSegment>& segment);
 
  private:

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -65,7 +65,8 @@ struct OpManagerTest : PoolTestBase, OpManager {
     return future;
   }
 
-  void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment) override {
+  void NotifyStashed(const OwnedEntryId& id, bool bypass_cooling,
+                     const io::Result<DiskSegment>& segment) override {
     VLOG(1) << std::get<0>(id) << " stashed";
     ASSERT_TRUE(segment);
     auto [it, inserted] = stashed_.emplace(id, *segment);
@@ -83,10 +84,13 @@ struct OpManagerTest : PoolTestBase, OpManager {
   }
 
   std::error_code Stash(PendingId id, std::string_view value) {
-    return PrepareAndStash(id, value.size(), [=](io::MutableBytes bytes) {
-      memcpy(bytes.data(), value.data(), value.size());
-      return value.size();
-    });
+    return PrepareAndStash(
+        id, value.size(),
+        [=](io::MutableBytes bytes) {
+          memcpy(bytes.data(), value.data(), value.size());
+          return value.size();
+        },
+        /*bypass_cooling=*/false);
   }
 
   void WaitForPendingStashes() {

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -27,7 +27,7 @@ size_t StashedValueSize(string_view value) {
 }  // namespace
 
 std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_view key,
-                                                     std::string_view value) {
+                                                     std::string_view value, bool bypass_cooling) {
   DCHECK_LT(value.size(), 2_KB);
 
   size_t value_bytes = StashedValueSize(value);
@@ -38,7 +38,8 @@ std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_v
   }
 
   current_bin_.bytes_ += value_bytes;
-  auto [it, inserted] = current_bin_.entries_.emplace(std::make_pair(dbid, key), string(value));
+  auto [it, inserted] = current_bin_.entries_.emplace(std::make_pair(dbid, key),
+                                                      BinValue{string(value), bypass_cooling});
   CHECK(inserted);
 
   return filled_bin;
@@ -65,11 +66,13 @@ size_t SmallBins::SerializeBin(FilledBin* bin, io::MutableBytes dest) {
   }
 
   // Store all values with sizes, n * (2 + x) bytes
-  for (const auto& [key, value] : bin->entries_) {
+  for (const auto& [key, bin_value] : bin->entries_) {
+    const std::string& value = bin_value.value;
     absl::little_endian::Store16(data, value.size());
     data += sizeof(uint16_t);
 
-    pending_set[key] = {size_t(data - dest.data()), value.size()};
+    pending_set[key] = {DiskSegment{size_t(data - dest.data()), value.size()},
+                        bin_value.bypass_cooling};
     memcpy(data, value.data(), value.size());
     data += value.size();
   }
@@ -94,11 +97,12 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
 
   uint16_t bytes = 0;
   SmallBins::KeySegmentList list;
-  for (auto& [key, sub_segment] : seg_map) {
+  for (auto& [key, location] : seg_map) {
+    const DiskSegment& sub_segment = location.segment;
     bytes += sub_segment.length;
 
     DiskSegment real_segment{segment.offset + sub_segment.offset, sub_segment.length};
-    list.emplace_back(key.first, key.second, real_segment);
+    list.emplace_back(key.first, key.second, location.bypass_cooling, real_segment);
   }
 
   stats_.stashed_entries_cnt += list.size();
@@ -120,7 +124,7 @@ std::vector<std::pair<DbIndex, std::string>> SmallBins::ReportStashAborted(BinId
 std::optional<SmallBins::BinId> SmallBins::Delete(DbIndex dbid, std::string_view key) {
   auto& entries = current_bin_.entries_;
   if (auto it = entries.find(make_pair(dbid, key)); it != entries.end()) {
-    size_t stashed_size = StashedValueSize(it->second);
+    size_t stashed_size = StashedValueSize(it->second.value);
     DCHECK_GE(current_bin_.bytes_, stashed_size);
 
     current_bin_.bytes_ -= stashed_size;

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -37,6 +37,13 @@ class SmallBins {
     bool fragmented = false, empty = false;
   };
 
+  // A pending value together with its per-key cooling-pool bypass flag. Kept per-key so a bin that
+  // mixes write-path and background entries preserves each entry's disposition.
+  struct BinValue {
+    std::string value;
+    bool bypass_cooling = false;
+  };
+
   // Packaged bin ready to be serialized with SerializeBin()
   struct FilledBin {
     friend class SmallBins;
@@ -47,11 +54,13 @@ class SmallBins {
     }
 
     unsigned bytes_ = 0;
-    tiering::EntryMap<std::string> entries_;
+    tiering::EntryMap<BinValue> entries_;
   };
 
-  // List of locations of values for corresponding keys of previously filled bin
-  using KeySegmentList = std::vector<std::tuple<DbIndex, std::string /* key*/, DiskSegment>>;
+  // List of locations of values for corresponding keys of previously filled bin, each with the
+  // per-key cooling-pool bypass flag recorded at Stash() time.
+  using KeySegmentList = std::vector<
+      std::tuple<DbIndex, std::string /* key*/, bool /* bypass_cooling */, DiskSegment>>;
 
   // List of item key db indices and hashes
   using KeyHashDbList = std::vector<std::tuple<DbIndex, uint64_t /* hash */, DiskSegment>>;
@@ -61,8 +70,10 @@ class SmallBins {
     return current_bin_.entries_.count(std::make_pair(dbid, key)) > 0;
   }
 
-  // Enqueue key/value pair for stash. Returns page to be stashed if it filled up.
-  std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value);
+  // Enqueue key/value pair for stash. Returns page to be stashed if it filled up. bypass_cooling is
+  // recorded per-key alongside the value and echoed back through ReportStashed().
+  std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value,
+                                 bool bypass_cooling);
 
   // Report that a stash succeeeded. Returns list of stored keys with calculated value locations.
   KeySegmentList ReportStashed(BinId id, DiskSegment segment);
@@ -99,8 +110,14 @@ class SmallBins {
   BinId last_bin_id_ = 0;
   FilledBin current_bin_{last_bin_id_};
 
-  // Pending stashes, their keys and value sizes
-  absl::flat_hash_map<unsigned /* id */, tiering::EntryMap<DiskSegment>> pending_bins_;
+  // In-page location of a pending value plus its per-key cooling-pool bypass flag.
+  struct PendingLocation {
+    DiskSegment segment;
+    bool bypass_cooling = false;
+  };
+
+  // Pending stashes, their keys and in-page locations
+  absl::flat_hash_map<unsigned /* id */, tiering::EntryMap<PendingLocation>> pending_bins_;
 
   // Map of bins that were stashed and should be deleted when number of entries reaches 0
   absl::flat_hash_map<size_t /*offset*/, StashInfo> stashed_bins_;

--- a/src/server/tiering/small_bins_test.cc
+++ b/src/server/tiering/small_bins_test.cc
@@ -4,6 +4,7 @@
 
 #include "server/tiering/small_bins.h"
 
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 
 #include <algorithm>
@@ -37,15 +38,38 @@ TEST_F(SmallBinsTest, SimpleStashRead) {
   // Fill single bin
   std::optional<SmallBins::FilledBin> bin;
   for (unsigned i = 0; !bin; i++)
-    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), /*bypass_cooling=*/false);
   auto [id, data] = Serialize(*bin);
 
   // Verify cut locations point to correct values
   auto segments = bins_.ReportStashed(id, DiskSegment{0, 4_KB});
-  for (auto [dbid, key, location] : segments) {
+  for (auto [dbid, key, bypass_cooling, location] : segments) {
     auto value = "v"s + key.substr(1);
     EXPECT_EQ(value, data.substr(location.offset, location.length));
   }
+}
+
+// The per-key cooling-pool bypass flag must round-trip through Stash -> SerializeBin ->
+// ReportStashed, preserved per entry even when a single bin mixes bypassed and non-bypassed keys.
+TEST_F(SmallBinsTest, BypassCoolingRoundTrip) {
+  // Fill a single bin, alternating the bypass flag per key (bypass == key index is even).
+  std::optional<SmallBins::FilledBin> bin;
+  for (unsigned i = 0; !bin; i++)
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), /*bypass_cooling=*/i % 2 == 0);
+  auto [id, data] = Serialize(*bin);
+
+  auto segments = bins_.ReportStashed(id, DiskSegment{0, 4_KB});
+  unsigned flagged = 0, unflagged = 0;
+  for (auto& [dbid, key, bypass_cooling, location] : segments) {
+    unsigned idx = 0;
+    CHECK(absl::SimpleAtoi(key.substr(1), &idx));
+    EXPECT_EQ(bypass_cooling, idx % 2 == 0) << key;
+    (bypass_cooling ? flagged : unflagged)++;
+  }
+
+  // The bin must actually mix both flag values, otherwise the per-key check is vacuous.
+  EXPECT_GT(flagged, 0u);
+  EXPECT_GT(unflagged, 0u);
 }
 
 TEST_F(SmallBinsTest, SimpleDeleteAbort) {
@@ -55,7 +79,7 @@ TEST_F(SmallBinsTest, SimpleDeleteAbort) {
   std::optional<SmallBins::FilledBin> bin;
   unsigned i = 0;
   for (; !bin; i++)
-    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), /*bypass_cooling=*/false);
   auto [id, data] = Serialize(*bin);
 
   // Delete all even values
@@ -78,7 +102,7 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
   std::optional<SmallBins::FilledBin> bin;
   unsigned i = 0;
   for (; !bin; i++)
-    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), /*bypass_cooling=*/false);
   auto [id, data] = Serialize(*bin);
 
   // Delete all even values
@@ -89,13 +113,13 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
 
   // Expect all odd keys still to exist
   EXPECT_EQ(segments.size(), i / 2);
-  for (auto& [dbid, key, segment] : segments) {
+  for (auto& [dbid, key, bypass_cooling, segment] : segments) {
     EXPECT_EQ(key, "k"s + data.substr(segment.offset, segment.length).substr(1));
   }
 
   // Delete all stashed values
   while (!segments.empty()) {
-    auto segment = std::get<2>(segments.back());
+    auto segment = std::get<DiskSegment>(segments.back());
     segments.pop_back();
     auto bin = bins_.Delete(segment);
 
@@ -113,7 +137,8 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
 TEST_F(SmallBinsTest, UpdateStatsAfterDelete) {
   // caused https://github.com/dragonflydb/dragonfly/issues/3240
   for (unsigned i = 0; i < 10; i++) {
-    auto spilled_bin = bins_.Stash(0, absl::StrCat("k", i), SmallString(128));
+    auto spilled_bin =
+        bins_.Stash(0, absl::StrCat("k", i), SmallString(128), /*bypass_cooling=*/false);
     ASSERT_FALSE(spilled_bin);
   }
 


### PR DESCRIPTION
## Summary

Adds an opt-in flag `--tiered_writes_cooling_bypass` (default `false`) that keeps **write/overwrite-driven** offloads out of the in-RAM cooling pool, so a burst of writes can no longer evict genuinely read-hot values down to disk.

## Motivation

When the tiered cooling layer (`--tiered_experimental_cooling`) is enabled, **every** offloaded value is retained in the in-RAM cooling pool (`cool_queue_`) — including values offloaded on the write/overwrite path. The cool pool is a fixed-size FIFO read cache; when it fills, `ReclaimMemory`/`PopCool` evicts from the back.

This hurts a common tiered-storage workload: **a large periodic write/refresh job mixed with latency-sensitive reads** (e.g. a catalog/geo dataset bulk-refreshed on a schedule while served read-heavy the rest of the time). During the refresh, the overwrite traffic streams freshly-written (cold, not-yet-read) values into the cooling pool, pushing genuinely read-hot entries out of RAM and onto disk — a read-latency regression that tracks the write job.

The write values don't belong in a *read* cache: nothing has read them yet. Retaining them only pays off if they're read back soon, which is not the case for a refresh/ingest job.

## What this changes

With `--tiered_writes_cooling_bypass=true`:

- Values offloaded via the **write path** are externalized **straight to disk**, bypassing the cooling pool.
- **Reads are unchanged** — a read still uploads the value back into RAM, so the read-hot working set is (re)admitted by actual reads, not by writes.
- **Background/scan-driven offload** (`RunOffloading`) is unaffected and keeps the normal cooling behavior.
- Only takes effect when `--tiered_experimental_cooling` is on. Default `false` → **zero behavior change unless explicitly enabled.**

## Implementation

The bypass intent is decided on the write path (`ShouldStash`) but consumed at stash completion (`SetExternal`), which is separated from the write by the async stash. It rides on the stash itself — **no side table**:

- A `bool bypass_cooling` on `StashDescriptor` (the "how to stash" option), set on the write path.
- It is carried across the async gap through `OpManager::Stash`/`PrepareAndStash` as an opaque `bypass_cooling` argument that is echoed back at completion via `NotifyStashed`/`ProcessStashed`. For an own-page (single-`PrimeValue`) stash the bit flows straight into `SetExternal(key, bypass_cooling, segment)`.
- For small-bin stashes the flag is recorded **per-key inside `SmallBins`** (the bin yields `[dbid, key, bypass, segment]` tuples), so batching preserves granularity when a bin mixes write-path and background entries; the bin-level flag is unused. List-node stashes never enter the cooling pool.
- At completion `SetExternal` calls `CoolDown` only when `experimental_cooling && !bypass_cooling`; otherwise it externalizes straight to disk (`PrimeValue::SetExternal`).

No `CompactObj`/`PrimeValue` state bit and no per-shard side set — the intent is passed as a stash parameter (per review; the earlier `cooling_bypass_pending_` map was dropped in `eb8a27a`).

## Benefit to users

- Makes the "write-heavy refresh + read-hot serving" pattern viable on tiered storage — the cool pool stays populated with values that are actually read, so read latency no longer degrades during write bursts.
- Fully opt-in and orthogonal to existing tiering behavior; off by default.

## Testing

- Added `TieredStorageTest.WritesCoolingBypass`: with cooling on, a stashed write grows `cold_storage_bytes` when the flag is off, and leaves it unchanged (disk-only) when the flag is on, while the value remains readable (uploaded back on access).
- CI is green across all build variants (including both `-Werror` g++ builds and the ubuntu-24 sanitizer build) and the test suite.

## Follow-up (not in this PR)

This addresses the **insertion** side (keep write-driven values out of the cool pool). A complementary **eviction**-side change — SIEVE/second-chance on cool eviction (`PopCool`), reusing the existing `touched` bit — would protect read-hot cooled values regardless of how they entered, and would make this insertion-side flag less necessary. Happy to follow up separately if the direction is agreeable.

