### PR TITLE
fix(facade): track in-flight V2 async commands 

### DIFF
--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -64,6 +64,19 @@ class ConnectionContext {
   //      wait for an in-flight command to finish.
   //   2. Flush-Before-Block: async_dispatch=true (only) makes MainService::DispatchCommand flush
   //      buffered pipeline replies before a blocking command (e.g. BLPOP) parks the fiber.
+  //
+  // V2 note:
+  // - These flags are on-spot markers raised around a single call, NOT a durable "this connection
+  //   is executing" state.
+  // - "Executing" is broader than running the command body: a V2 async command's reply is written
+  //   later, when its suspended reply coroutine is resumed. That reply-write is part of executing
+  //   the command, so the flag is raised around the resume too - not only the initial dispatch.
+  // - A V2 async command clears the flags as soon as the dispatch returns, while it may still be
+  //   in flight (its reply not yet written).
+  // - The only durable in-flight signal there is Connection::HasInFlightCommands().
+  // - Because the flags are read cross-fiber (DispatchTracker) but only at a fiber suspension
+  //   point, IsCurrentlyDispatching() may be transiently false mid-dispatch without any observer
+  //   seeing the gap.
   bool async_dispatch : 1;
   bool sync_dispatch : 1;
 

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -69,8 +69,9 @@ class ConnectionContext {
   // - These flags are on-spot markers raised around a single call, NOT a durable "this connection
   //   is executing" state.
   // - "Executing" is broader than running the command body: a V2 async command's reply is written
-  //   later, when its suspended reply coroutine is resumed. That reply-write is part of executing
-  //   the command, so the flag is raised around the resume too - not only the initial dispatch.
+  //   later, when its suspended reply coroutine is resumed. ReplyBatch keeps parsed_head_ on the
+  //   command until after SendReply() returns, so that reply-write window is covered by
+  //   HasInFlightCommands() rather than by these flags.
   // - A V2 async command clears the flags as soon as the dispatch returns, while it may still be
   //   in flight (its reply not yet written).
   // - The only durable in-flight signal there is Connection::HasInFlightCommands().

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2950,7 +2950,6 @@ bool Connection::ReplyBatch() {
     while (HasInFlightCommands() && parsed_head_->CanReply()) {
       current_wait_.reset();  // Clear the subscription before moving to the next command
       auto* cmd = parsed_head_;
-      AdvanceParsedHead(parsed_head_->next);
 
       // Pure coroutine replies don't preserve lifetimes
       const bool suspended = cmd->IsSuspendedReply();
@@ -2958,29 +2957,16 @@ bool Connection::ReplyBatch() {
       if (suspended)
         pause.emplace(reply_builder_.get());
 
-      // V2 only:
-      // - A command isn't "done" until its reply is written.
-      // - A suspended (coroutine) reply can do real work on resume (e.g. a tiered value's disk
-      //   read) and fiber-block inside SendReply().
-      // - We already advanced parsed_head_ past this command above (AdvanceParsedHead, before
-      // SendReply), so while
-      //   SendReply runs HasInFlightCommands() no longer counts it and reads false.
-      // - So we must mark the connection as dispatching across that SendReply: a CLIENT PAUSE /
-      //   DispatchTracker sampling mid-resume then still sees it busy and waits for the write.
-      // - A non-suspended reply just copies an already-built payload and can't preempt - no guard
-      // is needed.
-      // - We use sync_dispatch (not async_dispatch) because coro.resume() runs synchronously, and
-      //   async_dispatch would also force a flush-before-block; sync_dispatch is the right signal
-      //   for in-flight dispatch tracking.
-      auto set_sync_dispatch = [&](bool val) {
-        if (ioloop_v2_ && suspended) {
-          DCHECK(cc_->sync_dispatch != val);  // must strictly flip, never a redundant set
-          cc_->sync_dispatch = val;
-        }
-      };
-      set_sync_dispatch(true);
+      // V2 in-flight tracking:
+      // - A command isn't "done" until its reply is written. A suspended (coroutine) reply can do
+      //   real work on resume (e.g. a tiered value's disk read) and fiber-block inside SendReply().
+      // - We keep parsed_head_ pointing at this command across SendReply() and only advance it
+      //   AFTERWARDS. That way HasInFlightCommands() stays true for the whole reply-write, so a
+      //   CLIENT PAUSE / DispatchTracker sampling mid-resume still sees the connection busy (via
+      //   SendCheckpoint's HasInFlightCommands() check) and waits for the write to land.
+      // - A non-suspended reply just copies an already-built payload and can't preempt.
       cmd->SendReply();
-      set_sync_dispatch(false);
+      AdvanceParsedHead(cmd->next);
       replied++;
 
       if (reply_builder_->GetError())

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -686,8 +686,21 @@ void Connection::AsyncOperations::operator()(const MigrationRequestMessage& msg)
 }
 
 void Connection::AsyncOperations::operator()(CheckpointMessage msg) {
-  VLOG(2) << "[" << self->id_ << "] "
-          << "Decremented checkpoint at " << self->DebugInfo();
+  // V2 only:
+  // - ExecuteBatch() -> DispatchCommandSimple() returns while the command may still be in flight.
+  // - A checkpoint that lands in that window must NOT Dec() yet - otherwise a CLIENT PAUSE /
+  // DispatchTracker would return before the in-flight write actually happens.
+  // - That's why here we defer the blocking counter by holding it. We will release it once
+  // HasInFlightCommands() is false, by calling ReleaseDeferredCheckpoints().
+  // - A blocked connection is excluded: a blocked command isn't an in-flight write and may never
+  // complete, so deferring its checkpoint could hold the DispatchTracker forever. Instead, we Dec()
+  // it immediately.
+  if (self->ioloop_v2_ && self->HasInFlightCommands() && !self->cc_->blocked) {
+    DVLOG(2) << "[" << self->id_ << "] "
+             << "Deferring checkpoint (in-flight commands) at " << self->DebugInfo();
+    self->deferred_checkpoints_.push_back(std::move(msg.bc));
+    return;
+  }
 
   msg.bc->Dec();
 }
@@ -1918,9 +1931,27 @@ void Connection::ClearPipelinedMessages() {
   parsed_to_execute_ = nullptr;
   dispatch_waiting_count_ = 0;
 
+  ReleaseDeferredCheckpoints();
+
   QueueBackpressure& qbp = GetQueueBackpressure();
   qbp.NotifyPipelineWaiters();
   qbp.pubsub_ec.notifyAll();
+}
+
+void Connection::ReleaseDeferredCheckpoints() {
+  // Invariant: only the V2 loop should defer a checkpoint, else vector must be empty.
+  DCHECK(ioloop_v2_ || deferred_checkpoints_.empty());
+  // Invariant: we never release while an async command is still in flight - doing so would let a
+  // CLIENT PAUSE / DispatchTracker return before the write lands. Callers must hold this rule.
+  DCHECK(!HasInFlightCommands());
+
+  if (deferred_checkpoints_.empty())
+    return;
+
+  for (auto& bc : deferred_checkpoints_) {
+    bc->Dec();
+  }
+  deferred_checkpoints_.clear();
 }
 
 string Connection::DebugInfo() const {
@@ -2273,7 +2304,14 @@ void Connection::SendMonitorMessageAsync(string msg) {
 }
 
 void Connection::SendCheckpoint(fb2::BlockingCounter bc, bool ignore_paused, bool ignore_blocked) {
-  if (!IsCurrentlyDispatching())
+  // Only send a checkpoint if the connection has an "active" command the tracker must wait for:
+  // 1) It is dispatching now, OR
+  // 2) V2 only - an async command is still in flight after DispatchCommandSimple already returned.
+  // In that V2 use case: IsCurrentlyDispatching() is already false, so without checking
+  // HasInFlightCommands() the checkpoint would be skipped and CLIENT PAUSE / DispatchTracker
+  // could return before the write is done.
+  bool has_active_command = IsCurrentlyDispatching() || (ioloop_v2_ && HasInFlightCommands());
+  if (!has_active_command)
     return;
 
   if (cc_->paused && ignore_paused)
@@ -2845,10 +2883,10 @@ bool Connection::ExecuteBatch() {
     // V1 sets these flags elsewhere (DispatchSingle / the AsyncFiber paths), hence the ioloop_v2_
     // guard.
     //
-    // TODO(follow-up PR): an async command may still be in flight after this returns,
-    // yet sync_dispatch is cleared right below - so a CLIENT PAUSE / DispatchTracker started in
-    // that window can under-wait it. We need to defer the checkpoint until in-flight
-    // commands drain. The synchronous squash path (SquashPipelineV2) is already correct.
+    // Note: an async command may still be in flight after this returns, yet sync_dispatch is
+    // cleared right below - so a CLIENT PAUSE / DispatchTracker sampling that window would see the
+    // connection idle. That gap is closed in AsyncOperations::operator()(CheckpointMessage) and
+    // SendCheckpoint() by deferring the checkpoint's bc->Dec().
     if (ioloop_v2_) {
       // Invariant: both are clear on entry - the single V2 fiber never dispatches while already
       // dispatching, and every path above resets them before the next command is reached.
@@ -2915,11 +2953,34 @@ bool Connection::ReplyBatch() {
       AdvanceParsedHead(parsed_head_->next);
 
       // Pure coroutine replies don't preserve lifetimes
+      const bool suspended = cmd->IsSuspendedReply();
       std::optional<SinkReplyBuilder::ScopePause> pause;
-      if (cmd->IsSuspendedReply())
+      if (suspended)
         pause.emplace(reply_builder_.get());
 
+      // V2 only:
+      // - A command isn't "done" until its reply is written.
+      // - A suspended (coroutine) reply can do real work on resume (e.g. a tiered value's disk
+      //   read) and fiber-block inside SendReply().
+      // - We already advanced parsed_head_ past this command above (AdvanceParsedHead, before
+      // SendReply), so while
+      //   SendReply runs HasInFlightCommands() no longer counts it and reads false.
+      // - So we must mark the connection as dispatching across that SendReply: a CLIENT PAUSE /
+      //   DispatchTracker sampling mid-resume then still sees it busy and waits for the write.
+      // - A non-suspended reply just copies an already-built payload and can't preempt - no guard
+      // is needed.
+      // - We use sync_dispatch (not async_dispatch) because coro.resume() runs synchronously, and
+      //   async_dispatch would also force a flush-before-block; sync_dispatch is the right signal
+      //   for in-flight dispatch tracking.
+      auto set_sync_dispatch = [&](bool val) {
+        if (ioloop_v2_ && suspended) {
+          DCHECK(cc_->sync_dispatch != val);  // must strictly flip, never a redundant set
+          cc_->sync_dispatch = val;
+        }
+      };
+      set_sync_dispatch(true);
       cmd->SendReply();
+      set_sync_dispatch(false);
       replied++;
 
       if (reply_builder_->GetError())
@@ -3508,6 +3569,12 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
     } else {
       // Input available and under budget: parse, execute, reply.
       parse_status = RunParsePath();
+    }
+
+    // Release any checkpoints deferred while async commands were in flight, now that the in-flight
+    // run has drained.
+    if (!HasInFlightCommands()) {
+      ReleaseDeferredCheckpoints();
     }
 
     // A protocol error detected by parse-in-proactor (which runs in the recv callback and cannot

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -443,8 +443,16 @@ class Connection : public util::Connection {
   // Squashes pipelined commands from the dispatch queue to spread load over all threads
   void SquashPipeline();
 
-  // Clear pipelined messages, disaptching only intrusive ones.
+  // Clear pipelined messages, dispatching only intrusive ones.
   void ClearPipelinedMessages();
+
+  // Dec()s every BlockingCounter held in deferred_checkpoints_, then clear the vector.
+  // These belong to the checkpoint commands the V2 loop deferred in
+  // AsyncOperations(CheckpointMessage)while async commands were still in flight. Each counter
+  // belongs to a DispatchTracker (CLIENT PAUSE / REPLTAKEOVER / cluster migration / shutdown) that
+  // is blocked in Wait(). Decrementing it here signals that this connection's in-flight commands
+  // have landed.
+  void ReleaseDeferredCheckpoints();
 
   ClientInfo BuildClientInfo(unsigned thread_id) const;
 
@@ -582,6 +590,16 @@ class Connection : public util::Connection {
   std::error_code io_ec_;
   util::fb2::EventCount io_event_;
   std::optional<WaitEvent> current_wait_;
+
+  // - V2 only: used to store checkpoints (holding a BlockingCounter) whose bc->Dec() was deferred
+  // because async commands were still in-flight when the checkpoint was processed.
+  // - Pushing them in the back of the dispatch_q_ may create complexities, so holding them
+  // separately simplifies the solution.
+  // - They are released (bc->Dec()) once HasInFlightCommands() drops to false, or on connection
+  // close.
+  // - Assumption: usually this vectors holds 0-1 entries, and at any given (extreme) point of time,
+  // the number of deferred checkpoints is minimal (<10, no inlined vector required).
+  std::vector<util::fb2::BlockingCounter> deferred_checkpoints_;
 
   // how many bytes of the current request have been consumed
   size_t request_consumed_bytes_ = 0;

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1337,6 +1337,175 @@ async def test_multiple_blocking_commands_client_pause(async_client: aioredis.Re
     await all
 
 
+@pytest.mark.opt_only  # run against release/optimized build only
+@pytest.mark.exclude_epoll
+@dfly_args(
+    {
+        "proactor_threads": 4,
+        "enable_resp_io_loop_v2": "true",
+        # Tiered storage keeps a command in-flight on a thread-idle disk read, so CLIENT
+        # PAUSE's fiber rendezvous can't implicitly wait for it and mask the bug.
+        "tiered_prefix": "/tmp/tiered/pause_v2_backing",
+        "tiered_offload_threshold": "1.0",
+        "tiered_experimental_cooling": "false",
+        "maxmemory": "2G",
+    }
+)
+async def test_client_pause_v2_inflight_async_write_gap(df_server: DflyInstance):
+    """Regression: an in-flight async command on the V2 loop must keep CLIENT PAUSE waiting.
+
+    A tiered APPEND parks the shard fiber on a disk read, so the command stays in-flight
+    while returning a tiny reply. CLIENT PAUSE WRITE must not return until it completes.
+    Tuning parameters: VALUE_BYTES and SETTLE.
+    """
+    assert is_resp_io_loop_v2(df_server)
+
+    VALUE_BYTES = 256 * 1024 * 1024  # 256MB
+    SETTLE = 0.05
+
+    populator = df_server.client()
+    writer = df_server.client()
+    pauser = df_server.client()
+
+    await populator.execute_command("DEBUG", "POPULATE", 1, "huge", VALUE_BYTES, "RAND")
+    keys = await populator.keys("huge*")
+    assert len(keys) == 1
+    big_key = keys[0]
+
+    # Wait until the value is offloaded to disk (else APPEND reads from memory instantly).
+    async with async_timeout.timeout(60):
+        while int((await populator.info("TIERED")).get("tiered_entries", 0)) < 1:
+            await asyncio.sleep(0.2)
+
+    # Async write that must fetch the whole value from disk. Its fiber parks on the read.
+    inflight = asyncio.create_task(writer.execute_command("APPEND", big_key, "x"))
+
+    await asyncio.sleep(0.02)
+    assert not inflight.done(), "APPEND completed too fast to test; increase VALUE_BYTES"
+
+    # Issue a pause command on pauser connection while writer's append is still in-flight. It must not return until the append completes.
+    # It must not reply "OK" until every write command that was already in-flight at the moment it was issued has finished.
+    assert await pauser.execute_command("CLIENT", "PAUSE", "5000", "WRITE") == "OK"
+
+    await asyncio.sleep(SETTLE)  # give some time for asyncio to run the task completion callback.
+    inflight_done_after_pause = (
+        inflight.done()
+    )  # was the APPEND already complete when PAUSE returned?
+
+    # Teardown
+    try:
+        await pauser.execute_command("CLIENT", "UNPAUSE")
+    except Exception:
+        pass
+    if not inflight.done():
+        await asyncio.wait_for(inflight, timeout=60)
+
+    # Test outcome: CLIENT PAUSE must not return while the async command is still in-flight.
+    assert (
+        inflight_done_after_pause
+    ), "CLIENT PAUSE WRITE returned while an async command was still in flight"
+
+
+@pytest.mark.opt_only  # run against release/optimized build only
+@pytest.mark.exclude_epoll
+@dfly_args(
+    {
+        "proactor_threads": 4,
+        "enable_resp_io_loop_v2": "true",
+        # Tiered storage gives a long thread-idle in-flight window (see the test above).
+        "tiered_prefix": "/tmp/tiered/pause_v2_close_backing",
+        "tiered_offload_threshold": "1.0",
+        "tiered_experimental_cooling": "false",
+        "maxmemory": "2G",
+        # High timeout so a fast close-path release is distinguishable from a timeout release.
+        "pause_wait_timeout": 30,
+    }
+)
+async def test_client_pause_v2_close_releases_deferred_checkpoint(df_server: DflyInstance):
+    """Regression: closing a client mid-flight must release its deferred CLIENT PAUSE checkpoint.
+
+    A paused V2 connection with an in-flight async command defers its DispatchTracker
+    counter. If the client disconnects before the command lands, ClearPipelinedMessages
+    must release it so CLIENT PAUSE returns well before pause_wait_timeout.
+    """
+    assert is_resp_io_loop_v2(df_server)
+
+    VALUE_BYTES = 256 * 1024 * 1024  # 256MB
+    PAUSE_MS = 5000
+    PAUSE_WAIT_TIMEOUT = 30  # must match the dfly_args value above
+    RELEASE_BOUND = 10.0
+
+    populator = df_server.client()
+    pauser = df_server.client()
+
+    await populator.execute_command("DEBUG", "POPULATE", 1, "huge", VALUE_BYTES, "RAND")
+    keys = await populator.keys("huge*")
+    assert len(keys) == 1
+    big_key = keys[0]
+
+    async with async_timeout.timeout(60):
+        while int((await populator.info("TIERED")).get("tiered_entries", 0)) < 1:
+            await asyncio.sleep(0.2)
+
+    def enc(*args):
+        out = f"*{len(args)}\r\n".encode()
+        for a in args:
+            b = a if isinstance(a, bytes) else str(a).encode()
+            out += f"${len(b)}\r\n".encode() + b + b"\r\n"
+        return out
+
+    # Use raw socket so we can close it mid-flight (a df client would drain the reply first).
+    _, writer_sock = await asyncio.open_connection("127.0.0.1", df_server.port)
+
+    # Fire the async write (fetches the value from disk) and never read the reply.
+    writer_sock.write(enc("APPEND", big_key, "x"))
+    await writer_sock.drain()
+    await asyncio.sleep(0.03)
+
+    # Pause checkpoints the writer. Its in-flight command makes it defer the checkpoint.
+    pause_task = asyncio.create_task(
+        pauser.execute_command("CLIENT", "PAUSE", str(PAUSE_MS), "WRITE")
+    )
+    await asyncio.sleep(0.05)
+    assert not pause_task.done(), "CLIENT PAUSE returned before we could close the writer"
+
+    # Close the writer while its APPEND is still in flight and its checkpoint deferred.
+    t0 = time.monotonic()
+    writer_sock.close()
+    try:
+        await writer_sock.wait_closed()
+    except Exception:
+        pass
+
+    try:
+        # shield so the wait_for timeout does not cancel the pause task; we assert on it below.
+        # Catch only TimeoutError - any other exception means CLIENT PAUSE itself failed and must
+        # fail the test.
+        await asyncio.wait_for(asyncio.shield(pause_task), timeout=PAUSE_WAIT_TIMEOUT + 10)
+    except asyncio.TimeoutError:
+        pass
+    elapsed = time.monotonic() - t0
+
+    # Teardown - leave the server usable, regardless of the assertion outcome.
+    try:
+        await pauser.execute_command("CLIENT", "UNPAUSE")
+    except Exception:
+        pass
+
+    assert pause_task.done(), "CLIENT PAUSE never returned after the writer disconnected mid-flight"
+    # .result() re-raises if CLIENT PAUSE errored, so a failed pause fails the test here.
+    assert pause_task.result() == "OK", f"CLIENT PAUSE did not return OK: {pause_task.result()!r}"
+    assert elapsed < RELEASE_BOUND, (
+        f"CLIENT PAUSE took {elapsed:.2f}s after disconnect; expected the close-path release "
+        f"to unblock it well below pause_wait_timeout={PAUSE_WAIT_TIMEOUT}s"
+    )
+
+    # Make sure the server stays healthy and a subsequent pause with no in-flight work is not stuck.
+    assert await pauser.ping() is True
+    assert await pauser.execute_command("CLIENT", "PAUSE", "50", "WRITE") == "OK"
+    await pauser.execute_command("CLIENT", "UNPAUSE")
+
+
 async def test_lib_name_ver(async_client: aioredis.Redis):
     await async_client.execute_command("client setinfo lib-name dragonfly")
     await async_client.execute_command("client setinfo lib-ver 1.2.3.4")

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1356,12 +1356,11 @@ async def test_client_pause_v2_inflight_async_write_gap(df_server: DflyInstance)
 
     A tiered APPEND parks the shard fiber on a disk read, so the command stays in-flight
     while returning a tiny reply. CLIENT PAUSE WRITE must not return until it completes.
-    Tuning parameters: VALUE_BYTES and SETTLE.
+    Tuning parameter: VALUE_BYTES (make the disk read long enough to stay in-flight).
     """
     assert is_resp_io_loop_v2(df_server)
 
     VALUE_BYTES = 256 * 1024 * 1024  # 256MB
-    SETTLE = 0.05
 
     populator = df_server.client()
     writer = df_server.client()
@@ -1383,26 +1382,27 @@ async def test_client_pause_v2_inflight_async_write_gap(df_server: DflyInstance)
     await asyncio.sleep(0.02)
     assert not inflight.done(), "APPEND completed too fast to test; increase VALUE_BYTES"
 
-    # Issue a pause command on pauser connection while writer's append is still in-flight. It must not return until the append completes.
-    # It must not reply "OK" until every write command that was already in-flight at the moment it was issued has finished.
-    assert await pauser.execute_command("CLIENT", "PAUSE", "5000", "WRITE") == "OK"
+    # PAUSE must not return before the in-flight APPEND finishes. Race them: a correct server writes
+    # the APPEND reply before releasing the pause checkpoint, so APPEND wins. If PAUSE wins, the
+    # write slipped past CLIENT PAUSE - the bug. (A sleep+snapshot check masks it or is racy.)
+    pause_task = asyncio.create_task(pauser.execute_command("CLIENT", "PAUSE", "5000", "WRITE"))
+    done, _ = await asyncio.wait({pause_task, inflight}, return_when=asyncio.FIRST_COMPLETED)
+    pause_beat_inflight = pause_task in done and inflight not in done
 
-    await asyncio.sleep(SETTLE)  # give some time for asyncio to run the task completion callback.
-    inflight_done_after_pause = (
-        inflight.done()
-    )  # was the APPEND already complete when PAUSE returned?
+    # Let both finish so the pauser/writer connections are idle before teardown.
+    assert await asyncio.wait_for(pause_task, timeout=60) == "OK"
+    if not inflight.done():
+        await asyncio.wait_for(inflight, timeout=60)
 
     # Teardown
     try:
         await pauser.execute_command("CLIENT", "UNPAUSE")
     except Exception:
         pass
-    if not inflight.done():
-        await asyncio.wait_for(inflight, timeout=60)
 
     # Test outcome: CLIENT PAUSE must not return while the async command is still in-flight.
     assert (
-        inflight_done_after_pause
+        not pause_beat_inflight
     ), "CLIENT PAUSE WRITE returned while an async command was still in flight"
 
 


### PR DESCRIPTION
In the IoLoopV2 loop, DispatchCommandSimple() returns while a SUPPORT_ASYNC command may still be in flight (its reply is written later, when the suspended reply coroutine resumes). The dispatch flags are cleared right after the call, so a DispatchTracker (CLIENT PAUSE / REPLTAKEOVER / migration / shutdown) sampling that window sees the connection as idle and can return before the write lands. This PR closes the follow-up left by PR #7764 (commit 9d8408d5c1070b4e6040638d124b5ec4743a4d81).

Changes:
- Treat HasInFlightCommands() as an active command in SendCheckpoint(), not only IsCurrentlyDispatching().
- Defer a checkpoint that arrives while a V2 async command is in flight. release it once the run drains in IoLoopV2, or on close via ClearPipelinedMessages/ReleaseDeferredCheckpoints.
- Blocked commands are excluded, as they may never complete.
- Mark the connection dispatching across a suspended reply's SendReply(), which can fiber-block after parsed_head_ advanced.
- Document the dispatch flags as on-spot markers in conn_context.h.

Added 2 regression tests, which run only on release and for io_uring:
- test_client_pause_v2_inflight_async_write_gap: a tiered APPEND stays in flight. CLIENT PAUSE WRITE must not return until it completes.
- test_client_pause_v2_close_releases_deferred_checkpoint: closing the client mid-flight must release the deferred checkpoint so the pause returns well before pause_wait_timeout.
