### PR TITLE
feat: do more SIMD in OAHSet

### DIFF
--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -79,6 +79,14 @@ class OAHEntry {
   }
   void SetExtHash(uint64_t ext_hash);
 
+  // Sets the fingerprint on a FRESH entry (ext-hash bits still 0, heap ptr <= 52 bits): ORs
+  // directly, no read-mask. `shifted_ext_hash` must carry bits only in [kExtHashShift, 64); use
+  // SetExtHash if the entry may already hold a fingerprint.
+  void SetShiftedExtHash(uint64_t shifted_ext_hash) {
+    assert((shifted_ext_hash & ~kExtHashShiftedMask) == 0);
+    SetTaggedPtr(GetTaggedPtr() | shifted_ext_hash);
+  }
+
   // Reallocates the key blob if its page is underutilized; returns the usable-size delta and sets
   // *realloced when the buffer moved.
   ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);

--- a/src/core/oah_ptr.h
+++ b/src/core/oah_ptr.h
@@ -67,6 +67,12 @@ class OAHPtr {
       *slot_ = tagged_ptr;
       return 0;
     }
+    return InsertNonEmpty(tagged_ptr);
+  }
+
+  // Insert into a slot the caller has already proven non-empty, skipping Insert's Empty() check.
+  [[nodiscard]] size_t InsertNonEmpty(TaggedPtr tagged_ptr) {
+    assert(!Empty());
     if (!IsVector()) {
       TaggedPtr arr_tagged_ptr = Vector::Create(2);
       Vector arr(arr_tagged_ptr);

--- a/src/core/oah_set.cc
+++ b/src/core/oah_set.cc
@@ -4,6 +4,7 @@
 
 #include "core/oah_set.h"
 
+#include <algorithm>
 #include <bit>
 
 #include "base/logging.h"
@@ -11,26 +12,131 @@
 namespace dfly {
 
 template <typename Wide>
-OAHSet::LaneMasks OAHSet::ProbeLanes(const TaggedPtr* base, uint64_t ext_hash) noexcept {
+OAHSet::LaneMasks OAHSet::ProbeLanes(const TaggedPtr* base, uint64_t shifted_ext_hash) noexcept {
+  DCHECK_NE(shifted_ext_hash, 0u);  // never 0 (CalcExtHash remap), so empty lanes can't match
   auto data_v = Wide::Load(base);
-  auto hash_v = (data_v & Wide::Fill(OAHEntry::kExtHashShiftedMask)) >> OAHEntry::kExtHashShift;
-  // ~is_empty excludes empty lanes, whose zero hash would otherwise match a zero query hash.
+  // Mask covers the vector bit so vector slots never match a candidate (window probes then need
+  // no per-candidate IsVector test); ext-hash is never 0, so empty lanes can't match the query.
+  auto stored = data_v & Wide::Fill(OAHEntry::kExtHashShiftedMask | OAHPtr::kVectorBit);
   auto is_empty = data_v == uint64_t(0);
-  auto candidate = (hash_v == ext_hash) & ~is_empty;
+  auto candidate = stored == shifted_ext_hash;
   return {candidate.GetMSBs(), is_empty.GetMSBs()};
 }
 
 // Window may exceed one SIMD register: sweep in EntryWide strides, packing each
 // stride's masks (lane i of stride `off` -> bit off+i). uint32_t masks => <= 32 lanes.
+// Takes the unshifted fingerprint and shifts it in place. Erase/Find use this so the shift
+// stays out of their (larger) inlined bodies -- inlining it there measured a codegen regression.
 OAHSet::LaneMasks OAHSet::ProbeWindow(const TaggedPtr* base, uint64_t ext_hash) noexcept {
+  const uint64_t shifted_ext_hash = ext_hash << OAHEntry::kExtHashShift;
   LaneMasks w{0, 0};
   for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
-    const LaneMasks m = ProbeLanes<EntryWide>(base + off, ext_hash);
+    const LaneMasks m = ProbeLanes<EntryWide>(base + off, shifted_ext_hash);
     w.candidates |= m.candidates << off;
     w.empties |= m.empties << off;
   }
   return w;
 }
+
+// Twin of ProbeWindow taking the already-shifted fingerprint (no internal shift). AddImpl uses it
+// because it also needs the shifted value for SetShiftedExtHash -- one shift instead of two.
+OAHSet::LaneMasks OAHSet::ProbeWindowShifted(const TaggedPtr* base,
+                                             uint64_t shifted_ext_hash) noexcept {
+  LaneMasks w{0, 0};
+  for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
+    const LaneMasks m = ProbeLanes<EntryWide>(base + off, shifted_ext_hash);
+    w.candidates |= m.candidates << off;
+    w.empties |= m.empties << off;
+  }
+  return w;
+}
+
+uint32_t OAHSet::ScanWindowMask(const TaggedPtr* base, uint64_t target, uint32_t shift,
+                                uint32_t* vector_mask_out) noexcept {
+  uint32_t cand = 0;
+  uint32_t vec = 0;
+  for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
+    const EntryWide data = EntryWide::Load(base + off);
+    const uint32_t isvec =
+        ((data & EntryWide::Fill(OAHPtr::kVectorBit)) == OAHPtr::kVectorBit).GetMSBs();
+    const uint32_t matched = ((data >> shift) == target).GetMSBs();
+    // target == 0 also matches all-zero empties; drop them here (cheaper than a scalar re-read).
+    const uint32_t is_empty = (data == uint64_t(0)).GetMSBs();
+    cand |= (matched & ~is_empty & ~isvec) << off;
+    vec |= isvec << off;
+  }
+  *vector_mask_out = vec;
+  return cand;
+}
+
+template <typename Wide>
+uint32_t OAHSet::AffiliationMask(const TaggedPtr* base, uint64_t target, uint32_t shift) noexcept {
+  const Wide data = Wide::Load(base);
+  // Vector arrays may hold empty slots; exclude them so target == 0 doesn't report holes.
+  const uint32_t matched = ((data >> shift) == target).GetMSBs();
+  const uint32_t is_empty = (data == uint64_t(0)).GetMSBs();
+  return matched & ~is_empty;
+}
+
+template <bool Expire> bool OAHSet::ScanHomeBucket(uint32_t bucket_id, const ItemCb& cb) {
+  const uint32_t part = std::min(capacity_log_, kShiftLog);
+  DCHECK_GT(part, 0u);
+  // ScanWindowMask drops empty lanes, so `cand` holds only affiliated non-empty single entries.
+  const uint32_t shift = 64 - part;
+  const uint64_t target = bucket_id & ((uint64_t{1} << part) - 1);
+
+  const TaggedPtr* base = &entries_[bucket_id];
+  // Prefetch every window slot's blob to overlap the loads with the SIMD mask below (an empty
+  // slot prefetches null, a no-op).
+  for (uint32_t i = 0; i < kDisplacementSize; ++i)
+    PREFETCH_READ(reinterpret_cast<const char*>(base[i] & ~OAHEntry::kTagMask));
+
+  uint32_t vec_mask = 0;
+  uint32_t cand = ScanWindowMask(base, target, shift, &vec_mask);
+  bool reported = false;
+
+  while (cand) {
+    const uint32_t i = std::countr_zero(cand);
+    cand &= cand - 1;
+    OAHEntry e = At(bucket_id + i)[0];
+    if constexpr (Expire) {
+      ExpireIfNeeded(e);
+      if (e.Empty())
+        continue;
+    }
+    cb(e.Key());
+    reported = true;
+  }
+
+  if (vec_mask) {
+    DCHECK_EQ(vec_mask & (vec_mask - 1), 0u);
+    const uint32_t vi = std::countr_zero(vec_mask);
+    auto vec = At(bucket_id + vi).AsVector();
+    TaggedPtr* raw = vec.Raw();
+    const size_t vsize = vec.Size();
+    for (size_t b = 0; b < vsize; b += VectorWide::kLanes) {
+      uint32_t m = AffiliationMask<VectorWide>(&raw[b], target, shift);
+      while (m) {
+        const uint32_t j = std::countr_zero(m);
+        m &= m - 1;
+        OAHEntry el(raw[b + j]);
+        if constexpr (Expire) {
+          ExpireIfNeeded(el);
+          if (el.Empty())
+            continue;
+        }
+        cb(el.Key());
+        reported = true;
+      }
+    }
+  }
+
+  return reported;
+}
+
+// Explicit instantiations so the inline Scan (in the header) can call both specializations.
+template bool OAHSet::ScanHomeBucket<true>(uint32_t, const ItemCb&);
+template bool OAHSet::ScanHomeBucket<false>(uint32_t, const ItemCb&);
 
 // 2-lane SIMD strides. Vector sizes are always even (PtrVector grows by 2), so the
 // stride covers the array with no tail.
@@ -41,44 +147,19 @@ TaggedPtr* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std::string_view str, 
   DCHECK_GE(size, size_t(kVectorLaneStep));
   DCHECK_EQ(size % kVectorLaneStep, 0u);
 
+  const uint64_t shifted_ext_hash = ext_hash << OAHEntry::kExtHashShift;
   for (size_t base = 0; base < size; base += kVectorLaneStep) {
     auto cand_bits =
-        ProbeLanes<VectorWide>(reinterpret_cast<const uint64_t*>(&raw_arr[base]), ext_hash)
+        ProbeLanes<VectorWide>(reinterpret_cast<const uint64_t*>(&raw_arr[base]), shifted_ext_hash)
             .candidates;
     while (cand_bits) {
       const uint32_t j = std::countr_zero(cand_bits);
       cand_bits &= cand_bits - 1;
-      OAHEntry re(raw_arr[base + j]);
-      const bool match = re.Key() == str;
-      re.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-      if (match)
+      if (OAHEntry(raw_arr[base + j]).Key() == str)
         return &raw_arr[base + j];
     }
   }
   return nullptr;
-}
-
-// Window read stays in bounds: entries_ has kDisplacementSize-1 slack past BucketCount.
-OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t ext_bid, uint32_t cand_bits,
-                                      std::string_view str, uint64_t ext_hash) {
-  while (cand_bits) {
-    const uint32_t i = std::countr_zero(cand_bits);
-    cand_bits &= cand_bits - 1;
-    const uint32_t bucket_id = bid + i;
-    OAHPtr p = At(bucket_id);
-    if (p.IsVector())  // vectors live only at the extension point
-      continue;
-    OAHEntry e = p[0];
-    const bool match = e.Key() == str;
-    e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-    if (match)
-      return {&entries_[bucket_id], bucket_id, 0};
-  }
-  if (At(ext_bid).IsVector()) {
-    if (TaggedPtr* hit = ProbeExtensionVector(ext_bid, str, ext_hash))
-      return {hit, ext_bid, static_cast<uint32_t>(hit - At(ext_bid).AsVector().Raw())};
-  }
-  return {nullptr, 0, 0};
 }
 
 bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec) {
@@ -91,8 +172,12 @@ bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec) {
   auto bucket_id = BucketId(hash, capacity_log_);
   PREFETCH_READ(entries_.data() + bucket_id);
 
+  const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
+  const uint64_t shifted_ext_hash = ext_hash << OAHEntry::kExtHashShift;
+
   const ssize_t mem_before = zmalloc_used_memory_tl;
   TaggedPtr entry_tagged_ptr = OAHEntry::Create(str, EntryTTL(ttl_sec));
+  OAHEntry(entry_tagged_ptr).SetShiftedExtHash(shifted_ext_hash);  // reuse the shifted value
   if (ttl_sec != UINT32_MAX)
     expiration_used_ = true;
   const size_t entry_alloc_size = zmalloc_used_memory_tl - mem_before;
@@ -100,26 +185,42 @@ bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec) {
   const uint32_t ext_bid = GetExtensionPoint(bucket_id);
   PREFETCH_READ(At(ext_bid).Raw());
 
-  const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-  OAHEntry new_entry(entry_tagged_ptr);
-  new_entry.SetExtHash(ext_hash);
+  const LaneMasks masks = ProbeWindowShifted(&entries_[bucket_id], shifted_ext_hash);
 
-  const LaneMasks masks = ProbeWindow(&entries_[bucket_id], ext_hash);
-  const MatchResult m = FindMatch(bucket_id, ext_bid, masks.candidates, str, ext_hash);
-  if (m.matched && *m.matched != 0) {
-    OAHEntry::Destroy(entry_tagged_ptr);  // duplicate already present: discard the new blob
-    return false;
+  // Add/Find/Erase each inline their own probe (measured faster than a shared helper). Add needs
+  // only the matched cell, for the duplicate check and slot reuse.
+  TaggedPtr* matched = nullptr;
+  TaggedPtr* base = entries_.data();
+  for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
+    TaggedPtr* cell = &base[bucket_id + std::countr_zero(cand_bits)];
+    if (OAHEntry(*cell).Key() == str) {
+      matched = cell;
+      break;
+    }
+  }
+  if (!matched && At(ext_bid).IsVector())
+    matched = ProbeExtensionVector(ext_bid, str, ext_hash);
+
+  if (matched) {
+    OAHEntry dup(*matched);
+    ExpireIfNeeded(dup);  // reap an already-expired duplicate so its cell can be reused
+    if (!dup.Empty()) {
+      OAHEntry::Destroy(entry_tagged_ptr);  // live duplicate
+      return false;
+    }
+    // Reaped an expired duplicate: its cell is empty, so reuse it in place.
+    obj_alloc_used_ += entry_alloc_size;
+    ++size_;
+    *matched = entry_tagged_ptr;
+    return true;
   }
 
   obj_alloc_used_ += entry_alloc_size;
   ++size_;
-  // Reuse an expired duplicate's slot, else a free window lane, else spill to the vector.
-  if (m.matched) {
-    *m.matched = entry_tagged_ptr;
-  } else if (masks.empties) {
+  if (masks.empties) {
     At(bucket_id + std::countr_zero(masks.empties)).Assign(entry_tagged_ptr);
   } else {
-    ptr_vectors_alloc_used_ += At(ext_bid).Insert(entry_tagged_ptr);
+    ptr_vectors_alloc_used_ += At(ext_bid).InsertNonEmpty(entry_tagged_ptr);  // window full
   }
   return true;
 }
@@ -144,47 +245,100 @@ unsigned OAHSet::AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec, bo
   return res;
 }
 
