### PR TITLE
refactor: use ADL for CmdArgParser

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <absl/strings/ascii.h>
 #include <absl/strings/match.h>
 #include <absl/strings/numbers.h>
 
@@ -36,15 +37,22 @@ namespace facade {
 //   auto f  = parser.Next<FInt<1, 99>>("bad f");                // FInt with a custom out-of-range
 //                                                               // / non-integer error message
 //   auto s  = parser.Next<Validated<double, NotNan<kMsg>>>();   // parse + custom-error rule check
-//   auto u  = parser.Next(ParseUnit);                           // token parser fn: (sv, err) -> T
-//   auto n  = parser.Next(Number<int>);                         // full parser fn: (parser) -> T
-//   auto count = parser.NextOrDefault<size_t>(10);              // read optional with default
-//   auto conv  = parser.NextOrDefault(ParseUnit, 1.0);          // optional arg via a parser fn
-//   Range fields = parser.NextRange();                         // [N, e1..eN] counted list
-//   Range pairs  = parser.NextRange(2);                        // [N, f1,v1,..] N field/value pairs
-//   Range fs     = parser.NextRange(1, mismatch, true);        // consume-all variant
-//   Range rest   = parser.RemainingRange();                    // all remaining args, no count
-//   Range items  = parser.RemainingRange("need >=1 item");     // ...erroring if none remain
+//   auto sub = parser.Next<Upper>();                            // uppercased next arg (string)
+//   auto dur = parser.Next<Duration>();                         // custom type via ADL (see below)
+//   auto count = parser.NextOrDefault<size_t>(10);              // read optional arg, else default
+//   Range fields = parser.NextRange();                          // [N, e1..eN] counted list
+//   Range pairs  = parser.NextRange(2);                         // [N, f1,v1,..] field/value pairs
+//   Range fs     = parser.NextRange(1, mismatch, true);         // consume-all variant, exact fit
+//   Range rest   = parser.RemainingRange();                     // all remaining args, no count
+//   Range items  = parser.RemainingRange("need >=1 item");      // error if none remain
+//
+// Custom types: define a free `T ParseArg(CmdArgParser*, std::type_identity<T>)` in T's namespace
+// (found by ADL via the tag) so parser.Next<T>() and NextOrDefault<T>() parse T by driving the
+// parser. The tag only carries T for ADL; it holds no value, so nothing can be dereferenced.
+//     Duration ParseArg(CmdArgParser* p, std::type_identity<Duration>) {
+//       int64_t n = p->Next<int64_t>();
+//       return Duration{p->Check("MS") ? n : n * 1000};
+//     }
 //
 // Tag matching:
 //   parser.ExpectTag("LOAD");                                   // required literal keyword
@@ -57,6 +65,7 @@ namespace facade {
 // Bulk named options with Apply():
 //   parser.Apply(
 //       Exist("WITHSCORES", &with_scores),         // tag present -> sets bool true
+//       Flag("KEEPTTL", &flags, Opt::KEEPTTL),     // tag present -> OR bit into a flags field
 //       Tag("LIMIT", &offset, &limit),             // tag -> reads following args
 //       Tag("COUNT", &optional_count),             // std::optional<T>* supported directly
 //       Tag("GET", [&](CmdArgParser* p) {          // lambda: custom parsing on tag match
@@ -65,8 +74,8 @@ namespace facade {
 //       Map(&dir, "ASC", Dir::ASC, "DESC", Dir::DESC),   // tag -> fixed value mapping
 //       Tag("ATTR", Map(&mask, "v", Mask::Volatile,      // nested: outer tag + inner Map
 //                       "p", Mask::Permanent)),          //   (inner keyword required on match)
-//       OneOf(Exist("NX", &nx), Exist("XX", &xx))       // mutex — at most one may match
-//           .Err("NX and XX are incompatible"),        //   custom conflict message (optional)
+//       OneOf(Exist("NX", &nx), Exist("XX", &xx))       // mutex — at most one (add .Repeat() to
+//           .Err("NX and XX are incompatible"),        //   allow the same one twice); custom msg
 //       If(!read_only, Tag("STORE", &store_key)));    // runtime-gated option
 //
 // Strict vs lenient dispatch:
@@ -104,11 +113,20 @@ concept as_vnum = requires(T t) {
 
 struct CmdArgParser;
 
-// A parser callable for Next(fn), taking either fn(CmdArgParser*) (drives the parser, may consume
-// several args) or fn(std::string_view, RuleError&) (converts the next arg, sets err on failure).
+// A compile-time parser callable for Next<Fn>(): either Fn(CmdArgParser*) (drives the parser, may
+// consume several args) or Fn(std::string_view, RuleError&) (converts the next arg, sets err).
 template <class F>
 concept ParserFn =
     std::is_invocable_v<F, CmdArgParser*> || std::is_invocable_v<F, std::string_view, RuleError&>;
+
+// T is ArgParsable if a free `T ParseArg(CmdArgParser*, std::type_identity<T>)` is reachable by
+// ADL; such a T is read by parser.Next<T>(), with the free function driving the parser and
+// reporting its own errors. The type_identity tag carries T for ADL and holds no value to
+// dereference.
+template <class T>
+concept ArgParsable = requires(CmdArgParser* p) {
+  { ParseArg(p, std::type_identity<T>{}) } -> std::same_as<T>;
+};
 
 // Numeric conversion core shared by Num and Number; false if `arg` isn't a round-trippable T.
 template <class T> bool TryParseNum(std::string_view arg, T* out) {
@@ -183,6 +201,11 @@ template <auto min, auto max> using FInt = Validated<decltype(min), InRange<min,
 template <class T> constexpr bool is_optional = false;
 
 template <class U> constexpr bool is_optional<std::optional<U>> = true;
+
+// True for std::optional<U> whose U is ArgParsable; false (without touching value_type) otherwise.
+template <class T> constexpr bool optional_arg_parsable = false;
+
+template <class U> constexpr bool optional_arg_parsable<std::optional<U>> = ArgParsable<U>;
 
 struct CmdArgParser {
   enum ErrorType {
@@ -300,30 +323,38 @@ struct CmdArgParser {
   }
 
   template <class T = std::string_view, class... Ts> auto Next() {
-    if (cur_i_ + sizeof...(Ts) >= args_.size()) {
-      Report(OUT_OF_BOUNDS, cur_i_);
-      return std::conditional_t<sizeof...(Ts) == 0, decltype(Convert<T>(0)),
-                                std::tuple<T, Ts...>>();
-    }
-
-    if constexpr (sizeof...(Ts) == 0) {
-      auto idx = cur_i_++;
-      return Convert<T>(idx);
+    if constexpr (sizeof...(Ts) == 0 && ArgParsable<T>) {
+      return ParseArg(this, std::type_identity<T>{});
+    } else if constexpr (sizeof...(Ts) == 0 && optional_arg_parsable<T>) {
+      return T{Next<typename T::value_type>()};
     } else {
-      std::tuple<T, Ts...> res;
-      NextImpl<0>(&res);
-      cur_i_ += sizeof...(Ts) + 1;
-      return res;
+      if (cur_i_ + sizeof...(Ts) >= args_.size()) {
+        Report(OUT_OF_BOUNDS, cur_i_);
+        return std::conditional_t<sizeof...(Ts) == 0, decltype(Convert<T>(0)),
+                                  std::tuple<T, Ts...>>();
+      }
+
+      if constexpr (sizeof...(Ts) == 0) {
+        auto idx = cur_i_++;
+        return Convert<T>(idx);
+      } else {
+        std::tuple<T, Ts...> res;
+        NextImpl<0>(&res);
+        cur_i_ += sizeof...(Ts) + 1;
+        return res;
+      }
     }
   }
 
-  // Runs a parser callable (see ParserFn): a fn(CmdArgParser*) drives the parser; a
-  // fn(std::string_view, RuleError&) converts the next arg, its RuleError becoming a report.
-  template <class F>
-  requires ParserFn<F>
-  auto Next(F&& fn) {
+  // Runs a compile-time parser callable given as a template arg: parser.Next<Upper>(). Fn is either
+  // Fn(CmdArgParser*) (drives the parser) or Fn(std::string_view, RuleError&) (converts one arg,
+  // its RuleError becoming a report).
+  template <auto Fn>
+  requires ParserFn<decltype(Fn)>
+  auto Next() {
+    using F = decltype(Fn);
     if constexpr (std::is_invocable_v<F, CmdArgParser*>) {
-      return std::forward<F>(fn)(this);
+      return Fn(this);
     } else {
       using R = std::invoke_result_t<F, std::string_view, RuleError&>;
       static_assert(std::is_default_constructible_v<R> && !std::is_reference_v<R>,
@@ -334,7 +365,7 @@ struct CmdArgParser {
       }
       size_t idx = cur_i_++;
       RuleError e;
-      R val = std::forward<F>(fn)(SafeSV(idx), e);
+      R val = Fn(SafeSV(idx), e);
       if (e.failed)
         Report(e.msg.empty() ? INVALID_CASES : CUSTOM_ERROR, idx, std::string{e.msg});
       return e.failed ? R{} : val;
@@ -390,11 +421,12 @@ struct CmdArgParser {
     return HasNext() ? Next<T>() : default_value;
   }
 
-  // Runs a parser callable (see ParserFn) if an arg remains, else returns default_value.
-  template <class F, class D>
-  requires ParserFn<F>
-  auto NextOrDefault(F&& fn, D default_value) {
-    return HasNext() ? Next(std::forward<F>(fn)) : default_value;
+  // Like NextOrDefault<T>(), but runs a compile-time parser callable:
+  // NextOrDefault<ParseGeoUnit>(1).
+  template <auto Fn>
+  requires ParserFn<decltype(Fn)>
+  auto NextOrDefault(auto default_value) {
+    return HasNext() ? Next<Fn>() : default_value;
   }
 
   // Consumes the next arg; reports INVALID_NEXT if it doesn't match (case-insensitive).
@@ -625,9 +657,28 @@ struct CmdArgParser {
   ErrorInfo error_;
 };
 
-// Default parser callable for arithmetic types: Next(Number<int>) behaves like Next<int>().
+// Default parser callable for arithmetic types: Next<Number<int>>() behaves like Next<int>().
 template <class T> T Number(CmdArgParser* parser) {
   return parser->Next<T>();
+}
+
+// Parser callable that ASCII-uppercases the next arg: parser.Next<Upper>().
+inline std::string Upper(std::string_view arg, RuleError&) {
+  return absl::AsciiStrToUpper(arg);
+}
+
+// A [min, max] pair read from two consecutive T args; reports Msg if min > max. Read with
+// parser.Next<MinMax<...>>() or Tag(tag, &field) for an optional<MinMax<...>> field. Msg is a
+// reference NTTP: give it external linkage (inline constexpr) so a MinMax type exposed across
+// translation units stays a single entity (a header-local `constexpr` message would break ODR).
+template <class T, const auto& Msg> struct MinMax { T min{}, max{}; };
+
+template <class T, const auto& Msg>
+MinMax<T, Msg> ParseArg(CmdArgParser* p, std::type_identity<MinMax<T, Msg>>) {
+  auto [lo, hi] = p->Next<T, T>();
+  if (lo > hi)
+    p->ReportCustom(std::string{Msg});
+  return {lo, hi};
 }
 
 namespace detail {
@@ -659,6 +710,20 @@ struct ExistOpt : OptBase<ExistOpt> {
   bool TryApply(CmdArgParser* parser) const {
     if (parser->Check(tag)) {
       *field = true;
+      return true;
+    }
+    return false;
+  }
+};
+
+template <class T> struct FlagOpt : OptBase<FlagOpt<T>> {
+  std::string_view tag;
+  T* field;
+  T value;
+
+  bool TryApply(CmdArgParser* parser) const {
+    if (parser->Check(tag)) {
+      *field |= value;
       return true;
     }
     return false;
@@ -728,18 +793,35 @@ template <class Inner> struct IfOpt : OptBase<IfOpt<Inner>> {
   }
 };
 
+// At most one option from the group may match; a second match reports .Err(msg)/INVALID_CASES.
+// .Repeat() tolerates the same option repeating (only a different one conflicts), e.g. EXPIRE NX
+// NX.
 template <class... Opts> struct OneOfOpt : OptBase<OneOfOpt<Opts...>> {
   std::tuple<Opts...> opts;
-  mutable bool matched = false;
+  bool allow_repeat = false;
+  mutable int matched = -1;  // matched option index, -1 = none yet
+
+  OneOfOpt&& Repeat() && {
+    allow_repeat = true;
+    return std::move(*this);
+  }
 
   bool TryApply(CmdArgParser* parser) const {
-    bool any = std::apply([&](auto&... os) { return (os.TryApply(parser) || ...); }, opts);
-    if (!any)
+    return TryAt<0>(parser);
+  }
+
+ private:
+  template <size_t I> bool TryAt(CmdArgParser* parser) const {
+    if constexpr (I >= sizeof...(Opts)) {
       return false;
-    if (matched)
-      this->ReportErr(parser);
-    matched = true;
-    return true;
+    } else if (std::get<I>(opts).TryApply(parser)) {
+      if (matched != -1 && (!allow_repeat || matched != int(I)))
+        this->ReportErr(parser);
+      matched = I;
+      return true;
+    } else {
+      return TryAt<I + 1>(parser);
+    }
   }
 };
 
@@ -768,6 +850,12 @@ concept ParseOption = requires(const T& t, CmdArgParser* p) {
 
 inline detail::ExistOpt Exist(std::string_view tag, bool* field) {
   return {{}, tag, field};
+}
+
+// tag present -> ORs `value` into `*field` (e.g. a bitmask of flags).
+template <class T>
+detail::FlagOpt<T> Flag(std::string_view tag, T* field, std::type_identity_t<T> value) {
+  return {{}, tag, field, value};
 }
 
 template <class... Args> detail::TagOpt<Args...> Tag(std::string_view tag, Args*... args) {

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -15,6 +15,21 @@
 using namespace testing;
 using namespace std;
 
+namespace custom_arg {
+
+// Custom type whose ADL ParseArg lives here (not in facade), exercising Next<T>() via real ADL.
+struct Duration {
+  int64_t ms = 0;
+  bool operator==(const Duration&) const = default;
+};
+
+Duration ParseArg(facade::CmdArgParser* p, std::type_identity<Duration>) {
+  int64_t n = p->Next<int64_t>();
+  return Duration{p->Check("MS") ? n : n * 1000};
+}
+
+}  // namespace custom_arg
+
 namespace facade {
 
 class CmdArgParserTest : public testing::Test {
@@ -515,6 +530,64 @@ TEST_F(CmdArgParserTest, ApplyOneOf) {
   }
 }
 
+TEST_F(CmdArgParserTest, ApplyFlag) {
+  enum Bits : uint16_t { kNone = 0, kNx = 1 << 0, kXx = 1 << 1, kGet = 1 << 2 };
+
+  // Each present tag ORs its bit; absent tags leave it clear; duplicates are idempotent.
+  {
+    auto parser = Make({"GET", "NX", "GET"});
+    uint16_t flags = kNone;
+    parser.Apply(Flag("NX", &flags, uint16_t{kNx}), Flag("XX", &flags, uint16_t{kXx}),
+                 Flag("GET", &flags, uint16_t{kGet}));
+    EXPECT_EQ(flags, kNx | kGet);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  // Flag composes with OneOf: a conflicting pair still errors, but the same one repeats with
+  // Repeat.
+  {
+    auto parser = Make({"NX", "NX"});
+    uint16_t flags = kNone;
+    parser.Apply(
+        OneOf(Flag("NX", &flags, uint16_t{kNx}), Flag("XX", &flags, uint16_t{kXx})).Repeat());
+    EXPECT_EQ(flags, kNx);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {
+    auto parser = Make({"NX", "XX"});
+    uint16_t flags = kNone;
+    parser.Apply(
+        OneOf(Flag("NX", &flags, uint16_t{kNx}), Flag("XX", &flags, uint16_t{kXx})).Repeat());
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_CASES);
+  }
+}
+
+TEST_F(CmdArgParserTest, ApplyOneOfRepeat) {
+  auto set = [](int* dst, int v) { return [dst, v](CmdArgParser*) { *dst = v; }; };
+
+  {  // .Repeat() tolerates the SAME option repeating (idempotent), like Redis EXPIRE NX NX.
+    int nx = 0, xx = 0;
+    auto parser = Make({"NX", "NX"});
+    parser.Apply(OneOf(Tag("NX", set(&nx, 1)), Tag("XX", set(&xx, 1))).Repeat().Err("conflict"));
+    EXPECT_EQ(nx, 1);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {  // ...but a DIFFERENT option in the group still conflicts.
+    int nx = 0, xx = 0;
+    auto parser = Make({"NX", "XX"});
+    parser.Apply(OneOf(Tag("NX", set(&nx, 1)), Tag("XX", set(&xx, 1))).Repeat().Err("conflict"));
+    auto err = parser.TakeError();
+    EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
+    EXPECT_EQ(err.MakeReply().ToSv(), "conflict");
+  }
+  {  // Without .Repeat(), repeating the same option is still a conflict.
+    int nx = 0, xx = 0;
+    auto parser = Make({"NX", "NX"});
+    parser.Apply(OneOf(Tag("NX", set(&nx, 1)), Tag("XX", set(&xx, 1))).Err("conflict"));
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "conflict");
+  }
+}
+
 TEST_F(CmdArgParserTest, ApplyOptional) {
   // Tag present -> optional engaged.
   {
@@ -746,16 +819,22 @@ double ParseUnit(std::string_view sv, RuleError& err) {
   return -1.0;
 }
 
+// A full-form parser callable (CmdArgParser*): consumes several args, returns a compound type.
+std::pair<int, int> ParsePoint(CmdArgParser* p) {
+  int x = p->Next<int>();
+  return {x, p->Next<int>()};
+}
+
 TEST_F(CmdArgParserTest, ParserFunction) {
   {  // token form: fn(string_view, RuleError&) converts the next arg
     auto parser = Make({"KM", "M"});
-    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 1000.0);
-    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 1.0);
+    EXPECT_DOUBLE_EQ(parser.Next<ParseUnit>(), 1000.0);
+    EXPECT_DOUBLE_EQ(parser.Next<ParseUnit>(), 1.0);
     EXPECT_FALSE(parser.HasError());
   }
   {
     auto parser = Make({"YARD"});
-    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 0.0);  // value-initialized on failure
+    EXPECT_DOUBLE_EQ(parser.Next<ParseUnit>(), 0.0);  // value-initialized on failure
     auto err = parser.TakeError();
     EXPECT_TRUE(err);
     EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
@@ -763,20 +842,22 @@ TEST_F(CmdArgParserTest, ParserFunction) {
   }
   {
     auto parser = Make({});  // framework surfaces OUT_OF_BOUNDS before calling fn
-    EXPECT_DOUBLE_EQ(parser.Next(ParseUnit), 0.0);
+    EXPECT_DOUBLE_EQ(parser.Next<ParseUnit>(), 0.0);
     EXPECT_EQ(parser.TakeError().type, CmdArgParser::OUT_OF_BOUNDS);
   }
-  {  // full form: fn(CmdArgParser*) can consume several args and return a compound type
+  {  // full form: Fn(CmdArgParser*) can consume several args and return a compound type
     auto parser = Make({"3", "4"});
-    auto point = [](CmdArgParser* p) {
-      int x =
-          p->Next<int>();  // sequence reads explicitly; argument evaluation order is unspecified
-      return std::make_pair(x, p->Next<int>());
-    };
-    auto [x, y] = parser.Next(point);
+    auto [x, y] = parser.Next<ParsePoint>();
     EXPECT_EQ(x, 3);
     EXPECT_EQ(y, 4);
     EXPECT_FALSE(parser.HasError());
+  }
+  {  // NextOrDefault<Fn>() runs the callable if an arg remains, else returns the default
+    auto with_arg = Make({"KM"});
+    EXPECT_DOUBLE_EQ(with_arg.NextOrDefault<ParseUnit>(7.0), 1000.0);
+    auto empty = Make({});
+    EXPECT_DOUBLE_EQ(empty.NextOrDefault<ParseUnit>(7.0), 7.0);
+    EXPECT_FALSE(empty.HasError());
   }
 }
 
@@ -784,19 +865,92 @@ TEST_F(CmdArgParserTest, NumberParser) {
   // The Number<> default parser callable matches the built-in Next<T>() behavior and error kinds.
   {
     auto parser = Make({"42", "3.5"});
-    EXPECT_EQ(parser.Next(Number<int>), 42);
-    EXPECT_DOUBLE_EQ(parser.Next(Number<double>), 3.5);
+    EXPECT_EQ(parser.Next<Number<int>>(), 42);
+    EXPECT_DOUBLE_EQ(parser.Next<Number<double>>(), 3.5);
     EXPECT_FALSE(parser.HasError());
   }
   {
     auto parser = Make({"notanint"});
-    EXPECT_EQ(parser.Next(Number<int>), 0);
+    EXPECT_EQ(parser.Next<Number<int>>(), 0);
     EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
   }
   {
     auto parser = Make({"notafloat"});
-    EXPECT_DOUBLE_EQ(parser.Next(Number<double>), 0.0);
+    EXPECT_DOUBLE_EQ(parser.Next<Number<double>>(), 0.0);
     EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_FLOAT);
+  }
+}
+
+TEST_F(CmdArgParserTest, UpperParser) {
+  auto parser = Make({"set", "MiXeD", ""});
+  EXPECT_EQ(parser.Next<Upper>(), "SET");
+  EXPECT_EQ(parser.Next<Upper>(), "MIXED");
+  EXPECT_EQ(parser.Next<Upper>(), "");
+  EXPECT_FALSE(parser.HasError());
+  EXPECT_EQ(parser.Next<Upper>(), "");  // out of bounds -> empty + error
+  EXPECT_EQ(parser.TakeError().type, CmdArgParser::OUT_OF_BOUNDS);
+}
+
+TEST_F(CmdArgParserTest, CustomTypeAdl) {
+  using custom_arg::Duration;
+
+  static_assert(ArgParsable<Duration>);
+  static_assert(!ArgParsable<int>);
+
+  {  // the custom parser drives multiple args; a second read resumes where the first stopped
+    auto parser = Make({"5", "MS", "2"});
+    EXPECT_EQ(parser.Next<Duration>(), Duration{5});     // "5 MS" -> 5ms
+    EXPECT_EQ(parser.Next<Duration>(), Duration{2000});  // "2" -> 2s
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_FALSE(parser.HasNext());
+  }
+  {  // errors raised inside the custom parser propagate
+    auto parser = Make({"notanumber"});
+    (void)parser.Next<Duration>();
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
+  }
+  {  // NextOrDefault<T>() routes to it too, honoring the default when empty
+    auto parser = Make({});
+    EXPECT_EQ(parser.NextOrDefault<Duration>(Duration{99}), Duration{99});
+    EXPECT_FALSE(parser.HasError());
+  }
+  {  // optional<T> of an ArgParsable T routes through the same free function
+    auto parser = Make({"7", "MS"});
+    auto d = parser.Next<std::optional<Duration>>();
+    EXPECT_TRUE(d.has_value());
+    EXPECT_EQ(*d, Duration{7});
+    EXPECT_FALSE(parser.HasError());
+  }
+}
+
+constexpr char kNotOrdered[] = "min must be <= max";
+
+TEST_F(CmdArgParserTest, MinMaxParser) {
+  using Range = MinMax<uint32_t, kNotOrdered>;
+
+  {  // min <= max (equal allowed) parses into {min, max}
+    auto parser = Make({"3", "9", "5", "5"});
+    auto a = parser.Next<Range>();
+    EXPECT_EQ(a.min, 3u);
+    EXPECT_EQ(a.max, 9u);
+    auto b = parser.Next<Range>();  // equal endpoints are valid
+    EXPECT_EQ(b.min, 5u);
+    EXPECT_EQ(b.max, 5u);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {  // min > max reports the custom message
+    auto parser = Make({"9", "3"});
+    (void)parser.Next<Range>();
+    auto err = parser.TakeError();
+    EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
+    EXPECT_EQ(err.MakeReply().ToSv(), kNotOrdered);
+  }
+  {  // usable as an optional field via the optional<ArgParsable> path
+    auto parser = Make({"1", "4"});
+    auto r = parser.Next<std::optional<Range>>();
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->min, 1u);
+    EXPECT_EQ(r->max, 4u);
   }
 }
 

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -454,7 +454,7 @@ void AclFamily::Cat(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<facade::RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (parser.HasNext()) {
-    string category = absl::AsciiStrToUpper(parser.Next());
+    string category = parser.Next<facade::Upper>();
     if (!parser.Finalize())
       return rb->SendError(parser.TakeError().MakeReply());
 
@@ -587,7 +587,7 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
   }
 
-  string command = absl::AsciiStrToUpper(parser.Next());
+  string command = parser.Next<facade::Upper>();
   auto* cid = cmd_registry_->Find(command);
   if (!cid || cid->IsAlias()) {
     auto error = absl::StrCat("Command '", command, "' not found");

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -1194,7 +1194,7 @@ void BitFieldRo(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 void BitOp(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   static const std::array<string_view, 4> BITOP_OP_NAMES{OR_OP_NAME, XOR_OP_NAME, AND_OP_NAME,
                                                          NOT_OP_NAME};
-  string op = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string op = parser.Next<Upper>();
   string_view dest_key = parser.Next<string_view>();
 
   if (auto err = parser.TakeError(); err) {

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include "facade/cmd_arg_parser.h"
@@ -40,6 +41,12 @@ struct SlotRange {
 
   std::string ToString() const;
 };
+
+// Parses two slot ids [start, end] for parser.Next<SlotRange>() / Tag(tag, &optional<SlotRange>).
+inline SlotRange ParseArg(facade::CmdArgParser* p, std::type_identity<SlotRange>) {
+  auto [start, end] = p->Next<ParsedSlotId, ParsedSlotId>();
+  return {start, end};
+}
 
 class SlotRanges {
  public:

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -420,7 +420,7 @@ void ClusterFamily::Cluster(CmdArgParser parser, CommandContext* cmd_cntx) {
   // In emulated cluster mode, all slots are mapped to the same host, and number of cluster
   // instances is thus 1.
   ParsedArgs full_args = parser.UnparsedArgs();
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next());
+  string sub_cmd = parser.Next<Upper>();
 
   auto* builder = cmd_cntx->rb();
   if (!IsClusterEnabledOrEmulated()) {
@@ -471,7 +471,7 @@ void ClusterFamily::DflyCluster(CmdArgParser parser, CommandContext* cmd_cntx) {
     return builder->SendError("Cluster is disabled. Use --cluster_mode=yes to enable.");
   }
 
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next());  // remove subcommand name
+  string sub_cmd = parser.Next<Upper>();  // remove subcommand name
   if (sub_cmd == "GETSLOTINFO") {
     return DflyClusterGetSlotInfo(parser, cmd_cntx);
   } else if (sub_cmd == "CONFIG") {
@@ -835,7 +835,7 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgParser parser, CommandContext*
 }
 
 void ClusterFamily::DflyMigrate(CmdArgParser parser, CommandContext* cmd_cntx) {
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next());
+  string sub_cmd = parser.Next<Upper>();
 
   if (sub_cmd == "INIT") {
     InitMigration(parser, cmd_cntx);

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -638,7 +638,7 @@ DebugCmd::DebugCmd(ServerFamily* owner, cluster::ClusterFamily* cf, ConnectionCo
 }
 
 void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  string subcmd = absl::AsciiStrToUpper(parser.Next());
+  string subcmd = parser.Next<Upper>();
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
@@ -863,7 +863,7 @@ void DebugCmd::Reload(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void DebugCmd::Replica(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  string opt = absl::AsciiStrToUpper(parser.Next());
+  string opt = parser.Next<Upper>();
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (opt == "PAUSE" || opt == "RESUME") {
@@ -887,7 +887,7 @@ void DebugCmd::Replica(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void DebugCmd::Migration(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  string opt = absl::AsciiStrToUpper(parser.Next());
+  string opt = parser.Next<Upper>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (opt == "PAUSE" || opt == "RESUME") {
     cf_.PauseAllIncomingMigrations(opt == "PAUSE");
@@ -895,8 +895,6 @@ void DebugCmd::Migration(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
   }
   return cmd_cntx->SendError(UnknownSubCmd("MIGRATION", "DEBUG"));
 }
-
-enum PopulateFlag { FLAG_RAND, FLAG_TYPE, FLAG_ELEMENTS, FLAG_SLOT, FLAG_EXPIRE, FLAG_UNKNOWN };
 
 // Populate arguments format:
 // required: (total count) (key prefix) (val size)
@@ -908,40 +906,11 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgParser par
   options.total_count = parser.Next<uint64_t>();
   options.prefix = parser.NextOrDefault<string_view>("key");
   options.val_size = parser.NextOrDefault<uint32_t>(16);
-  while (parser.HasNext()) {
-    PopulateFlag flag = parser.MapNext("RAND", FLAG_RAND, "TYPE", FLAG_TYPE, "ELEMENTS",
-                                       FLAG_ELEMENTS, "SLOTS", FLAG_SLOT, "EXPIRE", FLAG_EXPIRE);
-    switch (flag) {
-      case FLAG_RAND:
-        options.populate_random_values = true;
-        break;
-      case FLAG_TYPE:
-        options.type = absl::AsciiStrToUpper(parser.Next<string_view>());
-        break;
-      case FLAG_ELEMENTS:
-        options.elements = parser.Next<uint32_t>();
-        break;
-      case FLAG_SLOT: {
-        auto [start, end] = parser.Next<FInt<0, 16383>, FInt<0, 16383>>();
-        options.slot_range = cluster::SlotRange{SlotId(start), SlotId(end)};
-        break;
-      }
-      case FLAG_EXPIRE: {
-        auto [min_ttl, max_ttl] = parser.Next<uint32_t, uint32_t>();
-        if (min_ttl >= max_ttl) {
-          cmd_cntx->SendError(kExpiryOutOfRange);
-          (void)parser.TakeError();
-          return nullopt;
-        }
-        options.expire_ttl_range = std::make_pair(min_ttl, max_ttl);
-        break;
-      }
-      default:
-        LOG(FATAL) << "Unexpected flag in PopulateArgs";
-        break;
-    }
-  }
-  if (parser.HasError()) {
+  parser.Apply(Exist("RAND", &options.populate_random_values),
+               Tag("TYPE", [&](CmdArgParser* p) { options.type = p->Next<Upper>(); }),
+               Tag("ELEMENTS", &options.elements), Tag("SLOTS", &options.slot_range),
+               Tag("EXPIRE", &options.expire_ttl_range));
+  if (!parser.Finalize()) {
     cmd_cntx->SendError(parser.TakeError().MakeReply());
     return nullopt;
   }
@@ -1883,9 +1852,9 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
     }
 
     if (options.expire_ttl_range.has_value()) {
-      uint32_t start = options.expire_ttl_range->first;
-      uint32_t end = options.expire_ttl_range->second;
-      uint32_t expire_ttl = rand() % (end - start) + start;
+      uint32_t start = options.expire_ttl_range->min;
+      uint32_t end = options.expire_ttl_range->max;
+      uint32_t expire_ttl = start == end ? start : rand() % (end - start) + start;
       VLOG(1) << "set key " << key << " expire ttl as " << expire_ttl;
       auto* cid = sf_.service().mutable_registry()->Find("EXPIRE");
       auto ttl_str = to_string(expire_ttl);

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "facade/cmd_arg_parser.h"
+#include "facade/error.h"
 #include "server/cluster/cluster_defs.h"
 #include "server/conn_context.h"
 
@@ -28,7 +29,7 @@ class DebugCmd {
     uint32_t elements = 1;
 
     std::optional<cluster::SlotRange> slot_range;
-    std::optional<std::pair<uint32_t, uint32_t>> expire_ttl_range;
+    std::optional<facade::MinMax<uint32_t, facade::kExpiryOutOfRange>> expire_ttl_range;
   };
 
  public:

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -152,7 +152,7 @@ DflyCmd::DflyCmd(ServerFamily* server_family) : sf_(server_family) {
 
 void DflyCmd::Run(CmdArgParser parser, CommandContext* cmd_cntx) {
   // Remaining-arg counts below are relative to the position after the subcommand token.
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string sub_cmd = parser.Next<Upper>();
 
   if (sub_cmd == "THREAD") {
     return Thread(parser, cmd_cntx);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1126,17 +1126,14 @@ void TtlGeneric(string_view key, TimeUnit unit, CommandContext* cmd_cntx) {
 
 int32_t ParseExpireOptions(CmdArgParser* parser) {
   int32_t flags = ExpireFlags::EXPIRE_ALWAYS;
-  parser->Apply(Tag("NX", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_NX; }),
-                Tag("XX", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_XX; }),
-                Tag("GT", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_GT; }),
-                Tag("LT", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_LT; }));
+  parser->Apply(
+      OneOf(Flag("NX", &flags, ExpireFlags::EXPIRE_NX), Flag("XX", &flags, ExpireFlags::EXPIRE_XX))
+          .Repeat()
+          .Err("NX and XX options at the same time are not compatible"),
+      OneOf(Flag("GT", &flags, ExpireFlags::EXPIRE_GT), Flag("LT", &flags, ExpireFlags::EXPIRE_LT))
+          .Repeat()
+          .Err("GT and LT options at the same time are not compatible"));
   parser->Finalize("Unsupported option: ");
-
-  // NX/XX and GT/LT are mutually exclusive; duplicate flags (e.g. NX NX) are tolerated like Redis.
-  if ((flags & ExpireFlags::EXPIRE_NX) && (flags & ExpireFlags::EXPIRE_XX))
-    parser->ReportCustom("NX and XX options at the same time are not compatible");
-  if ((flags & ExpireFlags::EXPIRE_GT) && (flags & ExpireFlags::EXPIRE_LT))
-    parser->ReportCustom("GT and LT options at the same time are not compatible");
   return flags;
 }
 
@@ -1389,7 +1386,7 @@ void GenericFamily::Persist(facade::CmdArgParser parser, CommandContext* cmd_cnt
 
 void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  int32_t expire_options = parser.Next<ParseExpireOptions>();
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
@@ -1408,7 +1405,7 @@ void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx
 
 void GenericFamily::ExpireAt(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  int32_t expire_options = parser.Next<ParseExpireOptions>();
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
@@ -1453,7 +1450,7 @@ void GenericFamily::Keys(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
 
 void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  int32_t expire_options = parser.Next<ParseExpireOptions>();
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
@@ -1476,7 +1473,7 @@ void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_c
 
 void GenericFamily::Pexpire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  int32_t expire_options = parser.Next<ParseExpireOptions>();
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -185,7 +185,7 @@ double ParseGeoUnit(std::string_view arg, facade::RuleError& err) {
 
 void ParseCircularShape(CmdArgParser* parser, GeoShape* shape, GeoSearchOpts* geo_ops) {
   shape->t.radius = parser->Next<double>();
-  geo_ops->conversion = shape->conversion = parser->Next(ParseGeoUnit);
+  geo_ops->conversion = shape->conversion = parser->Next<ParseGeoUnit>();
   shape->type = CIRCULAR_TYPE;
 }
 
@@ -243,17 +243,8 @@ void CmdGeoAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   ZSetFamily::ZParams zparams;
-  for (;;) {
-    if (parser.Check("XX")) {
-      zparams.flags |= ZADD_IN_XX;  // update only
-    } else if (parser.Check("NX")) {
-      zparams.flags |= ZADD_IN_NX;  // add new only.
-    } else if (parser.Check("CH")) {
-      zparams.ch = true;
-    } else {
-      break;
-    }
-  }
+  parser.Apply(Flag("XX", &zparams.flags, ZADD_IN_XX), Flag("NX", &zparams.flags, ZADD_IN_NX),
+               Exist("CH", &zparams.ch));
 
   auto* builder = cmd_cntx->rb();
   auto args = parser.RemainingRange();
@@ -349,7 +340,7 @@ void CmdGeoDist(CmdArgParser parser, CommandContext* cmd_cntx) {
     arg = parser.Next();
 
   // Optional trailing unit; Finalize() rejects both a missing required arg and any trailing args.
-  double distance_multiplier = parser.NextOrDefault(ParseGeoUnit, 1.0);
+  double distance_multiplier = parser.NextOrDefault<ParseGeoUnit>(1.0);
   if (!parser.Finalize()) {
     return rb->SendError(parser.TakeError().MakeReply());
   }
@@ -645,7 +636,7 @@ void CmdGeoSearch(CmdArgParser parser, CommandContext* cmd_cntx) {
                          [&](CmdArgParser* p) {
                            by_set = true;
                            std::tie(shape.t.r.width, shape.t.r.height) = p->Next<double, double>();
-                           geo_ops.conversion = shape.conversion = p->Next(ParseGeoUnit);
+                           geo_ops.conversion = shape.conversion = p->Next<ParseGeoUnit>();
                            shape.type = RECTANGLE_TYPE;
                          }))
                    .Err(kByRadiusBoxErr),

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2651,7 +2651,7 @@ void Service::PUnsubscribe(CmdArgParser parser, CommandContext* cmd_cntx) {
 // Not a real implementation. Serves as a decorator to accept some function commands
 // for testing.
 void Service::Function(CmdArgParser parser, CommandContext* cmd_cntx) {
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next());
+  string sub_cmd = parser.Next<Upper>();
 
   if (sub_cmd == "FLUSH") {
     return cmd_cntx->rb()->SendOk();
@@ -2697,7 +2697,7 @@ void Service::Pubsub(CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
   }
 
-  string subcmd = absl::AsciiStrToUpper(parser.Next());
+  string subcmd = parser.Next<Upper>();
 
   if (subcmd == "HELP") {
     string_view help_arr[] = {
@@ -2789,7 +2789,7 @@ void Service::Command(CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
   }
 
-  string subcmd = absl::AsciiStrToUpper(parser.Next());
+  string subcmd = parser.Next<Upper>();
 
   // COUNT
   if (subcmd == "COUNT") {
@@ -2798,7 +2798,7 @@ void Service::Command(CmdArgParser parser, CommandContext* cmd_cntx) {
 
   // INFO [cmd]
   if (subcmd == "INFO" && parser.HasNext()) {
-    string cmd = absl::AsciiStrToUpper(parser.Next());
+    string cmd = parser.Next<Upper>();
 
     if (const auto* cid = registry_.Find(cmd); cid) {
       rb->StartArray(1);

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -72,7 +72,7 @@ ScriptMgr::ScriptKey::ScriptKey(string_view sha) : array{} {
 
 void ScriptMgr::Run(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* builder,
                     ConnectionContext* cntx) {
-  string subcmd = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string subcmd = parser.Next<Upper>();
 
   if (subcmd == "HELP") {
     string_view kHelp[] = {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -121,7 +121,7 @@ search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
     } else if (parser->Check("M", &params.hnsw_m)) {
     } else if (parser->Check("EF_CONSTRUCTION", &params.hnsw_ef_construction)) {
     } else if (parser->Check("TYPE")) {
-      params.data_type = absl::AsciiStrToUpper(parser->Next<string_view>());
+      params.data_type = parser->Next<Upper>();
     } else if (parser->Check("EF_RUNTIME", &params.hnsw_ef_runtime)) {
     } else if (parser->Check("EPSILON")) {
       double epsilon = parser->Next<double>("Invalid EPSILON value");
@@ -374,7 +374,8 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
           absl::StrCat("Field type "sv, parser->Next(), " is not supported"sv));
     }
 
-    auto parsed_params = parser->Next(params_parser.value());
+    auto field_parser = params_parser.value();
+    auto parsed_params = field_parser(parser);
     if (!parsed_params) {
       return make_unexpected(parsed_params.error());
     }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2109,7 +2109,7 @@ void ClientHelp(SinkReplyBuilder* builder) {
 }
 
 void ServerFamily::Client(CmdArgParser parser, CommandContext* cmd_cntx) {
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string sub_cmd = parser.Next<Upper>();
   facade::ParsedArgs sub_args = parser.UnparsedArgs();
   auto* builder = cmd_cntx->rb();
 
@@ -2146,7 +2146,7 @@ void ServerFamily::Client(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void ServerFamily::Config(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   facade::ParsedArgs args = parser.UnparsedArgs();
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string sub_cmd = parser.Next<Upper>();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (sub_cmd == "HELP") {
@@ -3143,7 +3143,7 @@ void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void ServerFamily::Hello(CmdArgParser parser, CommandContext* cmd_cntx) {
-  facade::ParsedArgs args = parser.UnparsedArgs();
+  facade::ParsedArgs args = parser.UnparsedArgs();  // kept for the UnknownCmd error message
   // If no arguments are provided default to RESP2.
   bool is_resp3 = false;
   bool has_auth = false;
@@ -3153,31 +3153,28 @@ void ServerFamily::Hello(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view clientname;
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (!args.empty()) {
-    string_view proto_version = args[0];
+  if (parser.HasNext()) {
+    string_view proto_version = parser.Next();
     is_resp3 = proto_version == "3";
-    bool valid_proto_version = proto_version == "2" || is_resp3;
-    if (!valid_proto_version) {
+    if (proto_version != "2" && !is_resp3) {
       cmd_cntx->SendError(UnknownCmd("HELLO", args));
       return;
     }
 
-    for (uint32_t i = 1; i < args.size(); i++) {
-      auto sub_cmd = args[i];
-      auto moreargs = args.size() - 1 - i;
-      if (absl::EqualsIgnoreCase(sub_cmd, "AUTH") && moreargs >= 2) {
-        has_auth = true;
-        username = args[i + 1];
-        password = args[i + 2];
-        i += 2;
-      } else if (absl::EqualsIgnoreCase(sub_cmd, "SETNAME") && moreargs > 0) {
-        has_setname = true;
-        clientname = args[i + 1];
-        i += 1;
-      } else {
-        cmd_cntx->SendError(kSyntaxErr);
-        return;
-      }
+    parser.Apply(Tag("AUTH",
+                     [&](CmdArgParser* p) {
+                       has_auth = true;
+                       username = p->Next();
+                       password = p->Next();
+                     }),
+                 Tag("SETNAME", [&](CmdArgParser* p) {
+                   has_setname = true;
+                   clientname = p->Next();
+                 }));
+
+    if (!parser.Finalize()) {
+      cmd_cntx->SendError(parser.TakeError().MakeReply());
+      return;
     }
   }
 
@@ -3411,8 +3408,7 @@ void ServerFamily::ReplTakeOver(facade::CmdArgParser parser, CommandContext* cmd
   bool save_flag = static_cast<bool>(parser.Check("SAVE"));
 
   auto* builder = cmd_cntx->rb();
-  if (parser.HasNext())
-    return cmd_cntx->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));
+  parser.Finalize("Unsupported option:");
 
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
@@ -3606,7 +3602,7 @@ void ServerFamily::LastSave(facade::CmdArgParser parser, CommandContext* cmd_cnt
 
 void ServerFamily::Latency(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string sub_cmd = parser.Next<Upper>();
 
   if (sub_cmd == "LATEST" || sub_cmd == "HISTOGRAM") {
     return rb->SendEmptyArray();
@@ -3712,7 +3708,7 @@ void ServerFamily::SlowLog(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void ServerFamily::Module(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string sub_cmd = parser.Next<Upper>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (sub_cmd != "LIST")

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1042,46 +1042,54 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
 
   sparams.memcache_flags = cmd_cntx->mc_command() ? cmd_cntx->mc_command()->flags : 0;
 
-  while (parser.HasNext()) {
-    if (auto exp_type = parser.TryMapNext("EX", ExpT::EX, "PX", ExpT::PX, "EXAT", ExpT::EXAT,
-                                          "PXAT", ExpT::PXAT);
-        exp_type) {
-      auto int_arg = parser.Next<int64_t>();
-      if (parser.HasError())
-        break;
+  ExpT exp_type = ExpT::EX;
+  int64_t exp_arg = 0;
+  bool exp_defined = false;
 
-      // We can set expiry only once.
-      if (sparams.flags & SetCmd::SET_EXPIRE_AFTER_MS)
-        return facade::ErrorReply{kSyntaxErr};
+  auto expiry = [&](ExpT type) {
+    return [&, type](CmdArgParser* p) {
+      exp_type = type;
+      exp_arg = p->Next<int64_t>();
+      exp_defined = true;
+    };
+  };
 
-      sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
+  using SF = SetCmd::SetFlags;
+  // NX/XX and the expiry group each tolerate the same option repeating (last one wins) but reject a
+  // conflicting one, matching Redis. _MCFLAGS carries memcache flags on the replication path.
+  parser.Apply(OneOf(Flag("NX", &sparams.flags, SF::SET_IF_NOTEXIST),
+                     Flag("XX", &sparams.flags, SF::SET_IF_EXISTS))
+                   .Repeat(),
+               OneOf(Tag("EX", expiry(ExpT::EX)), Tag("PX", expiry(ExpT::PX)),
+                     Tag("EXAT", expiry(ExpT::EXAT)), Tag("PXAT", expiry(ExpT::PXAT)),
+                     Flag("KEEPTTL", &sparams.flags, SF::SET_KEEP_EXPIRE))
+                   .Repeat(),
+               Flag("GET", &sparams.flags, SF::SET_GET),
+               Flag("STICK", &sparams.flags, SF::SET_STICK),
+               Tag("_MCFLAGS", &sparams.memcache_flags));
 
-      // Since PXAT/EXAT can change this, we need to check this ahead
-      if (int_arg <= 0)
-        return facade::ErrorReply{InvalidExpireTime("set")};
+  if (!parser.Finalize())
+    return parser.TakeError().MakeReply();
 
-      const uint64_t now_ms = GetCurrentTimeMs();
-      DbSlice::ExpireParams expiry{*exp_type, int_arg, now_ms};
+  if (exp_defined) {
+    // Since PXAT/EXAT can change this, we need to check this ahead
+    if (exp_arg <= 0)
+      return facade::ErrorReply{InvalidExpireTime("set")};
 
-      auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
-      if (abs_ms < 0)
-        return facade::ErrorReply{InvalidExpireTime("set")};
+    const uint64_t now_ms = GetCurrentTimeMs();
+    DbSlice::ExpireParams expiry_params{exp_type, exp_arg, now_ms};
 
-      // Remove existed key if the key is expired already
-      if (rel_ms < 0)
-        return NegativeExpire{};
+    auto [rel_ms, abs_ms] = expiry_params.Calculate(now_ms, false);
+    if (abs_ms < 0)
+      return facade::ErrorReply{InvalidExpireTime("set")};
 
-      tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
-    } else if (!parser.Check("_MCFLAGS", &sparams.memcache_flags)) {
-      uint16_t flag = parser.MapNext(  //
-          "GET", SetCmd::SET_GET, "STICK", SetCmd::SET_STICK, "KEEPTTL", SetCmd::SET_KEEP_EXPIRE,
-          "XX", SetCmd::SET_IF_EXISTS, "NX", SetCmd::SET_IF_NOTEXIST);
-      sparams.flags |= flag;
-    }
+    // Remove existed key if the key is expired already
+    if (rel_ms < 0)
+      return NegativeExpire{};
+
+    sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
+    tie(sparams.expire_after_ms, ignore) = expiry_params.Calculate(now_ms, true);
   }
-
-  if (auto err = parser.TakeError(); err)
-    return err.MakeReply();
 
   if (auto* mc = cmd_cntx->mc_command()) {
     using MP = facade::MemcacheParser;
@@ -1101,12 +1109,6 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
         return NegativeExpire{};
       tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
     }
-  }
-
-  auto has_mask = [&](uint16_t m) { return (sparams.flags & m) == m; };
-  if (has_mask(SetCmd::SET_IF_EXISTS | SetCmd::SET_IF_NOTEXIST) ||
-      has_mask(SetCmd::SET_KEEP_EXPIRE | SetCmd::SET_EXPIRE_AFTER_MS)) {
-    return facade::ErrorReply{kSyntaxErr};
   }
 
   return sparams;

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -179,6 +179,22 @@ TEST_F(StringFamilyTest, SetOptionsSyntaxError) {
   EXPECT_THAT(Run({"SET", "foo", "bar", "EX", "18446744073709561"}), ErrArg("invalid expire time"));
 }
 
+// Repeating the same option is tolerated (last one wins), matching Redis; only conflicting options
+// error out (covered by SetOptionsSyntaxError above).
+TEST_F(StringFamilyTest, SetDuplicateOptions) {
+  EXPECT_EQ(Run({"set", "key", "val", "NX", "NX"}), "OK");
+  EXPECT_EQ(Run({"set", "key", "val", "XX", "XX"}), "OK");
+  EXPECT_EQ(Run({"set", "key", "val", "GET", "GET"}), "val");
+  EXPECT_EQ(Run({"set", "key", "val", "KEEPTTL", "KEEPTTL"}), "OK");
+
+  // Last expiry wins.
+  EXPECT_EQ(Run({"set", "key", "val", "EX", "100", "EX", "500"}), "OK");
+  EXPECT_THAT(Run({"ttl", "key"}), IntArg(500));
+
+  // A bad value in a later duplicate is still reported.
+  EXPECT_THAT(Run({"set", "key", "val", "EX", "100", "EX", "abc"}), ErrArg(kInvalidIntErr));
+}
+
 TEST_F(StringFamilyTest, Set) {
   auto resp = Run({"set", "foo", "bar", "XX"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2077,38 +2077,21 @@ void CmdBZPopMax(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
-  facade::ParsedArgs args = parser.UnparsedArgs();
-  string_view key = args[0];
+  string_view key = parser.Next();
 
   ZSetFamily::ZParams zparams;
-  size_t i = 1;
-  for (; i < args.size() - 1; ++i) {
-    string cur_arg = absl::AsciiStrToUpper(args[i]);
-
-    if (cur_arg == "XX") {
-      zparams.flags |= ZADD_IN_XX;  // update only
-    } else if (cur_arg == "NX") {
-      zparams.flags |= ZADD_IN_NX;  // add new only.
-    } else if (cur_arg == "GT") {
-      zparams.flags |= ZADD_IN_GT;
-    } else if (cur_arg == "LT") {
-      zparams.flags |= ZADD_IN_LT;
-    } else if (cur_arg == "CH") {
-      zparams.ch = true;
-    } else if (cur_arg == "INCR") {
-      zparams.flags |= ZADD_IN_INCR;
-    } else {
-      break;
-    }
-  }
+  parser.Apply(Flag("XX", &zparams.flags, ZADD_IN_XX), Flag("NX", &zparams.flags, ZADD_IN_NX),
+               Flag("GT", &zparams.flags, ZADD_IN_GT), Flag("LT", &zparams.flags, ZADD_IN_LT),
+               Exist("CH", &zparams.ch), Flag("INCR", &zparams.flags, ZADD_IN_INCR));
 
   auto* builder = cmd_cntx->rb();
-  if ((args.size() - i) % 2 != 0) {
+  auto args = parser.RemainingRange();
+  if (args.empty() || args.size() % 2 != 0) {
     builder->SendError(kSyntaxErr);
     return;
   }
 
-  if ((zparams.flags & ZADD_IN_INCR) && (i + 2 < args.size())) {
+  if ((zparams.flags & ZADD_IN_INCR) && args.size() > 2) {
     builder->SendError("INCR option supports a single increment-element pair");
     return;
   }
@@ -2129,7 +2112,7 @@ void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   absl::flat_hash_set<string_view> members_set;
   absl::InlinedVector<ScoredMemberView, 4> members;
 
-  unsigned num_members = (args.size() - i) / 2;
+  unsigned num_members = args.size() / 2;
 
   // We sort the fields if the expected encoding could be listpack.
   bool to_sort_fields = false;
@@ -2141,7 +2124,7 @@ void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
     to_sort_fields = true;
   }
 
-  for (; i < args.size(); i += 2) {
+  for (size_t i = 0; i < args.size(); i += 2) {
     string_view cur_arg = args[i];
     double val = 0;
 
@@ -2712,8 +2695,7 @@ void CmdZRandMember(CmdArgParser parser, CommandContext* cmd_cntx) {
   ZSetFamily::RangeParams params;
   params.with_scores = static_cast<bool>(parser.Check("WITHSCORES"));
 
-  if (parser.HasNext())
-    return rb->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));
+  parser.Finalize("Unsupported option:");
 
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 


### PR DESCRIPTION
Summary: This PR refactors facade::CmdArgParser to support ADL-based parsing for custom types and to standardize parser-function usage via compile-time callables.

Changes:

- Added ArgParsable + ADL hook (ParseArg(CmdArgParser*, T*)) so Next<T>() can parse user-defined types.
- Reworked parser-function support to use parser.Next<Fn>() (NTTP) and removed the runtime Next(fn)/NextOrDefault(fn, ...) APIs.
- Introduced reusable helpers: Upper (token parser), MinMax (two-value pair with ordering validation), and Flag (bit-OR option).
- Enhanced OneOf with .Repeat() to allow idempotent repeats while still rejecting conflicts.
- Updated multiple command families (ACL/Cluster/Debug/Generic/Geo/Main/Script/Server/String/ZSet) to use the new parsing primitives.
- Adjusted DEBUG POPULATE expiry range handling and TTL selection for equal endpoints.
- Expanded unit tests to cover ADL custom types, Upper, MinMax, Flag, and OneOf().Repeat() behavior.

Technical Notes: Error semantics remain centralized through CmdArgParser::ErrorInfo::MakeReply(); most new parsing paths still surface invalid input as syntax error unless a custom message is provided.