### PR TITLE
feat: new format for OAHEntry size

### DIFF
--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 
@@ -9,28 +9,35 @@
 namespace dfly {
 
 OAHEntry::TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
-  uint32_t key_size = key.size();
+  const uint32_t key_size = key.size();
+  assert(key_size <= kMaxKeySize);
   uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
-  uint32_t key_len_field_size = key_size <= std::numeric_limits<uint8_t>::max() ? 1 : 4;
 
-  auto* blob = (char*)zmalloc(key_len_field_size + key_size + expiry_size);
+  uint8_t control;
+  uint32_t size_field_len;  // control byte + trailing extra size bytes
+  if (key_size <= kInlineSizeMax) {
+    control = static_cast<uint8_t>(key_size);
+    size_field_len = 1;
+  } else if (key_size <= kOneExtraByteMax) {
+    control = static_cast<uint8_t>(kBigSizeBit | (key_size & kLowSizeMask));
+    size_field_len = 2;
+  } else {
+    control = static_cast<uint8_t>(kBigSizeBit | kThreeBytesBit | (key_size & kLowSizeMask));
+    size_field_len = 4;
+  }
 
+  auto* blob = (char*)zmalloc(expiry_size + size_field_len + key_size);
   TaggedPtr tagged_ptr = reinterpret_cast<TaggedPtr>(blob);
-  OAHEntry entry(tagged_ptr);  // accessor over the local control word being built
   if (expiry_size) {
-    entry.SetExpiryBit(true);
+    tagged_ptr |= kExpiryBit;
     std::memcpy(blob, &expiry, sizeof(expiry));
   }
 
-  auto* key_size_pos = blob + expiry_size;
-  if (key_len_field_size == 1) {
-    entry.SetSsoBit();
-    uint8_t sso_key_size = key_size;
-    std::memcpy(key_size_pos, &sso_key_size, key_len_field_size);
-  } else {
-    std::memcpy(key_size_pos, &key_size, key_len_field_size);
-  }
-  std::memcpy(key_size_pos + key_len_field_size, key.data(), key_size);
+  char* p = blob + expiry_size;
+  *p++ = static_cast<char>(control);
+  for (uint32_t extra = key_size >> kLowSizeBits, i = 1; i < size_field_len; ++i, extra >>= 8)
+    *p++ = static_cast<char>(extra & 0xFF);
+  std::memcpy(p, key.data(), key_size);
   return tagged_ptr;
 }
 
@@ -89,22 +96,17 @@ ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
 }
 
