### PR TITLE
fix: fix mgetparallel flaky test

### DIFF
--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -237,7 +237,7 @@ TEST_P(LatentCoolingTSTest, MGET) {
 TEST_F(PureDiskTSTest, MGETParallel) {
   // Create kMax strings and offload them. Each value fills its own page so each key maps to a
   // distinct pending read, making concurrent reads observable via pending_read_cnt.
-  const int kMax = 200;
+  const int kMax = 500;
   std::string value(3000, 'c');
   for (int i = 0; i < kMax; i++)
     Run({"SET", absl::StrCat("key:", i), value});
@@ -245,7 +245,7 @@ TEST_F(PureDiskTSTest, MGETParallel) {
 
   // Build a batch of GET/MGET commands of varying widths
   vector<vector<string>> cmds;
-  for (int i = 0; i < 200; i++) {
+  for (int i = 0; i < 500; i++) {
     int width = 1 + (i * 7) % 13;  // 1..13 keys
     vector<string> cmd = {width == 1 ? "GET" : "MGET"};
     for (int j = 0; j < width; j++)
@@ -254,15 +254,14 @@ TEST_F(PureDiskTSTest, MGETParallel) {
   }
 
   // Sample the peak number of in-flight tiered reads on the shard while the batch runs
-  atomic_uint32_t peak_reads{0};
-  atomic_uint64_t sample_count{0};
+  uint32_t peak_reads = 0;
+  uint64_t sample_count = 0;
   atomic_bool sampling{true};
   auto sampler = pp_->at(0)->LaunchFiber([&] {
     while (sampling.load(memory_order_relaxed)) {
       uint32_t cur = EngineShard::tlocal()->tiered_storage()->GetStats().pending_read_cnt;
-      sample_count.fetch_add(1, memory_order_relaxed);
-      if (cur > peak_reads.load(memory_order_relaxed))
-        peak_reads.store(cur, memory_order_relaxed);
+      sample_count++;
+      peak_reads = std::max(cur, peak_reads);
       ThisFiber::Yield();
     }
   });
@@ -273,13 +272,15 @@ TEST_F(PureDiskTSTest, MGETParallel) {
   sampling.store(false, memory_order_relaxed);
   sampler.JoinIfNeeded();
   auto m = GetMetrics();
-  LOG(INFO) << "peak_reads=" << peak_reads.load() << " samples=" << sample_count.load()
+  LOG(INFO) << "peak_reads=" << peak_reads << " samples=" << sample_count
             << " total_fetches=" << m.tiered_stats.total_fetches
             << " total_stashes=" << m.tiered_stats.total_stashes;
 
   // Must be more than max arguments
-  EXPECT_GT(peak_reads.load(memory_order_relaxed), 10u)
-      << "expected concurrent tiered reads while executing the squashed batch";
+  if (sample_count > 0) {
+    EXPECT_GT(peak_reads, 10u)
+        << "expected concurrent tiered reads while executing the squashed batch";
+  }
 }
 
 // Issue many APPEND commands to an offloaded value that are executed at once (with CLIENT PAUSE).


### PR DESCRIPTION
Reduce test flakyness by checking the limit only if the measuring lambda ran