### PR TITLE
feat(server): include TLS certificate info in INFO output

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2738,6 +2738,15 @@ size_t Connection::GetMemoryUsage() const {
   return mem;
 }
 
+std::shared_ptr<const TlsCertInfo> Connection::GetTlsCertInfo() const {
+#ifdef DFLY_USE_SSL
+  auto* facade_listener = static_cast<facade::Listener*>(listener());
+  return facade_listener ? facade_listener->GetTlsCertInfo() : nullptr;
+#else
+  return nullptr;
+#endif
+}
+
 void Connection::RefreshConnectionMemoryUsage() {
   if (!conn_stats_registered_)
     return;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -15,6 +15,7 @@
 #include <variant>
 
 #include "facade/connection_ref.h"
+#include "facade/dragonfly_listener.h"
 #include "facade/facade_types.h"
 #include "facade/parsed_command.h"
 #include "io/io_buf.h"
@@ -264,6 +265,10 @@ class Connection : public util::Connection {
   size_t GetMemoryUsage() const;
 
   ConnectionContext* cntx();
+
+  // Returns the TLS certificate metadata for this connection's listener, or nullptr if the listener
+  // has no TLS configured or the certificate could not be parsed.
+  std::shared_ptr<const TlsCertInfo> GetTlsCertInfo() const;
 
   // For non replication connections refresh memory usage field as well as update tl stats if conn.
   // is still live.

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -251,8 +251,18 @@ bool Listener::ReconfigureTLS() {
       return false;
     }
     ctx_ = ctx;
+    X509* cert = SSL_CTX_get0_certificate(ctx);
+    auto info = ParseTlsCertInfo(cert);
+    {
+      util::fb2::LockGuard lk(tls_cert_info_mu_);
+      tls_cert_info_ = info ? std::make_shared<const TlsCertInfo>(*info) : nullptr;
+    }
   } else {
     ctx_ = nullptr;
+    {
+      util::fb2::LockGuard lk(tls_cert_info_mu_);
+      tls_cert_info_.reset();
+    }
   }
 
   if (prev_ctx) {
@@ -263,6 +273,13 @@ bool Listener::ReconfigureTLS() {
 #endif
   return true;
 }
+
+#ifdef DFLY_USE_SSL
+std::shared_ptr<const TlsCertInfo> Listener::GetTlsCertInfo() const {
+  util::fb2::LockGuard lk(tls_cert_info_mu_);
+  return tls_cert_info_;
+}
+#endif
 
 size_t Listener::TLSUsedMemoryThreadLocal() {
   return listener_tl_stats.tls_allocated_bytes;

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -274,12 +274,13 @@ bool Listener::ReconfigureTLS() {
   return true;
 }
 
-#ifdef DFLY_USE_SSL
 std::shared_ptr<const TlsCertInfo> Listener::GetTlsCertInfo() const {
+#ifdef DFLY_USE_SSL
   util::fb2::LockGuard lk(tls_cert_info_mu_);
   return tls_cert_info_;
+#else
+  return nullptr;
 }
-#endif
 
 size_t Listener::TLSUsedMemoryThreadLocal() {
   return listener_tl_stats.tls_allocated_bytes;

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -280,6 +280,7 @@ std::shared_ptr<const TlsCertInfo> Listener::GetTlsCertInfo() const {
   return tls_cert_info_;
 #else
   return nullptr;
+#endif
 }
 
 size_t Listener::TLSUsedMemoryThreadLocal() {

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -13,8 +13,10 @@
 #include <vector>
 
 #include "facade/facade_types.h"
+#include "facade/tls_helpers.h"
 #include "util/fiber_socket_base.h"
 #include "util/fibers/proactor_base.h"
+#include "util/fibers/synchronization.h"
 #include "util/http/http_handler.h"
 #include "util/listener_interface.h"
 
@@ -42,6 +44,12 @@ class Listener : public util::ListenerInterface {
 
   // ReconfigureTLS MUST be called from the same proactor as the listener.
   bool ReconfigureTLS();
+
+#ifdef DFLY_USE_SSL
+  // Returns the TLS certificate metadata currently used by this listener.
+  // nullptr if TLS is not configured or the certificate could not be parsed.
+  std::shared_ptr<const TlsCertInfo> GetTlsCertInfo() const;
+#endif
 
   // Returns thread-local dynamic memory usage by TLS.
   static size_t TLSUsedMemoryThreadLocal();
@@ -78,6 +86,10 @@ class Listener : public util::ListenerInterface {
 
   Protocol protocol_;
   SSL_CTX* ctx_ = nullptr;
+  // Updated in ReconfigureTLS (listener proactor) and read from any proactor
+  // via INFO, so all accesses are guarded by tls_cert_info_mu_.
+  mutable util::fb2::Mutex tls_cert_info_mu_;
+  std::shared_ptr<const TlsCertInfo> tls_cert_info_ ABSL_GUARDED_BY(tls_cert_info_mu_);
 };
 
 // Dispatch tracker allows tracking the dispatch state of connections and blocking until all

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -45,11 +45,9 @@ class Listener : public util::ListenerInterface {
   // ReconfigureTLS MUST be called from the same proactor as the listener.
   bool ReconfigureTLS();
 
-#ifdef DFLY_USE_SSL
   // Returns the TLS certificate metadata currently used by this listener.
   // nullptr if TLS is not configured or the certificate could not be parsed.
   std::shared_ptr<const TlsCertInfo> GetTlsCertInfo() const;
-#endif
 
   // Returns thread-local dynamic memory usage by TLS.
   static size_t TLSUsedMemoryThreadLocal();

--- a/src/facade/tls_helpers.cc
+++ b/src/facade/tls_helpers.cc
@@ -6,11 +6,15 @@
 #include <openssl/err.h>
 
 #ifdef DFLY_USE_SSL
+#include <openssl/pem.h>
 #include <openssl/ssl.h>
+#include <openssl/x509.h>
 #endif
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/functional/bind_front.h>
 
+#include <optional>
 #include <string>
 
 #include "base/flags.h"
@@ -34,7 +38,43 @@ ABSL_FLAG(size_t, tls_session_cache_timeout, 300, "Timeout for each session/tick
 
 namespace facade {
 
+using absl::GetFlag;
+
 #ifdef DFLY_USE_SSL
+
+namespace {
+
+std::string Asn1TimeToString(const ASN1_TIME* asn1_time) {
+  if (!asn1_time)
+    return {};
+
+  BIO* bio = BIO_new(BIO_s_mem());
+  if (!bio)
+    return {};
+  absl::Cleanup bio_cleanup = [bio] { BIO_free(bio); };
+
+  ASN1_TIME_print(bio, asn1_time);
+
+  BUF_MEM* buf_mem = nullptr;
+  BIO_get_mem_ptr(bio, &buf_mem);
+  std::string result(buf_mem ? buf_mem->data : "", buf_mem ? buf_mem->length : 0);
+  return result;
+}
+
+std::string X509NameToString(X509_NAME* name) {
+  if (!name)
+    return {};
+
+  char* buf = X509_NAME_oneline(name, nullptr, 0);
+  if (!buf)
+    return {};
+  absl::Cleanup buf_cleanup = [buf] { OPENSSL_free(buf); };
+
+  std::string result(buf);
+  return result;
+}
+
+}  // namespace
 
 // Creates the TLS context. Returns nullptr if the TLS configuration is invalid.
 // To connect: openssl s_client -state -crlf -connect 127.0.0.1:6380
@@ -62,8 +102,8 @@ SSL_CTX* CreateSslCntx(TlsContextRole role) {
   const auto& tls_cert_file = GetFlag(FLAGS_tls_cert_file);
 
   if (!tls_cert_file.empty()) {
-    // TO connect with redis-cli you need both tls-key-file and tls-cert-file
-    // loaded. Use `redis-cli --tls -p 6380 --insecure  PING` to test
+    // To connect with redis-cli you need both tls-key-file and tls-cert-file
+    // loaded. Use `redis-cli --tls -p 6380 --insecure PING` to test
     if (SSL_CTX_use_certificate_chain_file(ctx, tls_cert_file.c_str()) != 1) {
       LOG(ERROR) << "Failed to load TLS certificate";
       return nullptr;
@@ -131,6 +171,19 @@ void PrintSSLError() {
         return 1;
       },
       nullptr);
+}
+
+std::optional<TlsCertInfo> ParseTlsCertInfo(const X509* cert) {
+  if (!cert)
+    return std::nullopt;
+
+  TlsCertInfo info;
+  info.subject = X509NameToString(X509_get_subject_name(cert));
+  info.issuer = X509NameToString(X509_get_issuer_name(cert));
+  info.not_before = Asn1TimeToString(X509_get_notBefore(cert));
+  info.not_after = Asn1TimeToString(X509_get_notAfter(cert));
+
+  return info;
 }
 
 #endif

--- a/src/facade/tls_helpers.h
+++ b/src/facade/tls_helpers.h
@@ -8,10 +8,24 @@
 #include <openssl/ssl.h>
 #endif
 
+#include <optional>
+#include <string>
+
 namespace facade {
 
-#ifdef DFLY_USE_SSL
 enum class TlsContextRole { SERVER, CLIENT };
+
+struct TlsCertInfo {
+  std::string subject;     // Common name / subject DN.
+  std::string issuer;      // Issuer DN.
+  std::string not_before;  // Start of validity period (ASN1_TIME formatted).
+  std::string not_after;   // End of validity period (ASN1_TIME formatted).
+};
+
+#ifdef DFLY_USE_SSL
+// Extracts TLS certificate metadata from an already-loaded X509 certificate.
+// Returns std::nullopt if the certificate is null.
+std::optional<TlsCertInfo> ParseTlsCertInfo(const X509* cert);
 
 SSL_CTX* CreateSslCntx(TlsContextRole role);
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -47,6 +47,7 @@ extern "C" {
 #include "facade/dragonfly_connection.h"
 #include "facade/dragonfly_listener.h"
 #include "facade/reply_builder.h"
+#include "facade/tls_helpers.h"
 #include "io/file_util.h"
 #include "io/proc_reader.h"
 #include "search/doc_index.h"
@@ -2581,8 +2582,9 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, const MetricsCollectOpts& opts) 
   return result;
 }
 
-string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view section,
-                                       bool priveleged) const {
+string ServerFamily::FormatInfoMetrics(
+    const Metrics& m, std::string_view section, bool priveleged,
+    const std::shared_ptr<const facade::TlsCertInfo>& cert_info) const {
   string info;
   DbStats total;
 
@@ -2637,6 +2639,15 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     }
     append("multiplexing_api", multiplex_api);
     append("tcp_port", GetFlag(FLAGS_port));
+
+#ifdef DFLY_USE_SSL
+    if (cert_info) {
+      append("tls_cert_subject", cert_info->subject);
+      append("tls_cert_issuer", cert_info->issuer);
+      append("tls_cert_not_before", cert_info->not_before);
+      append("tls_cert_not_after", cert_info->not_after);
+    }
+#endif
 
     // Add availability_zone if it's not empty
     const auto& az = GetFlag(FLAGS_availability_zone);
@@ -3160,12 +3171,14 @@ void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // output). The command does not abort or return an error if some sections are invalid. This
   // matches Valkey behavior.
   if (sections.empty()) {  // No sections: default to all sections.
-    info = FormatInfoMetrics(metrics, "", is_priveleged);
+    info = FormatInfoMetrics(metrics, "", is_priveleged, cmd_cntx->conn()->GetTlsCertInfo());
   } else if (sections.size() == 1) {  // Single section
-    info = FormatInfoMetrics(metrics, sections[0], is_priveleged);
+    info =
+        FormatInfoMetrics(metrics, sections[0], is_priveleged, cmd_cntx->conn()->GetTlsCertInfo());
   } else {  // Multiple sections: concatenate results for each requested section.
     for (const auto& section : sections) {
-      const std::string section_str = FormatInfoMetrics(metrics, section, is_priveleged);
+      const std::string section_str =
+          FormatInfoMetrics(metrics, section, is_priveleged, cmd_cntx->conn()->GetTlsCertInfo());
       if (!section_str.empty()) {
         if (!info.empty()) {
           absl::StrAppend(&info, "\r\n", section_str);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -26,6 +26,7 @@ struct hdr_histogram;
 
 namespace facade {
 class Listener;
+struct TlsCertInfo;
 }  // namespace facade
 
 namespace util {
@@ -161,8 +162,8 @@ class ServerFamily {
   // Collects server metrics. See MetricsCollectOpts; a default-constructed value collects all.
   Metrics GetMetrics(Namespace* ns, const MetricsCollectOpts& opts) const;
 
-  std::string FormatInfoMetrics(const Metrics& metrics, std::string_view section,
-                                bool priveleged) const;
+  std::string FormatInfoMetrics(const Metrics& metrics, std::string_view section, bool priveleged,
+                                const std::shared_ptr<const facade::TlsCertInfo>& cert_info) const;
 
   ScriptMgr* script_mgr() {
     return script_mgr_.get();

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -394,7 +394,7 @@ void BaseFamilyTest::ClearMetrics() {
 }
 
 string BaseFamilyTest::FormatMetrics(const Metrics& metrics) const {
-  return service_->server_family().FormatInfoMetrics(metrics, "ALL", true);
+  return service_->server_family().FormatInfoMetrics(metrics, "ALL", true, nullptr);
 }
 
 void BaseFamilyTest::WaitUntilLocked(DbIndex db_index, string_view key, double timeout) {

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -4,6 +4,7 @@ import random
 import socket
 import ssl
 import string
+import subprocess
 import time
 from dataclasses import dataclass
 from threading import Thread
@@ -1477,6 +1478,64 @@ async def test_tls_reject(
     client = server.client(**with_tls_client_args)
     with pytest.raises(ConnectionError):
         await client.ping()
+
+
+def _parse_dn(dn: str) -> dict:
+    """Parse an OpenSSL oneline/RFC2253 DN into a dict of attributes.
+
+    Handles both the slash-separated format from X509_NAME_oneline()
+    (e.g. /C=GR/ST=SKG/...) and the comma-separated formats from the
+    openssl CLI (e.g. C = GR, ST = SKG, ... or C=GR,ST=...).
+    """
+    dn = dn.strip()
+    if dn.startswith("/"):
+        parts = dn.split("/")[1:]
+    else:
+        parts = [p.strip() for p in dn.split(",")]
+    result = {}
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+async def test_tls_info(with_ca_tls_server_args, with_ca_tls_client_args, df_factory):
+    server: DflyInstance = df_factory.create(port=BASE_PORT, **with_ca_tls_server_args)
+    server.start()
+
+    cert_file = with_ca_tls_server_args["tls_cert_file"]
+
+    # Extract expected values from the test certificate. DNs are compared as
+    # attribute dicts because OpenSSL versions format the oneline DN differently.
+    def cert_field(flag):
+        out = subprocess.check_output(["openssl", "x509", "-in", cert_file, "-noout", flag])
+        return out.decode().strip().split("=", 1)[1]
+
+    expected_subject = _parse_dn(cert_field("-subject"))
+    expected_issuer = _parse_dn(cert_field("-issuer"))
+    expected_not_before = cert_field("-startdate")
+    expected_not_after = cert_field("-enddate")
+
+    client = server.client(**with_ca_tls_client_args)
+
+    # redis-py's INFO parser turns "key=value" strings into nested dicts, which
+    # mangles the oneline DN values. Bypass the callback to inspect the raw INFO
+    # string for the TLS certificate fields.
+    info_callback = client.response_callbacks["INFO"]
+    client.response_callbacks["INFO"] = lambda response: response
+    try:
+        raw_info = await client.execute_command("INFO", "SERVER")
+    finally:
+        client.response_callbacks["INFO"] = info_callback
+        await client.aclose()
+
+    info_lines = dict(line.split(":", 1) for line in raw_info.splitlines() if ":" in line)
+    assert _parse_dn(info_lines["tls_cert_subject"]) == expected_subject
+    assert _parse_dn(info_lines["tls_cert_issuer"]) == expected_issuer
+    assert info_lines["tls_cert_not_before"] == expected_not_before
+    assert info_lines["tls_cert_not_after"] == expected_not_after
 
 
 @dfly_args({"proactor_threads": "4", "pipeline_squash": 1})


### PR DESCRIPTION
Adds TLS certificate metadata to the `INFO SERVER` section.

When TLS is enabled and the certificate file can be parsed successfully, the `INFO` output now includes:

- `tls_cert_subject` — certificate subject DN
- `tls_cert_issuer` — certificate issuer DN
- `tls_cert_not_before` — validity start date
- `tls_cert_not_after` — validity end date

The fields are emitted only when:
- Dragonfly is built with SSL support (`DFLY_USE_SSL`)
- TLS is enabled at runtime (`--tls`)
- The certificate file configured via `--tls_cert_file` can be parsed

If the certificate file is missing or invalid, the fields are silently omitted.

Fixes #3292