### PR TITLE
test(replication): disable noisy test_bug_5221

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -3585,6 +3585,7 @@ async def test_replicate_hset_with_expiry(df_factory: DflyInstanceFactory):
     assert result["name"] == "1234"
 
 
+@pytest.mark.skip("Too noisy, see https://github.com/dragonflydb/dragonfly/issues/7801")
 async def test_bug_5221(df_factory):
     master = df_factory.create(
         proactor_threads=1,


### PR DESCRIPTION
Skip test_bug_5221 in replication_test.py as it is too noisy and fails too much.

We will enable it back after uploading PR for:
https://github.com/dragonflydb/dragonfly/issues/7801
