### PR TITLE
fix(server): MGET don't acess tx after running

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -516,7 +516,7 @@ struct GetResp {
   uint32_t ttl_sec = 0;
 };
 
-struct MGetResponse {
+struct alignas(64) MGetResponse {
   explicit MGetResponse(size_t size = 0) : resp_arr(size) {
   }
 
@@ -1465,27 +1465,6 @@ cmd::CmdR CmdDecrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
   return IncrByGeneric(cmd_cntx, key, -val);
 }
 
-// Reorder per-shard results according to argument order of primary command
-void ReorderShardResults(absl::Span<MGetResponse> mget_resp, const Transaction* t,
-                         absl::Span<optional<GetResp>> dest) {
-  for (ShardId sid = 0; sid < mget_resp.size(); ++sid) {
-    if (!t->IsActive(sid))
-      continue;
-
-    auto& src = mget_resp[sid];
-    ShardArgs shard_args = t->GetShardArgs(sid);
-    unsigned src_indx = 0;
-    for (auto it = shard_args.begin(); it != shard_args.end(); ++it, ++src_indx) {
-      if (!src.resp_arr[src_indx])
-        continue;
-
-      DCHECK_LT(it.index(), dest.size());
-      auto& item = dest[it.index()];
-      item = src.resp_arr[src_indx];
-    }
-  }
-}
-
 cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, std::optional<DbSlice::ExpireParams> gat_params) {
   const auto& tail_args = cmd_cntx->tail_args();
   DCHECK_GE(tail_args.size(), 1U);
@@ -1501,16 +1480,30 @@ cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, std::optional<DbSlice::ExpirePar
 
   unique_ptr<MGetResponse[]> mget_resp(new MGetResponse[shard_set->size()]);
 
+  size_t arg_len = tail_args.size();
+  unique_ptr<optional<GetResp>[]> mget_results(new optional<GetResp>[arg_len]);
+
   auto gat_ptr = gat_params ? &*gat_params : nullptr;
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    mget_resp[shard->shard_id()] = OpMGet(tiering_bc, &tiering_err, cmd_flags, t, shard, gat_ptr);
+    ShardId sid = shard->shard_id();
+    MGetResponse resp = OpMGet(tiering_bc, &tiering_err, cmd_flags, t, shard, gat_ptr);
+
+    // Reorder shard resuls based on key indices in commands
+    ShardArgs shard_args = t->GetShardArgs(sid);
+    unsigned src_indx = 0;
+    for (auto it = shard_args.begin(); it != shard_args.end(); ++it, ++src_indx) {
+      if (!resp.resp_arr[src_indx])
+        continue;
+      DCHECK_LT(it.index(), arg_len);
+      mget_results[it.index()] = resp.resp_arr[src_indx];
+    }
+
+    // Keep the per-shard storage alive: GetResp::value string_views point into resp.storage.
+    mget_resp[sid] = std::move(resp);
     return OpStatus::OK;
   };
 
-  // Waiter objects needs to be used to keep tx alive in its scope for ReorderShardResults
-  cmd::SingleHopWaiter waiter{cmd_cntx, cb};
-  auto result = co_await waiter;
-  CHECK_EQ(OpStatus::OK, result);
+  co_await cmd::SingleHop(cb);
 
   // wait for all tiered reads to finish and check for errors
   tiering_bc->Wait();
@@ -1518,12 +1511,6 @@ cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, std::optional<DbSlice::ExpirePar
     cmd_cntx->rb()->SendError(err.message());
     co_return std::nullopt;
   }
-
-  size_t arg_len = tail_args.size();
-
-  unique_ptr<optional<GetResp>[]> mget_results(new optional<GetResp>[arg_len]);
-  ReorderShardResults(absl::MakeSpan(mget_resp.get(), shard_set->size()), cmd_cntx->tx(),
-                      absl::MakeSpan(mget_results.get(), arg_len));
 
   SinkReplyBuilder::ReplyScope scope{cmd_cntx->rb()};
   if (cmd_cntx->mc_command()) {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -233,6 +233,55 @@ TEST_P(LatentCoolingTSTest, MGET) {
     EXPECT_EQ(elements[i], values[i]);
 }
 
+// Test that squashed GET/MGET commands over offloaded values run their disk reads concurrently.
+TEST_F(PureDiskTSTest, MGETParallel) {
+  // Create kMax strings and offload them. Each value fills its own page so each key maps to a
+  // distinct pending read, making concurrent reads observable via pending_read_cnt.
+  const int kMax = 200;
+  std::string value(3000, 'c');
+  for (int i = 0; i < kMax; i++)
+    Run({"SET", absl::StrCat("key:", i), value});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= kMax; });
+
+  // Build a batch of GET/MGET commands of varying widths
+  vector<vector<string>> cmds;
+  for (int i = 0; i < 200; i++) {
+    int width = 1 + (i * 7) % 13;  // 1..13 keys
+    vector<string> cmd = {width == 1 ? "GET" : "MGET"};
+    for (int j = 0; j < width; j++)
+      cmd.emplace_back(absl::StrCat("key:", (i * 7 + j) % kMax));
+    cmds.push_back(std::move(cmd));
+  }
+
+  // Sample the peak number of in-flight tiered reads on the shard while the batch runs
+  atomic_uint32_t peak_reads{0};
+  atomic_uint64_t sample_count{0};
+  atomic_bool sampling{true};
+  auto sampler = pp_->at(0)->LaunchFiber([&] {
+    while (sampling.load(memory_order_relaxed)) {
+      uint32_t cur = EngineShard::tlocal()->tiered_storage()->GetStats().pending_read_cnt;
+      sample_count.fetch_add(1, memory_order_relaxed);
+      if (cur > peak_reads.load(memory_order_relaxed))
+        peak_reads.store(cur, memory_order_relaxed);
+      ThisFiber::Yield();
+    }
+  });
+
+  // Dispatch them all at once through the squashing pipeline.
+  RunMany(cmds);
+
+  sampling.store(false, memory_order_relaxed);
+  sampler.JoinIfNeeded();
+  auto m = GetMetrics();
+  LOG(INFO) << "peak_reads=" << peak_reads.load() << " samples=" << sample_count.load()
+            << " total_fetches=" << m.tiered_stats.total_fetches
+            << " total_stashes=" << m.tiered_stats.total_stashes;
+
+  // Must be more than max arguments
+  EXPECT_GT(peak_reads.load(memory_order_relaxed), 10u)
+      << "expected concurrent tiered reads while executing the squashed batch";
+}
+
 // Issue many APPEND commands to an offloaded value that are executed at once (with CLIENT PAUSE).
 // They should all finish within the same io completion loop.
 TEST_F(TieredStorageTest, AppendStorm) {


### PR DESCRIPTION
MGet was previously referring to transaction data (with GetShardArgs) after the shard callbacks finished running, so it was accessing the transaction after usage + conclusion. This makes re-using the same transaction more difficult.

Instead, MGet now reorders its results in the shard threads, so no access is needed afterwards to restore the original order