### PR TITLE
feat(search): add vector data-type foundation (types, kernels, validation)

### DIFF
--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -40,6 +40,24 @@ inline std::pair<ShardId, DocId> DecomposeGlobalDocId(GlobalDocId id) {
 
 enum class VectorSimilarity { L2, IP, COSINE };
 
+enum class VectorDataType { FLOAT32, FLOAT64, FLOAT16, BFLOAT16, INT8, UINT8 };
+
+constexpr size_t ElementSize(VectorDataType dt) {
+  switch (dt) {
+    case VectorDataType::FLOAT32:
+      return 4;
+    case VectorDataType::FLOAT64:
+      return 8;
+    case VectorDataType::FLOAT16:
+    case VectorDataType::BFLOAT16:
+      return 2;
+    case VectorDataType::INT8:
+    case VectorDataType::UINT8:
+      return 1;
+  }
+  return 4;
+}
+
 using OwnedFtVector = std::pair<std::unique_ptr<float[]>, size_t /* dimension (size) */>;
 using BorrowedFtVector = const char*;
 

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -89,7 +89,7 @@ struct SchemaField {
     size_t capacity = 1000;                       // initial capacity
     size_t hnsw_ef_construction = 200;
     size_t hnsw_m = 16;
-    std::string data_type = "FLOAT32";
+    VectorDataType data_type = VectorDataType::FLOAT32;
     uint32_t hnsw_ef_runtime = 10;
     double hnsw_epsilon = kDefaultHnswEpsilon;
   };

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -2114,6 +2114,8 @@ TEST_F(SearchTest, VectorDistanceTypedDtypes) {
   EXPECT_FLOAT_EQ(HalfToFloat(0xC000), -2.0f);
   EXPECT_FLOAT_EQ(HalfToFloat(0x0000), 0.0f);
   EXPECT_FLOAT_EQ(HalfToFloat(0x4200), 3.0f);
+  EXPECT_FLOAT_EQ(HalfToFloat(0x0001), std::ldexp(1.0f, -24));  // smallest subnormal half
+  EXPECT_FLOAT_EQ(HalfToFloat(0x0200), std::ldexp(1.0f, -15));  // subnormal half
   EXPECT_FLOAT_EQ(Bf16ToFloat(0x3F80), 1.0f);
   EXPECT_FLOAT_EQ(Bf16ToFloat(0x4000), 2.0f);
   EXPECT_FLOAT_EQ(Bf16ToFloat(0x40C0), 6.0f);

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -2108,6 +2108,43 @@ TEST_F(SearchTest, VectorDistanceBasic) {
   EXPECT_LT(ip_same, 0.0f);  // Should be negative for non-normalized vectors
 }
 
+TEST_F(SearchTest, VectorDistanceTypedDtypes) {
+  EXPECT_FLOAT_EQ(HalfToFloat(0x3C00), 1.0f);
+  EXPECT_FLOAT_EQ(HalfToFloat(0x4000), 2.0f);
+  EXPECT_FLOAT_EQ(HalfToFloat(0xC000), -2.0f);
+  EXPECT_FLOAT_EQ(HalfToFloat(0x0000), 0.0f);
+  EXPECT_FLOAT_EQ(HalfToFloat(0x4200), 3.0f);
+  EXPECT_FLOAT_EQ(Bf16ToFloat(0x3F80), 1.0f);
+  EXPECT_FLOAT_EQ(Bf16ToFloat(0x4000), 2.0f);
+  EXPECT_FLOAT_EQ(Bf16ToFloat(0x40C0), 6.0f);
+
+  // Every dtype holding {1,2,3} vs {4,5,6} must match the float32 reference under all metrics
+  // (integers 1..6 are exactly representable in all six dtypes).
+  const std::vector<float> f1 = {1.0f, 2.0f, 3.0f};
+  const std::vector<float> f2 = {4.0f, 5.0f, 6.0f};
+  auto check = [&](const void* a, const void* b, VectorDataType dt) {
+    for (auto sim : {VectorSimilarity::L2, VectorSimilarity::IP, VectorSimilarity::COSINE}) {
+      float ref = VectorDistance(f1.data(), f2.data(), 3, sim);
+      float got = VectorDistance(a, b, 3, sim, dt);
+      EXPECT_NEAR(got, ref, 1e-4) << "dtype=" << VectorDataTypeToString(dt);
+    }
+  };
+
+  const int8_t i8a[3] = {1, 2, 3}, i8b[3] = {4, 5, 6};
+  const uint8_t u8a[3] = {1, 2, 3}, u8b[3] = {4, 5, 6};
+  const float f32a[3] = {1, 2, 3}, f32b[3] = {4, 5, 6};
+  const double f64a[3] = {1, 2, 3}, f64b[3] = {4, 5, 6};
+  const uint16_t f16a[3] = {0x3C00, 0x4000, 0x4200}, f16b[3] = {0x4400, 0x4500, 0x4600};
+  const uint16_t bf16a[3] = {0x3F80, 0x4000, 0x4040}, bf16b[3] = {0x4080, 0x40A0, 0x40C0};
+
+  check(i8a, i8b, VectorDataType::INT8);
+  check(u8a, u8b, VectorDataType::UINT8);
+  check(f32a, f32b, VectorDataType::FLOAT32);
+  check(f64a, f64b, VectorDataType::FLOAT64);
+  check(f16a, f16b, VectorDataType::FLOAT16);
+  check(bf16a, bf16b, VectorDataType::BFLOAT16);
+}
+
 TEST_F(SearchTest, VectorDistanceConsistency) {
   // Test that results are consistent across multiple calls
   std::vector<float> vec1 = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};

--- a/src/core/search/vector_utils.cc
+++ b/src/core/search/vector_utils.cc
@@ -4,6 +4,7 @@
 
 #include "core/search/vector_utils.h"
 
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -123,12 +124,11 @@ float HalfToFloat(uint16_t h) {
     if (mant == 0) {
       bits = sign;  // +/- zero
     } else {
-      exp = 127 - 15 + 1;  // normalize the subnormal
-      while ((mant & 0x400) == 0) {
-        mant <<= 1;
-        exp--;
-      }
-      mant &= 0x3FF;
+      // Normalize the subnormal: shift the mantissa left until bit 10 is set. `mant` is in
+      // [1, 0x3FF], so countl_zero is in [22, 31] and the shift in [1, 10].
+      int shift = std::countl_zero(mant) - 21;
+      exp = (127 - 15 + 1) - shift;
+      mant = (mant << shift) & 0x3FF;
       bits = sign | (exp << 23) | (mant << 13);
     }
   } else if (exp == 0x1F) {
@@ -156,82 +156,55 @@ uint16_t LoadU16(const void* base, size_t i) {
   return v;
 }
 
-// Byte-safe reads: native-width blobs may be unaligned (borrowed keyspace storage), so a
-// typed deref would be UB. memcpy lowers to a single load on the target ISAs.
-float LoadF32(const void* base, size_t i) {
-  float v;
-  memcpy(&v, static_cast<const char*>(base) + i * sizeof(float), sizeof(v));
-  return v;
-}
-
-double LoadF64(const void* base, size_t i) {
-  double v;
-  memcpy(&v, static_cast<const char*>(base) + i * sizeof(double), sizeof(v));
-  return v;
-}
-
-// Reads element i of a native-width blob, widened to Acc (double for FLOAT64, else float).
-template <VectorDataType DT> struct Reader;
-template <> struct Reader<VectorDataType::FLOAT32> {
-  using Acc = float;
-  static float Get(const void* p, size_t i) {
-    return LoadF32(p, i);
-  }
-};
-template <> struct Reader<VectorDataType::FLOAT64> {
-  using Acc = double;
-  static double Get(const void* p, size_t i) {
-    return LoadF64(p, i);
-  }
-};
-template <> struct Reader<VectorDataType::FLOAT16> {
-  using Acc = float;
-  static float Get(const void* p, size_t i) {
-    return HalfToFloat(LoadU16(p, i));
-  }
-};
-template <> struct Reader<VectorDataType::BFLOAT16> {
-  using Acc = float;
-  static float Get(const void* p, size_t i) {
-    return Bf16ToFloat(LoadU16(p, i));
-  }
-};
-template <> struct Reader<VectorDataType::INT8> {
-  using Acc = float;
-  static float Get(const void* p, size_t i) {
-    return static_cast<const int8_t*>(p)[i];
-  }
-};
-template <> struct Reader<VectorDataType::UINT8> {
-  using Acc = float;
-  static float Get(const void* p, size_t i) {
-    return static_cast<const uint8_t*>(p)[i];
+// Reads element i of type Elem via memcpy — byte-safe for unaligned native-width blobs (e.g.
+// borrowed keyspace storage) — and widens it to Acc.
+template <class Elem, class AccT> struct PodReader {
+  using Acc = AccT;
+  static Acc Get(const void* p, size_t i) {
+    Elem v;
+    memcpy(&v, static_cast<const char*>(p) + i * sizeof(Elem), sizeof(v));
+    return static_cast<Acc>(v);
   }
 };
 
-template <VectorDataType DT> float L2Typed(const void* u, const void* v, size_t dims) {
-  using Acc = typename Reader<DT>::Acc;
+// Reads a 16-bit half/bfloat element and widens it to float via the given decoder.
+template <float (*Decode)(uint16_t)> struct HalfReader {
+  using Acc = float;
+  static float Get(const void* p, size_t i) {
+    return Decode(LoadU16(p, i));
+  }
+};
+
+using ReaderF32 = PodReader<float, float>;
+using ReaderF64 = PodReader<double, double>;
+using ReaderI8 = PodReader<int8_t, float>;
+using ReaderU8 = PodReader<uint8_t, float>;
+using ReaderF16 = HalfReader<HalfToFloat>;
+using ReaderBF16 = HalfReader<Bf16ToFloat>;
+
+template <class R> float L2Typed(const void* u, const void* v, size_t dims) {
+  using Acc = typename R::Acc;
   Acc sum = 0;
   for (size_t i = 0; i < dims; i++) {
-    Acc d = Reader<DT>::Get(u, i) - Reader<DT>::Get(v, i);
+    Acc d = R::Get(u, i) - R::Get(v, i);
     sum += d * d;
   }
   return static_cast<float>(std::sqrt(sum));
 }
 
-template <VectorDataType DT> float IPTyped(const void* u, const void* v, size_t dims) {
-  using Acc = typename Reader<DT>::Acc;
+template <class R> float IPTyped(const void* u, const void* v, size_t dims) {
+  using Acc = typename R::Acc;
   Acc sum = 0;
   for (size_t i = 0; i < dims; i++)
-    sum += Reader<DT>::Get(u, i) * Reader<DT>::Get(v, i);
+    sum += R::Get(u, i) * R::Get(v, i);
   return static_cast<float>(Acc(1) - sum);
 }
 
-template <VectorDataType DT> float CosineTyped(const void* u, const void* v, size_t dims) {
-  using Acc = typename Reader<DT>::Acc;
+template <class R> float CosineTyped(const void* u, const void* v, size_t dims) {
+  using Acc = typename R::Acc;
   Acc uv = 0, uu = 0, vv = 0;
   for (size_t i = 0; i < dims; i++) {
-    Acc a = Reader<DT>::Get(u, i), b = Reader<DT>::Get(v, i);
+    Acc a = R::Get(u, i), b = R::Get(v, i);
     uv += a * b;
     uu += a * a;
     vv += b * b;
@@ -241,15 +214,15 @@ template <VectorDataType DT> float CosineTyped(const void* u, const void* v, siz
   return 0.0f;
 }
 
-template <VectorDataType DT>
+template <class R>
 float DistByMetric(const void* u, const void* v, size_t dims, VectorSimilarity sim) {
   switch (sim) {
     case VectorSimilarity::L2:
-      return L2Typed<DT>(u, v, dims);
+      return L2Typed<R>(u, v, dims);
     case VectorSimilarity::IP:
-      return IPTyped<DT>(u, v, dims);
+      return IPTyped<R>(u, v, dims);
     case VectorSimilarity::COSINE:
-      return CosineTyped<DT>(u, v, dims);
+      return CosineTyped<R>(u, v, dims);
   }
   return 0.0f;
 }
@@ -260,17 +233,17 @@ float VectorDistance(const void* u, const void* v, size_t dims, VectorSimilarity
                      VectorDataType dt) {
   switch (dt) {
     case VectorDataType::FLOAT32:
-      return DistByMetric<VectorDataType::FLOAT32>(u, v, dims, sim);
+      return DistByMetric<ReaderF32>(u, v, dims, sim);
     case VectorDataType::FLOAT64:
-      return DistByMetric<VectorDataType::FLOAT64>(u, v, dims, sim);
+      return DistByMetric<ReaderF64>(u, v, dims, sim);
     case VectorDataType::FLOAT16:
-      return DistByMetric<VectorDataType::FLOAT16>(u, v, dims, sim);
+      return DistByMetric<ReaderF16>(u, v, dims, sim);
     case VectorDataType::BFLOAT16:
-      return DistByMetric<VectorDataType::BFLOAT16>(u, v, dims, sim);
+      return DistByMetric<ReaderBF16>(u, v, dims, sim);
     case VectorDataType::INT8:
-      return DistByMetric<VectorDataType::INT8>(u, v, dims, sim);
+      return DistByMetric<ReaderI8>(u, v, dims, sim);
     case VectorDataType::UINT8:
-      return DistByMetric<VectorDataType::UINT8>(u, v, dims, sim);
+      return DistByMetric<ReaderU8>(u, v, dims, sim);
   }
   return 0.0f;
 }

--- a/src/core/search/vector_utils.cc
+++ b/src/core/search/vector_utils.cc
@@ -5,7 +5,10 @@
 #include "core/search/vector_utils.h"
 
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <memory>
+#include <optional>
 
 #include "base/logging.h"
 
@@ -111,6 +114,167 @@ float VectorDistance(const float* u, const float* v, size_t dims, VectorSimilari
   return 0.0f;
 }
 
+float HalfToFloat(uint16_t h) {
+  uint32_t sign = static_cast<uint32_t>(h & 0x8000) << 16;
+  uint32_t exp = (h >> 10) & 0x1F;
+  uint32_t mant = h & 0x3FF;
+  uint32_t bits;
+  if (exp == 0) {
+    if (mant == 0) {
+      bits = sign;  // +/- zero
+    } else {
+      exp = 127 - 15 + 1;  // normalize the subnormal
+      while ((mant & 0x400) == 0) {
+        mant <<= 1;
+        exp--;
+      }
+      mant &= 0x3FF;
+      bits = sign | (exp << 23) | (mant << 13);
+    }
+  } else if (exp == 0x1F) {
+    bits = sign | 0x7F800000u | (mant << 13);  // inf / nan
+  } else {
+    bits = sign | ((exp + 112) << 23) | (mant << 13);  // rebias 127 - 15 = 112
+  }
+  float out;
+  memcpy(&out, &bits, sizeof(out));
+  return out;
+}
+
+float Bf16ToFloat(uint16_t b) {
+  uint32_t bits = static_cast<uint32_t>(b) << 16;
+  float out;
+  memcpy(&out, &bits, sizeof(out));
+  return out;
+}
+
+namespace {
+
+uint16_t LoadU16(const void* base, size_t i) {
+  uint16_t v;
+  memcpy(&v, static_cast<const char*>(base) + i * sizeof(uint16_t), sizeof(v));
+  return v;
+}
+
+// Byte-safe reads: native-width blobs may be unaligned (borrowed keyspace storage), so a
+// typed deref would be UB. memcpy lowers to a single load on the target ISAs.
+float LoadF32(const void* base, size_t i) {
+  float v;
+  memcpy(&v, static_cast<const char*>(base) + i * sizeof(float), sizeof(v));
+  return v;
+}
+
+double LoadF64(const void* base, size_t i) {
+  double v;
+  memcpy(&v, static_cast<const char*>(base) + i * sizeof(double), sizeof(v));
+  return v;
+}
+
+// Reads element i of a native-width blob, widened to Acc (double for FLOAT64, else float).
+template <VectorDataType DT> struct Reader;
+template <> struct Reader<VectorDataType::FLOAT32> {
+  using Acc = float;
+  static float Get(const void* p, size_t i) {
+    return LoadF32(p, i);
+  }
+};
+template <> struct Reader<VectorDataType::FLOAT64> {
+  using Acc = double;
+  static double Get(const void* p, size_t i) {
+    return LoadF64(p, i);
+  }
+};
+template <> struct Reader<VectorDataType::FLOAT16> {
+  using Acc = float;
+  static float Get(const void* p, size_t i) {
+    return HalfToFloat(LoadU16(p, i));
+  }
+};
+template <> struct Reader<VectorDataType::BFLOAT16> {
+  using Acc = float;
+  static float Get(const void* p, size_t i) {
+    return Bf16ToFloat(LoadU16(p, i));
+  }
+};
+template <> struct Reader<VectorDataType::INT8> {
+  using Acc = float;
+  static float Get(const void* p, size_t i) {
+    return static_cast<const int8_t*>(p)[i];
+  }
+};
+template <> struct Reader<VectorDataType::UINT8> {
+  using Acc = float;
+  static float Get(const void* p, size_t i) {
+    return static_cast<const uint8_t*>(p)[i];
+  }
+};
+
+template <VectorDataType DT> float L2Typed(const void* u, const void* v, size_t dims) {
+  using Acc = typename Reader<DT>::Acc;
+  Acc sum = 0;
+  for (size_t i = 0; i < dims; i++) {
+    Acc d = Reader<DT>::Get(u, i) - Reader<DT>::Get(v, i);
+    sum += d * d;
+  }
+  return static_cast<float>(std::sqrt(sum));
+}
+
+template <VectorDataType DT> float IPTyped(const void* u, const void* v, size_t dims) {
+  using Acc = typename Reader<DT>::Acc;
+  Acc sum = 0;
+  for (size_t i = 0; i < dims; i++)
+    sum += Reader<DT>::Get(u, i) * Reader<DT>::Get(v, i);
+  return static_cast<float>(Acc(1) - sum);
+}
+
+template <VectorDataType DT> float CosineTyped(const void* u, const void* v, size_t dims) {
+  using Acc = typename Reader<DT>::Acc;
+  Acc uv = 0, uu = 0, vv = 0;
+  for (size_t i = 0; i < dims; i++) {
+    Acc a = Reader<DT>::Get(u, i), b = Reader<DT>::Get(v, i);
+    uv += a * b;
+    uu += a * a;
+    vv += b * b;
+  }
+  if (Acc denom = uu * vv; denom != Acc(0))
+    return static_cast<float>(Acc(1) - uv / std::sqrt(denom));
+  return 0.0f;
+}
+
+template <VectorDataType DT>
+float DistByMetric(const void* u, const void* v, size_t dims, VectorSimilarity sim) {
+  switch (sim) {
+    case VectorSimilarity::L2:
+      return L2Typed<DT>(u, v, dims);
+    case VectorSimilarity::IP:
+      return IPTyped<DT>(u, v, dims);
+    case VectorSimilarity::COSINE:
+      return CosineTyped<DT>(u, v, dims);
+  }
+  return 0.0f;
+}
+
+}  // namespace
+
+float VectorDistance(const void* u, const void* v, size_t dims, VectorSimilarity sim,
+                     VectorDataType dt) {
+  switch (dt) {
+    case VectorDataType::FLOAT32:
+      return DistByMetric<VectorDataType::FLOAT32>(u, v, dims, sim);
+    case VectorDataType::FLOAT64:
+      return DistByMetric<VectorDataType::FLOAT64>(u, v, dims, sim);
+    case VectorDataType::FLOAT16:
+      return DistByMetric<VectorDataType::FLOAT16>(u, v, dims, sim);
+    case VectorDataType::BFLOAT16:
+      return DistByMetric<VectorDataType::BFLOAT16>(u, v, dims, sim);
+    case VectorDataType::INT8:
+      return DistByMetric<VectorDataType::INT8>(u, v, dims, sim);
+    case VectorDataType::UINT8:
+      return DistByMetric<VectorDataType::UINT8>(u, v, dims, sim);
+  }
+  return 0.0f;
+}
+
 std::string_view VectorSimilarityToString(VectorSimilarity sim) {
   switch (sim) {
     case VectorSimilarity::L2:
@@ -122,6 +286,41 @@ std::string_view VectorSimilarityToString(VectorSimilarity sim) {
   }
   DCHECK(false) << "Unhandled VectorSimilarity enum value: " << static_cast<int>(sim);
   return "L2";
+}
+
+std::string_view VectorDataTypeToString(VectorDataType dt) {
+  switch (dt) {
+    case VectorDataType::FLOAT32:
+      return "FLOAT32";
+    case VectorDataType::FLOAT64:
+      return "FLOAT64";
+    case VectorDataType::FLOAT16:
+      return "FLOAT16";
+    case VectorDataType::BFLOAT16:
+      return "BFLOAT16";
+    case VectorDataType::INT8:
+      return "INT8";
+    case VectorDataType::UINT8:
+      return "UINT8";
+  }
+  DCHECK(false) << "Unhandled VectorDataType enum value: " << static_cast<int>(dt);
+  return "FLOAT32";
+}
+
+std::optional<VectorDataType> ParseVectorDataType(std::string_view name) {
+  if (name == "FLOAT32")
+    return VectorDataType::FLOAT32;
+  if (name == "FLOAT64")
+    return VectorDataType::FLOAT64;
+  if (name == "FLOAT16")
+    return VectorDataType::FLOAT16;
+  if (name == "BFLOAT16")
+    return VectorDataType::BFLOAT16;
+  if (name == "INT8")
+    return VectorDataType::INT8;
+  if (name == "UINT8")
+    return VectorDataType::UINT8;
+  return std::nullopt;
 }
 
 float DistanceToSimilarity(float distance, VectorSimilarity sim) {

--- a/src/core/search/vector_utils.h
+++ b/src/core/search/vector_utils.h
@@ -22,7 +22,21 @@ float IPDistance(const float* u, const float* v, size_t dims);
 float CosineDistance(const float* u, const float* v, size_t dims);
 float VectorDistance(const float* u, const float* v, size_t dims, VectorSimilarity sim);
 
+// Distance between two native-width vector blobs of the given dtype. Elements are widened to
+// float (double for FLOAT64) before the metric is applied, matching the reference engine.
+float VectorDistance(const void* u, const void* v, size_t dims, VectorSimilarity sim,
+                     VectorDataType dt);
+
+// Widen a half-precision (h) or bfloat16 (b) element, given as its raw 16-bit pattern, to float.
+float HalfToFloat(uint16_t h);
+float Bf16ToFloat(uint16_t b);
+
 std::string_view VectorSimilarityToString(VectorSimilarity sim);
+
+std::string_view VectorDataTypeToString(VectorDataType dt);
+
+// Parses a vector TYPE token (e.g. "INT8"), which must be uppercase; std::nullopt if unsupported.
+std::optional<VectorDataType> ParseVectorDataType(std::string_view name);
 
 // L2: 1/(1+d*d) -- knn_dist is raw L2 here, so squaring matches the 1/(1+L2_sq) similarity.
 // IP/COSINE: (2-d)/2 -- knn_dist is (1 - score) for both metrics.

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -220,38 +220,39 @@ string DocIndexInfo::BuildRestoreCommand() const {
                     SearchFieldTypeToString(finfo.type));
 
     // Store specific params
-    Overloaded info{[](monostate) {},
-                    [out = &out](const search::SchemaField::VectorParams& params) {
-                      auto sim = search::VectorSimilarityToString(params.sim);
-                      if (params.use_hnsw) {
-                        absl::StrAppend(out, " HNSW 16 TYPE ", params.data_type, " DIM ",
-                                        params.dim, " DISTANCE_METRIC ", sim, " INITIAL_CAP ",
-                                        params.capacity, " M ", params.hnsw_m, " EF_CONSTRUCTION ",
-                                        params.hnsw_ef_construction, " EF_RUNTIME ",
-                                        params.hnsw_ef_runtime, " EPSILON ", params.hnsw_epsilon);
-                      } else {
-                        absl::StrAppend(out, " FLAT 8 TYPE ", params.data_type, " DIM ", params.dim,
-                                        " DISTANCE_METRIC ", sim, " INITIAL_CAP ", params.capacity);
-                      }
-                    },
-                    [out = &out](const search::SchemaField::TagParams& params) {
-                      absl::StrAppend(out, " ", "SEPARATOR", " ", string{params.separator});
-                      if (params.case_sensitive)
-                        absl::StrAppend(out, " ", "CASESENSITIVE");
-                      if (params.with_suffixtrie)
-                        absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
-                    },
-                    [out = &out](const search::SchemaField::TextParams& params) {
-                      absl::StrAppend(out, " ", "WEIGHT", " ", std::to_string(params.weight));
-                      if (params.with_suffixtrie)
-                        absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
-                      if (params.no_stem)
-                        absl::StrAppend(out, " ", "NOSTEM");
-                    },
-                    [out = &out](const search::SchemaField::NumericParams& params) {
-                      absl::StrAppend(out, " ", "BLOCKSIZE", " ",
-                                      std::to_string(params.block_size));
-                    }};
+    Overloaded info{
+        [](monostate) {},
+        [out = &out](const search::SchemaField::VectorParams& params) {
+          auto sim = search::VectorSimilarityToString(params.sim);
+          if (params.use_hnsw) {
+            absl::StrAppend(out, " HNSW 16 TYPE ", search::VectorDataTypeToString(params.data_type),
+                            " DIM ", params.dim, " DISTANCE_METRIC ", sim, " INITIAL_CAP ",
+                            params.capacity, " M ", params.hnsw_m, " EF_CONSTRUCTION ",
+                            params.hnsw_ef_construction, " EF_RUNTIME ", params.hnsw_ef_runtime,
+                            " EPSILON ", params.hnsw_epsilon);
+          } else {
+            absl::StrAppend(out, " FLAT 8 TYPE ", search::VectorDataTypeToString(params.data_type),
+                            " DIM ", params.dim, " DISTANCE_METRIC ", sim, " INITIAL_CAP ",
+                            params.capacity);
+          }
+        },
+        [out = &out](const search::SchemaField::TagParams& params) {
+          absl::StrAppend(out, " ", "SEPARATOR", " ", string{params.separator});
+          if (params.case_sensitive)
+            absl::StrAppend(out, " ", "CASESENSITIVE");
+          if (params.with_suffixtrie)
+            absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
+        },
+        [out = &out](const search::SchemaField::TextParams& params) {
+          absl::StrAppend(out, " ", "WEIGHT", " ", std::to_string(params.weight));
+          if (params.with_suffixtrie)
+            absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
+          if (params.no_stem)
+            absl::StrAppend(out, " ", "NOSTEM");
+        },
+        [out = &out](const search::SchemaField::NumericParams& params) {
+          absl::StrAppend(out, " ", "BLOCKSIZE", " ", std::to_string(params.block_size));
+        }};
     visit(info, finfo.special_params);
 
     // Store shared field flags

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -44,6 +44,7 @@
 #include "server/search/aggregator.h"
 #include "server/search/doc_index.h"
 #include "server/search/global_hnsw_index.h"
+#include "server/server_state.h"
 #include "server/transaction.h"
 #include "src/core/overloaded.h"
 
@@ -121,7 +122,13 @@ search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
     } else if (parser->Check("M", &params.hnsw_m)) {
     } else if (parser->Check("EF_CONSTRUCTION", &params.hnsw_ef_construction)) {
     } else if (parser->Check("TYPE")) {
-      params.data_type = absl::AsciiStrToUpper(parser->Next<string_view>());
+      std::string type_name = absl::AsciiStrToUpper(parser->Next<string_view>());
+      if (auto dt = search::ParseVectorDataType(type_name); dt)
+        params.data_type = *dt;
+      else if (auto* ss = ServerState::tlocal(); ss && ss->gstate() == GlobalState::LOADING)
+        params.data_type = search::VectorDataType::FLOAT32;  // legacy snapshot: coerce unknown TYPE
+      else
+        parser->ReportCustom("Not supported data type is given");
     } else if (parser->Check("EF_RUNTIME", &params.hnsw_ef_runtime)) {
     } else if (parser->Check("EPSILON")) {
       double epsilon = parser->Next<double>("Invalid EPSILON value");
@@ -2875,7 +2882,7 @@ void CmdFtInfo(CmdArgParser parser, CommandContext* cmd_cntx) {
       info.emplace_back("algorithm");
       info.emplace_back(vparams.use_hnsw ? "HNSW" : "FLAT");
       info.emplace_back("data_type");
-      info.emplace_back(vparams.data_type);
+      info.emplace_back(search::VectorDataTypeToString(vparams.data_type));
       info.emplace_back("dim");
       info.emplace_back(std::to_string(vparams.dim));
       info.emplace_back("distance_metric");

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1835,6 +1835,16 @@ TEST_F(SearchFamilyTest, AggregateLoad) {
   EXPECT_THAT(resp, ErrArg("LOAD cannot be applied after projectors or reducers"));
 }
 
+TEST_F(SearchFamilyTest, VectorUnknownTypeRejected) {
+  // A non-standard TYPE is rejected on a normal FT.CREATE (the replay-only coerce does not apply).
+  for (string_view bogus : {"BOGUS", "FP32", "FLOAT8", ""}) {
+    EXPECT_THAT(Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "v", "VECTOR", "FLAT", "6", "TYPE",
+                     bogus, "DIM", "3", "DISTANCE_METRIC", "L2"}),
+                ErrArg("Parse error of vector parameters"))
+        << "TYPE=" << bogus;
+  }
+}
+
 TEST_F(SearchFamilyTest, Vector) {
   auto resp = Run({"ft.create", "ann", "ON", "HASH", "SCHEMA", "vector", "VECTOR", "HNSW", "8",
                    "TYPE", "FLOAT32", "DIM", "100", "distance_metric", "cosine", "M", "64"});


### PR DESCRIPTION
Introduces the type infrastructure for native-width vector data types in the search module, without changing storage or query behavior yet. Existing FLOAT32 indexes are unaffected; follow-up PRs will wire this into FLAT/HNSW/JSON storage.

Changes:
- Add `VectorDataType` enum {FLOAT32, FLOAT64, FLOAT16, BFLOAT16, INT8, UINT8} + `ElementSize()`; `VectorParams::data_type` becomes this enum (was a free-form string).
- Add typed distance kernels: each element is widened to `float` (`double` accumulator for FLOAT64) before L2/IP/COSINE; scalar `HalfToFloat`/`Bf16ToFloat` decoders, no SIMD dep.
- Byte-safe (`memcpy`) element reads, so unaligned native-width blobs are not an alignment/UB risk on any target.
- Validate `TYPE` on `FT.CREATE` (reject unknown names). Coerce unknown -> FLOAT32 only during RDB/replica load (`LOADING` state), so legacy snapshots with a free-form TYPE still load instead of losing the index.
- `FT.INFO` and index restore serialize the canonical dtype token via `VectorDataTypeToString`.

Tests:
- `VectorDistanceTypedDtypes` - every dtype x {L2, IP, COSINE} matches the FLOAT32 reference.
- `VectorUnknownTypeRejected` - `FT.CREATE ... TYPE <bogus>` returns an error.

Notes:
- No functional change for non-float dtypes yet: they parse/validate but are not stored until the FLAT-storage PR. FLOAT32 behavior is unchanged.
- Part 1 of 4 (**foundation** -> FLAT -> HNSW -> JSON).