### PR TITLE
Handle EPERM in io_uring support check

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -532,7 +532,7 @@ bool ShouldUseEpollAPI(const base::sys::KernelVersion& kver) {
 
   iouring_res = -iouring_res;
 
-  if (iouring_res == ENOSYS) {
+  if (iouring_res == ENOSYS || iouring_res == EPERM) {
     LOG(WARNING) << "iouring API is not supported. switching to epoll.";
   } else if (iouring_res == ENOMEM) {
     LOG(WARNING) << "io_uring does not have enough memory. That can happen when your "

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -532,15 +532,17 @@ bool ShouldUseEpollAPI(const base::sys::KernelVersion& kver) {
 
   iouring_res = -iouring_res;
 
-  if (iouring_res == ENOSYS || iouring_res == EPERM) {
-    LOG(WARNING) << "iouring API is not supported. switching to epoll.";
+  if (iouring_res == ENOSYS) {
+    LOG(WARNING) << "iouring API is not supported. Switching to epoll.";
   } else if (iouring_res == ENOMEM) {
     LOG(WARNING) << "io_uring does not have enough memory. That can happen when your "
                     "max locked memory is too limited. If you run via docker, "
                     "try adding '--ulimit memlock=-1' to \"docker run\" command."
                     "Meanwhile, switching to epoll";
+  } else if (iouring_res == EPERM) {
+    LOG(WARNING) << "Check if io_uring is disabled via /proc/sys/kernel/io_uring_disabled. Switching to epoll.";
   } else {
-    LOG(WARNING) << "Weird error " << iouring_res << " switching to epoll";
+    LOG(WARNING) << "Weird error " << strerror(iouring_res) << " switching to epoll";
   }
 
   return true;

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -540,7 +540,8 @@ bool ShouldUseEpollAPI(const base::sys::KernelVersion& kver) {
                     "try adding '--ulimit memlock=-1' to \"docker run\" command."
                     "Meanwhile, switching to epoll";
   } else if (iouring_res == EPERM) {
-    LOG(WARNING) << "Check if io_uring is disabled via /proc/sys/kernel/io_uring_disabled. Switching to epoll.";
+    LOG(WARNING) << "Check if io_uring is disabled via /proc/sys/kernel/io_uring_disabled. "
+                    "Switching to epoll.";
   } else {
     LOG(WARNING) << "Weird error " << strerror(iouring_res) << " switching to epoll";
   }


### PR DESCRIPTION
WSL return EPERM to indicate that iouring is not supported
