### PR TITLE
refactor(server): migrate StartMultiLockedAhead chain to ParsedArgs

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2036,7 +2036,7 @@ void Service::CallFromScript(Interpreter::CallArgs& ca, CommandContext* cmd_cntx
       {
         CmdArgVec keys(info->key_backing.begin(), info->key_backing.end());
         tx->MultiSwitchCmd(registry_.Find("EVAL"));
-        tx->StartMultiLockedAhead(cntx->ns, cntx->db_index(), keys, false);
+        tx->StartMultiLockedAhead(cntx->ns, cntx->db_index(), CmdArgList{keys}, keys.size(), false);
       }
       return;
     case CT::ACALL:
@@ -2136,7 +2136,8 @@ Transaction::MultiMode DetermineMultiMode(ScriptMgr::ScriptParams params) {
 
 // Starts multi transaction. Returns true if transaction was scheduled.
 // Skips scheduling if multi mode requires declaring keys, but no keys were declared.
-bool StartMulti(ConnectionContext* cntx, Transaction::MultiMode tx_mode, CmdArgList keys) {
+bool StartMulti(ConnectionContext* cntx, Transaction::MultiMode tx_mode,
+                const facade::ParsedArgs& args, size_t num_keys) {
   Transaction* tx = cntx->transaction;
   DCHECK(tx);
   Namespace* ns = cntx->ns;
@@ -2147,9 +2148,9 @@ bool StartMulti(ConnectionContext* cntx, Transaction::MultiMode tx_mode, CmdArgL
       tx->StartMultiGlobal(ns, dbid);
       return true;
     case Transaction::LOCK_AHEAD:
-      if (keys.empty())
+      if (num_keys == 0)
         return false;
-      tx->StartMultiLockedAhead(ns, dbid, keys);
+      tx->StartMultiLockedAhead(ns, dbid, args, num_keys);
       return true;
     case Transaction::NON_ATOMIC:
       tx->StartMultiNonAtomic();
@@ -2252,11 +2253,6 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, 
     cmd_cntx->SetupTx(cid, cmd_cntx->tx());
   };
 
-  CmdArgVec tx_keys;  // TODO: remove this once we get rid of CmdArgList in transaction
-  tx_keys.reserve(eval_args.num_keys);
-  for (unsigned i = 0; i < eval_args.num_keys; ++i)
-    tx_keys.push_back(eval_args.keys_args[i]);
-
   if (CanRunSingleShardMulti(sid.has_value(), script_mode, *tx)) {
     sinfo->stats.tx_shards = 1;
     // It might be that there are no declared keys, but there is only a single shard
@@ -2275,7 +2271,8 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, 
     });
 
     ++ss->stats.eval_shardlocal_coordination_cnt;
-    tx->PrepareSingleSquash(conn_cntx->ns, real_sid, conn_cntx->db_index(), tx_keys, script_mode);
+    tx->PrepareSingleSquash(conn_cntx->ns, real_sid, conn_cntx->db_index(), eval_args.keys_args,
+                            eval_args.num_keys, script_mode);
 
     tx->ScheduleSingleHop([&](Transaction*, EngineShard*) {
       boost::intrusive_ptr<Transaction> stub_tx =
@@ -2307,7 +2304,7 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, 
         return cmd_cntx->SendError(err);
       }
     } else {
-      scheduled = StartMulti(conn_cntx, script_mode, tx_keys);
+      scheduled = StartMulti(conn_cntx, script_mode, eval_args.keys_args, eval_args.num_keys);
       sinfo->stats.tx_shards = tx->GetUniqueShardCnt();
     }
 
@@ -2477,7 +2474,7 @@ void Service::Exec(CmdArgParser, CommandContext* cmd_cntx) {
 
   bool scheduled = false;
   if (multi_mode != Transaction::NOT_DETERMINED) {
-    scheduled = StartMulti(cntx, multi_mode, keys);
+    scheduled = StartMulti(cntx, multi_mode, CmdArgList{keys}, keys.size());
   }
 
   // EXEC should not run if any of the watched keys expired.

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -138,7 +138,7 @@ TEST_F(MultiTxTest, MultiUnlock) {
   auto* ns = &namespaces->GetDefaultNamespace();
   string_view keys[4] = {kKey1, kKey2, kKey3, kKey4};
 
-  pp_->at(0)->Await([&] { tx->StartMultiLockedAhead(ns, 0, keys); });
+  pp_->at(0)->Await([&] { tx->StartMultiLockedAhead(ns, 0, CmdArgList{keys}, std::size(keys)); });
 
   for (auto key : keys)
     EXPECT_TRUE(IsLocked(0, key));

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -254,14 +254,15 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
   }
 }
 
-void Transaction::PrepareMultiFps(CmdArgList keys) {
+void Transaction::PrepareMultiFps(const facade::ParsedArgs& args, size_t num_keys) {
   DCHECK_EQ(multi_->mode, LOCK_AHEAD);
-  DCHECK_GT(keys.size(), 0u);
+  DCHECK_GT(num_keys, 0u);
 
   auto& tag_fps = multi_->tag_fps;
 
-  tag_fps.reserve(keys.size());
-  for (string_view str : keys) {
+  tag_fps.reserve(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    string_view str = args[i];
     ShardId sid = Shard(str, shard_set->size());
     tag_fps.emplace(sid, LockTag(str).Fingerprint());
   }
@@ -443,18 +444,18 @@ void Transaction::StartMultiGlobal(Namespace* ns, DbIndex dbid) {
   ScheduleInternal();
 }
 
-void Transaction::StartMultiLockedAhead(Namespace* ns, DbIndex dbid, CmdArgList keys,
-                                        bool skip_scheduling) {
-  DVLOG(1) << "StartMultiLockedAhead on " << keys.size() << " keys";
+void Transaction::StartMultiLockedAhead(Namespace* ns, DbIndex dbid, const facade::ParsedArgs& args,
+                                        size_t num_keys, bool skip_scheduling) {
+  DVLOG(1) << "StartMultiLockedAhead on " << num_keys << " keys";
   DCHECK(multi_);
 
   multi_->mode = LOCK_AHEAD;
   multi_->lock_mode = LockMode();
 
-  PrepareMultiFps(keys);
+  PrepareMultiFps(args, num_keys);
 
-  InitBase(ns, dbid, keys);
-  InitByKeys(KeyIndex(0, keys.size()));
+  InitBase(ns, dbid, args);
+  InitByKeys(KeyIndex(0, num_keys));
 
   if (!skip_scheduling)
     ScheduleInternal();
@@ -551,10 +552,11 @@ string Transaction::DebugId(std::optional<ShardId> sid) const {
   return res;
 }
 
-void Transaction::PrepareSingleSquash(Namespace* ns, ShardId sid, DbIndex db, CmdArgList keys,
+void Transaction::PrepareSingleSquash(Namespace* ns, ShardId sid, DbIndex db,
+                                      const facade::ParsedArgs& args, size_t num_keys,
                                       MultiMode mode) {
   if (mode == LOCK_AHEAD) {
-    StartMultiLockedAhead(ns, db, keys, true);  // delay locking until first hop
+    StartMultiLockedAhead(ns, db, args, num_keys, true);  // delay locking until first hop
   } else {
     DCHECK_EQ(mode, GLOBAL);
     StartMultiGlobal(ns, db);

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -244,14 +244,15 @@ class Transaction {
   void PrepareSquashedMultiHop(const CommandId* cid, absl::FunctionRef<bool(ShardId)> enabled);
 
   // Prepare transaction to do a single ScheduleSingleHop() for squashing
-  void PrepareSingleSquash(Namespace* ns, ShardId sid, DbIndex db, CmdArgList keys, MultiMode mode);
+  void PrepareSingleSquash(Namespace* ns, ShardId sid, DbIndex db, const facade::ParsedArgs& args,
+                           size_t num_keys, MultiMode mode);
 
   // Start multi in GLOBAL mode.
   void StartMultiGlobal(Namespace* ns, DbIndex dbid);
 
-  // Start multi in LOCK_AHEAD mode with given keys.
-  void StartMultiLockedAhead(Namespace* ns, DbIndex dbid, CmdArgList keys,
-                             bool skip_scheduling = false);
+  // Start multi in LOCK_AHEAD mode with the first num_keys elements of args as keys.
+  void StartMultiLockedAhead(Namespace* ns, DbIndex dbid, const facade::ParsedArgs& args,
+                             size_t num_keys, bool skip_scheduling = false);
 
   // Start multi in NON_ATOMIC mode.
   void StartMultiNonAtomic();
@@ -513,7 +514,7 @@ class Transaction {
   void StoreKeysInArgs(const KeyIndex& key_index);
 
   // Multi transactions unlock asynchronously, so they need to keep fingerprints of keys.
-  void PrepareMultiFps(CmdArgList keys);
+  void PrepareMultiFps(const facade::ParsedArgs& args, size_t num_keys);
 
   void ScheduleInternal();
 


### PR DESCRIPTION
## Summary
- `Transaction::StartMultiLockedAhead`, `PrepareMultiFps`, `PrepareSingleSquash`, and the file-local `StartMulti()` helper now take `(const facade::ParsedArgs&, size_t num_keys)` instead of `CmdArgList`, matching `InitBase`/`full_args_` which already use `ParsedArgs`.
- Removes the transitional `tx_keys` `CmdArgVec` copy in `Service::EvalInternal` (previously needed only to satisfy the `CmdArgList` parameter type) by passing `eval_args.keys_args`/`eval_args.num_keys` straight through.

## Test plan
- [x] `ninja dragonfly multi_test`
- [x] `./multi_test` — 59 passed, 2 pre-existing skips
- [x] `pytest tests/dragonfly/eval_test.py` — 15 passed
- [x] `pre-commit run` on changed files