+template <bool Expire>
 OAHSet::iterator OAHSet::FindInternal(uint32_t bid, std::string_view str, uint64_t hash) {
   const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-  const uint32_t cand_bits = ProbeWindow(&entries_[bid], ext_hash).candidates;
-  const MatchResult m = FindMatch(bid, GetExtensionPoint(bid), cand_bits, str, ext_hash);
-  if (m.matched && *m.matched != 0)  // empty => matched but just expired, i.e. gone
-    return iterator{this, m.bucket_id, m.pos_in_vec};
+  const LaneMasks masks = ProbeWindow(&entries_[bid], ext_hash);
+
+  // Find returns an iterator built straight from the match. With no TTLs a key match is always
+  // live, so ExpireIfNeeded and the resulting empty re-check are compiled out.
+  TaggedPtr* base = entries_.data();
+  for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
+    const uint32_t bucket_id = bid + std::countr_zero(cand_bits);
+    OAHEntry e(base[bucket_id]);
+    if (e.Key() == str) {
+      if constexpr (Expire) {
+        ExpireIfNeeded(e);
+        if (e.Empty())
+          return end();
+      }
+      return iterator{this, bucket_id, 0};
+    }
+  }
+  const uint32_t ext_bid = GetExtensionPoint(bid);
+  if (At(ext_bid).IsVector()) {
+    if (TaggedPtr* hit = ProbeExtensionVector(ext_bid, str, ext_hash)) {
+      if constexpr (Expire) {
+        OAHEntry e(*hit);
+        ExpireIfNeeded(e);
+        if (e.Empty())
+          return end();
+      }
+      return iterator{this, ext_bid, static_cast<uint32_t>(hit - At(ext_bid).AsVector().Raw())};
+    }
+  }
   return end();
 }
 
 OAHSet::iterator OAHSet::Find(std::string_view member) {
   if (entries_.empty())
     return end();
-  uint64_t hash = Hash(member);
-  return FindInternal(BucketId(hash, capacity_log_), member, hash);
+  const uint64_t hash = Hash(member);
+  const uint32_t bid = BucketId(hash, capacity_log_);
+  return expiration_used_ ? FindInternal<true>(bid, member, hash)
+                          : FindInternal<false>(bid, member, hash);
 }
 
 bool OAHSet::Erase(std::string_view str) {
   if (entries_.empty())
     return false;
-  uint64_t hash = Hash(str);
-  auto item = FindInternal(BucketId(hash, capacity_log_), str, hash);
-  if (item == end())
+  const uint64_t hash = Hash(str);
+  const uint32_t bid = BucketId(hash, capacity_log_);
+  const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
+  const LaneMasks masks = ProbeWindow(&entries_[bid], ext_hash);
+
+  // Erase keeps the matched cell (to free it) and whether the hit lives in an extension vector.
+  TaggedPtr* matched = nullptr;
+  TaggedPtr* base = entries_.data();
+  for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
+    TaggedPtr* cell = &base[bid + std::countr_zero(cand_bits)];
+    if (OAHEntry(*cell).Key() == str) {
+      matched = cell;
+      break;
+    }
+  }
+  const uint32_t ext_bid = GetExtensionPoint(bid);
+  bool in_vector = false;
+  if (!matched && At(ext_bid).IsVector()) {
+    matched = ProbeExtensionVector(ext_bid, str, ext_hash);
+    in_vector = matched != nullptr;
+  }
+  if (!matched)
     return false;
