### PR TITLE
fix: tiered-storage crash when commands read an offloaded string value

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -47,6 +47,7 @@ extern "C" {
 #include "server/server_state.h"
 #include "server/set_family.h"
 #include "server/string_stats.h"
+#include "server/tiered_storage.h"
 #include "server/transaction.h"
 
 using namespace std;
@@ -456,8 +457,19 @@ OpResult<ValueCompressInfo> EstimateCompression(ConnectionContext* cntx, string_
     return info;
   }
 
-  string scratch;
-  string_view value = it->second.GetSlice(&scratch);
+  string scratch, materialized;
+  string_view value;
+  if (it->second.IsExternal()) {
+    auto res =
+        ReadTieredString(db_index, key, it->second, EngineShard::tlocal()->tiered_storage()).Get();
+    if (!res) {
+      return OpStatus::IO_ERROR;
+    }
+    materialized = std::move(res).value();
+    value = materialized;
+  } else {
+    value = it->second.GetSlice(&scratch);
+  }
 
   info.raw_size = value.size();
   info.compressed_size = info.raw_size;

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -100,12 +100,10 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_STRING);
   RETURN_ON_BAD_STATUS(op_res);
   auto& res = *op_res;
-  bool was_external = false;
   if (res.is_new) {
     hll.resize(getSparseHllInitSize());
     initSparseHll(StringToHllPtr(hll));
   } else {
-    was_external = res.it->second.IsExternal();
     auto val = ReadHll(op_args, key, res.it->second);
     RETURN_ON_BAD_STATUS(val);
     hll = std::move(val).value();
@@ -148,7 +146,8 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
     hll = string{hll_sds, sdslen(hll_sds)};
     sdsfree(hll_sds);
   }
-  if (was_external) {
+  // ReadHll may have warmed the value back into memory; re-check before Delete.
+  if (res.it->second.IsExternal()) {
     res.post_updater.ReduceHeapUsage();
     op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
   }

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -883,7 +883,16 @@ OpResult<std::string> OpJsonGet(const OpArgs& op_args, string_view key,
     json_ptr = it->second.GetJson();
   } else if (it->second.ObjType() == OBJ_STRING) {
     string tmp;
-    it->second.GetString(&tmp);
+    if (it->second.IsExternal()) {
+      auto res = ReadTieredString(op_args.db_cntx.db_index, key, it->second,
+                                  op_args.shard->tiered_storage())
+                     .Get();
+      if (!res)
+        return OpStatus::IO_ERROR;
+      tmp = std::move(res).value();
+    } else {
+      it->second.GetString(&tmp);
+    }
     auto parsed_json = ShardJsonFromString(tmp);
     if (!parsed_json) {
       return OpStatus::WRONG_TYPE;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -273,7 +273,22 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
     return false;
   }
 
-  return ExtendExisting(it_res->it, key, val, prepend);
+  auto& res = *it_res;
+  if (res.it->second.IsExternal()) {
+    auto tier = ReadTieredString(op_args.db_cntx.db_index, key, res.it->second,
+                                 op_args.shard->tiered_storage())
+                    .Get();
+    if (!tier)
+      return OpStatus::IO_ERROR;
+    string slice = std::move(tier).value();
+    string new_val = prepend ? absl::StrCat(val, slice) : absl::StrCat(slice, val);
+    res.post_updater.ReduceHeapUsage();
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    res.it->second.SetString(new_val);
+    return true;
+  }
+
+  return ExtendExisting(res.it, key, val, prepend);
 }
 
 OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val) {
@@ -295,8 +310,20 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
   if (add_res.it->second.Size() == 0)
     return OpStatus::INVALID_FLOAT;
 
+  const bool was_external = add_res.it->second.IsExternal();
   string tmp;
-  string_view slice = add_res.it->second.GetSlice(&tmp);
+  string_view slice;
+  if (was_external) {
+    auto res = ReadTieredString(op_args.db_cntx.db_index, key, add_res.it->second,
+                                op_args.shard->tiered_storage())
+                   .Get();
+    if (!res)
+      return OpStatus::IO_ERROR;
+    tmp = std::move(res).value();
+    slice = tmp;
+  } else {
+    slice = add_res.it->second.GetSlice(&tmp);
+  }
 
   double base = 0;
   if (!ParseDouble(slice, &base)) {
@@ -311,6 +338,10 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
 
   char* str = RedisReplyBuilder::FormatDouble(base, buf, sizeof(buf));
 
+  if (was_external) {
+    add_res.post_updater.ReduceHeapUsage();
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &add_res.it->second);
+  }
   add_res.it->second.SetString(str);
 
   return base;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -282,13 +282,17 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
       return OpStatus::IO_ERROR;
     string slice = std::move(tier).value();
     string new_val = prepend ? absl::StrCat(val, slice) : absl::StrCat(slice, val);
-    res.post_updater.ReduceHeapUsage();
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    // The read may have warmed the value back into memory; re-check before Delete.
+    if (res.it->second.IsExternal()) {
+      res.post_updater.ReduceHeapUsage();
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    }
     res.it->second.SetString(new_val);
     return true;
   }
 
