### PR TITLE
perf: shrink squash callback and avoid regex stack overflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ git log --oneline -10
 - Global mutable state
 - Edit without reading
 - Skip tests
+- Use `std::regex` in fiber/server paths (recursive implementation can overflow small fiber stacks)
 - Use `./tools/docker/build.sh` for local development (use `ninja` instead)
 - Use `make` for incremental builds (use `ninja` instead)
 

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -641,14 +641,20 @@ uint64_t LargeString::HashCode() const {
 void LargeString::SetString(string_view s, MemoryResource* mr) {
   DCHECK(!s.empty());
 
+  bool allocate = (ptr == nullptr);
+
   // Force a fresh buffer when either (a) the new value doesn't fit, or
   // (b) read_pending is set (in-place overwrite would corrupt pinned readers).
   // ReleasePtr either deallocates the old buffer or orphans it to its pending
   // PendingRead entry; either way `ptr` is reset before the new allocation.
-  if (s.size() > zmalloc_size(ptr) || read_pending) {
+  if (ptr && (s.size() > zmalloc_size(ptr) || read_pending)) {
     ReleasePtr(this, mr);
+    allocate = true;
+  }
+  if (allocate) {
     ptr = mr->allocate(s.size(), kAlignSize);
   }
+
   memcpy(ptr, s.data(), s.size());
   sz = s.size();
 }

--- a/src/core/small_string.cc
+++ b/src/core/small_string.cc
@@ -34,6 +34,8 @@ thread_local TL tl;
 
 constexpr XXH64_hash_t kHashSeed = 24061983;  // same as in compact_object.cc
 
+static constexpr unsigned kMaxSize = (1 << 8) - 1;
+
 }  // namespace
 
 void SmallString::InitThreadLocal(void* heap) {

--- a/src/core/small_string.h
+++ b/src/core/small_string.h
@@ -15,7 +15,6 @@ class PageUsage;
 // Requires explicit memory management
 class SmallString {
   static constexpr unsigned kPrefLen = 10;
-  static constexpr unsigned kMaxSize = (1 << 8) - 1;
 
  public:
   static void InitThreadLocal(void* heap);

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -295,11 +295,18 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
 
   Transaction* tx = cntx_->transaction;
   ServerState::tlocal()->stats.squash_width_freq_arr[num_shards - 1]++;
-  uint64_t start = CycleClock::Now();
-  atomic_uint64_t max_sched_cycles{0}, max_exec_cycles{0};
-  base::SpinLock lock;
-  uint64_t fiber_running_cycles{0}, proactor_running_cycles{0};
-  uint32_t max_sched_thread_id{0}, max_sched_seq_num{0};
+
+  struct CbCntx {
+    uint64_t start = CycleClock::Now();
+    atomic_uint64_t max_sched_cycles{0}, max_exec_cycles{0};
+    base::SpinLock lock;
+    uint64_t fiber_running_cycles{0}, proactor_running_cycles{0};
+    uint64_t min_threshold_cycles{0};
+    uint32_t max_sched_thread_id{0}, max_sched_seq_num{0};
+    RespVersion version;
+  } cb_cntx;
+
+  cb_cntx.version = rb->GetRespVersion();
 
   // Atomic transactions (that have all keys locked) perform hops and run squashed commands via
   // stubs, non-atomic ones just run the commands in parallel.
@@ -309,28 +316,28 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
     tx->ScheduleSingleHop(
         [this, rb](auto* tx, auto* es) { return SquashedHopCb(es, rb->GetRespVersion()); });
   } else {
-    fb2::BlockingCounter bc(num_shards);
+    fb2::FiberBlockingCounter bc(num_shards);
     DVLOG(1) << "Squashing " << num_shards << " " << tx->DebugId();
 
     // Saves work in case logging is disable (i.e. log_squash_threshold_cached is high).
-    const uint64_t min_threshold_cycles = CycleClock::FromUsec(log_squash_threshold_cached / 5);
-    auto cb = [&, bc, rb]() mutable {
-      uint64_t sched_time = CycleClock::Now() - start;
+    cb_cntx.min_threshold_cycles = CycleClock::FromUsec(log_squash_threshold_cached / 5);
+    auto cb = [bc, &cb_cntx, this]() mutable {
+      uint64_t sched_time = CycleClock::Now() - cb_cntx.start;
 
       // Update max_sched_cycles in lock-free fashion, to avoid contention
-      uint64_t current = max_sched_cycles.load(memory_order_relaxed);
-      while (sched_time > min_threshold_cycles && sched_time > current) {
-        if (max_sched_cycles.compare_exchange_weak(current, sched_time, memory_order_relaxed,
-                                                   memory_order_relaxed)) {
-          lock_guard<base::SpinLock> g(lock);
+      uint64_t current = cb_cntx.max_sched_cycles.load(memory_order_relaxed);
+      while (sched_time > cb_cntx.min_threshold_cycles && sched_time > current) {
+        if (cb_cntx.max_sched_cycles.compare_exchange_weak(
+                current, sched_time, memory_order_relaxed, memory_order_relaxed)) {
+          lock_guard<base::SpinLock> g(cb_cntx.lock);
 
           // If it is still the longest scheduling time
-          if (max_sched_cycles.load(memory_order_relaxed) == sched_time) {
+          if (cb_cntx.max_sched_cycles.load(memory_order_relaxed) == sched_time) {
             // Store the stats from the callback with longest scheduling time.
-            fiber_running_cycles = ThisFiber::GetRunningTimeCycles();
-            proactor_running_cycles = ProactorBase::me()->GetCurrentBusyCycles();
-            max_sched_thread_id = ProactorBase::me()->GetPoolIndex();
-            max_sched_seq_num = fb2::GetFiberRunSeq();
+            cb_cntx.fiber_running_cycles = ThisFiber::GetRunningTimeCycles();
+            cb_cntx.proactor_running_cycles = ProactorBase::me()->GetCurrentBusyCycles();
+            cb_cntx.max_sched_thread_id = ProactorBase::me()->GetPoolIndex();
+            cb_cntx.max_sched_seq_num = fb2::GetFiberRunSeq();
           }
           break;
         }
@@ -342,22 +349,24 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
         ThisFiber::Yield();
         stats_.yields++;
       }
-      this->SquashedHopCb(EngineShard::tlocal(), rb->GetRespVersion());
-      uint64_t exec_time = CycleClock::Now() - start;
-      current = max_exec_cycles.load(memory_order_relaxed);
+      this->SquashedHopCb(EngineShard::tlocal(), cb_cntx.version);
+      uint64_t exec_time = CycleClock::Now() - cb_cntx.start;
+      current = cb_cntx.max_exec_cycles.load(memory_order_relaxed);
       while (exec_time > current) {
-        if (max_exec_cycles.compare_exchange_weak(current, exec_time, memory_order_relaxed,
-                                                  memory_order_relaxed))
+        if (cb_cntx.max_exec_cycles.compare_exchange_weak(current, exec_time, memory_order_relaxed,
+                                                          memory_order_relaxed))
           break;
       }
 
-      bc->Dec();  // Release barrier: Must be the last one in the callback.
+      std::move(bc).Release();  // Release barrier: Must be the last one in the callback.
     };
+
+    static_assert(sizeof(cb) <= 32);
     for (unsigned i = 0; i < sharded_.size(); ++i) {
       if (!sharded_[i].dispatched.empty())
         shard_set->AddL2(i, cb);
     }
-    bc->Wait();
+    bc.Wait();
   }
 
   uint64_t after_hop = CycleClock::Now();
@@ -386,24 +395,25 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   }
 
   uint64_t after_reply = CycleClock::Now();
-  uint64_t total_usec = CycleClock::ToUsec(after_reply - start);
+  uint64_t total_usec = CycleClock::ToUsec(after_reply - cb_cntx.start);
   stats_.hop_usec += total_usec;
   stats_.reply_usec += CycleClock::ToUsec(after_reply - after_hop);
   stats_.hops++;
   stats_.squashed_commands += order_.size();
 
   if (total_usec > log_squash_threshold_cached) {
-    uint64_t max_sched_usec = CycleClock::ToUsec(max_sched_cycles.load());
-    uint64_t fiber_running_usec = CycleClock::ToUsec(fiber_running_cycles);
-    uint64_t proactor_running_usec = CycleClock::ToUsec(proactor_running_cycles);
-    uint64_t max_exec_usec = CycleClock::ToUsec(max_exec_cycles.load());
+    uint64_t max_sched_usec = CycleClock::ToUsec(cb_cntx.max_sched_cycles.load());
+    uint64_t fiber_running_usec = CycleClock::ToUsec(cb_cntx.fiber_running_cycles);
+    uint64_t proactor_running_usec = CycleClock::ToUsec(cb_cntx.proactor_running_cycles);
+    uint64_t max_exec_usec = CycleClock::ToUsec(cb_cntx.max_exec_cycles.load());
 
     LOG_EVERY_T(INFO, 0.1)
         << "Squashed " << order_.size() << " commands. "
         << "Total/Fanout/MaxSchedTime/ThreadCbTime/ThreadId/FiberCbTime/FiberSeq/"
         << "MaxExecTime: " << total_usec << "/" << num_shards_ << "/" << max_sched_usec << "/"
-        << proactor_running_usec << "/" << max_sched_thread_id << "/" << fiber_running_usec << "/"
-        << "/" << max_sched_seq_num << "/" << max_exec_usec << "\ncoordinator thread running time: "
+        << proactor_running_usec << "/" << cb_cntx.max_sched_thread_id << "/" << fiber_running_usec
+        << "/" << cb_cntx.max_sched_seq_num << "/" << max_exec_usec
+        << "\ncoordinator thread running time: "
         << CycleClock::ToUsec(ProactorBase::me()->GetCurrentBusyCycles());
   }
 

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -11,7 +11,6 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
 
-#include <regex>
 #include <string>
 
 #include "base/flags.h"
@@ -239,14 +238,22 @@ void ScriptMgr::GCCmd(Transaction* tx, SinkReplyBuilder* builder) const {
 
 // Check if script starts with lua flags instructions (--df flags=...).
 io::Result<optional<ScriptMgr::ScriptParams>, GenericError> DeduceParams(string_view body) {
-  static const regex kRegex{R"(^\s*?--!df flags=([^\s\n\r]*)[\s\n\r])"};
-  cmatch matches;
+  while (!body.empty() && absl::ascii_isspace(body.front()))
+    body.remove_prefix(1);
 
-  if (!regex_search(body.data(), matches, kRegex))
+  constexpr string_view kPrefix = "--!df flags=";
+  if (!absl::ConsumePrefix(&body, kPrefix))
+    return nullopt;
+
+  size_t flags_len = 0;
+  while (flags_len < body.size() && !absl::ascii_isspace(body[flags_len]))
+    ++flags_len;
+
+  if (flags_len == body.size())
     return nullopt;
 
   ScriptMgr::ScriptParams params;
-  if (auto err = ScriptMgr::ScriptParams::ApplyFlags(matches.str(1), &params); err)
+  if (auto err = ScriptMgr::ScriptParams::ApplyFlags(body.substr(0, flags_len), &params); err)
     return nonstd::make_unexpected(err);
 
   return params;


### PR DESCRIPTION
## Summary

Shrink the per-shard squash callback capture while preserving inline storage, and remove `std::regex` from Lua script flag parsing to avoid recursive stack usage on sanitizer fiber stacks.

## Changes

- `multi_command_squasher.cc`: move squash callback state into `CbCntx`, use `FiberBlockingCounter`, and keep the callback within the inline buffer.
- `script_mgr.cc`: replace script flag `std::regex_search` with a bounded string parser.
- `AGENTS.md`: document avoiding `std::regex` in fiber/server paths.
- `compact_object.cc`: handle `ptr == nullptr` in `LargeString::SetString`.
- `small_string.{cc,h}`: move `SmallString::kMaxSize` into the `.cc` anonymous namespace.
- `helio`: submodule bump.
