### PR TITLE
fix: skip heartbeat expiry/eviction while optimistic tx is suspended

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -208,6 +208,14 @@ unsigned PrimeEvictionPolicy::GarbageCollect(const PrimeTable::HotBuckets& eb, P
       if (bucket_it->first.HasExpire()) {
         string_view key = bucket_it->first.GetSlice(&scratch);
         ++checked_;
+        // Deleting expired keys here without checking the lock table is safe: transaction
+        // callbacks are serialized per shard (see EngineShard::running_tx_), so no suspended
+        // transaction can hold a reference to this entry while the insert that triggered this
+        // GC runs. The running transaction itself cannot reference it either: expiry is
+        // evaluated with the transaction's fixed clock (Transaction::time_now_ms_), so any key
+        // it already accessed is not expired from this GC's point of view. Locks held by
+        // queued (not yet running) transactions don't matter - they hold no references, and
+        // for them the key just expired a moment earlier.
         auto prime_it = db_slice_->ExpireIfNeeded(
             cntx_, DbSlice::Iterator(bucket_it, StringOrView::FromView(key)));
         if (prime_it.is_done())

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -787,7 +787,14 @@ void EngineShard::Heartbeat() {
   // This is determined by attempting to check if shard lock can be acquired.
   const bool can_acquire_global_lock = shard_lock()->Check(IntentLock::Mode::EXCLUSIVE);
 
-  if (db_slice.WillBlockOnJournalWrite() || !can_acquire_global_lock) {
+  // Also skip if a transaction callback is suspended mid-execution on this shard (e.g. an
+  // optimistic transaction that preempted on a journal write without registering its keys in
+  // the lock table, see ScheduleInShard's lazy lock registration).
+  // Note that this stalls the heartbeat for as long as callbacks keep getting suspended.
+  // If this starves expiry/eviction in practice, the design should consider changing direction:
+  // lazily register the suspended transaction's locks here (like ScheduleInShard does) and
+  // proceed instead of skipping.
+  if (db_slice.WillBlockOnJournalWrite() || !can_acquire_global_lock || running_tx_ != nullptr) {
     uint64_t now = absl::GetCurrentTimeNanos();
 
     uint64_t elapsed_ms = (now - stalled_start_ns_) / 1000000;


### PR DESCRIPTION
1. A single-shard SET runs optimistically without registering key locks.
2. The SET preempts mid-callback: PostEdit → RecordJournal → JournalSlice::CallOnChange → JournalStreamer::ThrottleIfNeeded
3. Heartbeat: RetireExpiredAndEvict → FreeMemWithEvictionStepAtomic protects in-use keys only via the lock table and the preempted SET's key is not there, so it gets evicted mid-transaction.
4. The SET fiber resumes and its AutoUpdater destructor finds the key gone -- DCHECK

resolves #7801