### PR TITLE
feat(tiering): Prefetch neighboring tiered list nodes on load

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -423,7 +423,7 @@ size_t QList::Node::GetLZF(void** data) const {
 }
 
 void QList::Node::SetExternal(size_t offset, uint32_t size) {
-  DCHECK(entry && !io_pending);
+  DCHECK(entry && !IsStashPending());
   zfree(entry);
   offloaded = 1;
   ext_offset = offset;
@@ -447,7 +447,7 @@ size_t QList::DefragIfNeeded(PageUsage* page_usage) {
 
   for (Node* curr = head_; curr; curr = curr->next) {
     // Skip offloaded or pending nodes
-    if (curr->offloaded || curr->io_pending) {
+    if (curr->offloaded || curr->IsStashPending()) {
       continue;
     }
 
@@ -936,7 +936,7 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
     //    get accessed again. Another reason for missing offloaded nodes is that node_id can be
     //    off due to merges (can be improved in future).
     if (node_id >= threshold && node_id + threshold < len_) {
-      if (!node->offloaded && !node->io_pending) {
+      if (!node->offloaded && !node->IsStashPending()) {
         tiering_params_->offload(this, node);
       }
     } else if (num_offloaded_nodes * 2 + threshold * 2 < len_) {
@@ -951,12 +951,12 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
       // due to usual access patterns of adding items via lpush/rpush.
       while (traverse_node_id <= len_ / 2 && (num_offloaded_nodes + 2 * threshold) < len_) {
         if (traverse_node_id >= threshold) {
-          if (fw->offloaded == 0 && fw->io_pending == 0) {
+          if (fw->offloaded == 0 && !fw->IsStashPending()) {
             tiering_params_->offload(this, fw);
           }
 
           // Avoid offloading the same node twice when fw and rev meet in the middle.
-          if (rev != fw && rev->offloaded == 0 && rev->io_pending == 0) {
+          if (rev != fw && rev->offloaded == 0 && !rev->IsStashPending()) {
             tiering_params_->offload(this, rev);
           }
         }
@@ -1052,7 +1052,7 @@ void QList::Materialize(Node* node) {
     return;
 
   // Cancel stash in progress before loading.
-  if (node->io_pending) {
+  if (node->IsStashPending()) {
     tiering_params_->cleanup(this, node);
   }
 

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -83,6 +83,14 @@ class QList {
       return encoding != QUICKLIST_NODE_ENCODING_RAW;
     }
 
+    bool IsStashPending() const {
+      return io_pending && !offloaded;
+    }
+
+    bool IsLoadPending() const {
+      return io_pending && offloaded;
+    }
+
     size_t GetLZF(void** data) const;
 
     void SetExternal(size_t offset, uint32_t sz);

--- a/src/core/tiering_types.cc
+++ b/src/core/tiering_types.cc
@@ -29,7 +29,7 @@ void FragmentRef::ClearOffloaded() {
 
 bool FragmentRef::HasStashPending() const {
   return std::visit(Overloaded{[](CompactValue* pv) { return pv->HasStashPending(); },
-                               [](QList::Node* node) { return node->io_pending != 0; }},
+                               [](QList::Node* node) { return node->IsStashPending(); }},
                     val_);
 }
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -74,6 +74,10 @@ ABSL_FLAG(unsigned, list_tiering_threshold, 0,
 ABSL_FLAG(uint32_t, list_compress_dict_threshold, 0,
           "Minimum list malloc usage in bytes before attempting ZSTD dictionary compression. "
           "0 disables. Note: compression is synchronous and may block the thread.");
+ABSL_FLAG(uint32_t, list_tiering_prefetch_depth, 0,
+          "Before loading a tiered list node, scan up to this many neighboring nodes and "
+          "issue asynchronous load requests for any that are offloaded. A value of 0 disables "
+          "prefetching.");
 
 namespace dfly {
 
@@ -106,7 +110,26 @@ void OffloadListNode(QList* ql, QList::Node* node) {
 
 void LoadListNode(QList* ql, QList::Node* node) {
   TieredStorage* ts = EngineShard::tlocal()->tiered_storage();
+  const uint32_t tiering_prefetch_depth = absl::GetFlag(FLAGS_list_tiering_prefetch_depth);
   DCHECK(ts);
+
+  // If the list is large enough, scan up to `tiering_prefetch_depth` neighboring nodes in each
+  // direction and asynchronously load any offloaded nodes.
+  if (tiering_prefetch_depth > 0 && ql->node_count() >= 2 * tiering_prefetch_depth) {
+    auto prefetch = [&](QList::Node* n, bool forward) {
+      for (uint32_t i = 0; i < tiering_prefetch_depth && n != nullptr && n != node;
+           ++i, n = forward ? n->next : n->prev) {
+        if (!n->offloaded || n->io_pending) {
+          continue;
+        }
+        QList::stats.onload_requests++;
+        PrefetchTieredListNode(ql->GetDbIndex(), ql, n, ts);
+      }
+    };
+    prefetch(node->next, true);
+    prefetch(node->prev, false);
+  }
+
   QList::stats.onload_requests++;
   auto res = ReadTieredListNode(ql->GetDbIndex(), ql, node, node->GetExternalSlice(), ts).Get();
   if (!res) {
@@ -118,9 +141,14 @@ void CleanupListNode(QList* ql, QList::Node* node) {
   TieredStorage* ts = EngineShard::tlocal()->tiered_storage();
   DCHECK(ts);
   if (!ts->IsClosed()) {
-    if (node->io_pending) {
+    if (node->IsStashPending()) {
       ts->CancelStash(tiering::ListNodeId{ql->GetDbIndex(), ql, node}, node);
     } else {
+      if (node->IsLoadPending()) {
+        // Background prefetch load still in flight: detach its callback so it doesn't touch this
+        // node once freed, then free the disk segment directly since it was never uploaded back.
+        ts->CancelLoad(node->GetExternalSlice());
+      }
       // We don't pass QList pointer so we need to decrease num_offloaded_nodes_ now.
       ql->AdjustOffloadNodeCount(-1);
       ts->Delete(ql->GetDbIndex(), node);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -500,6 +500,10 @@ bool TieredStorage::HasModificationPending(tiering::DiskSegment segment) const {
   return op_manager_->HasModificationPending(segment);
 }
 
+void TieredStorage::CancelLoad(tiering::DiskSegment segment) {
+  op_manager_->CancelPendingLoad(segment);
+}
+
 void TieredStorage::ReadInternal(tiering::ReadId id, const tiering::DiskSegment& segment,
                                  const tiering::Decoder& decoder,
                                  std::function<void(io::Result<tiering::Decoder*>)> cb,
@@ -909,6 +913,20 @@ TieredStorage::TResult<bool> ReadTieredListNode(DbIndex dbid, QList* ql, QList::
   ts->Read(tiering::ListNodeId{dbid, ql, node}, segment, tiering::ListNodeDecoder{ql},
            std::move(read_cb));
   return fut;
+}
+
+void PrefetchTieredListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts) {
+  DCHECK(node->offloaded);
+  DCHECK(!node->io_pending);
+  node->io_pending = 1;
+  auto read_cb = [node](const io::Result<tiering::ListNodeDecoder*>& res) {
+    node->io_pending = 0;
+    if (!res) {
+      LOG(WARNING) << "Failed to prefetch list node from tiered storage: " << res.error().message();
+    }
+  };
+  ts->Read(tiering::ListNodeId{dbid, ql, node}, node->GetExternalSlice(),
+           tiering::ListNodeDecoder{ql}, std::move(read_cb));
 }
 
 template <typename T>

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -100,6 +100,9 @@ class TieredStorage : public TieredStorageBase {
   // Cancel pending stash for the value. Must have HasStashPending() true.
   void CancelStash(tiering::PendingId id, tiering::FragmentRef fragment_ref);
 
+  // Cancel pending load for the value. Must have IsLoadPending() true.
+  void CancelLoad(tiering::DiskSegment segment);
+
   // Run offloading loop until i/o device is loaded or all entries were traversed
   void RunOffloading(DbIndex dbid);
 
@@ -203,6 +206,10 @@ TieredStorage::TResult<bool> ReadTieredListNode(DbIndex dbid, QList* ql, QList::
                                                 const tiering::DiskSegment& segment,
                                                 TieredStorage* ts);
 
+// Prefetches offloaded list node. This is async and does not block the caller.
+// The node's io_pending is set to true until the read completes, and cleared on completion.
+void PrefetchTieredListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts);
+
 // Reads offloaded value, and applies modifications on it and return generic result from callback.
 // Unlike with immutable Reads - the modified value will be uploaded back to memory.
 // This is handled by OpManager when modf completes.
@@ -286,6 +293,9 @@ class TieredStorage : public TieredStorageBase {
   void CancelStash(tiering::PendingId id, tiering::FragmentRef fragment_ref) {
   }
 
+  void CancelLoad(tiering::DiskSegment segment) {
+  }
+
   TieredStats GetStats() const {
     return {};
   }
@@ -337,6 +347,9 @@ inline TieredStorage::TResult<bool> ReadTieredListNode(DbIndex dbid, QList* ql, 
                                                        const tiering::DiskSegment& segment,
                                                        TieredStorage* ts) {
   return {};
+}
+
+inline void PrefetchTieredListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts) {
 }
 
 template <typename T>

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -862,7 +862,7 @@ TEST_F(ListNodeTieringTest, DeleteAfterStash) {
   }
 
   // Wait until stash is complete (io_pending cleared, offloaded=1) before DEL
-  // to avoid the io_pending use-after-free path.
+  // to avoid the use-after-free path for a pending stash.
   ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
 
   EXPECT_THAT(Run({"DEL", "mylist"}), IntArg(1));
@@ -936,7 +936,7 @@ TEST_F(ListNodeTieringTest, StashedDataMatchesOnLoad) {
   EXPECT_THAT(Run({"LLEN", "mylist"}), IntArg(kItems));
 }
 
-// DEL a list whose interior nodes have io_pending=1.
+// DEL a list whose interior nodes have io_pending=1 (stash in flight).
 TEST_F(ListNodeTieringTest, DeleteWhileNodePending) {
   const int kItems = 6;
   for (int i = 0; i < kItems; i++) {
@@ -983,7 +983,7 @@ TEST_F(ListNodeTieringTest, RenameWithStashedNodes) {
   EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);  // after reads nodes come back to memory
 }
 
-// RENAME a list while its nodes are still io_pending.
+// RENAME a list while its nodes are still io_pending (stash in flight).
 TEST_F(ListNodeTieringTest, RenameWhileNodesPending) {
   const int kItems = 6;
   vector<string> expected;
@@ -1031,7 +1031,7 @@ TEST_F(ListNodeTieringTest, ExpireListWithStashedNodes) {
   ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
 }
 
-// PEXPIRE a list while its nodes are still io_pending
+// PEXPIRE a list while its nodes are still io_pending (stash in flight)
 TEST_F(ListNodeTieringTest, ExpireListWhileNodesPending) {
   const int kItems = 6;
   for (int i = 0; i < kItems; i++) {
@@ -1054,7 +1054,7 @@ TEST_F(ListNodeTieringTest, ExpireListWhileNodesPending) {
   ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
 }
 
-// FLUSHALL while list nodes are io_pending or fully offloaded.
+// FLUSHALL while list nodes are io_pending (stash in flight) or fully offloaded.
 TEST_F(ListNodeTieringTest, FlushAllWithTieredListNodes) {
   const int kLists = 4;
   const int kItems = 6;

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -84,6 +84,9 @@ void OpManager::CancelPendingLoad(DiskSegment segment) {
   DCHECK(it != pending_reads_.end());
   auto* ops = it->second.Find(segment);
   DCHECK(ops);
+  for (auto& read_cb : ops->read_cbs) {
+    read_cb(nonstd::make_unexpected(make_error_code(errc::operation_canceled)));
+  }
   ops->read_cbs.clear();
 }
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -79,6 +79,20 @@ void OpManager::CancelPending(PendingId id) {
   pending_stash_ver_.erase(ToOwned(id));
 }
 
+void OpManager::CancelPendingLoad(DiskSegment segment) {
+  auto it = pending_reads_.find(segment.ContainingPages().offset);
+  if (it == pending_reads_.end())
+    return;
+
+  auto& entry_ops = it->second.entry_ops;
+  for (size_t i = 0; i < entry_ops.size(); i++) {
+    if (entry_ops[i].segment.offset == segment.offset) {
+      entry_ops.erase(entry_ops.begin() + i);
+      return;
+    }
+  }
+}
+
 void OpManager::DeleteOffloaded(DiskSegment segment) {
   EntryOps* pending_read = nullptr;
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -81,16 +81,10 @@ void OpManager::CancelPending(PendingId id) {
 
 void OpManager::CancelPendingLoad(DiskSegment segment) {
   auto it = pending_reads_.find(segment.ContainingPages().offset);
-  if (it == pending_reads_.end())
-    return;
-
-  auto& entry_ops = it->second.entry_ops;
-  for (size_t i = 0; i < entry_ops.size(); i++) {
-    if (entry_ops[i].segment.offset == segment.offset) {
-      entry_ops.erase(entry_ops.begin() + i);
-      return;
-    }
-  }
+  DCHECK(it != pending_reads_.end());
+  auto* ops = it->second.Find(segment);
+  DCHECK(ops);
+  ops->read_cbs.clear();
 }
 
 void OpManager::DeleteOffloaded(DiskSegment segment) {

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -60,6 +60,9 @@ class OpManager {
   // Cancel entry with pending io
   void CancelPending(PendingId id);
 
+  // Cancel pending read for offloaded entry.
+  void CancelPendingLoad(DiskSegment segment);
+
   // Delete offloaded entry located at the segment.
   void DeleteOffloaded(DiskSegment segment);
 


### PR DESCRIPTION
Add list_tiering_prefetch_depth flag to asynchronously load offloaded list nodes near the
one being accessed, so sequential list access can find them already resident once needed. 
Also disambiguate io_pending into IsStashPending()/IsLoadPending() on QList::Node and
add CancelLoad() to abort an in-flight prefetch when its node is deleted.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