-uint32_t OAHEntry::GetKeySize() const {
-  if (HasSso()) {
-    uint8_t size = 0;
-    std::memcpy(&size, Raw() + GetExpirySize(), sizeof(size));
-    return size;
+std::string_view OAHEntry::KeyBig(const char* p, uint8_t control) const {
+  uint32_t size = control & kLowSizeMask;
+  uint32_t extra = static_cast<uint8_t>(p[1]);
+  const char* key = p + 2;  // control byte + 1 extra size byte
+  if (control & kThreeBytesBit) {
+    extra |= static_cast<uint32_t>(static_cast<uint8_t>(p[2])) << 8;
+    extra |= static_cast<uint32_t>(static_cast<uint8_t>(p[3])) << 16;
+    key = p + 4;  // control byte + 3 extra size bytes
   }
-  uint32_t size = 0;
-  std::memcpy(&size, Raw() + GetExpirySize(), sizeof(size));
-  return size;
-}
-
-void OAHEntry::SetExpiryBit(bool b) {
-  if (b)
-    SetTaggedPtr(GetTaggedPtr() | kExpiryBit);
-  else
-    SetTaggedPtr(GetTaggedPtr() & ~kExpiryBit);
+  size |= extra << kLowSizeBits;
+  return {key, size};
 }
 
 }  // namespace dfly

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 
@@ -24,18 +24,22 @@ class PageUsage;
 
 // oah_entry.h - a single set member: a string key plus its expiry and cached hash.
 //
-// OAHEntry is a non-owning accessor over a TaggedPtr that points at a [expiry, key_size, key] heap
+// OAHEntry is a non-owning accessor over a TaggedPtr that points at a [expiry?, control, key] heap
 // blob. It manages that string: the static Create()/Destroy() allocate and free the blob, and
 // SetExpiry/SetExtHash/ReallocIfNeeded update it in place. The top 12 and bottom 3 bits of a heap
 // pointer are always free (user addresses are <= 52 bits), so flags live there: bit 0 stays clear
-// for OAHPtr's entry/vector tag, OAHEntry uses bits 1-2 (expiry/sso) and 52-63 (cached hash).
+// for OAHPtr's entry/vector tag, OAHEntry uses bit 1 (expiry) and 52-63 (cached hash).
+//
+// The blob begins with an optional 4-byte expiry, then a control byte encoding the key size (see
+// the kBigSizeBit/kThreeBytesBit block): keys < 64B store the size inline in the low 6 bits; larger
+// keys keep 5 low bits in the control byte plus 1 extra byte (< 8KB) or 3 extra bytes (< 0.5GB).
+// The control byte's top bit is a reserved ASCII/raw encoding flag, currently always 0.
 class OAHEntry {
  public:
   // A uint64_t packing the heap pointer together with tag/flag bits in its free low/high bits.
   using TaggedPtr = uint64_t;
 
   static constexpr size_t kExpiryBit = 1ULL << 1;
-  static constexpr size_t kSsoBit = 1ULL << 2;  // 1-byte (vs 4) key-length field
 
   static constexpr size_t kExtHashShift = 52;
   static constexpr uint32_t kExtHashSize = 12;
@@ -43,6 +47,21 @@ class OAHEntry {
   static constexpr size_t kExtHashShiftedMask = kExtHashMask << kExtHashShift;
 
   static constexpr size_t kTagMask = (4095ULL << 52) | 7;  // 12 high + 3 low tag bits
+
+  // Control-byte layout (the first blob byte after the optional expiry):
+  //   bit 7    : reserved ASCII/raw encoding flag (currently always 0)
+  //   bit 6    : kBigSizeBit    - size doesn't fit in 6 bits, extra bytes follow
+  //   bit 5    : kThreeBytesBit - when kBigSizeBit set: 3 extra size bytes (else 1)
+  //   bits 0-5 : inline size (< 64B); or bits 0-4 hold the low 5 bits of a larger size
+  static constexpr uint8_t kEncodingBit = 1u << 7;  // reserved, kept 0 for now
+  static constexpr uint8_t kBigSizeBit = 1u << 6;
+  static constexpr uint8_t kThreeBytesBit = 1u << 5;
+  static constexpr uint8_t kInlineSizeMask = 0x3F;              // 6-bit inline size
+  static constexpr uint8_t kLowSizeMask = 0x1F;                 // 5 low size bits for larger keys
+  static constexpr uint32_t kLowSizeBits = 5;                   // bits taken from the control byte
+  static constexpr uint32_t kInlineSizeMax = kInlineSizeMask;   // 63
+  static constexpr uint32_t kOneExtraByteMax = (1u << 13) - 1;  // 8191 (5 + 8 bits)
+  static constexpr uint32_t kMaxKeySize = (1u << 29) - 1;       // 5 + 24 bits (< 0.5GB)
 
   static TaggedPtr Create(std::string_view key, uint32_t expiry = UINT32_MAX);
   static void Destroy(TaggedPtr tagged_ptr);
@@ -64,7 +83,11 @@ class OAHEntry {
   }
 
   std::string_view Key() const {
-    return {GetKeyData(), GetKeySize()};
+    const char* p = Raw() + GetExpirySize();
+    uint8_t control = static_cast<uint8_t>(*p);
+    if ((control & kBigSizeBit) == 0)
+      return {p + 1, static_cast<size_t>(control & kInlineSizeMask)};
+    return KeyBig(p, control);
   }
 
   bool HasExpiry() const {
@@ -108,23 +131,13 @@ class OAHEntry {
   }
 
  protected:
-  const char* GetKeyData() const {
-    uint32_t key_field_size = HasSso() ? 1 : 4;
-    return Raw() + GetExpirySize() + key_field_size;
-  }
-  uint32_t GetKeySize() const;
-
-  void SetExpiryBit(bool b);
+  // Slow path of Key() for keys >= 64B: decodes the multibyte size field starting at control
+  // byte `p` (already read into `control`) and returns the key view.
+  std::string_view KeyBig(const char* p, uint8_t control) const;
 
   // Reallocates the key blob with `expiry`, preserving the key and stored ext-hash.
   void Rebuild(uint32_t expiry);
 
-  void SetSsoBit() {
-    SetTaggedPtr(GetTaggedPtr() | kSsoBit);
-  }
-  bool HasSso() const {
-    return (GetTaggedPtr() & kSsoBit) != 0;
-  }
   std::uint32_t GetExpirySize() const {
     return HasExpiry() ? sizeof(std::uint32_t) : 0;
   }

--- a/src/core/oah_map.h
+++ b/src/core/oah_map.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/core/oah_pair.cc
+++ b/src/core/oah_pair.cc
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/core/oah_pair.h
+++ b/src/core/oah_pair.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/core/oah_ptr.h
+++ b/src/core/oah_ptr.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 
@@ -142,6 +142,44 @@ TEST_F(OAHSetTest, OAHEntryTest) {
   EXPECT_EQ(test.GetExpiry(), 2);
 
   OAHEntry::Destroy(test.Release());
+}
+
+TEST_F(OAHSetTest, OAHEntryKeySizes) {
+  // Round-trips the control-byte size encoding across its boundaries: inline (< 64B),
+  // 1 extra byte (< 8KB) and 3 extra bytes (larger), with and without an expiry.
+  for (uint32_t sz : {0u, 1u, 63u, 64u, 255u, 8191u, 8192u, 100000u}) {
+    string key(sz, 'x');
+    if (sz)
+      key[sz - 1] = 'z';  // make the tail byte observable
+
+    for (uint32_t expiry : {UINT32_MAX, 7u}) {
+      uint64_t bits = OAHEntry::Create(key, expiry);
+      OAHEntry e(bits);
+      EXPECT_EQ(e.Key().size(), sz);
+      EXPECT_EQ(e.Key(), key);
+      EXPECT_EQ(e.HasExpiry(), expiry != UINT32_MAX);
+      if (expiry != UINT32_MAX) {
+        EXPECT_EQ(e.GetExpiry(), expiry);
+      }
+      OAHEntry::Destroy(e.Release());
+    }
+  }
+}
+
+TEST_F(OAHSetTest, LargeKeys) {
+  // The size encoding must round-trip through the full Add/Find/Erase path, not just OAHEntry.
+  vector<string> keys = {string(10, 'a'), string(63, 'b'), string(64, 'c'), string(8192, 'd'),
+                         string(70000, 'e')};
+  for (const auto& k : keys)
+    EXPECT_TRUE(ss_->Add(k));
+  for (const auto& k : keys)
+    EXPECT_FALSE(ss_->Add(k));  // duplicate detection relies on Key() decoding the size
+  for (const auto& k : keys)
+    EXPECT_TRUE(ss_->Contains(k));
+  EXPECT_EQ(ss_->UpperBoundSize(), keys.size());
+  for (const auto& k : keys)
+    EXPECT_TRUE(ss_->Erase(k));
+  EXPECT_EQ(ss_->UpperBoundSize(), 0u);
 }
 
 TEST_F(OAHSetTest, OAHPtrInsertRemove) {

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 


### PR DESCRIPTION
Summary: This PR changes the on-heap layout/encoding of OAHEntry key sizes to use a compact control byte format while preserving optional expiry and cached-hash tagging.

Changes:

- Replaces the old [expiry, key_size(1|4), key] blob format with [expiry?, control, key].
- Encodes key length in a single control byte for keys < 64B, and uses 1 or 3 extra size bytes for larger keys (up to ~0.5GB).
- Removes the tagged-pointer SSO bit and associated size decoding helpers.
- Updates OAHEntry::Create() to emit the new control/extra-bytes layout and set the expiry flag directly.
- Updates OAHEntry::Key() to decode the new layout, with a KeyBig() slow path for large keys.
- Adds unit tests covering boundary sizes and full Add/Find/Erase behavior for large keys.

Technical Notes: The new size format reduces per-entry overhead for small keys while still supporting large keys via a variable-length size field.