### PR TITLE
fix(server): validate startup flags in main()

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -144,6 +144,9 @@ using strings::HumanReadableNumBytes;
 
 namespace dfly {
 
+// Forward-declared here to avoid pulling the heavy protocol_client.h into this translation unit.
+bool ValidateClientTlsFlags();
+
 namespace {
 
 #if ABSL_HAVE_ADDRESS_SANITIZER
@@ -1117,6 +1120,15 @@ Usage: dragonfly [FLAGS]
 
   if (GetFlag(FLAGS_dbnum) > dfly::kMaxDbId) {
     LOG(ERROR) << "dbnum is too big. Exiting...";
+    return 1;
+  }
+
+  // Validate startup flags (TLS + snapshot filename) BEFORE creating the pidfile and before
+  // starting the proactor pool. They return false on a bad config; we exit cleanly (code 1)
+  // here, before the fiber runtime exists, which avoids a stale pidfile and aborting during
+  // fiber-runtime teardown.
+  if (!dfly::ValidateServerTlsFlags() || !dfly::ValidateClientTlsFlags() ||
+      !dfly::ValidateSnapshotFilenameFlags()) {
     return 1;
   }
 

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -77,9 +77,9 @@ std::string ProtocolClient::ServerContext::Description() const {
   return absl::StrCat(host, ":", port);
 }
 
-void ValidateClientTlsFlags() {
+bool ValidateClientTlsFlags() {
   if (!GetFlag(FLAGS_tls_replication)) {
-    return;
+    return true;
   }
 
   bool has_auth = false;
@@ -87,7 +87,7 @@ void ValidateClientTlsFlags() {
   if (!GetFlag(FLAGS_tls_key_file).empty()) {
     if (GetFlag(FLAGS_tls_cert_file).empty()) {
       LOG(ERROR) << "tls_cert_file flag should be set";
-      exit(1);
+      return false;
     }
     has_auth = true;
   }
@@ -97,8 +97,10 @@ void ValidateClientTlsFlags() {
 
   if (!has_auth) {
     LOG(ERROR) << "No authentication method configured!";
-    exit(1);
+    return false;
   }
+
+  return true;
 }
 
 #ifdef DFLY_USE_SSL

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -29,7 +29,7 @@ class ConnectionContext;
 class JournalExecutor;
 struct JournalReader;
 
-void ValidateClientTlsFlags();
+bool ValidateClientTlsFlags();
 
 // A helper class for implementing a Redis client that talks to a redis server.
 // This class should be inherited from.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -339,34 +339,6 @@ std::shared_ptr<detail::SnapshotStorage> CreateCloudSnapshotStorage(std::string_
   }
 }
 
-// Check that if TLS is used at least one form of client authentication is
-// enabled. That means either using a password or giving a root
-// certificate for authenticating client certificates which will
-// be required.
-bool ValidateServerTlsFlags() {
-  if (!absl::GetFlag(FLAGS_tls)) {
-    return true;
-  }
-
-  bool has_auth = false;
-
-  if (!dfly::GetPassword().empty()) {
-    has_auth = true;
-  }
-
-  if (!(absl::GetFlag(FLAGS_tls_ca_cert_file).empty() &&
-        absl::GetFlag(FLAGS_tls_ca_cert_dir).empty())) {
-    has_auth = true;
-  }
-
-  if (!has_auth) {
-    LOG(ERROR) << "TLS configured but no authentication method is used!";
-    return false;
-  }
-
-  return true;
-}
-
 template <typename T> void UpdateMax(T* maxv, T current) {
   *maxv = std::max(*maxv, current);
 }
@@ -994,6 +966,39 @@ bool IsMaster() {
 
 }  // namespace
 
+bool ValidateServerTlsFlags() {
+  if (!absl::GetFlag(FLAGS_tls)) {
+    return true;
+  }
+
+  bool has_auth = false;
+
+  if (!dfly::GetPassword().empty()) {
+    has_auth = true;
+  }
+
+  if (!(absl::GetFlag(FLAGS_tls_ca_cert_file).empty() &&
+        absl::GetFlag(FLAGS_tls_ca_cert_dir).empty())) {
+    has_auth = true;
+  }
+
+  if (!has_auth) {
+    LOG(ERROR) << "TLS configured but no authentication method is used!";
+    return false;
+  }
+
+  return true;
+}
+
+bool ValidateSnapshotFilenameFlags() {
+  auto ec = detail::ValidateFilename(GetFlag(FLAGS_dbfilename), GetFlag(FLAGS_df_snapshot_format));
+  if (ec) {
+    LOG(ERROR) << ec.Format();
+    return false;
+  }
+  return true;
+}
+
 void SlowLogGet(facade::ParsedArgs args, std::string_view sub_cmd, util::ProactorPool* pp,
                 CommandContext* cmd_cntx) {
   size_t requested_slow_log_length = UINT32_MAX;
@@ -1138,17 +1143,10 @@ ServerFamily::ServerFamily(Service* service) : service_(*service) {
     DCHECK_EQ(CONFIG_RUN_ID_SIZE, master_replid_.size());
   }
 
-  if (auto ec =
-          detail::ValidateFilename(GetFlag(FLAGS_dbfilename), GetFlag(FLAGS_df_snapshot_format));
-      ec) {
-    LOG(ERROR) << ec.Format();
-    exit(1);
-  }
+  // Note: startup flag validation (TLS + snapshot filename) runs in main() before the proactor
+  // pool starts. Calling exit() here - after pool->Run() - would tear down the live fiber
+  // runtime and can abort (SIGABRT). Keep these checks out of this ctor.
 
-  if (!ValidateServerTlsFlags()) {
-    exit(1);
-  }
-  ValidateClientTlsFlags();
   dfly_cmd_ = make_unique<DflyCmd>(this);
   legacy_format_metrics_ = GetFlag(FLAGS_keep_legacy_memory_metrics);
 }

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -46,6 +46,14 @@ class SnapshotStorage;
 
 std::string GetPassword();
 
+// Validates server-side TLS flags: when --tls is set, at least one auth method must be
+// configured (a password or a CA cert). Returns false on an invalid configuration.
+bool ValidateServerTlsFlags();
+
+// Validates the --dbfilename / --df_snapshot_format flags (filename format, no directory
+// separators, extension vs snapshot format). Returns false on an invalid configuration.
+bool ValidateSnapshotFilenameFlags();
+
 class CommandContext;
 class CommandRegistry;
 class DflyCmd;


### PR DESCRIPTION
Negative startup tests intermittently aborted at teardown instead of
exiting cleanly. Seen in the ARM64 Debug "Regression Tests" run for
tls_conf_test.py::test_client_tls_no_auth and ::test_tls_no_auth (and
the bad-dbfilename path, e.g. test_path_escapes): the test body passed
but the process died with SIGABRT ("did not terminate gracefully, exit
code -6") rather than exiting with code 1.

Root cause: ValidateServerTlsFlags() (--tls), ValidateClientTlsFlags()
(--tls_replication) and ValidateFilename() (--dbfilename) all ran in
the ServerFamily ctor, which is constructed after pool->Run(), and
called exit(1) on a bad config. Calling std::exit() while the proactor
pool is live tears down the fiber runtime mid-flight and trips the
~FiberInterface use_count DCHECK in helio -> SIGABRT. Debug-only and
scheduling-dependent, so flaky; it surfaced after a recent helio bump
shifted startup fiber scheduling.

Fix: all three validators now return bool instead of calling exit(1),
and main() runs them before the pidfile is created and before
pool->Run(), returning 1 on failure. A bad config now exits cleanly
(code 1) before any fiber runtime exists and without leaving a stale
pidfile behind. ValidateServerTlsFlags() is moved out of the anonymous
namespace (declared in server_family.h), ValidateSnapshotFilenameFlags()
wraps detail::ValidateFilename(), and ValidateClientTlsFlags() is
forward-declared in dfly_main.cc to avoid pulling the heavy
protocol_client.h into the main translation unit. The ServerFamily
ctor no longer calls exit(). Remaining exit() sites (snapshot load,
cloud-storage init) are runtime failures, not flag checks, and are out
of scope.

Reproduce: start many instances concurrently under load with a bad
config, e.g. 16 parallel starts of `dragonfly --tls_replication`
each with --proactor_threads=16 (also --tls or --dbfilename=bad/name).
Pre-fix a start aborts with SIGABRT (shell exit 134) within a few
hundred launches; sequential starts rarely hit the race. With the fix
every start exits cleanly with code 1.