### PR TITLE
feat: compile-time grammar for CmdArgParser

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -12,40 +12,40 @@
 namespace facade {
 
 void CmdArgParser::ExpectTag(std::string_view tag) {
-  if (cur_i_ >= args_.size()) {
+  if (cur_i_ >= size_) {
     Report(OUT_OF_BOUNDS, cur_i_);
     return;
   }
 
   auto idx = cur_i_++;
-  auto val = args_[idx];
+  auto val = SVAt(idx);
   if (!absl::EqualsIgnoreCase(val, tag)) {
     Report(INVALID_NEXT, idx);
   }
 }
 
 void CmdArgParser::ExpectTag(std::string_view tag, std::string error_msg) {
-  if (cur_i_ >= args_.size()) {
+  if (cur_i_ >= size_) {
     Report(CUSTOM_ERROR, cur_i_, std::move(error_msg));
     return;
   }
 
   auto idx = cur_i_++;
-  if (!absl::EqualsIgnoreCase(args_[idx], tag))
+  if (!absl::EqualsIgnoreCase(SVAt(idx), tag))
     Report(CUSTOM_ERROR, idx, std::move(error_msg));
 }
 
 std::string_view CmdArgParser::ExpectStartsWith(std::string_view prefix, std::string error_msg) {
-  if (cur_i_ >= args_.size()) {
+  if (cur_i_ >= size_) {
     Report(CUSTOM_ERROR, cur_i_, std::move(error_msg));
-    return {};
+    return std::string_view{""};
   }
 
   auto idx = cur_i_++;
-  auto val = args_[idx];
+  auto val = SVAt(idx);
   if (!absl::StartsWith(val, prefix)) {
     Report(CUSTOM_ERROR, idx, std::move(error_msg));
-    return {};
+    return std::string_view{""};
   }
   val.remove_prefix(prefix.size());
   return val;
@@ -68,11 +68,6 @@ ErrorReply CmdArgParser::ErrorInfo::MakeReply() const {
       return ErrorReply{kSyntaxErr};
   };
   return ErrorReply{kSyntaxErr};
-}
-
-CmdArgParser::~CmdArgParser() {
-  DCHECK(!error_) << "Parsing error occured but not checked";
-  // TODO DCHECK(!HasNext()) << "Not all args were processed";
 }
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -7,6 +7,7 @@
 #include <absl/strings/match.h>
 #include <absl/strings/numbers.h>
 
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <concepts>
@@ -54,24 +55,26 @@ namespace facade {
 //   auto maybe_mode = parser.TryMapNext("ASC", Dir::ASC,        // like MapNext but returns
 //                                       "DESC", Dir::DESC);     // nullopt (no error) on miss
 //
-// Bulk named options with Apply():
-//   parser.Apply(
-//       Exist("WITHSCORES", &with_scores),         // tag present -> sets bool true
-//       Tag("LIMIT", &offset, &limit),             // tag -> reads following args
-//       Tag("COUNT", &optional_count),             // std::optional<T>* supported directly
-//       Tag("GET", [&](CmdArgParser* p) {          // lambda: custom parsing on tag match
-//         patterns.push_back(p->Next<string_view>());
-//       }),
-//       Map(&dir, "ASC", Dir::ASC, "DESC", Dir::DESC),   // tag -> fixed value mapping
-//       Tag("ATTR", Map(&mask, "v", Mask::Volatile,      // nested: outer tag + inner Map
-//                       "p", Mask::Permanent)),          //   (inner keyword required on match)
-//       OneOf(Exist("NX", &nx), Exist("XX", &xx))       // mutex — at most one may match
-//           .Err("NX and XX are incompatible"),        //   custom conflict message (optional)
-//       If(!read_only, Tag("STORE", &store_key)));    // runtime-gated option
+// Compile-time grammar for CmdArgParser: a `static constexpr` grammar built from consteval
+// factories (Compile/Args/Options/OneOf/Flag/Exist/Field/Map/Choice/Action/If) bound to members of
+// a target struct T. Nothing is built per call; Apply keeps only a tiny stack state. The factories
+// live in `facade`; Exist/OneOf overload the runtime combinators.
 //
-// Strict vs lenient dispatch:
-//   parser.Apply(...)        — stops at first unmatched arg; pair with Finalize() to error
-//   parser.ApplyOrSkip(...)  — silently skips unknown tags one-by-one
+//   struct P { std::string_view key; uint16_t flags = 0; uint32_t mc = 0; int64_t ttl = 0; };
+//   enum : uint16_t { kNx = 1, kXx = 2 };
+//   static constexpr auto kGrammar = Compile(
+//       Args(&P::key),
+//       Options(OneOf("NX and XX are incompatible",
+//                     Flag("NX", &P::flags, kNx), Flag("XX", &P::flags, kXx)),
+//               Action("EX", +[](CmdArgParser* p, P* o) { o->ttl = p->Next<int64_t>(); }),
+//               Field("MCFLAGS", &P::mc)));
+//   P o;
+//   kGrammar.Apply(&parser, &o);
+//   if (!parser.Finalize()) ...
+//
+// Options stops at the first unmatched argument; pair the grammar with Finalize() to reject
+// leftovers. The legacy parser.Apply(Exist(...), Tag(...), Map(...), OneOf(...), If(...)) runtime
+// combinators remain until their callers migrate.
 //
 // Navigating manually:
 //   if (parser.HasNext()) { ... }                               // is there another arg?
@@ -282,26 +285,33 @@ struct CmdArgParser {
 
  public:
   explicit CmdArgParser(const cmn::BackedArguments& bargs, uint32_t offset = 0)
-      : args_{bargs, offset} {
+      : args_{bargs, offset}, size_{args_.size()} {
   }
 
-  explicit CmdArgParser(const ParsedArgs& args) : args_{args} {
+  explicit CmdArgParser(const ParsedArgs& args) : args_{args}, size_{args_.size()} {
   }
 
-  CmdArgParser(const ParsedArgs& args, uint32_t offset) : args_{args.Tail(offset)} {
+  CmdArgParser(const ParsedArgs& args, uint32_t offset)
+      : args_{args.Tail(offset)}, size_{args_.size()} {
   }
 
-  // DCHECKs that any error was consumed.
-  ~CmdArgParser();
+  // Asserts that any error was consumed.
+  ~CmdArgParser() {
+    assert(!error_ && "Parsing error occured but not checked");
+  }
 
   // Returns the arg `ahead` positions past the cursor without consuming it (empty if out of range).
   std::string_view Peek(size_t ahead = 0) {
     return SafeSV(cur_i_ + ahead);
   }
 
+  std::string_view CurrentUnchecked() const {
+    return SVAt(cur_i_);
+  }
+
   template <class T = std::string_view, class... Ts> auto Next() {
-    if (cur_i_ + sizeof...(Ts) >= args_.size()) {
-      Report(OUT_OF_BOUNDS, cur_i_);
+    if (cur_i_ + sizeof...(Ts) >= size_) {
+      ReportCode(OUT_OF_BOUNDS, cur_i_);
       return std::conditional_t<sizeof...(Ts) == 0, decltype(Convert<T>(0)),
                                 std::tuple<T, Ts...>>();
     }
@@ -311,8 +321,10 @@ struct CmdArgParser {
       return Convert<T>(idx);
     } else {
       std::tuple<T, Ts...> res;
-      NextImpl<0>(&res);
-      cur_i_ += sizeof...(Ts) + 1;
+      const size_t base = cur_i_;
+      // Report() moves cur_i_ on failure, so every conversion uses the captured base.
+      cur_i_ = base + sizeof...(Ts) + 1;
+      NextImpl<0>(&res, base);
       return res;
     }
   }
@@ -328,13 +340,13 @@ struct CmdArgParser {
       using R = std::invoke_result_t<F, std::string_view, RuleError&>;
       static_assert(std::is_default_constructible_v<R> && !std::is_reference_v<R>,
                     "token parser must return a default-constructible value type");
-      if (cur_i_ >= args_.size()) {
+      if (cur_i_ >= size_) {
         Report(OUT_OF_BOUNDS, cur_i_);
         return R{};
       }
       size_t idx = cur_i_++;
       RuleError e;
-      R val = std::forward<F>(fn)(SafeSV(idx), e);
+      R val = std::forward<F>(fn)(SVAt(idx), e);
       if (e.failed)
         Report(e.msg.empty() ? INVALID_CASES : CUSTOM_ERROR, idx, std::string{e.msg});
       return e.failed ? R{} : val;
@@ -380,7 +392,7 @@ struct CmdArgParser {
   // is provided and no args remain, reports it as a custom error.
   Range RemainingRange(std::string_view empty_err = {}) {
     Range r{args_.Tail(cur_i_)};
-    cur_i_ = args_.size();
+    cur_i_ = size_;
     if (!empty_err.empty() && r.empty())
       ReportCustom(std::string{empty_err});
     return r;
@@ -413,12 +425,12 @@ struct CmdArgParser {
   // BITFIELD's "#index" form.
   template <class T> T NextWithPrefix(std::string_view prefix, bool* prefixed) {
     static_assert(std::is_integral_v<T>);
-    if (cur_i_ >= args_.size()) {
+    if (cur_i_ >= size_) {
       Report(OUT_OF_BOUNDS, cur_i_);
       return {};
     }
     size_t idx = cur_i_++;
-    std::string_view val = SafeSV(idx);
+    std::string_view val = SVAt(idx);
     *prefixed = absl::StartsWith(val, prefix);
     if (*prefixed)
       val.remove_prefix(prefix.size());
@@ -431,14 +443,14 @@ struct CmdArgParser {
   }
 
   template <class... Cases> auto MapNext(Cases&&... cases) {
-    if (cur_i_ >= args_.size()) {
+    if (cur_i_ >= size_) {
       Report(OUT_OF_BOUNDS, cur_i_);
       return typename decltype(MapImpl(std::string_view(),
                                        std::forward<Cases>(cases)...))::value_type{};
     }
 
     auto idx = cur_i_++;
-    auto res = MapImpl(SafeSV(idx), std::forward<Cases>(cases)...);
+    auto res = MapImpl(SVAt(idx), std::forward<Cases>(cases)...);
     if (!res) {
       Report(INVALID_CASES, idx);
       return typename decltype(res)::value_type{};
@@ -450,11 +462,11 @@ struct CmdArgParser {
   template <class... Cases>
   auto TryMapNext(Cases&&... cases)
       -> std::optional<std::tuple_element_t<1, std::tuple<Cases...>>> {
-    if (cur_i_ >= args_.size()) {
+    if (cur_i_ >= size_) {
       return std::nullopt;
     }
 
-    auto res = MapImpl(SafeSV(cur_i_), std::forward<Cases>(cases)...);
+    auto res = MapImpl(SVAt(cur_i_), std::forward<Cases>(cases)...);
     cur_i_ = res ? cur_i_ + 1 : cur_i_;
     return res;
   }
@@ -462,11 +474,10 @@ struct CmdArgParser {
   // Consumes `tag` if next and reads the following args-into-pointers; no-op otherwise. The result
   // is the tag match only: a bad/missing value still returns true but latches an error (check it).
   template <class... Args> bool Check(std::string_view tag, Args*... args) {
-    if (cur_i_ >= args_.size())
+    if (cur_i_ >= size_)
       return false;
 
-    std::string_view arg = SafeSV(cur_i_);
-    if (!absl::EqualsIgnoreCase(arg, tag))
+    if (!absl::EqualsIgnoreCase(SVAt(cur_i_), tag))
       return false;
 
     ++cur_i_;
@@ -475,15 +486,14 @@ struct CmdArgParser {
     return true;
   }
 
-  // Greedily matches remaining args against the options. See the file header for usage.
+  // TODO: remove — superseded by the compile-time cap grammar (Compile/Options/...). Greedily
+  // matches remaining args against the options, stopping at the first unmatched arg.
   template <class... Opts> void Apply(Opts... opts) {
     while (HasNext() && (opts.TryApply(this) || ...)) {
     }
   }
 
-  // Like Apply, but silently skips unmatched args (one at a time) instead of stopping. Use when
-  // unknown tags should be ignored rather than reported. Prefer Apply + Finalize when strictness
-  // is desired.
+  // TODO: remove. Like Apply, but silently skips unmatched args one at a time instead of stopping.
   template <class... Opts> void ApplyOrSkip(Opts... opts) {
     while (HasNext()) {
       if (!(opts.TryApply(this) || ...))
@@ -492,12 +502,16 @@ struct CmdArgParser {
   }
 
   CmdArgParser& Skip(size_t n) {
-    if (cur_i_ + n > args_.size()) {
+    if (cur_i_ + n > size_) {
       Report(OUT_OF_BOUNDS, cur_i_);
     } else {
       cur_i_ += n;
     }
     return *this;
+  }
+
+  void AdvanceUnchecked() {
+    ++cur_i_;
   }
 
   // Requires all args consumed and no prior error. If args remain, reports the generic UNPROCESSED
@@ -526,7 +540,11 @@ struct CmdArgParser {
   }
 
   bool HasNext() {
-    return cur_i_ < args_.size() && !error_;
+    return cur_i_ < size_ && !error_;
+  }
+
+  bool InBounds() const {
+    return cur_i_ < size_;
   }
 
   bool HasError() const {
@@ -536,7 +554,7 @@ struct CmdArgParser {
   ErrorInfo TakeError();
 
   bool HasAtLeast(size_t i) const {
-    return !error_ && i <= args_.size() - cur_i_;
+    return !error_ && i <= size_ - cur_i_;
   }
 
   // Reports a custom error (error_type >= CUSTOM_ERROR) at the previously-consumed index
@@ -555,7 +573,15 @@ struct CmdArgParser {
   void Report(int error_type, size_t idx, std::string msg = {}) {
     if (!error_) {
       error_ = {error_type, idx, std::move(msg)};
-      cur_i_ = args_.size();
+      cur_i_ = size_;
+    }
+  }
+
+  void ReportCode(int error_type, size_t idx) {
+    if (!error_) {
+      error_.type = error_type;
+      error_.index = idx;
+      cur_i_ = size_;
     }
   }
 
@@ -571,10 +597,10 @@ struct CmdArgParser {
     return std::nullopt;
   }
 
-  template <size_t shift, class Tuple> void NextImpl(Tuple* t) {
-    std::get<shift>(*t) = Convert<std::tuple_element_t<shift, Tuple>>(cur_i_ + shift);
+  template <size_t shift, class Tuple> void NextImpl(Tuple* t, size_t base) {
+    std::get<shift>(*t) = Convert<std::tuple_element_t<shift, Tuple>>(base + shift);
     if constexpr (constexpr auto next = shift + 1; next < std::tuple_size_v<Tuple>)
-      NextImpl<next>(t);
+      NextImpl<next>(t, base);
   }
 
   template <class T> T Convert(size_t idx) {
@@ -586,15 +612,17 @@ struct CmdArgParser {
     } else if constexpr (std::is_arithmetic_v<T>) {
       return Num<T>(idx);
     } else if constexpr (std::is_constructible_v<T, std::string_view>) {
-      return static_cast<T>(SafeSV(idx));
+      return static_cast<T>(SVAt(idx));
     } else if constexpr (as_vnum<T>) {
       using U = decltype(T::value);
-      U val = Num<U>(idx);
-      if (error_)
-        return {};  // malformed number already reported
+      U val{};
+      if (!TryParseNum(SVAt(idx), &val)) {
+        ReportCode(std::is_floating_point_v<U> ? INVALID_FLOAT : INVALID_INT, idx);
+        return {};
+      }
       if (RuleError e = T::validate(val); e.failed) {
         if (e.msg.empty())
-          Report(std::is_floating_point_v<U> ? INVALID_FLOAT : INVALID_INT, idx);
+          ReportCode(std::is_floating_point_v<U> ? INVALID_FLOAT : INVALID_INT, idx);
         else
           Report(CUSTOM_ERROR, idx, std::string{e.msg});
         return {};
@@ -603,24 +631,28 @@ struct CmdArgParser {
     }
   }
 
+  // Preserve a non-null data() for empty arguments (#3627).
+  std::string_view SVAt(size_t i) const {
+    std::string_view sv = args_[i];
+    return sv.empty() ? std::string_view{""} : sv;
+  }
+
   std::string_view SafeSV(size_t i) const {
-    using namespace std::literals::string_view_literals;
-    if (i >= args_.size())
-      return ""sv;
-    return args_[i].empty() ? ""sv : args_[i];
+    return i >= size_ ? std::string_view{""} : SVAt(i);
   }
 
   template <typename T> T Num(size_t idx) {
     T out{};
-    if (TryParseNum(SafeSV(idx), &out))
+    if (TryParseNum(SVAt(idx), &out))
       return out;
-    Report(std::is_floating_point_v<T> ? INVALID_FLOAT : INVALID_INT, idx);
+    ReportCode(std::is_floating_point_v<T> ? INVALID_FLOAT : INVALID_INT, idx);
     return {};
   }
 
  private:
   size_t cur_i_ = 0;
   ParsedArgs args_;
+  size_t size_ = 0;
 
   ErrorInfo error_;
 };
@@ -630,11 +662,13 @@ template <class T> T Number(CmdArgParser* parser) {
   return parser->Next<T>();
 }
 
+// TODO: remove — the runtime combinator family (the options below and their Exist/Tag/Map/If/OneOf
+// factories) is superseded by the compile-time cap grammar; kept until the last parser.Apply
+// callers migrate.
 namespace detail {
 
-// CRTP base for Apply() options: adds a fluent .Err(msg) whose message ReportErr() surfaces on
-// failure (OneOf conflict, nested Tag mismatch), else the generic INVALID_CASES syntax error. The
-// message is owned (copied) so temporaries like absl::StrCat(...) are safe.
+// CRTP base for Apply() options: a fluent .Err(msg) surfaced by ReportErr() on failure, else the
+// generic INVALID_CASES error.
 template <class Derived> struct OptBase {
   std::string err = {};
 
@@ -766,6 +800,315 @@ concept ParseOption = requires(const T& t, CmdArgParser* p) {
 
 }  // namespace detail
 
+namespace cap_detail {
+
+struct NoState {};
+
+template <class T, class... M>
+void ReadMembers(CmdArgParser* p, T* o, const std::tuple<M T::*...>& fields) {
+  std::apply(
+      [&](auto... field) {
+        if constexpr (sizeof...(M) == 1)
+          ((o->*field = p->Next<M>()), ...);
+        else
+          std::tie(o->*field...) = p->Next<M...>();
+      },
+      fields);
+}
+
+inline bool TagMatch(std::string_view cur, std::string_view tag) {
+  if (cur.size() != tag.size())
+    return false;
+  // TODO: Dispatch on compile-time tag metadata while preserving Abseil's comparison semantics.
+  return absl::EqualsIgnoreCase(cur, tag);
+}
+
+template <class Derived, class T> struct TaggedRule {
+  using Target = T;
+  using State = NoState;
+
+  consteval explicit TaggedRule(std::string_view tag) : tag_(tag) {
+  }
+
+  bool Consume(CmdArgParser* p, std::string_view cur, T* o, State&) const {
+    if (!TagMatch(cur, tag_))
+      return false;
+    p->AdvanceUnchecked();
+    static_cast<const Derived*>(this)->OnMatch(p, o);
+    return true;
+  }
+
+ private:
+  std::string_view tag_;
+};
+
+template <class T, class M> struct Flag : TaggedRule<Flag<T, M>, T> {
+  consteval Flag(const char* tag, M T::*field, M value)
+      : TaggedRule<Flag<T, M>, T>(tag), field_(field), value_(value) {
+  }
+
+  void OnMatch(CmdArgParser*, T* o) const {
+    o->*field_ |= value_;
+  }
+
+ private:
+  M T::*field_;
+  M value_;
+};
+
+template <class T> struct Exist : TaggedRule<Exist<T>, T> {
+  consteval Exist(const char* tag, bool T::*field) : TaggedRule<Exist<T>, T>(tag), field_(field) {
+  }
+
+  void OnMatch(CmdArgParser*, T* o) const {
+    o->*field_ = true;
+  }
+
+ private:
+  bool T::*field_;
+};
+
+template <class T, class... M> struct Field : TaggedRule<Field<T, M...>, T> {
+  consteval Field(const char* tag, M T::*... fields)
+      : TaggedRule<Field<T, M...>, T>(tag), fields_(fields...) {
+  }
+
+  void OnMatch(CmdArgParser* p, T* o) const {
+    ReadMembers(p, o, fields_);
+  }
+
+ private:
+  std::tuple<M T::*...> fields_;
+};
+
+template <class T> struct Action : TaggedRule<Action<T>, T> {
+  consteval Action(const char* tag, void (*fn)(CmdArgParser*, T*))
+      : TaggedRule<Action<T>, T>(tag), fn_(fn) {
+  }
+
+  void OnMatch(CmdArgParser* p, T* o) const {
+    fn_(p, o);
+  }
+
+ private:
+  void (*fn_)(CmdArgParser*, T*);
+};
+
+template <class T, class M, size_t N> struct Map {
+  using Target = T;
+  using State = NoState;
+  consteval Map(M T::*field, std::array<std::string_view, N> tags, std::array<M, N> values)
+      : field_(field), tags_(tags), values_(values) {
+  }
+  bool Consume(CmdArgParser* p, std::string_view cur, T* o, State&) const {
+    for (size_t i = 0; i < N; ++i) {
+      if (TagMatch(cur, tags_[i])) {
+        p->AdvanceUnchecked();
+        o->*field_ = values_[i];
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  M T::*field_;
+  std::array<std::string_view, N> tags_;
+  std::array<M, N> values_;
+};
+
+template <class T, class M, size_t N> struct Choice : TaggedRule<Choice<T, M, N>, T> {
+  consteval Choice(std::string_view tag, M T::*field, std::array<std::string_view, N> keys,
+                   std::array<M, N> values)
+      : TaggedRule<Choice<T, M, N>, T>(tag), field_(field), keys_(keys), values_(values) {
+  }
+
+  void OnMatch(CmdArgParser* p, T* o) const {
+    std::string_view val = p->template Next<std::string_view>();
+    for (size_t i = 0; i < N; ++i) {
+      if (TagMatch(val, keys_[i])) {
+        o->*field_ = values_[i];
+        return;
+      }
+    }
+    p->Report(CmdArgParser::INVALID_CASES);
+  }
+
+ private:
+  M T::*field_;
+  std::array<std::string_view, N> keys_;
+  std::array<M, N> values_;
+};
+
+template <class T, class Inner> struct If {
+  using Target = T;
+  using State = typename Inner::State;
+  consteval If(bool T::*cond, bool want, Inner inner) : cond_(cond), want_(want), inner_(inner) {
+  }
+  bool Consume(CmdArgParser* p, std::string_view cur, T* o, State& st) const {
+    return (o->*cond_ == want_) && inner_.Consume(p, cur, o, st);
+  }
+
+ private:
+  bool T::*cond_;
+  bool want_;
+  Inner inner_;
+};
+
+template <class T, class... M> struct Args {
+  using Target = T;
+  using State = NoState;
+  consteval explicit Args(M T::*... fields) : fields_(fields...) {
+  }
+  void Consume(CmdArgParser* p, T* o, State&) const {
+    ReadMembers(p, o, fields_);
+  }
+
+ private:
+  std::tuple<M T::*...> fields_;
+};
+
+template <class T, class... Alts> struct OneOf {
+  using Target = T;
+  struct State {
+    signed char matched = -1;
+  };
+  consteval OneOf(std::string_view err, Alts... alts) : err_(err), alts_(alts...) {
+  }
+  bool Consume(CmdArgParser* p, std::string_view cur, T* o, State& st) const {
+    return TryAt<0>(p, cur, o, st);
+  }
+
+ private:
+  template <size_t I> bool TryAt(CmdArgParser* p, std::string_view cur, T* o, State& st) const {
+    if constexpr (I >= sizeof...(Alts)) {
+      return false;
+    } else {
+      typename std::tuple_element_t<I, std::tuple<Alts...>>::State alt_st{};
+      if (std::get<I>(alts_).Consume(p, cur, o, alt_st)) {
+        if (st.matched >= 0 && st.matched != static_cast<signed char>(I))
+          ReportConflict(p);
+        st.matched = static_cast<signed char>(I);
+        return true;
+      }
+      return TryAt<I + 1>(p, cur, o, st);
+    }
+  }
+  void ReportConflict(CmdArgParser* p) const {
+    if (err_.empty())
+      p->Report(CmdArgParser::INVALID_CASES);
+    else
+      p->ReportCustom(std::string{err_});
+  }
+  std::string_view err_;
+  std::tuple<Alts...> alts_;
+};
+
+template <class T, class... Rules> struct Options {
+  using Target = T;
+  using State = std::tuple<typename Rules::State...>;
+  consteval explicit Options(Rules... rules) : rules_(rules...) {
+  }
+  void Consume(CmdArgParser* p, T* o, State& st) const {
+    while (p->InBounds()) {
+      std::string_view cur = p->CurrentUnchecked();
+      if (!Match(p, cur, o, st, std::index_sequence_for<Rules...>{}))
+        break;
+    }
+  }
+
+ private:
+  template <size_t... I>
+  bool Match(CmdArgParser* p, std::string_view cur, T* o, State& st,
+             std::index_sequence<I...>) const {
+    return (std::get<I>(rules_).Consume(p, cur, o, std::get<I>(st)) || ...);
+  }
+  std::tuple<Rules...> rules_;
+};
+
+template <class T, class... Elems> struct Grammar {
+  using Target = T;
+  consteval explicit Grammar(Elems... elems) : elems_(elems...) {
+  }
+  void Apply(CmdArgParser* p, T* o) const {
+    std::tuple<typename Elems::State...> st{};
+    Run(p, o, st, std::index_sequence_for<Elems...>{});
+  }
+
+ private:
+  template <size_t... I>
+  void Run(CmdArgParser* p, T* o, std::tuple<typename Elems::State...>& st,
+           std::index_sequence<I...>) const {
+    (std::get<I>(elems_).Consume(p, o, std::get<I>(st)), ...);
+  }
+  std::tuple<Elems...> elems_;
+};
+
+}  // namespace cap_detail
+
+template <class T, class M>
+consteval auto Flag(const char* tag, M T::*field, std::type_identity_t<M> value) {
+  return cap_detail::Flag<T, M>{tag, field, value};
+}
+template <class T> consteval auto Exist(const char* tag, bool T::*field) {
+  return cap_detail::Exist<T>{tag, field};
+}
+template <class T, class... M> consteval auto Field(const char* tag, M T::*... fields) {
+  static_assert(sizeof...(M) > 0, "Field expects at least one member");
+  return cap_detail::Field<T, M...>{tag, fields...};
+}
+template <class T> consteval auto Action(const char* tag, void (*fn)(CmdArgParser*, T*)) {
+  return cap_detail::Action<T>{tag, fn};
+}
+template <class T, class M, class... Cs> consteval auto Map(M T::*field, Cs... cs) {
+  static_assert(sizeof...(Cs) % 2 == 0, "Map expects alternating tag/value pairs");
+  constexpr size_t N = sizeof...(Cs) / 2;
+  std::array<std::string_view, N> tags{};
+  std::array<M, N> values{};
+  auto cases = std::tuple{cs...};
+  [&]<size_t... I>(std::index_sequence<I...>) {
+    ((tags[I] = std::get<2 * I>(cases), values[I] = std::get<2 * I + 1>(cases)), ...);
+  }
+  (std::make_index_sequence<N>{});
+  return cap_detail::Map<T, M, N>{field, tags, values};
+}
+template <class T, class M, class... Cs>
+consteval auto Choice(const char* tag, M T::*field, Cs... cs) {
+  static_assert(sizeof...(Cs) % 2 == 0, "Choice expects alternating key/value pairs");
+  constexpr size_t N = sizeof...(Cs) / 2;
+  std::array<std::string_view, N> keys{};
+  std::array<M, N> values{};
+  auto cases = std::tuple{cs...};
+  [&]<size_t... I>(std::index_sequence<I...>) {
+    ((keys[I] = std::get<2 * I>(cases), values[I] = std::get<2 * I + 1>(cases)), ...);
+  }
+  (std::make_index_sequence<N>{});
+  return cap_detail::Choice<T, M, N>{tag, field, keys, values};
+}
+template <class T, class Inner> consteval auto If(bool T::*cond, Inner inner) {
+  return cap_detail::If<T, Inner>{cond, true, inner};
+}
+template <class T, class Inner> consteval auto IfNot(bool T::*cond, Inner inner) {
+  return cap_detail::If<T, Inner>{cond, false, inner};
+}
+template <class T, class... M> consteval auto Args(M T::*... fields) {
+  static_assert(sizeof...(M) > 0, "Args expects at least one member");
+  return cap_detail::Args<T, M...>{fields...};
+}
+template <class... Alts> consteval auto OneOf(std::string_view err, Alts... alts) {
+  using T = typename std::tuple_element_t<0, std::tuple<Alts...>>::Target;
+  return cap_detail::OneOf<T, Alts...>{err, alts...};
+}
+template <class... Rules> consteval auto Options(Rules... rules) {
+  using T = typename std::tuple_element_t<0, std::tuple<Rules...>>::Target;
+  return cap_detail::Options<T, Rules...>{rules...};
+}
+template <class... Elems> consteval auto Compile(Elems... elems) {
+  using T = typename std::tuple_element_t<0, std::tuple<Elems...>>::Target;
+  return cap_detail::Grammar<T, Elems...>{elems...};
+}
+
+// TODO: remove — runtime combinator factories, superseded by the consteval cap factories above.
 inline detail::ExistOpt Exist(std::string_view tag, bool* field) {
   return {{}, tag, field};
 }
@@ -780,8 +1123,6 @@ requires std::is_invocable_v<Func, CmdArgParser*> detail::LambdaOpt<Func> Tag(st
   return {{}, tag, std::move(func)};
 }
 
-// Nested option: outer tag + inner sub-option (e.g. Map). After outer matches, inner must match
-// the following arg or INVALID_CASES is reported.
 template <detail::ParseOption Inner>
 detail::TagNestedOpt<Inner> Tag(std::string_view tag, Inner inner) {
   return {{}, tag, std::move(inner)};
@@ -795,7 +1136,7 @@ template <class Inner> detail::IfOpt<Inner> If(bool cond, Inner inner) {
   return {{}, cond, std::move(inner)};
 }
 
-template <class... Opts> detail::OneOfOpt<Opts...> OneOf(Opts... opts) {
+template <detail::ParseOption... Opts> detail::OneOfOpt<Opts...> OneOf(Opts... opts) {
   return {{}, {std::move(opts)...}};
 }
 

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -5,6 +5,7 @@
 #include "facade/cmd_arg_parser.h"
 
 #include <absl/base/casts.h>
+#include <benchmark/benchmark.h>
 #include <gmock/gmock.h>
 
 #include <cmath>
@@ -45,6 +46,41 @@ TEST_F(CmdArgParserTest, BasicTypes) {
 
   EXPECT_FALSE(parser.HasNext());
   EXPECT_FALSE(parser.HasError());
+}
+
+TEST_F(CmdArgParserTest, EmptyArgumentNormalization) {
+  std::string_view args[] = {{}, {}, {}, {}, {}};
+  ASSERT_EQ(args[0].data(), nullptr);
+
+  ParsedArgs parsed{cmn::ArgSlice{args, std::size(args)}};
+  CmdArgParser parser{parsed};
+  EXPECT_NE(parser.CurrentUnchecked().data(), nullptr);
+
+  std::string_view value;
+  EXPECT_TRUE(parser.Check("", &value));
+  EXPECT_NE(value.data(), nullptr);
+
+  parser.ExpectTag("");
+  parser.ExpectTag("", "expected empty argument");
+  EXPECT_NE(parser.ExpectStartsWith("", "expected empty argument").data(), nullptr);
+  EXPECT_TRUE(parser.Finalize());
+
+  std::string_view arg;
+  CmdArgParser invalid_prefix{ParsedArgs{cmn::ArgSlice{&arg, 1}}};
+  EXPECT_NE(invalid_prefix.ExpectStartsWith("x", "missing prefix").data(), nullptr);
+  EXPECT_TRUE(invalid_prefix.TakeError());
+}
+
+TEST_F(CmdArgParserTest, MultiNextErrorPreservesCursor) {
+  auto parser = Make({"1", "bad", "also-bad"});
+
+  auto values = parser.Next<int, int, int>();
+  EXPECT_EQ(std::get<0>(values), 1);
+  EXPECT_EQ(std::get<1>(values), 0);
+  EXPECT_EQ(parser.UnparsedStart(), 3u);
+  auto err = parser.TakeError();
+  EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+  EXPECT_EQ(err.index, 1u);
 }
 
 TEST_F(CmdArgParserTest, BoundError) {
@@ -963,5 +999,425 @@ TEST_F(CmdArgParserTest, FinalizeUnexpected) {
     EXPECT_EQ(err.index, 1u);  // points at the first leftover arg, not the consumed one
   }
 }
+
+namespace {
+struct SetLike {
+  std::string_view key;
+  std::string_view value;
+  uint16_t flags = 0;
+  uint32_t mc = 0;
+  uint32_t offset = 0;
+  uint32_t count = 0;
+  int64_t ttl = 0;
+  bool ttl_set = false;
+};
+enum SetLikeFlags : uint16_t { kNx = 1 << 0, kXx = 1 << 1, kGet = 1 << 2 };
+
+consteval auto MakeSetLikeGrammar() {
+  return Compile(Args(&SetLike::key, &SetLike::value),
+                 Options(OneOf("NX and XX are incompatible", Flag("NX", &SetLike::flags, kNx),
+                               Flag("XX", &SetLike::flags, kXx)),
+                         Action(
+                             "EX",
+                             +[](CmdArgParser* p, SetLike* o) {
+                               o->ttl = p->Next<int64_t>();
+                               o->ttl_set = true;
+                             }),
+                         Flag("GET", &SetLike::flags, kGet), Field("MCFLAGS", &SetLike::mc),
+                         Field("LIMIT", &SetLike::offset, &SetLike::count)));
+}
+}  // namespace
+
+TEST_F(CmdArgParserTest, CapGrammar) {
+  static constexpr auto kGrammar = MakeSetLikeGrammar();
+  auto apply = [&](std::initializer_list<std::string_view> args, SetLike* o) {
+    auto parser = Make(args);
+    kGrammar.Apply(&parser, o);
+    parser.Finalize();
+    return parser.TakeError();
+  };
+
+  {
+    SetLike o;
+    EXPECT_FALSE(apply({"mykey", "myval", "NX", "GET"}, &o));
+    EXPECT_EQ(o.key, "mykey");
+    EXPECT_EQ(o.value, "myval");
+    EXPECT_EQ(o.flags, kNx | kGet);
+  }
+  {
+    SetLike o;
+    EXPECT_FALSE(apply({"k", "v", "EX", "100"}, &o));
+    EXPECT_TRUE(o.ttl_set);
+    EXPECT_EQ(o.ttl, 100);
+  }
+  {
+    SetLike o;
+    EXPECT_FALSE(apply({"k", "v", "MCFLAGS", "42"}, &o));
+    EXPECT_EQ(o.mc, 42u);
+  }
+  {
+    SetLike o;
+    EXPECT_FALSE(apply({"k", "v", "LIMIT", "2", "10"}, &o));
+    EXPECT_EQ(o.offset, 2u);
+    EXPECT_EQ(o.count, 10u);
+  }
+  {
+    SetLike o;
+    auto err = apply({"k", "v", "NX", "XX"}, &o);
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.MakeReply().ToSv(), "NX and XX are incompatible");
+  }
+  {
+    SetLike o;
+    EXPECT_FALSE(apply({"k", "v", "NX", "NX"}, &o));
+    EXPECT_EQ(o.flags, kNx);
+  }
+  {
+    SetLike o;
+    EXPECT_FALSE(apply({"k", "v"}, &o));
+    EXPECT_EQ(o.key, "k");
+    EXPECT_EQ(o.value, "v");
+    EXPECT_EQ(o.flags, 0);
+  }
+  {
+    SetLike o;
+    EXPECT_TRUE(apply({"k"}, &o));
+  }
+  {
+    SetLike o;
+    auto err = apply({}, &o);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+  }
+  {
+    SetLike o;
+    auto err = apply({"k", "v", "LIMIT", "2"}, &o);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+  }
+  {
+    SetLike o;
+    EXPECT_TRUE(apply({"k", "v", "GET", "FOO"}, &o));
+    EXPECT_EQ(o.flags, kGet);
+  }
+  {
+    SetLike o;
+    EXPECT_TRUE(apply({"k", "v", "EX", "notanint"}, &o));
+  }
+}
+
+namespace {
+struct HeadTail {
+  std::string_view head;
+  bool flag = false;
+  std::string_view tail;
+};
+consteval auto MakeHeadTailGrammar() {
+  return Compile(Args(&HeadTail::head), Options(Exist("F", &HeadTail::flag)),
+                 Args(&HeadTail::tail));
+}
+}  // namespace
+
+TEST_F(CmdArgParserTest, CapGrammarPositionalAfterOptions) {
+  static constexpr auto kGrammar = MakeHeadTailGrammar();
+  auto run = [&](std::initializer_list<std::string_view> args, HeadTail* o) {
+    auto parser = Make(args);
+    kGrammar.Apply(&parser, o);
+    parser.Finalize();
+    return parser.TakeError();
+  };
+
+  {
+    HeadTail o;
+    EXPECT_FALSE(run({"h", "F", "t"}, &o));
+    EXPECT_EQ(o.head, "h");
+    EXPECT_TRUE(o.flag);
+    EXPECT_EQ(o.tail, "t");
+  }
+  {
+    HeadTail o;
+    EXPECT_FALSE(run({"h", "t"}, &o));
+    EXPECT_EQ(o.head, "h");
+    EXPECT_FALSE(o.flag);
+    EXPECT_EQ(o.tail, "t");
+  }
+}
+
+namespace {
+enum class Dir { kAsc, kDesc };
+struct MapIf {
+  Dir dir = Dir::kAsc;
+  bool read_only = false;
+  std::string_view store;
+};
+consteval auto MakeMapIfGrammar() {
+  return Compile(Options(Map(&MapIf::dir, "ASC", Dir::kAsc, "DESC", Dir::kDesc),
+                         IfNot(&MapIf::read_only, Field("STORE", &MapIf::store))));
+}
+}  // namespace
+
+TEST_F(CmdArgParserTest, CapGrammarMapIf) {
+  static constexpr auto kGrammar = MakeMapIfGrammar();
+  auto run = [&](std::initializer_list<std::string_view> args, MapIf* o) {
+    auto parser = Make(args);
+    kGrammar.Apply(&parser, o);
+    parser.Finalize();
+    return parser.TakeError();
+  };
+
+  {
+    MapIf o;
+    EXPECT_FALSE(run({"DESC"}, &o));
+    EXPECT_EQ(o.dir, Dir::kDesc);
+  }
+  {
+    MapIf o;
+    EXPECT_FALSE(run({"ASC", "STORE", "dst"}, &o));
+    EXPECT_EQ(o.dir, Dir::kAsc);
+    EXPECT_EQ(o.store, "dst");
+  }
+  {
+    MapIf o;
+    o.read_only = true;
+    EXPECT_TRUE(run({"STORE", "dst"}, &o));
+    EXPECT_EQ(o.store, "");
+  }
+}
+
+TEST_F(CmdArgParserTest, CapTagMatch) {
+  using cap_detail::TagMatch;
+  EXPECT_TRUE(TagMatch("EX", "EX"));
+  EXPECT_TRUE(TagMatch("ex", "EX"));
+  EXPECT_TRUE(TagMatch("Ex", "eX"));
+  EXPECT_FALSE(TagMatch("E", "EX"));
+  EXPECT_FALSE(TagMatch("EXX", "EX"));
+  EXPECT_FALSE(TagMatch("EY", "EX"));
+  EXPECT_FALSE(TagMatch("", "EX"));
+  EXPECT_TRUE(TagMatch("", ""));
+  EXPECT_FALSE(TagMatch(std::string_view{"E\0", 2}, "EX"));
+}
+
+namespace {
+enum class Agg { kSum, kMin, kMax };
+struct ChoiceTarget {
+  Agg agg = Agg::kSum;
+};
+consteval auto MakeChoiceGrammar() {
+  return Compile(Options(Choice("AGGREGATE", &ChoiceTarget::agg, "SUM", Agg::kSum, "MIN", Agg::kMin,
+                                "MAX", Agg::kMax)));
+}
+}  // namespace
+
+TEST_F(CmdArgParserTest, CapGrammarChoice) {
+  static constexpr auto kGrammar = MakeChoiceGrammar();
+  auto run = [&](std::initializer_list<std::string_view> args, ChoiceTarget* o) {
+    auto parser = Make(args);
+    kGrammar.Apply(&parser, o);
+    parser.Finalize();
+    return parser.TakeError();
+  };
+
+  {
+    ChoiceTarget o;
+    EXPECT_FALSE(run({"AGGREGATE", "MAX"}, &o));
+    EXPECT_EQ(o.agg, Agg::kMax);
+  }
+  {
+    ChoiceTarget o;
+    EXPECT_FALSE(run({"aggregate", "min"}, &o));
+    EXPECT_EQ(o.agg, Agg::kMin);
+  }
+  {
+    ChoiceTarget o;
+    EXPECT_TRUE(run({"AGGREGATE", "BOGUS"}, &o));
+  }
+  {
+    ChoiceTarget o;
+    EXPECT_TRUE(run({"AGGREGATE"}, &o));
+  }
+}
+
+namespace {
+
+enum BenchFlags : uint16_t { kBNx = 1 << 0, kBXx = 1 << 1, kBGet = 1 << 2 };
+enum class BenchDir : uint8_t { kAsc, kDesc };
+
+struct BenchTarget {
+  std::string_view key;
+  std::string_view value;
+  uint16_t flags = 0;
+  bool stick = false;
+  bool keepttl = false;
+  int64_t ttl = 0;
+  bool ttl_set = false;
+  uint32_t mc = 0;
+  BenchDir dir = BenchDir::kAsc;
+  bool read_only = false;
+  std::string_view store;
+};
+
+consteval auto MakeBenchGrammar() {
+  auto expiry = +[](CmdArgParser* p, BenchTarget* o) {
+    o->ttl = p->Next<int64_t>();
+    o->ttl_set = true;
+  };
+  return Compile(
+      Args(&BenchTarget::key, &BenchTarget::value),
+      Options(
+          OneOf("", Flag("NX", &BenchTarget::flags, kBNx), Flag("XX", &BenchTarget::flags, kBXx)),
+          Action("EX", expiry), Action("PX", expiry), Action("EXAT", expiry),
+          Action("PXAT", expiry), Flag("GET", &BenchTarget::flags, kBGet),
+          Map(&BenchTarget::dir, "ASC", BenchDir::kAsc, "DESC", BenchDir::kDesc),
+          IfNot(&BenchTarget::read_only, Field("STORE", &BenchTarget::store)),
+          Exist("STICK", &BenchTarget::stick), Exist("KEEPTTL", &BenchTarget::keepttl),
+          Field("MCFLAGS", &BenchTarget::mc)));
+}
+
+cmn::BackedArguments MakeStorage(std::initializer_list<std::string_view> args) {
+  std::vector<std::string_view> v(args);
+  cmn::BackedArguments s;
+  s.Assign(v.begin(), v.end(), v.size());
+  return s;
+}
+
+CmdArgParser BenchArgs(bool with_options) {
+  static const cmn::BackedArguments kNoOpts = MakeStorage({"mykey", "myval"});
+  static const cmn::BackedArguments kOpts = MakeStorage(
+      {"mykey", "myval", "NX", "EX", "100", "GET", "DESC", "STORE", "dst", "MCFLAGS", "7"});
+  return CmdArgParser{with_options ? kOpts : kNoOpts};
+}
+
+}  // namespace
+
+static void BM_RuntimeParse(benchmark::State& state) {
+  CmdArgParser proto = BenchArgs(state.range(0));
+  for (auto _ : state) {
+    CmdArgParser parser = proto;
+    BenchTarget o;
+    o.key = parser.Next();
+    o.value = parser.Next();
+    auto expiry = [&](CmdArgParser* p) {
+      o.ttl = p->Next<int64_t>();
+      o.ttl_set = true;
+    };
+    parser.Apply(OneOf(Tag("NX", [&](CmdArgParser*) { o.flags |= kBNx; }),
+                       Tag("XX", [&](CmdArgParser*) { o.flags |= kBXx; })),
+                 OneOf(Tag("EX", expiry), Tag("PX", expiry), Tag("EXAT", expiry),
+                       Tag("PXAT", expiry), Exist("KEEPTTL", &o.keepttl)),
+                 Tag("GET", [&](CmdArgParser*) { o.flags |= kBGet; }),
+                 Map(&o.dir, "ASC", BenchDir::kAsc, "DESC", BenchDir::kDesc),
+                 If(!o.read_only, Tag("STORE", &o.store)), Exist("STICK", &o.stick),
+                 Tag("MCFLAGS", &o.mc));
+    benchmark::DoNotOptimize(parser.Finalize());
+    benchmark::DoNotOptimize(o);
+  }
+}
+BENCHMARK(BM_RuntimeParse)->Arg(0)->Arg(1);
+
+static void BM_CapParse(benchmark::State& state) {
+  CmdArgParser proto = BenchArgs(state.range(0));
+  static constexpr auto kGrammar = MakeBenchGrammar();
+  for (auto _ : state) {
+    CmdArgParser parser = proto;
+    BenchTarget o;
+    kGrammar.Apply(&parser, &o);
+    benchmark::DoNotOptimize(parser.Finalize());
+    benchmark::DoNotOptimize(o);
+  }
+}
+BENCHMARK(BM_CapParse)->Arg(0)->Arg(1);
+
+static void BM_ManualParse(benchmark::State& state) {
+  CmdArgParser proto = BenchArgs(state.range(0));
+  for (auto _ : state) {
+    CmdArgParser parser = proto;
+    ParsedArgs args = parser.UnparsedArgs();
+    BenchTarget o;
+    bool ok = true;
+    size_t n = args.size();
+    o.key = args[0];
+    o.value = args[1];
+    for (size_t i = 2; i < n; ++i) {
+      std::string_view a = args[i];
+      if (absl::EqualsIgnoreCase(a, "NX")) {
+        o.flags |= kBNx;
+      } else if (absl::EqualsIgnoreCase(a, "XX")) {
+        o.flags |= kBXx;
+      } else if (absl::EqualsIgnoreCase(a, "GET")) {
+        o.flags |= kBGet;
+      } else if (absl::EqualsIgnoreCase(a, "ASC")) {
+        o.dir = BenchDir::kAsc;
+      } else if (absl::EqualsIgnoreCase(a, "DESC")) {
+        o.dir = BenchDir::kDesc;
+      } else if (!o.read_only && absl::EqualsIgnoreCase(a, "STORE")) {
+        if (++i >= n) {
+          ok = false;
+          break;
+        }
+        o.store = args[i];
+      } else if (absl::EqualsIgnoreCase(a, "STICK")) {
+        o.stick = true;
+      } else if (absl::EqualsIgnoreCase(a, "KEEPTTL")) {
+        o.keepttl = true;
+      } else if (absl::EqualsIgnoreCase(a, "EX") || absl::EqualsIgnoreCase(a, "PX") ||
+                 absl::EqualsIgnoreCase(a, "EXAT") || absl::EqualsIgnoreCase(a, "PXAT")) {
+        if (++i >= n || !absl::SimpleAtoi(args[i], &o.ttl)) {
+          ok = false;
+          break;
+        }
+        o.ttl_set = true;
+      } else if (absl::EqualsIgnoreCase(a, "MCFLAGS")) {
+        if (++i >= n || !absl::SimpleAtoi(args[i], &o.mc)) {
+          ok = false;
+          break;
+        }
+      } else {
+        ok = false;
+        break;
+      }
+    }
+    benchmark::DoNotOptimize(ok);
+    benchmark::DoNotOptimize(o);
+  }
+}
+BENCHMARK(BM_ManualParse)->Arg(0)->Arg(1);
+
+static void BM_ManualWithParser(benchmark::State& state) {
+  CmdArgParser proto = BenchArgs(state.range(0));
+  for (auto _ : state) {
+    CmdArgParser parser = proto;
+    BenchTarget o;
+    o.key = parser.Next();
+    o.value = parser.Next();
+    while (parser.HasNext()) {
+      if (parser.Check("NX"))
+        o.flags |= kBNx;
+      else if (parser.Check("XX"))
+        o.flags |= kBXx;
+      else if (parser.Check("GET"))
+        o.flags |= kBGet;
+      else if (parser.Check("ASC"))
+        o.dir = BenchDir::kAsc;
+      else if (parser.Check("DESC"))
+        o.dir = BenchDir::kDesc;
+      else if (!o.read_only && parser.Check("STORE"))
+        o.store = parser.Next();
+      else if (parser.Check("STICK"))
+        o.stick = true;
+      else if (parser.Check("KEEPTTL"))
+        o.keepttl = true;
+      else if (parser.Check("EX") || parser.Check("PX") || parser.Check("EXAT") ||
+               parser.Check("PXAT")) {
+        o.ttl = parser.Next<int64_t>();
+        o.ttl_set = true;
+      } else if (parser.Check("MCFLAGS")) {
+        o.mc = parser.Next<uint32_t>();
+      } else {
+        break;
+      }
+    }
+    benchmark::DoNotOptimize(parser.Finalize());
+    benchmark::DoNotOptimize(o);
+  }
+}
+BENCHMARK(BM_ManualWithParser)->Arg(0)->Arg(1);
 
 }  // namespace facade

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -163,34 +163,38 @@ bool ParseDouble(string_view src, double* value) {
 }
 
 OpResult<ScanOpts> ScanOpts::TryFrom(const facade::ParsedArgs& args, bool allow_novalues) {
+  using namespace facade;
   ScanOpts scan_opts;
-  facade::CmdArgParser parser{args};
+  scan_opts.allow_novalues = allow_novalues;
+  CmdArgParser parser{args};
 
-  parser.Apply(
-      facade::If(allow_novalues, facade::Exist("NOVALUES", &scan_opts.novalues)),
-      facade::Tag(
+  static constexpr auto kGrammar = Compile(Options(
+      If(&ScanOpts::allow_novalues, Exist("NOVALUES", &ScanOpts::novalues)),
+      Action(
           "COUNT",
-          [&](facade::CmdArgParser* p) { scan_opts.limit = max(size_t{1}, p->Next<size_t>()); }),
-      facade::Tag("MATCH",
-                  [&](facade::CmdArgParser* p) {
-                    std::string_view pattern = p->Next();
-                    if (pattern != "*")
-                      scan_opts.matcher.reset(new GlobMatcher{pattern, true});
-                  }),
-      facade::Tag("TYPE",
-                  [&](facade::CmdArgParser* p) {
-                    CompactObjType obj_type = ObjTypeFromString(p->Next());
-                    if (obj_type == kInvalidCompactObjType) {
-                      p->Report(facade::CmdArgParser::INVALID_CASES);
-                      return;
-                    }
-                    scan_opts.type_filter = obj_type;
-                  }),
-      facade::Tag("BUCKET", &scan_opts.bucket_id),
-      facade::Tag("ATTR", facade::Map(&scan_opts.mask, "v", ScanOpts::Mask::Volatile, "p",
-                                      ScanOpts::Mask::Permanent, "a", ScanOpts::Mask::Accessed, "u",
-                                      ScanOpts::Mask::Untouched)),
-      facade::Tag("MINMSZ", &scan_opts.min_malloc_size));
+          +[](CmdArgParser* p, ScanOpts* o) { o->limit = max(size_t{1}, p->Next<size_t>()); }),
+      Action(
+          "MATCH",
+          +[](CmdArgParser* p, ScanOpts* o) {
+            std::string_view pattern = p->Next();
+            if (pattern != "*")
+              o->matcher.reset(new GlobMatcher{pattern, true});
+          }),
+      Action(
+          "TYPE",
+          +[](CmdArgParser* p, ScanOpts* o) {
+            CompactObjType obj_type = ObjTypeFromString(p->Next());
+            if (obj_type == kInvalidCompactObjType) {
+              p->Report(CmdArgParser::INVALID_CASES);
+              return;
+            }
+            o->type_filter = obj_type;
+          }),
+      Field("BUCKET", &ScanOpts::bucket_id),
+      Choice("ATTR", &ScanOpts::mask, "v", ScanOpts::Mask::Volatile, "p", ScanOpts::Mask::Permanent,
+             "a", ScanOpts::Mask::Accessed, "u", ScanOpts::Mask::Untouched),
+      Field("MINMSZ", &ScanOpts::min_malloc_size)));
+  kGrammar.Apply(&parser, &scan_opts);
 
   if (!parser.Finalize()) {
     auto err = parser.TakeError();

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -93,6 +93,7 @@ struct ScanOpts {
   std::optional<Mask> mask;
   size_t min_malloc_size = 0;
   bool novalues = false;
+  bool allow_novalues = false;
 };
 
 // I use relative time from Feb 1, 2023 in seconds.

--- a/src/server/cuckoo_filter_family.cc
+++ b/src/server/cuckoo_filter_family.cc
@@ -131,27 +131,32 @@ OpStatus OpCompact(const OpArgs& op_args, string_view key) {
 }
 
 struct InsertOptions {
+  string_view key;
   uint64_t capacity = kDefaultCapacity;
   bool nocreate = false;
 };
+
+constexpr auto kInsertGrammar =
+    Compile(Args(&InsertOptions::key), Options(Field("CAPACITY", &InsertOptions::capacity),
+                                               Exist("NOCREATE", &InsertOptions::nocreate)));
 
 // Shared op for CF.INSERT and CF.INSERTNX. Returns one integer per item:
 //   1  — item inserted
 //   0  — item already exists (nx only)
 //  -1  — filter is full, item could not be inserted
 // Returns KEY_NOTFOUND if nocreate is set and the key does not exist.
-OpResult<vector<int>> OpInsert(const OpArgs& op_args, string_view key, ParsedArgs items,
-                               const InsertOptions& opts, bool nx) {
+OpResult<vector<int>> OpInsert(const OpArgs& op_args, ParsedArgs items, const InsertOptions& opts,
+                               bool nx) {
   auto& db_slice = op_args.GetDbSlice();
 
   DbSlice::ItAndUpdater it_and_updater;
   if (opts.nocreate) {
-    auto find_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_CUCKOOFILTER);
+    auto find_res = db_slice.FindMutable(op_args.db_cntx, opts.key, OBJ_CUCKOOFILTER);
     if (!find_res)
       return find_res.status();
     it_and_updater = std::move(*find_res);
   } else {
-    auto add_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CUCKOOFILTER);
+    auto add_res = db_slice.AddOrFind(op_args.db_cntx, opts.key, OBJ_CUCKOOFILTER);
     RETURN_ON_BAD_STATUS(add_res);
     if (add_res->is_new) {
       add_res->it->second.SetCuckooFilter(CuckooFilterOptions{.capacity = opts.capacity});
@@ -188,30 +193,36 @@ OpStatus OpReserve(const OpArgs& op_args, string_view key, const CuckooFilterOpt
   return OpStatus::OK;
 }
 
-void CmdReserve(CmdArgParser parser, CommandContext* cmd_cntx) {
-  string_view key = parser.Next();
-  uint64_t capacity = parser.Next<Validated<uint64_t, NotEq<uint64_t{0}, kCapacityErr>>>();
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-
-  // The uint8_t/uint16_t widths reject over-max values already; the rules add CF's zero/cap bounds.
+struct ReserveOpts {
+  string_view key;
+  Validated<uint64_t, NotEq<uint64_t{0}, kCapacityErr>> capacity;
   Validated<uint8_t, NotEq<uint8_t{0}, kBucketSizeErr>> bucket_size{
       CuckooFilterOptions::kDefaultSlotsPerBucket};
   Validated<uint16_t, NotEq<uint16_t{0}, kMaxIterationsErr>> max_iterations{
       CuckooFilterOptions::kDefaultMaxIterations};
   Validated<uint16_t, Bounded<uint16_t{0}, uint16_t{32767}, kExpansionErr>> expansion{
       CuckooFilterOptions::kDefaultExpansion};
+};
 
-  parser.Apply(Tag("BUCKETSIZE", &bucket_size), Tag("MAXITERATIONS", &max_iterations),
-               Tag("EXPANSION", &expansion));
+constexpr auto kReserveGrammar =
+    Compile(Args(&ReserveOpts::key, &ReserveOpts::capacity),
+            Options(Field("BUCKETSIZE", &ReserveOpts::bucket_size),
+                    Field("MAXITERATIONS", &ReserveOpts::max_iterations),
+                    Field("EXPANSION", &ReserveOpts::expansion)));
 
+void CmdReserve(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  ReserveOpts opts;
+  kReserveGrammar.Apply(&parser, &opts);
   if (!parser.Finalize()) {
     return rb->SendError(parser.TakeError().MakeReply());
   }
 
-  CuckooFilterOptions options{capacity, bucket_size, max_iterations, expansion};
+  CuckooFilterOptions options{opts.capacity, opts.bucket_size, opts.max_iterations, opts.expansion};
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpReserve(t->GetOpArgs(shard), key, options);
+    return OpReserve(t->GetOpArgs(shard), opts.key, options);
   };
 
   OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
@@ -347,16 +358,14 @@ void CmdDel(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdInsertImpl(CmdArgParser parser, CommandContext* cmd_cntx, bool nx) {
-  string_view key = parser.Next();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  RETURN_ON_PARSE_ERROR(parser, rb);
 
   InsertOptions opts;
-  parser.Apply(Tag("CAPACITY", &opts.capacity), Exist("NOCREATE", &opts.nocreate));
+  kInsertGrammar.Apply(&parser, &opts);
   RETURN_ON_PARSE_ERROR(parser, rb);
 
   if (!opts.nocreate && opts.capacity == 0)
-    return rb->SendError("CF: capacity must be greater than 0");
+    return rb->SendError(kCapacityErr);
 
   if (!parser.Check("ITEMS")) {
     return rb->SendError("CF.INSERT requires ITEMS keyword");
@@ -365,7 +374,7 @@ void CmdInsertImpl(CmdArgParser parser, CommandContext* cmd_cntx, bool nx) {
   RETURN_ON_PARSE_ERROR(parser, rb);
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpInsert(t->GetOpArgs(shard), key, items, opts, nx);
+    return OpInsert(t->GetOpArgs(shard), items, opts, nx);
   };
 
   OpResult<vector<int>> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));

--- a/src/server/cuckoo_filter_family_test.cc
+++ b/src/server/cuckoo_filter_family_test.cc
@@ -270,6 +270,13 @@ TEST_F(CuckooFilterFamilyTest, InsertWithCapacity) {
   EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(1))));
 }
 
+TEST_F(CuckooFilterFamilyTest, InsertZeroCapacity) {
+  EXPECT_THAT(Run({"cf.insert", "cf", "capacity", "0", "items", "x"}),
+              ErrArg("capacity must be greater than 0"));
+  EXPECT_THAT(Run({"cf.insert", "cf", "capacity", "0", "nocreate", "items", "x"}),
+              ErrArg("no such key"));
+}
+
 TEST_F(CuckooFilterFamilyTest, InsertNocreate) {
   // NOCREATE on missing key returns an error.
   EXPECT_THAT(Run({"cf.insert", "cf", "nocreate", "items", "a"}), ErrArg("no such key"));

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -830,6 +830,7 @@ void DebugCmd::Reload(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   bool no_save = false;
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  // TODO: remove runtime parsing (single option -> Check).
   parser.Apply(Exist("NOSAVE", &no_save));
   if (!parser.Finalize()) {
     (void)parser.TakeError();

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -286,6 +286,7 @@ OpResult<RestoreArgs> RestoreArgs::TryFrom(facade::ParsedArgs args) {
   // range-checked at parse time via FInt — out-of-range values surface as INVALID_INT.
   FInt<int64_t{0}, std::numeric_limits<int64_t>::max()> idle_time{};
   FInt<0, 255> freq{};
+  // TODO: remove runtime parsing (migrate to cap grammar).
   parser.Apply(Exist("REPLACE", &out_args.replace_), Exist("ABSTTL", &out_args.abs_time_),
                Exist("STICK", &out_args.sticky_), Tag("IDLETIME", &idle_time), Tag("FREQ", &freq));
 
@@ -2001,15 +2002,21 @@ void SortGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_read_onl
   SortParams params;
   params.is_read_only = is_read_only;
 
-  parser.Apply(
-      Exist("ALPHA", &params.alpha), Map(&params.reversed, "DESC", true, "ASC", false),
-      Tag("LIMIT",
-          [&](CmdArgParser* p) {
+  static constexpr auto kGrammar = Compile(Options(
+      Exist("ALPHA", &SortParams::alpha), Map(&SortParams::reversed, "DESC", true, "ASC", false),
+      Action(
+          "LIMIT",
+          +[](CmdArgParser* p, SortParams* o) {
             auto [offset, limit] = p->Next<uint32_t, uint32_t>();
-            params.bounds = std::pair{offset, limit};
+            o->bounds = std::pair{offset, limit};
           }),
-      If(!is_read_only, Tag("STORE", &params.store_key)), Tag("BY", &params.by_pattern),
-      Tag("GET", [&](CmdArgParser* p) { params.get_patterns.push_back(p->Next<string_view>()); }));
+      IfNot(&SortParams::is_read_only, Field("STORE", &SortParams::store_key)),
+      Field("BY", &SortParams::by_pattern),
+      Action(
+          "GET", +[](CmdArgParser* p, SortParams* o) {
+            o->get_patterns.push_back(p->Next<string_view>());
+          })));
+  kGrammar.Apply(&parser, &params);
 
   if (!parser.Finalize()) {
     return cmd_cntx->SendError(parser.TakeError().MakeReply());

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -625,6 +625,7 @@ void CmdGeoSearch(CmdArgParser parser, CommandContext* cmd_cntx) {
 
   string_view key = parser.Next();
 
+  // TODO: remove runtime parsing (migrate to cap grammar).
   parser.Apply(OneOf(Tag("FROMMEMBER",
                          [&](CmdArgParser* p) {
                            from_set = true;

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1044,6 +1044,7 @@ void CmdHGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
         return p->ReportCustom(InvalidExpireTime(cmd_name));
     };
   };
+  // TODO: remove runtime parsing (migrate to cap grammar).
   parser.Apply(OneOf(Tag("EX", read_expiry(ExpT::EX)), Tag("PX", read_expiry(ExpT::PX)),
                      Tag("EXAT", read_expiry(ExpT::EXAT)), Tag("PXAT", read_expiry(ExpT::PXAT)),
                      Exist("PERSIST", &exp_params.persist)));

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1315,6 +1315,7 @@ void CmdLPos(CmdArgParser parser, CommandContext* cmd_cntx) {
   std::optional<uint32_t> count;
   uint32_t max_len = 0;
 
+  // TODO: remove runtime parsing (migrate to cap grammar).
   parser.ApplyOrSkip(Tag("RANK", &rank), Tag("COUNT", &count), Tag("MAXLEN", &max_len));
 
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -256,6 +256,7 @@ using absl::StrCat;
 using namespace facade;
 using namespace util;
 using detail::SaveStagesController;
+
 using http::StringResponse;
 using strings::HumanReadableNumBytes;
 
@@ -3626,8 +3627,11 @@ void ServerFamily::ShutdownCmd(facade::CmdArgParser parser, CommandContext* cmd_
     bool abort = false;
   } opts;
 
-  parser.Apply(Exist("SAVE", &opts.save), Exist("SAFE", &opts.save), Exist("NOSAVE", &opts.no_save),
-               Exist("NOW", &opts.now), Exist("FORCE", &opts.force), Exist("ABORT", &opts.abort));
+  static constexpr auto kGrammar =
+      Compile(Options(Exist("SAVE", &ShutdownOpts::save), Exist("SAFE", &ShutdownOpts::save),
+                      Exist("NOSAVE", &ShutdownOpts::no_save), Exist("NOW", &ShutdownOpts::now),
+                      Exist("FORCE", &ShutdownOpts::force), Exist("ABORT", &ShutdownOpts::abort)));
+  kGrammar.Apply(&parser, &opts);
 
   if (!parser.Finalize())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1351,6 +1351,7 @@ cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
       defined = true;
     };
   };
+  // TODO: remove runtime parsing (migrate to cap grammar).
   parser.Apply(OneOf(Tag("EX", expiry(ExpT::EX)), Tag("PX", expiry(ExpT::PX)),
                      Tag("EXAT", expiry(ExpT::EXAT)), Tag("PXAT", expiry(ExpT::PXAT)),
                      Exist("PERSIST", &persist)));

--- a/src/server/topk_family.cc
+++ b/src/server/topk_family.cc
@@ -354,6 +354,7 @@ void TopkFamily::List(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   bool with_count = false;
 
+  // TODO: remove runtime parsing (single option -> Check).
   parser.Apply(OneOf(Exist("WITHCOUNT", &with_count)));
 
   if (!parser.Finalize())

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -979,7 +979,20 @@ struct SetOpArgs {
   unsigned num_keys;
   vector<double> weights;
   bool with_scores = false;
+  bool store = false;
 };
+
+constexpr auto kSetOpGrammar =
+    Compile(Options(facade::Action(
+                        "WEIGHTS",
+                        +[](CmdArgParser* p, SetOpArgs* o) {
+                          o->weights.resize(o->num_keys, 1);
+                          for (unsigned i = 0; i < o->num_keys; ++i)
+                            o->weights[i] = p->Next<double>();
+                        }),
+                    Choice("AGGREGATE", &SetOpArgs::agg_type, "SUM", AggType::SUM, "MIN",
+                           AggType::MIN, "MAX", AggType::MAX),
+                    IfNot(&SetOpArgs::store, Exist("WITHSCORES", &SetOpArgs::with_scores))));
 
 OpResult<ScoredMap> IntersectResults(vector<OpResult<ScoredMap>>& results, AggType agg_type) {
   ScoredMap result;
@@ -1014,20 +1027,10 @@ OpResult<SetOpArgs> ParseSetOpArgs(CmdArgParser parser, bool store) {
   if (parser.TakeError()) {
     return OpStatus::SYNTAX_ERR;
   }
+  op_args.store = store;
 
-  parser.Apply(Tag("WEIGHTS",
-                   [&op_args](CmdArgParser* p) {
-                     op_args.weights.resize(op_args.num_keys, 1);
-                     for (unsigned i = 0; i < op_args.num_keys; ++i)
-                       op_args.weights[i] = p->Next<double>();
-                   }),
-               Tag("AGGREGATE", Map(&op_args.agg_type, "SUM", AggType::SUM, "MIN", AggType::MIN,
-                                    "MAX", AggType::MAX)),
-               // The *STORE variants do not offer the WITHSCORES option.
-               If(!store, Exist("WITHSCORES", &op_args.with_scores)));
+  kSetOpGrammar.Apply(&parser, &op_args);
 
-  // A non-float WEIGHTS value surfaces as INVALID_FLOAT; any other failure (unknown option, bad
-  // AGGREGATE type, or leftover args caught by Finalize) is a plain syntax error.
   if (auto err = parser.TakeError(); err) {
     return err.type == CmdArgParser::INVALID_FLOAT ? OpStatus::INVALID_FLOAT : OpStatus::SYNTAX_ERR;
   }
@@ -1786,6 +1789,7 @@ void ZRangeGeneric(facade::ParsedArgs args, ZSetFamily::RangeParams range_params
     };
   };
 
+  // TODO: remove runtime parsing (migrate to cap grammar).
   parser.Apply(Tag("BYSCORE", set_interval(RP::SCORE)), Tag("BYLEX", set_interval(RP::LEX)),
                Exist("REV", &range_params.reverse), Exist("WITHSCORES", &range_params.with_scores),
                Tag("LIMIT", [&](CmdArgParser* p) {


### PR DESCRIPTION
Summary: Introduces a compile-time, consteval-built grammar system for facade::CmdArgParser to avoid per-call option tree construction and improve hot-path parsing performance.

Changes:

- Refactors CmdArgParser internals (cached size_, SVAt normalization, new Current()/Advance()/InBounds(), and a lightweight ReportCode() path) to support faster parsing and better multi-arg error behavior.
- Adds the compile-time grammar framework (Compile/Args/Options/OneOf/Flag/Exist/Field/Map/Choice/Action/If/IfNot) and keeps the legacy runtime combinators temporarily for incremental migration.
- Migrates several command parsers to the new grammar (SCAN opts, CF.RESERVE/CF.INSERT, SORT, SHUTDOWN, ZUNION/ZINTER option parsing).
- Expands unit tests for new parser behavior and adds a benchmark suite in cmd_arg_parser_test to quantify runtime-combinator vs compile-time grammar overhead.

Technical Notes: The new grammar is a single shared immutable static constexpr object; per-parse state is kept on the stack, and strictness remains enforced via Finalize() after Apply() stops at the first unmatched token.