### PR TITLE
fix: fix typo 'Fore more' -> 'For more' in docker README

### DIFF
--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -48,21 +48,21 @@ OK
 1) "hello"
 127.0.0.1:6379> get hello
 "world"
-127.0.0.1:6379> 
+127.0.0.1:6379>
 ```
 
 ## Step 3
 
-Continue being great and build your app with the power of DragonflyDB!  
+Continue being great and build your app with the power of DragonflyDB!
 
 ## Tuning Dragonfly DB
-If you are attempting to tune Dragonfly DB for performance, consider `NAT` performance costs associated with containerization.  
+If you are attempting to tune Dragonfly DB for performance, consider `NAT` performance costs associated with containerization.
 > ## Performance Tuning
 > ---
-> In `docker-compose`, there is a meaningful difference between an `overlay` network(which relies on docker `NAT` traversal on every request) and using the `host` network(see [`docker-compose.yml`](https://github.com/dragonflydb/dragonfly/blob/main/contrib/docker/docker-compose.yml)).  
-> &nbsp;  
-> Fore more information, see the [official docker-compose network_mode Docs](https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode)  
-> &nbsp;  
+> In `docker-compose`, there is a meaningful difference between an `overlay` network(which relies on docker `NAT` traversal on every request) and using the `host` network(see [`docker-compose.yml`](https://github.com/dragonflydb/dragonfly/blob/main/contrib/docker/docker-compose.yml)).
+> &nbsp;
+> For more information, see the [official docker-compose network_mode Docs](https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode)
+> &nbsp;
 
 ### More Build Options
 - [Docker Quick Start](/docs/quick-start/)


### PR DESCRIPTION
Fix a typo in the Docker contribution README: 'Fore more information' should be 'For more information'.