+
+  OAHEntry victim(*matched);
+  const bool removed = !IsExpired(victim);  // already-expired target => not-removed (like Redis)
+
   --size_;
-  OAHEntry victim = *item;
   obj_alloc_used_ -= victim.AllocSize();
   OAHEntry::Destroy(victim.Release());
 
-  OAHPtr bucket = At(item.bucket_id());
-  if (bucket.IsVector() && bucket.AsVector().Empty()) {
-    ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
-    bucket.Clear();
+  if (in_vector) {  // reclaim the vector if the erase emptied it
+    OAHPtr bucket = At(ext_bid);
+    auto vec = bucket.AsVector();
+    if (vec.Empty()) {
+      ptr_vectors_alloc_used_ -= vec.AllocSize();
+      bucket.Clear();
+    }
   }
-  return true;
+  return removed;
 }
 
 OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
   OAHPtr bucket = At(b);
   if (!bucket.IsVector()) {
     OAHEntry e = bucket[0];
-    e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+    ExpireIfNeeded(e);
     return e.Empty() ? end() : iterator{this, b, 0};
   }
   auto vec = bucket.AsVector();
@@ -192,7 +346,7 @@ OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
     OAHEntry entry(vec[pos]);
     if (!entry)
       continue;
-    entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+    ExpireIfNeeded(entry);
     if (entry)
       return iterator{this, b, pos};
   }

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -282,15 +282,14 @@ class OAHSet {  // Open Addressing Hash Set
       return 0;
 
     uint32_t bucket_id = cursor >> (32 - capacity_log_);
+    const bool expire = expiration_used_;
 
-    // First find the bucket to scan, skip empty buckets.
+    // First find the bucket to scan, skip empty buckets. Dispatch the per-entry expiry handling
+    // once via the compile-time-specialized ScanHomeBucket (no-TTL sets skip it entirely).
     for (; bucket_id < BucketCount(); ++bucket_id) {
-      bool res = false;
-      for (uint32_t i = 0; i < kDisplacementSize; i++) {
-        const uint32_t shifted_bid = bucket_id + i;
-        res |= ScanBucket(At(shifted_bid), cb, bucket_id);
-      }
-      if (res)
+      const bool reported =
+          expire ? ScanHomeBucket<true>(bucket_id, cb) : ScanHomeBucket<false>(bucket_id, cb);
+      if (reported)
         break;
     }
 
@@ -399,17 +398,17 @@ class OAHSet {  // Open Addressing Hash Set
       return;
 
     for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
-      if (bucket[pos]) {
-        // Check for TTL expiration during shrink - skip expired elements
-        if (bucket[pos].HasExpiry() && bucket[pos].GetExpiry() <= time_now_) {
-          obj_alloc_used_ -= bucket[pos].AllocSize();
-          --size_;
-          continue;
-        }
-
-        uint32_t new_bucket_id = FindEmptyAround(RehashEntry(bucket[pos]));
-        ptr_vectors_alloc_used_ += At(new_bucket_id).Insert(bucket.Remove(pos));
+      OAHEntry entry = bucket[pos];
+      if (!entry)
+        continue;
+      // Drop entries whose TTL has passed instead of rehashing them (no-TTL sets skip the check).
+      if (expiration_used_ && IsExpired(entry)) {
+        obj_alloc_used_ -= entry.AllocSize();
+        --size_;
+        continue;
       }
+      uint32_t new_bucket_id = FindEmptyAround(RehashEntry(entry));
+      ptr_vectors_alloc_used_ += At(new_bucket_id).Insert(bucket.Remove(pos));
     }
 
     if (bucket.IsVector()) {
@@ -422,31 +421,6 @@ class OAHSet {  // Open Addressing Hash Set
   static uint32_t GetExtensionPoint(uint32_t bid) {
     constexpr uint32_t extension_point_shift = kDisplacementSize - 1;
     return bid | extension_point_shift;
-  }
-
-  template <std::invocable<std::string_view> T>
-  bool ScanBucket(OAHPtr entry, const T& cb, uint32_t bucket_id) {
-    if (!entry.IsVector()) {
-      OAHEntry e = entry[0];
-      e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-      if (CheckBucketAffiliation(e, bucket_id)) {
-        cb(e.Key());
-        return true;
-      }
-    } else {
-      auto arr = entry.AsVector();
-      bool result = false;
-      for (TaggedPtr& cell : arr) {
-        OAHEntry el(cell);
-        el.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-        if (CheckBucketAffiliation(el, bucket_id)) {
-          cb(el.Key());
-          result = true;
-        }
-      }
-      return result;
-    }
-    return false;
   }
 
   uint32_t EntryTTL(uint32_t ttl_sec) const {
@@ -476,49 +450,48 @@ class OAHSet {  // Open Addressing Hash Set
     uint32_t empties;     // empty lanes (data_ == 0); Add picks a slot from these
   };
 
-  // Vectorized hash probe over Wide::kLanes consecutive lanes from `base`. Backs
-  // the window (EntryWide) and extension-vector (VectorWide) scans.
+  // Vectorized hash probe over Wide::kLanes consecutive lanes from `base`. `shifted_ext_hash` is
+  // the query pre-shifted to bits [kExtHashShift, 64) so the stored hash is compared in place.
   template <typename Wide>
-  static LaneMasks ProbeLanes(const TaggedPtr* base, uint64_t ext_hash) noexcept;
+  static LaneMasks ProbeLanes(const TaggedPtr* base, uint64_t shifted_ext_hash) noexcept;
 
   // Combined candidate/empty masks over the whole window (lane i -> bit i).
   LaneMasks ProbeWindow(const TaggedPtr* base, uint64_t ext_hash) noexcept;
 
-  // Searches the extension-point vector for `str`. Returns the matched slot
-  // (possibly now-empty after expiry, which the caller reuses) or nullptr.
+  // ProbeWindow variant taking the already-shifted fingerprint (see the .cc for why they split).
+  LaneMasks ProbeWindowShifted(const TaggedPtr* base, uint64_t shifted_ext_hash) noexcept;
+
+  // Returns lanes in a scan window holding single entries affiliated with the
+  // home bucket, and separately reports vector lanes.
+  static uint32_t ScanWindowMask(const TaggedPtr* base, uint64_t target, uint32_t shift,
+                                 uint32_t* vector_mask_out) noexcept;
+
+  // Lanes affiliated with the home bucket (top `part` bits of ext-hash == target) and
+  // non-empty. Used for the extension-point vector (no vector-bit lanes to exclude).
+  template <typename Wide>
+  static uint32_t AffiliationMask(const TaggedPtr* base, uint64_t target, uint32_t shift) noexcept;
+
+  // Scans one stable-SCAN home bucket window and reports live affiliated entries. Templated on
+  // Expire: no-TTL sets skip the per-entry lazy expiration and the post-expiry empty re-check.
+  template <bool Expire> bool ScanHomeBucket(uint32_t bucket_id, const ItemCb& cb);
+
+  // Searches the extension-point vector for `str`. Returns the matched slot, or nullptr if absent.
+  // Callers derive the vector position (Find) or the in-vector flag (Erase) from the result; it
+  // does not expire, so the returned entry may be live or already-expired.
   TaggedPtr* ProbeExtensionVector(uint32_t ext_bid, std::string_view str, uint64_t ext_hash);
 
-  // Outcome of a key probe. A raw slot (not an iterator) so the caller can reuse a
-  // matched-but-just-expired entry, which is Empty() and would trip operator[]'s assert.
-  struct MatchResult {
-    TaggedPtr* matched;   // ptr to matched cell, or null if absent; may be 0 (just expired)
-    uint32_t bucket_id;   // location of `matched`, for building an iterator
-    uint32_t pos_in_vec;  // position within a vector bucket (0 for single entries)
-  };
-
-  // Shared core of AddImpl and FindInternal: scans the window (cand_bits from a
-  // prior ProbeLanes) then the extension vector for `str`.
-  MatchResult FindMatch(uint32_t bid, uint32_t ext_bid, uint32_t cand_bits, std::string_view str,
-                        uint64_t ext_hash);
-
-  // Probes for `str`; returns an iterator to the live entry or end(). Shared by
-  // Find and Erase.
-  iterator FindInternal(uint32_t bid, std::string_view str, uint64_t hash);
+  // Probes for `str`; returns an iterator to the live entry or end(). Used by Find. Templated on
+  // Expire: when no TTLs exist a key match is provably live, so the empty re-check is dropped.
+  template <bool Expire> iterator FindInternal(uint32_t bid, std::string_view str, uint64_t hash);
 
   static uint64_t CalcExtHash(uint64_t hash, uint32_t capacity_log) {
     const uint32_t start_hash_bit = capacity_log > kShiftLog ? capacity_log - kShiftLog : 0;
     const uint32_t ext_hash_shift = 64 - start_hash_bit - OAHEntry::kExtHashSize;
-    return (hash >> ext_hash_shift) & OAHEntry::kExtHashMask;
-  }
-
-  bool CheckBucketAffiliation(OAHEntry entry, uint32_t bucket_id) {
-    if (entry.Empty())
-      return false;
-    uint32_t bucket_id_hash_part = capacity_log_ > kShiftLog ? kShiftLog : capacity_log_;
-    uint32_t bucket_mask = (1 << bucket_id_hash_part) - 1;
-    bucket_id &= bucket_mask;
-    uint32_t stored_bucket_id = entry.GetHash() >> (OAHEntry::kExtHashSize - bucket_id_hash_part);
-    return bucket_id == stored_bucket_id;
+    const uint64_t h = (hash >> ext_hash_shift) & OAHEntry::kExtHashMask;
+    // Remap the rare all-zero fingerprint to 1 so empty (all-zero) slots never match a real
+    // entry, letting the SIMD probes drop the empty mask. Full entropy otherwise; home-prefix
+    // bits stay 0.
+    return h ? h : 1;
   }
 
   // Recomputes the entry's hash, refreshes its stored ext-hash, and returns its new bucket.
@@ -526,6 +499,23 @@ class OAHSet {  // Open Addressing Hash Set
     uint64_t hash = Hash(entry.Key());
     entry.SetExtHash(CalcExtHash(hash, capacity_log_));
     return BucketId(hash, capacity_log_);
+  }
+
+  // Lazily expires `entry` when it carries a live TTL. Templated on Expire so no-TTL callers
+  // select the <false> instantiation, whose body compiles to nothing.
+  template <bool Expire> void ExpireIfNeeded(OAHEntry entry) {
+    if constexpr (Expire)
+      entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+  }
+
+  // Runtime dispatch on expiration_used_: no-TTL sets run no expiry code at all.
+  void ExpireIfNeeded(OAHEntry entry) {
+    expiration_used_ ? ExpireIfNeeded<true>(entry) : ExpireIfNeeded<false>(entry);
+  }
+
+  // True when `entry`'s TTL has elapsed (HasExpiry() already covers the no-TTL case).
+  bool IsExpired(OAHEntry entry) const {
+    return entry.HasExpiry() && entry.GetExpiry() <= time_now_;
   }
 
   mutable size_t obj_alloc_used_ = 0;

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -1232,7 +1232,9 @@ void BM_Scan(benchmark::State& state) {
     size_t seen = 0;
     do {
       cursor = ss.Scan(cursor, [&](auto key) {
-        benchmark::DoNotOptimize(key);
+        // Reading the key size dereferences the key blob, simulating real usage where the
+        // scanned key is actually consumed (a bare no-op callback would hide that memory cost).
+        benchmark::DoNotOptimize(key.size());
         ++seen;
       });
     } while (cursor != 0);

--- a/src/core/simd_op.h
+++ b/src/core/simd_op.h
@@ -19,18 +19,32 @@
 
 namespace dfly {
 
+// Wide (>256-bit) instances return/pass vectors by value in unoptimized builds, which GCC flags
+// with -Wpsabi (an AVX512 ABI note). SimdOp is header-only and always inlined in optimized builds,
+// so no real ABI boundary exists; silence the false positive on GCC (clang does not emit it).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpsabi"
+#endif
+
 // SimdOp<T, N> wraps N consecutive uint64_t lanes behind the GCC/Clang
 // vector-extension type. Compare ops produce another SimdOp whose lanes are
 // all-ones or all-zeros, which GetMSBs() then compresses to a scalar.
+//
+// vector_size requires a power-of-two lane count, so the storage vector is widened to
+// kVecLanes = bit_ceil(N); the padding lanes are loaded as zero and masked out of
+// GetMSBs(). For power-of-two N there is no padding and codegen is unchanged.
 template <class T, std::size_t N> class SimdOp {
   static_assert(std::is_integral_v<T>, "lane type must be integral");
   static_assert(sizeof(T) == 8, "only 64-bit lanes are supported today");
-  static_assert(N == 2 || N == 4, "only N=2 (SSE/NEON) and N=4 (AVX2) are supported today");
+  static_assert(N >= 2 && N <= 64 && N % 2 == 0, "N must be an even lane count in [2, 64]");
 
-  using Vec __attribute__((vector_size(sizeof(T) * N))) = T;
+  static constexpr std::size_t kVecLanes = std::bit_ceil(N);
+  using Vec __attribute__((vector_size(sizeof(T) * kVecLanes))) = T;
 
  public:
-  using BitsType = std::uint32_t;
+  // Up to 32 lanes fit a uint32_t mask; 64 lanes need 64 bits.
+  using BitsType = std::conditional_t<(N > 32), std::uint64_t, std::uint32_t>;
   static constexpr std::size_t kLanes = N;
 
   constexpr SimdOp() noexcept = default;
@@ -42,9 +56,15 @@ template <class T, std::size_t N> class SimdOp {
   }
 
   static SimdOp Load(const T* ptr) noexcept {
-    Vec v;
-    std::memcpy(&v, ptr, sizeof(Vec));
-    return v;
+    if constexpr (N == kVecLanes) {
+      Vec v;
+      std::memcpy(&v, ptr, sizeof(Vec));
+      return v;
+    } else {
+      Vec v{};  // zero the padding lanes so they never set a bit in GetMSBs
+      std::memcpy(&v, ptr, sizeof(T) * N);
+      return v;
+    }
   }
 
   constexpr SimdOp operator&(const SimdOp& o) const noexcept {
@@ -71,50 +91,71 @@ template <class T, std::size_t N> class SimdOp {
     return Vec(v_ == (Vec{} + value));
   }
 
-  // Packs the most-significant bit of every lane into a uint32_t bitmask
-  // (LSB = lane 0). For the output of `operator==` (lanes are all-ones or
-  // all-zeros) this is equivalent to "bit i set iff lane i is non-zero".
+  // Packs each lane's sign bit (bit 63) into a bitmask (LSB = lane 0), x86 movemask semantics on
+  // all ISAs. Per-group masks are combined with a fold expression (unrolled, independent groups);
+  // the trailing mask strips padding lanes when N is not a power of two.
   BitsType GetMSBs() const noexcept {
-    // We hand-write the per-ISA movemask because no portable C++ /
-    // vector-extension formulation lowers to a single movemask instruction
-    // — every alternative we tried measured ~5% slower on OAHSet's hot path.
+    // Hand-written per-ISA movemask: no portable formulation lowers to a single movemask, and
+    // every alternative measured ~5% slower on OAHSet's hot path.
+    BitsType bits = 0;
 #if defined(__AVX2__)
-    if constexpr (N == 4) {
-      __m256i raw;
-      std::memcpy(&raw, &v_, sizeof(raw));
-      return static_cast<BitsType>(_mm256_movemask_pd(_mm256_castsi256_pd(raw)));
-    } else {
+    if constexpr (kVecLanes == 2) {
       __m128i raw;
       std::memcpy(&raw, &v_, sizeof(raw));
-      return static_cast<BitsType>(_mm_movemask_pd(_mm_castsi128_pd(raw)));
+      bits = static_cast<BitsType>(_mm_movemask_pd(_mm_castsi128_pd(raw)));
+    } else {
+      [&]<std::size_t... G>(std::index_sequence<G...>) {
+        ((bits |= static_cast<BitsType>(Movemask256<G>()) << (4 * G)), ...);
+      }
+      (std::make_index_sequence<kVecLanes / 4>{});
     }
 #elif defined(__ARM_NEON)
-    // NEON has no movemask; vshrn_n_u64 collapses each 64-bit lane to its
-    // top 32 bits in one instruction. For N=4 we run it on both 128-bit
-    // halves and stitch the two 2-bit results together.
-    uint64x2_t halves[N / 2];
-    std::memcpy(halves, &v_, sizeof(v_));
-    BitsType bits = 0;
-    for (std::size_t h = 0; h < N / 2; ++h) {
-      uint32x2_t narrow = vshrn_n_u64(halves[h], 32);
-      std::uint64_t packed;
-      std::memcpy(&packed, &narrow, sizeof(packed));
-      bits |= (static_cast<BitsType>((packed & 1u) | ((packed >> 31) & 2u))) << (2 * h);
+    // NEON has no movemask; vshrn_n_u64 narrows a 128-bit half to 2 sign bits per group.
+    [&]<std::size_t... H>(std::index_sequence<H...>) {
+      ((bits |= static_cast<BitsType>(NeonPack2<H>()) << (2 * H)), ...);
+    }
+    (std::make_index_sequence<kVecLanes / 2>{});
+#else
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      ((bits |= static_cast<BitsType>(static_cast<std::make_unsigned_t<T> >(v_[I]) >> 63) << I),
+       ...);
+    }
+    (std::make_index_sequence<kVecLanes>{});
+#endif
+    if constexpr (N != kVecLanes) {
+      bits &= static_cast<BitsType>((BitsType{1} << N) - 1);  // drop padding lanes
     }
     return bits;
-#else
-    BitsType m = 0;
-    for (std::size_t i = 0; i < N; ++i)
-      m |= static_cast<BitsType>(v_[i] != 0) << i;
-    return m;
-#endif
   }
 
  private:
+#if defined(__AVX2__)
+  // movemask of the G-th 256-bit group (lanes [4G, 4G+4)); the offset is a compile-time constant.
+  template <std::size_t G> int Movemask256() const noexcept {
+    __m256i raw;
+    std::memcpy(&raw, reinterpret_cast<const char*>(&v_) + 32 * G, sizeof(raw));
+    return _mm256_movemask_pd(_mm256_castsi256_pd(raw));
+  }
+#elif defined(__ARM_NEON)
+  // 2-bit sign mask of the H-th 128-bit group (lanes [2H, 2H+2)).
+  template <std::size_t H> unsigned NeonPack2() const noexcept {
+    uint64x2_t half;
+    std::memcpy(&half, reinterpret_cast<const char*>(&v_) + 16 * H, sizeof(half));
+    uint32x2_t narrow = vshrn_n_u64(half, 32);
+    std::uint64_t packed;
+    std::memcpy(&packed, &narrow, sizeof(packed));
+    return static_cast<unsigned>(((packed >> 31) & 1u) | ((packed >> 62) & 2u));
+  }
+#endif
+
   constexpr SimdOp(Vec v) noexcept : v_(v) {  // NOLINT(google-explicit-constructor)
   }
 
   Vec v_{};
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace dfly

--- a/src/core/simd_op_test.cc
+++ b/src/core/simd_op_test.cc
@@ -13,6 +13,33 @@ namespace dfly {
 
 using U64x2 = SimdOp<std::uint64_t, 2>;
 using U64x4 = SimdOp<std::uint64_t, 4>;
+using U64x6 = SimdOp<std::uint64_t, 6>;
+using U64x8 = SimdOp<std::uint64_t, 8>;
+
+TEST(SimdOpTest, WideGetMSBsN8) {
+  // N=8 exercises the multi-group fold in GetMSBs.
+  std::uint64_t arr[8] = {1, 0, 3, 0, 5, 6, 0, 8};
+  EXPECT_EQ((U64x8::Load(arr) == uint64_t(0)).GetMSBs(), 0b01001010u);  // zero lanes: 1,3,6
+
+  std::uint64_t signs[8] = {~0ULL, 0, ~0ULL, ~0ULL, 0, ~0ULL, 0, ~0ULL};
+  EXPECT_EQ(U64x8::Load(signs).GetMSBs(), 0b10101101u);  // sign-bit set lanes
+
+  auto v = U64x8::Load(arr);
+  EXPECT_EQ((v == uint64_t(5)).GetMSBs(), 0b00010000u);  // only lane 4 == 5
+  EXPECT_EQ(((v & U64x8::Fill(0)) == uint64_t(0)).GetMSBs(), 0xFFu);
+}
+
+TEST(SimdOpTest, NonPowerOfTwoNMasksPadding) {
+  // N=6 widens storage to 8 lanes; the 2 padding lanes are zero-filled and must be masked out of
+  // GetMSBs -- notably they must NOT appear in a `== 0` probe.
+  std::uint64_t arr[6] = {0, 5, 0, 9, 5, 0};
+  auto v = U64x6::Load(arr);
+  EXPECT_EQ((v == uint64_t(0)).GetMSBs(), 0b100101u);  // zero lanes 0,2,5; padding masked off
+  EXPECT_EQ((v == uint64_t(5)).GetMSBs(), 0b010010u);  // lanes 1,4
+
+  std::uint64_t signs[6] = {~0ULL, 0, 0, 0, 0, ~0ULL};
+  EXPECT_EQ(U64x6::Load(signs).GetMSBs(), 0b100001u);  // sign lanes 0,5 only, no padding bits
+}
 
 TEST(SimdOpTest, FillAndLoadAreEquivalent) {
   std::uint64_t arr[4] = {7, 7, 7, 7};
@@ -68,6 +95,14 @@ TEST(SimdOpTest, ToBitsLsbIsLaneZero) {
   std::uint64_t arr[4] = {42, 0, 0, 0};
   auto v = U64x4::Load(arr);
   EXPECT_EQ((v == uint64_t(42)).GetMSBs(), 0x1u);
+}
+
+TEST(SimdOpTest, GetMSBsReadsLaneSignBits) {
+  // GetMSBs extracts each lane's sign bit (bit 63), not "is non-zero" -- lane 1 (0x7FFF..) has
+  // its low bits set but bit 63 clear, so it must not appear in the mask.
+  std::uint64_t arr[4] = {0x8000000000000000ULL, 0x7FFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0};
+  EXPECT_EQ(U64x4::Load(arr).GetMSBs(), 0b0101u);
+  EXPECT_EQ(U64x2::Load(arr).GetMSBs(), 0b0001u);
 }
 
 TEST(SimdOpTest, U64x2WorksForVectorSearch) {

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -825,7 +825,9 @@ void BM_Scan(benchmark::State& state) {
     size_t seen = 0;
     do {
       cursor = ss.Scan(cursor, [&](auto key) {
-        benchmark::DoNotOptimize(key);
+        // Reading the key size dereferences the key blob, simulating real usage where the
+        // scanned key is actually consumed (a bare no-op callback would hide that memory cost).
+        benchmark::DoNotOptimize(sdslen(key));
         ++seen;
       });
     } while (cursor != 0);


### PR DESCRIPTION
Summary: This PR increases SIMD usage in OAHSet to accelerate probing and stable SCAN, and tightens SimdOp::GetMSBs() semantics to match x86 movemask behavior.

Changes:

- Adds OAHEntry::SetShiftedExtHash() and a shifted-fingerprint probing variant to avoid redundant shifts on insert.
- Reworks SIMD probing to compare the stored shifted fingerprint in-place and exclude vector slots via the vector tag bit.
- Ensures query fingerprints are never zero (remapping rare zero to 1) so empty-lane masking can be avoided in hot probes.
- Inlines Add/Find/Erase probing logic and introduces InsertNonEmpty() to skip redundant empty checks when spilling to the extension slot.
- Implements a SIMD-assisted stable SCAN path (ScanWindowMask/AffiliationMask) with compile-time-specialized TTL handling.

Technical Notes: ExpireIfNeeded is dispatched via expiration_used_ to compile out expiry work for no-TTL sets, and new unit tests cover the corrected GetMSBs() sign-bit extraction semantics.