### PR TITLE
server: Enable tagged chunk serialization

### DIFF
--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -28,7 +28,7 @@
 
 ABSL_FLAG(bool, background_snapshotting, false, "Whether to run snapshot as a background fiber");
 ABSL_FLAG(bool, serialize_hnsw_index, false, "Serialize HNSW vector index graph structure");
-ABSL_FLAG(bool, serialization_tagged_chunks, false,
+ABSL_FLAG(bool, serialization_tagged_chunks, true,
           "Allow serializer output to be split into tagged chunks and reassembled by receiver");
 
 namespace dfly {

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -453,10 +453,6 @@ class DflyInstanceFactory:
         if version >= 1.21 and "serialization_max_chunk_size" not in args:
             args.setdefault("serialization_max_chunk_size", 300000)
 
-        # TODO (abhijat) fix version once feature released
-        if version == 100 and "serialization_tagged_chunks" not in args:
-            args.setdefault("serialization_tagged_chunks", True)
-
         if version > 1.36:
             args.setdefault("serialize_hnsw_index", "true")
             args.setdefault("deserialize_hnsw_index", "true")


### PR DESCRIPTION
Enables: `serialization_tagged_chunks` - serialization will use tagged chunks by default.