### PR TITLE
fix: tiered-storage crashes in HLL commands under pipeline squashing

### DIFF
--- a/src/server/cmd_support.cc
+++ b/src/server/cmd_support.cc
@@ -10,16 +10,22 @@
 
 namespace dfly::cmd {
 
+Transaction::RunnableResult SingleHopWaiter::operator()(Transaction* tx, EngineShard* es) const {
+  auto res = callback(tx, es);
+  status_ = res.status;
+  return res;
+}
+
 bool SingleHopWaiter::await_ready() noexcept {
   auto* tx = cmd_cntx->tx();
 
   if (!cmd_cntx->IsDeferredReply()) {
     // Use fiber blocking in synchronous mode
-    tx->ScheduleSingleHop(callback);
+    tx->ScheduleSingleHop(*this);
     return true;
   } else {
     // Schedule async hop and keep transaction alive
-    tx->SingleHopAsync(callback);
+    tx->SingleHopAsync(*this);
     tx_keepalive_ = tx;
     return false;
   }
@@ -30,7 +36,7 @@ void SingleHopWaiter::await_suspend(std::coroutine_handle<> handle) const noexce
 }
 
 facade::OpStatus SingleHopWaiter::await_resume() const noexcept {
-  return *cmd_cntx->tx()->LocalResultPtr();
+  return status_;
 }
 
 void CmdR::Coro::return_value(const facade::ErrorReply& err) const noexcept {

--- a/src/server/cmd_support.cc
+++ b/src/server/cmd_support.cc
@@ -6,14 +6,22 @@
 
 #include <absl/cleanup/cleanup.h>
 
+#include <new>
+
 #include "base/logging.h"
 
 namespace dfly::cmd {
 
 Transaction::RunnableResult SingleHopWaiter::operator()(Transaction* tx, EngineShard* es) const {
-  auto res = callback(tx, es);
-  status_ = res.status;
-  return res;
+  try {
+    auto res = callback(tx, es);
+    status_ = res.status;
+    return res;
+  } catch (const std::bad_alloc&) {
+    // RunCallback maps this to OUT_OF_MEMORY; mirror it so the snapshot matches.
+    status_ = facade::OpStatus::OUT_OF_MEMORY;
+    throw;
+  }
 }
 
 bool SingleHopWaiter::await_ready() noexcept {
@@ -21,14 +29,22 @@ bool SingleHopWaiter::await_ready() noexcept {
 
   if (!cmd_cntx->IsDeferredReply()) {
     // Use fiber blocking in synchronous mode
-    tx->ScheduleSingleHop(*this);
+    tx->ScheduleSingleHop(callback);
     return true;
-  } else {
-    // Schedule async hop and keep transaction alive
-    tx->SingleHopAsync(*this);
-    tx_keepalive_ = tx;
-    return false;
   }
+
+  // Async hop. Only single-shard commands can be pipeline-squashed onto a reused
+  // transaction, so snapshot their status during the hop. Multi-shard hops run
+  // callbacks on several shards concurrently, so writing status_ from them would
+  // race; they instead read the transaction's aggregated result, which their own
+  // (non-reused) transaction preserves.
+  use_snapshot_ = tx->GetUniqueShardCnt() == 1;
+  if (use_snapshot_)
+    tx->SingleHopAsync(*this);
+  else
+    tx->SingleHopAsync(callback);
+  tx_keepalive_ = tx;
+  return false;
 }
 
 void SingleHopWaiter::await_suspend(std::coroutine_handle<> handle) const noexcept {
@@ -36,7 +52,7 @@ void SingleHopWaiter::await_suspend(std::coroutine_handle<> handle) const noexce
 }
 
 facade::OpStatus SingleHopWaiter::await_resume() const noexcept {
-  return status_;
+  return use_snapshot_ ? status_ : *cmd_cntx->tx()->LocalResultPtr();
 }
 
 void CmdR::Coro::return_value(const facade::ErrorReply& err) const noexcept {

--- a/src/server/cmd_support.h
+++ b/src/server/cmd_support.h
@@ -46,15 +46,18 @@ struct SingleHopWaiter {
   facade::OpStatus await_resume() const noexcept;
 
   // Runs the callback and snapshots its status. Scheduled in place of the raw
-  // callback so await_resume() returns this snapshot instead of the transaction
-  // result, which under pipeline squashing may already be reused by the next
-  // command by the time the coroutine resumes.
+  // callback for single-shard hops so await_resume() returns this snapshot
+  // instead of the transaction result, which under pipeline squashing may
+  // already be reused by the next command by the time the coroutine resumes.
   Transaction::RunnableResult operator()(Transaction* tx, EngineShard* es) const;
 
   CommandContext* cmd_cntx;
   Transaction::RunnableType callback;
   boost::intrusive_ptr<Transaction> tx_keepalive_ = nullptr;
   mutable facade::OpStatus status_ = facade::OpStatus::OK;
+  // Set when status_ holds the hop result (single-shard). Multi-shard hops
+  // aggregate into the transaction and are never squashed onto a reused tx.
+  bool use_snapshot_ = false;
 };
 
 // Extension of SingleHopWaiter capturing the return value of the callback

--- a/src/server/cmd_support.h
+++ b/src/server/cmd_support.h
@@ -45,9 +45,16 @@ struct SingleHopWaiter {
   void await_suspend(std::coroutine_handle<> handle) const noexcept;
   facade::OpStatus await_resume() const noexcept;
 
+  // Runs the callback and snapshots its status. Scheduled in place of the raw
+  // callback so await_resume() returns this snapshot instead of the transaction
+  // result, which under pipeline squashing may already be reused by the next
+  // command by the time the coroutine resumes.
+  Transaction::RunnableResult operator()(Transaction* tx, EngineShard* es) const;
+
   CommandContext* cmd_cntx;
   Transaction::RunnableType callback;
   boost::intrusive_ptr<Transaction> tx_keepalive_ = nullptr;
+  mutable facade::OpStatus status_ = facade::OpStatus::OK;
 };
 
 // Extension of SingleHopWaiter capturing the return value of the callback

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -321,6 +321,10 @@ OpResult<int> PFMergeInternal(string_view key, Transaction* tx, SinkReplyBuilder
     auto op_res = db_slice.AddOrFind(t->GetDbContext(), key, OBJ_STRING);
     RETURN_ON_BAD_STATUS(op_res);
     auto& res = *op_res;
+    if (!res.is_new && res.it->second.IsExternal()) {
+      res.post_updater.ReduceHeapUsage();
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    }
     res.it->second.SetString(hll);
 
     if (op_args.shard->journal()) {

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -17,6 +17,7 @@ extern "C" {
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
+#include "server/tiered_storage.h"
 #include "server/transaction.h"
 
 namespace dfly {
@@ -74,6 +75,20 @@ bool ConvertToDenseIfNeeded(string* hll) {
   return hll_validity == HLL_VALID_DENSE;
 }
 
+// Reads an HLL value, materializing it from tiered storage if offloaded.
+OpResult<string> ReadHll(const OpArgs& op_args, string_view key, const PrimeValue& pv) {
+  if (pv.IsExternal()) {
+    auto res =
+        ReadTieredString(op_args.db_cntx.db_index, key, pv, op_args.shard->tiered_storage()).Get();
+    if (!res)
+      return OpStatus::IO_ERROR;
+    return std::move(res).value();
+  }
+  string hll;
+  pv.GetString(&hll);
+  return hll;
+}
+
 OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values) {
   auto& db_slice = op_args.GetDbSlice();
 
@@ -82,11 +97,15 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_STRING);
   RETURN_ON_BAD_STATUS(op_res);
   auto& res = *op_res;
+  bool was_external = false;
   if (res.is_new) {
     hll.resize(getSparseHllInitSize());
     initSparseHll(StringToHllPtr(hll));
   } else {
-    res.it->second.GetString(&hll);
+    was_external = res.it->second.IsExternal();
+    auto val = ReadHll(op_args, key, res.it->second);
+    RETURN_ON_BAD_STATUS(val);
+    hll = std::move(val).value();
   }
   if (isValidHLL(StringToHllPtr(hll)) == HLL_INVALID) {
     return OpStatus::INVALID_VALUE;
@@ -126,6 +145,10 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
     hll = string{hll_sds, sdslen(hll_sds)};
     sdsfree(hll_sds);
   }
+  if (was_external) {
+    res.post_updater.ReduceHeapUsage();
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+  }
   res.it->second.SetString(hll);
   return std::min(updated, 1);
 }
@@ -150,27 +173,25 @@ OpResult<int64_t> CountHllsSingle(const OpArgs& op_args, string_view key) {
 
   auto it = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
   if (it.ok()) {
-    string hll;
-    string_view hll_view = it.value()->second.GetSlice(&hll);
+    auto hll_res = ReadHll(op_args, key, it.value()->second);
+    RETURN_ON_BAD_STATUS(hll_res);
+    string hll = std::move(hll_res).value();
 
-    switch (isValidHLL(StringToHllPtr(hll_view))) {
+    switch (isValidHLL(StringToHllPtr(hll))) {
       case HLL_VALID_DENSE:
         break;
       case HLL_VALID_SPARSE:
-        // Even in the case of a read - we still want to convert the hll to dense format, as it
-        // could originate in Redis (like in replication or rdb load).
-        hll = hll_view;
+        // Convert to dense on read too: a sparse value may originate from a foreign import.
         if (!ConvertToDenseIfNeeded(&hll)) {
           return OpStatus::CORRUPTED_HLL;
         }
-        hll_view = hll;
         break;
       case HLL_INVALID:
       default:
         return OpStatus::INVALID_VALUE;
     }
 
-    return pfcountSingle(StringToHllPtr(hll_view));
+    return pfcountSingle(StringToHllPtr(hll));
   } else if (it.status() == OpStatus::WRONG_TYPE) {
     return it.status();
   } else {
@@ -185,8 +206,9 @@ OpResult<vector<string>> ReadValues(const OpArgs& op_args, const ShardArgs& keys
     for (string_view key : keys) {
       auto it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
       if (it.ok()) {
-        string hll;
-        it.value()->second.GetString(&hll);
+        auto hll_res = ReadHll(op_args, key, it.value()->second);
+        RETURN_ON_BAD_STATUS(hll_res);
+        string hll = std::move(hll_res).value();
         if (!ConvertToDenseIfNeeded(&hll)) {
           return OpStatus::CORRUPTED_HLL;
         }

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -48,6 +48,9 @@ void HandleOpValueResult(const OpResult<T>& result, SinkReplyBuilder* builder) {
       case OpStatus::CORRUPTED_HLL:
         builder->SendError(facade::StatusToMsg(OpStatus::CORRUPTED_HLL));
         break;
+      case OpStatus::IO_ERROR:
+        builder->SendError(facade::StatusToMsg(OpStatus::IO_ERROR));
+        break;
       default:
         builder->SendLong(0);  // in case we don't have the value we should just send 0
         break;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -519,11 +519,14 @@ struct GetResp {
 };
 
 struct MGetResponse {
-  explicit MGetResponse(size_t size = 0) : resp_arr(size) {
+  explicit MGetResponse(size_t size = 0) : resp_arr(size), index_map(size) {
   }
 
   std::unique_ptr<char[]> storage;
   absl::InlinedVector<std::optional<GetResp>, 2> resp_arr;
+  // Global argument index of each resp_arr slot, captured during the hop so the
+  // reply can be reordered without touching the transaction afterwards.
+  absl::InlinedVector<uint32_t, 2> index_map;
 };
 
 template <typename Iter> using SearchKey = std::function<OpResult<Iter>(string_view)>;
@@ -565,7 +568,9 @@ MGetResponse CollectKeys(BlockingCounter wait_bc, AggregateError* err, MemcacheC
     key_index.reserve(keys.Size());
   }
 
-  for (string_view key : keys) {
+  for (auto arg_it = keys.begin(); arg_it != keys.end(); ++arg_it) {
+    string_view key = *arg_it;
+    response.index_map[index] = arg_it.index();
     if (mget_dedup_keys) {
       auto [it, inserted] = key_index.try_emplace(key, index);
       if (!inserted) {  // duplicate -> point to the first occurrence.
@@ -1464,23 +1469,17 @@ cmd::CmdR CmdDecrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
   return IncrByGeneric(cmd_cntx, key, -val);
 }
 
-// Reorder per-shard results according to argument order of primary command
-void ReorderShardResults(absl::Span<MGetResponse> mget_resp, const Transaction* t,
-                         absl::Span<optional<GetResp>> dest) {
-  for (ShardId sid = 0; sid < mget_resp.size(); ++sid) {
-    if (!t->IsActive(sid))
-      continue;
-
-    auto& src = mget_resp[sid];
-    ShardArgs shard_args = t->GetShardArgs(sid);
-    unsigned src_indx = 0;
-    for (auto it = shard_args.begin(); it != shard_args.end(); ++it, ++src_indx) {
+// Reorder per-shard results into argument order using the indices captured
+// during the hop. Inactive shards leave an empty resp_arr, so no transaction
+// state is consulted here.
+void ReorderShardResults(absl::Span<MGetResponse> mget_resp, absl::Span<optional<GetResp>> dest) {
+  for (auto& src : mget_resp) {
+    for (size_t src_indx = 0; src_indx < src.resp_arr.size(); ++src_indx) {
       if (!src.resp_arr[src_indx])
         continue;
 
-      DCHECK_LT(it.index(), dest.size());
-      auto& item = dest[it.index()];
-      item = src.resp_arr[src_indx];
+      DCHECK_LT(src.index_map[src_indx], dest.size());
+      dest[src.index_map[src_indx]] = src.resp_arr[src_indx];
     }
   }
 }
@@ -1506,10 +1505,11 @@ cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, std::optional<DbSlice::ExpirePar
     return OpStatus::OK;
   };
 
-  // Waiter objects needs to be used to keep tx alive in its scope for ReorderShardResults
+  // The waiter keeps the transaction alive while the hop runs. Its result is not
+  // consulted: under pipeline squashing the transaction is reused for the next
+  // command once the hop completes, so all per-shard data is captured in the hop.
   cmd::SingleHopWaiter waiter{cmd_cntx, cb};
-  auto result = co_await waiter;
-  CHECK_EQ(OpStatus::OK, result);
+  co_await waiter;
 
   // wait for all tiered reads to finish and check for errors
   tiering_bc->Wait();
@@ -1521,7 +1521,7 @@ cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, std::optional<DbSlice::ExpirePar
   size_t arg_len = tail_args.size();
 
   unique_ptr<optional<GetResp>[]> mget_results(new optional<GetResp>[arg_len]);
-  ReorderShardResults(absl::MakeSpan(mget_resp.get(), shard_set->size()), cmd_cntx->tx(),
+  ReorderShardResults(absl::MakeSpan(mget_resp.get(), shard_set->size()),
                       absl::MakeSpan(mget_results.get(), arg_len));
 
   SinkReplyBuilder::ReplyScope scope{cmd_cntx->rb()};

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1318,4 +1318,29 @@ TEST_F(PureDiskTSTest, MGetSquashOnExternal) {
   EXPECT_EQ(CheckedInt({"STRLEN", "k0"}), 5000);
 }
 
+// PFMERGE overwrites its destination; an offloaded destination must not hit
+// CompactObj::SetString's CHECK(!IsExternal()).
+TEST_F(PureDiskTSTest, PFMergeIntoExternal) {
+  BuildDenseHll("dst");
+  BuildDenseHll("src");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 2; });
+
+  EXPECT_EQ(Run({"PFMERGE", "dst", "src"}), "OK");
+}
+
+// A squashed async command reads its result after the shared transaction was
+// reused by a later command; SETNX must not observe that command's status.
+TEST_F(PureDiskTSTest, SetNxSquashResult) {
+  Run({"RPUSH", "mylist", "a"});  // wrong type for INCR
+  for (int rep = 0; rep < 300; ++rep) {
+    vector<vector<string>> batch;
+    for (int i = 0; i < 8; ++i) {
+      batch.push_back({"SETNX", absl::StrCat("k", i), "v"});
+      batch.push_back({"INCR", "mylist"});  // leaves WRONG_TYPE
+    }
+    RunMany(batch);
+  }
+  EXPECT_EQ(Run({"PING"}), "PONG");
+}
+
 }  // namespace dfly

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1276,19 +1276,21 @@ TEST_F(PureDiskTSTest, BitopsBitFieldRoOnExternal) {
 // HLL reads its value synchronously (GetSlice/GetString), which must handle
 // an offloaded value instead of tripping CHECK(!IsExternal()).
 TEST_F(PureDiskTSTest, PFCountOnExternal) {
-  BuildDenseHll("hll");
+  BuildDenseHll("hll");  // 6000 distinct elements
   ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
 
-  EXPECT_GT(CheckedInt({"PFCOUNT", "hll"}), 0);
+  // Estimate is within a few percent; a wrong error->0 mapping would fail here.
+  EXPECT_NEAR(CheckedInt({"PFCOUNT", "hll"}), 6000, 600);
 }
 
 TEST_F(PureDiskTSTest, PFMergeOnExternal) {
-  BuildDenseHll("src1");
-  BuildDenseHll("src2");
+  BuildDenseHll("src1");  // src1:* elements
+  BuildDenseHll("src2");  // disjoint src2:* elements
   ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 2; });
 
   EXPECT_EQ(Run({"PFMERGE", "dst", "src1", "src2"}), "OK");
-  EXPECT_GT(CheckedInt({"PFCOUNT", "dst"}), 0);
+  // Disjoint sources -> merged cardinality is the sum (~12000).
+  EXPECT_NEAR(CheckedInt({"PFCOUNT", "dst"}), 12000, 1200);
 }
 
 // RunMany squashes the batch (like Connection::SquashPipeline); a squashed read
@@ -1297,10 +1299,11 @@ TEST_F(PureDiskTSTest, PFMergeOnExternal) {
 TEST_F(PureDiskTSTest, MGetSquashOnExternal) {
   const int kNum = 12;
   const string big(5000, 'A');
+  auto val = [&](int i) { return absl::StrCat(big, "-", i); };  // distinct per key
   for (int rep = 0; rep < 200; ++rep) {
     vector<vector<string>> batch;
     for (int i = 0; i < kNum; ++i)
-      batch.push_back({"SET", absl::StrCat("k", i), big});
+      batch.push_back({"SET", absl::StrCat("k", i), val(i)});
     for (int i = 0; i < kNum; ++i)
       batch.push_back({"GET", absl::StrCat("k", i)});  // second access -> offload
     for (int j = 0; j < 8; ++j) {
@@ -1309,13 +1312,21 @@ TEST_F(PureDiskTSTest, MGetSquashOnExternal) {
         mget.push_back(absl::StrCat("k", i));
       batch.push_back(std::move(mget));
       for (int i = 0; i < kNum; ++i)
-        batch.push_back({"SETNX", absl::StrCat("k", i), "x"});
+        batch.push_back({"SETNX", absl::StrCat("k", i), "x"});  // skipped, keys exist
     }
     RunMany(batch);
   }
 
   EXPECT_EQ(Run({"PING"}), "PONG");
-  EXPECT_EQ(CheckedInt({"STRLEN", "k0"}), 5000);
+  // MGET must return each value in argument order (the reorder path corruption
+  // that #7816/#7817 hit would scramble or drop entries).
+  vector<string> mget = {"MGET"};
+  for (int i = 0; i < kNum; ++i)
+    mget.push_back(absl::StrCat("k", i));
+  auto vec = Run(absl::MakeSpan(mget)).GetVec();
+  ASSERT_EQ(vec.size(), size_t(kNum));
+  for (int i = 0; i < kNum; ++i)
+    EXPECT_EQ(vec[i], val(i));
 }
 
 // PFMERGE overwrites its destination; an offloaded destination must not hit
@@ -1341,6 +1352,9 @@ TEST_F(PureDiskTSTest, SetNxSquashResult) {
     RunMany(batch);
   }
   EXPECT_EQ(Run({"PING"}), "PONG");
+  // SETNX still reports its own outcome, not a neighbour's status.
+  EXPECT_EQ(CheckedInt({"SETNX", "fresh", "v"}), 1);
+  EXPECT_EQ(CheckedInt({"SETNX", "fresh", "w"}), 0);
 }
 
 }  // namespace dfly

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -72,6 +72,16 @@ class TieredStorageTest : public BaseFamilyTest {
   void UpdateFromFlags() {
     pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->UpdateFromFlags(); });
   }
+
+  // A single huge PFADD stays sparse and too small to offload; batch to force dense.
+  void BuildDenseHll(string_view key) {
+    for (int base = 0; base < 6000; base += 100) {
+      vector<string> add = {"PFADD", string(key)};
+      for (int i = base; i < base + 100; ++i)
+        add.push_back(absl::StrCat(key, ":", i));
+      Run(absl::MakeSpan(add));
+    }
+  }
 };
 
 // Test that should run with both modes of "cooling"
@@ -1261,6 +1271,51 @@ TEST_F(PureDiskTSTest, BitopsBitFieldRoOnExternal) {
   ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
 
   EXPECT_THAT(Run({"BITFIELD_RO", "bm", "GET", "u8", "0"}), RespArray(ElementsAre(IntArg(42))));
+}
+
+// HLL reads its value synchronously (GetSlice/GetString), which must handle
+// an offloaded value instead of tripping CHECK(!IsExternal()).
+TEST_F(PureDiskTSTest, PFCountOnExternal) {
+  BuildDenseHll("hll");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  EXPECT_GT(CheckedInt({"PFCOUNT", "hll"}), 0);
+}
+
+TEST_F(PureDiskTSTest, PFMergeOnExternal) {
+  BuildDenseHll("src1");
+  BuildDenseHll("src2");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 2; });
+
+  EXPECT_EQ(Run({"PFMERGE", "dst", "src1", "src2"}), "OK");
+  EXPECT_GT(CheckedInt({"PFCOUNT", "dst"}), 0);
+}
+
+// RunMany squashes the batch (like Connection::SquashPipeline); a squashed read
+// suspending for a tiered read while values offload concurrently must not
+// corrupt the shared transaction.
+TEST_F(PureDiskTSTest, MGetSquashOnExternal) {
+  const int kNum = 12;
+  const string big(5000, 'A');
+  for (int rep = 0; rep < 200; ++rep) {
+    vector<vector<string>> batch;
+    for (int i = 0; i < kNum; ++i)
+      batch.push_back({"SET", absl::StrCat("k", i), big});
+    for (int i = 0; i < kNum; ++i)
+      batch.push_back({"GET", absl::StrCat("k", i)});  // second access -> offload
+    for (int j = 0; j < 8; ++j) {
+      vector<string> mget = {"MGET"};
+      for (int i = 0; i < kNum; ++i)
+        mget.push_back(absl::StrCat("k", i));
+      batch.push_back(std::move(mget));
+      for (int i = 0; i < kNum; ++i)
+        batch.push_back({"SETNX", absl::StrCat("k", i), "x"});
+    }
+    RunMany(batch);
+  }
+
+  EXPECT_EQ(Run({"PING"}), "PONG");
+  EXPECT_EQ(CheckedInt({"STRLEN", "k0"}), 5000);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fuzzing surfaced five crashes that reduce to one root cause: values offloaded to tiered storage (External) are mishandled by HLL commands, and pipeline squashing turns that mishandling into shared-transaction state corruption. This fixes the read/write paths and makes the squashed async-command result robust.

Changes:
- **HLL (`hll_family.cc`)**: PFADD/PFCOUNT/PFMERGE now materialize an offloaded value with a synchronous tiered read instead of `GetString`/`GetSlice`, and release the disk segment before overwriting a tiered destination.
- **`SingleHopWaiter` (`cmd_support`)**: snapshot the hop status during execution instead of reading the transaction result on resume, which under squashing may already belong to a later command. Fixes the "Invalid result" abort in SETNX and any async command that inspects its own status.
- **Tests (`tiered_storage_test.cc`)**: add 5 regression tests covering these paths with offloading forced on.

Fixes: #7814
Fixes: #7815
Fixes: #7816
Fixes: #7817
Fixes: #7818