-  return ExtendExisting(res.it, key, val, prepend);
+  ExtendExisting(res.it, key, val, prepend);
+  return true;
 }
 
 OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val) {
@@ -338,7 +342,9 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
 
   char* str = RedisReplyBuilder::FormatDouble(base, buf, sizeof(buf));
 
-  if (was_external) {
+  // The tiered read may have warmed the value back into memory; re-check so Delete
+  // only runs while it is still external.
+  if (add_res.it->second.IsExternal()) {
     add_res.post_updater.ReduceHeapUsage();
     op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &add_res.it->second);
   }

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1345,6 +1345,17 @@ TEST_F(PureDiskTSTest, McAppendOnExternal) {
   EXPECT_EQ(Run({"STRLEN", "k"}), 4102);
 }
 
+// Memcached PREPEND shares the ExtendOrSkip path and prepends at the front.
+TEST_F(PureDiskTSTest, McPrependOnExternal) {
+  Run({"SET", "k", string(4096, 'x')});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+
+  RunMC(MemcacheParser::PREPEND, "k", MCArgs{"pre", 0});
+  EXPECT_EQ(Run({"GETRANGE", "k", "0", "2"}), "pre");
+  EXPECT_EQ(Run({"STRLEN", "k"}), 4099);
+}
+
 // JSON.GET reads plain string keys with GetString() before parsing.
 TEST_F(PureDiskTSTest, JsonGetOnExternalString) {
   const string doc = absl::StrCat("\"", string(4094, 'a'), "\"");

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1334,6 +1334,19 @@ TEST_F(PureDiskTSTest, IncrByFloatOnExternal) {
   EXPECT_EQ(Run({"GET", "num"}), "5");
 }
 
+// A prior read marks the value touched, so the INCRBYFLOAT read warms it back into
+// memory (non-external); Delete must be gated on a fresh IsExternal() re-check.
+TEST_F(PureDiskTSTest, IncrByFloatOnExternalWarmedUp) {
+  const string val = "3.5" + string(4093, '0');
+  Run({"SET", "num", val});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+  Run({"GET", "num"});  // touch: the next read uploads the value
+
+  EXPECT_EQ(Run({"INCRBYFLOAT", "num", "1.5"}), "5");
+  EXPECT_EQ(Run({"GET", "num"}), "5");
+}
+
 // Memcached APPEND goes through ExtendOrSkip -> ExtendExisting -> GetSlice()
 // (unlike RESP APPEND, which is tiered-aware via OpExtend).
 TEST_F(PureDiskTSTest, McAppendOnExternal) {
@@ -1354,6 +1367,18 @@ TEST_F(PureDiskTSTest, McPrependOnExternal) {
   RunMC(MemcacheParser::PREPEND, "k", MCArgs{"pre", 0});
   EXPECT_EQ(Run({"GETRANGE", "k", "0", "2"}), "pre");
   EXPECT_EQ(Run({"STRLEN", "k"}), 4099);
+}
+
+// A prior read warms the value in on the APPEND read, so ExtendOrSkip must gate
+// Delete on a fresh IsExternal() re-check.
+TEST_F(PureDiskTSTest, McAppendOnExternalWarmedUp) {
+  Run({"SET", "k", string(4096, 'x')});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+  Run({"GET", "k"});  // touch: the next read uploads the value
+
+  RunMC(MemcacheParser::APPEND, "k", MCArgs{"suffix", 0});
+  EXPECT_EQ(Run({"STRLEN", "k"}), 4102);
 }
 
 // JSON.GET reads plain string keys with GetString() before parsing.
@@ -1394,6 +1419,18 @@ TEST_F(PureDiskTSTest, PFMergeOnExternal) {
   EXPECT_EQ(Run({"PFMERGE", "dst", "src1", "src2"}), "OK");
   // Disjoint sources -> merged cardinality is the sum (~12000).
   EXPECT_NEAR(CheckedInt({"PFCOUNT", "dst"}), 12000, 1200);
+}
+
+// PFCOUNT touches the HLL, so the PFADD read warms it back into memory; AddToHll
+// must gate Delete on a fresh IsExternal() re-check.
+TEST_F(PureDiskTSTest, PFAddOnExternalWarmedUp) {
+  BuildDenseHll("hll");
+  // Wait for the final HLL (not just an intermediate build value) to be offloaded.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries >= 1; });
+  Run({"PFCOUNT", "hll"});  // touch: the next read uploads the value
+
+  Run({"PFADD", "hll", "extra-element"});
+  EXPECT_NEAR(CheckedInt({"PFCOUNT", "hll"}), 6000, 600);
 }
 
 // RunMany squashes the batch (like Connection::SquashPipeline); a squashed read

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1322,6 +1322,49 @@ TEST_F(PureDiskTSTest, BitopsBitFieldRoOnExternal) {
   EXPECT_THAT(Run({"BITFIELD_RO", "bm", "GET", "u8", "0"}), RespArray(ElementsAre(IntArg(42))));
 }
 
+// INCRBYFLOAT must not GetSlice() an offloaded value. The value is a valid float
+// padded to fill a page so it offloads.
+TEST_F(PureDiskTSTest, IncrByFloatOnExternal) {
+  const string val = "3.5" + string(4093, '0');
+  Run({"SET", "num", val});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+
+  EXPECT_EQ(Run({"INCRBYFLOAT", "num", "1.5"}), "5");
+  EXPECT_EQ(Run({"GET", "num"}), "5");
+}
+
+// Memcached APPEND goes through ExtendOrSkip -> ExtendExisting -> GetSlice()
+// (unlike RESP APPEND, which is tiered-aware via OpExtend).
+TEST_F(PureDiskTSTest, McAppendOnExternal) {
+  Run({"SET", "k", string(4096, 'x')});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+
+  RunMC(MemcacheParser::APPEND, "k", MCArgs{"suffix", 0});
+  EXPECT_EQ(Run({"STRLEN", "k"}), 4102);
+}
+
+// JSON.GET reads plain string keys with GetString() before parsing.
+TEST_F(PureDiskTSTest, JsonGetOnExternalString) {
+  const string doc = absl::StrCat("\"", string(4094, 'a'), "\"");
+  Run({"SET", "doc", doc});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+
+  EXPECT_EQ(Run({"JSON.GET", "doc"}), doc);
+}
+
+// DEBUG OBJECT COMPRESS reads via a raw prime-table lookup (no warmup) + GetSlice().
+TEST_F(PureDiskTSTest, DebugObjectCompressOnExternal) {
+  Run({"SET", "k", string(4096, 'x')});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+  ASSERT_GE(GetMetrics().db_stats[0].tiered_entries, 1u);
+
+  auto resp = Run({"DEBUG", "OBJECT", "k", "COMPRESS"});
+  EXPECT_THAT(resp.GetString(), testing::HasSubstr("raw_size: 4096"));
+}
+
 // HLL reads its value synchronously (GetSlice/GetString), which must handle
 // an offloaded value instead of tripping CHECK(!IsExternal()).
 TEST_F(PureDiskTSTest, PFCountOnExternal) {


### PR DESCRIPTION
Several commands read a string value synchronously via `GetSlice()`/`GetString()` without materializing it from tiered storage first. When the value was offloaded to disk, this tripped `CHECK(!IsExternal())` in `CompactObj` and aborted the server.

Changes:
- `INCRBYFLOAT` (`OpIncrFloat`): materialize the offloaded value, and drop the on-disk entry before rewriting it in place.
- Memcached `APPEND`/`PREPEND` (`ExtendOrSkip`): same materialize + delete-before-write (the RESP `APPEND`/`PREPEND` path via `OpExtend` was already tiered-aware).
- `JSON.GET` on a plain string key (`OpJsonGet`): materialize the value before parsing.
- `DEBUG OBJECT <key> COMPRESS` (`EstimateCompression`): materialize the value before estimating its compressed size.
- Tests: add `PureDiskTSTest` cases reproducing each crash on an offloaded value.

Fixes: #7833