### PR TITLE
feat(search): store & search vectors at native width (FLAT + HNSW, all dtypes)

### DIFF
--- a/src/core/page_usage_stats_test.cc
+++ b/src/core/page_usage_stats_test.cc
@@ -473,7 +473,8 @@ class MockDocument final : public search::DocumentAccessor {
   std::optional<StringList> GetStrings(std::string_view active_field) const override {
     return {{words[absl::GetCurrentTimeNanos() % words.size()]}};
   }
-  std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim) const override {
+  std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim,
+                                      search::VectorDataType dtype) const override {
     return std::nullopt;
   }
   std::optional<NumsList> GetNumbers(std::string_view active_field) const override {

--- a/src/core/search/ast_expr.cc
+++ b/src/core/search/ast_expr.cc
@@ -66,12 +66,12 @@ AstTagsNode::AstTagsNode(AstExpr&& l, TagValue tag) {
   tags.push_back(std::move(tag));
 }
 
-AstKnnNode::AstKnnNode(uint32_t limit, std::string_view field, OwnedFtVector vec,
+AstKnnNode::AstKnnNode(uint32_t limit, std::string_view field, std::string blob,
                        std::string_view score_alias, std::optional<uint32_t> ef_runtime)
     : filter{nullptr},
       limit{limit},
       field{field.substr(1)},
-      vec{std::move(vec)},
+      blob{std::move(blob)},
       score_alias{score_alias.empty() ? absl::StrCat("__", field.substr(1), "_score")
                                       : std::string{score_alias}},
       ef_runtime{ef_runtime} {
@@ -82,11 +82,11 @@ AstKnnNode::AstKnnNode(AstNode&& filter, AstKnnNode&& self) {
   this->filter = make_unique<AstNode>(std::move(filter));
 }
 
-AstVectorRangeNode::AstVectorRangeNode(std::string field, double radius, OwnedFtVector vec,
+AstVectorRangeNode::AstVectorRangeNode(std::string field, double radius, std::string blob,
                                        std::string score_alias, std::optional<double> epsilon)
     : field{field.substr(1)},
       radius{radius},
-      vec{std::move(vec)},
+      blob{std::move(blob)},
       score_alias{std::move(score_alias)},
       epsilon{epsilon} {
 }

--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -162,8 +162,8 @@ struct AstTagsNode {
 // Applies nearest neighbor search to the final result set
 struct AstKnnNode {
   AstKnnNode() = default;
-  AstKnnNode(uint32_t limit, std::string_view field, OwnedFtVector vec,
-             std::string_view score_alias, std::optional<uint32_t> ef_runtime);
+  AstKnnNode(uint32_t limit, std::string_view field, std::string blob, std::string_view score_alias,
+             std::optional<uint32_t> ef_runtime);
 
   AstKnnNode(AstNode&& sub, AstKnnNode&& self);
 
@@ -180,7 +180,7 @@ struct AstKnnNode {
   std::unique_ptr<AstNode> filter;
   size_t limit;
   std::string field;
-  OwnedFtVector vec;
+  std::string blob;  // raw query-vector bytes, decoded at search time using the field dtype
   std::string score_alias;
   std::optional<uint32_t> ef_runtime;
 
@@ -190,7 +190,7 @@ struct AstKnnNode {
 // Applies vector range search: returns all docs with distance(vec, doc_vec) <= radius
 struct AstVectorRangeNode {
   AstVectorRangeNode() = default;
-  AstVectorRangeNode(std::string field, double radius, OwnedFtVector vec, std::string score_alias,
+  AstVectorRangeNode(std::string field, double radius, std::string blob, std::string score_alias,
                      std::optional<double> epsilon);
 
   AstVectorRangeNode(const AstVectorRangeNode&) = delete;
@@ -205,7 +205,7 @@ struct AstVectorRangeNode {
 
   std::string field;
   double radius;
-  OwnedFtVector vec;
+  std::string blob;  // raw query-vector bytes, decoded at search time using the field dtype
   std::string score_alias;
   std::optional<double> epsilon;
 };

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/container/inlined_vector.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -58,7 +59,8 @@ constexpr size_t ElementSize(VectorDataType dt) {
   return 4;
 }
 
-using OwnedFtVector = std::pair<std::unique_ptr<float[]>, size_t /* dimension (size) */>;
+// Owns a vector's native-width bytes (int8=1B/elem, fp16=2B, fp32=4B, ...); second is elem count.
+using OwnedFtVector = std::pair<std::unique_ptr<std::byte[]>, size_t /* dimension (size) */>;
 using BorrowedFtVector = const char*;
 
 // Query params represent named parameters for queries supplied via PARAMS.
@@ -102,7 +104,8 @@ struct DocumentAccessor {
   virtual std::optional<StringList> GetStrings(std::string_view active_field) const = 0;
 
   /* Returns nullopt if the specified field is not a vector */
-  virtual std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim) const = 0;
+  virtual std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim,
+                                              VectorDataType dtype) const = 0;
 
   /* Return nullopt if the specified field is not a list of doubles */
   virtual std::optional<NumsList> GetNumbers(std::string_view active_field) const = 0;

--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -9,6 +9,8 @@
 #include <hnswlib/space_ip.h>
 #include <hnswlib/space_l2.h>
 
+#include <cstddef>
+
 #include "base/logging.h"
 #include "core/search/hnsw_alg.h"
 #include "core/search/mrmw_mutex.h"
@@ -23,44 +25,33 @@ using namespace std;
 namespace {
 
 class HnswSpace : public hnswlib::SpaceInterface<float> {
-  unsigned dim_;
-  VectorSimilarity sim_;
+  struct DistParams {
+    size_t dim;  // must stay first: hnsw_alg.h reads *((size_t*)dist_func_param_) as dim
+    VectorSimilarity sim;
+    VectorDataType dt;
+  };
+  DistParams params_;
 
-  static float L2DistanceStatic(const void* pVect1, const void* pVect2, const void* param) {
-    return L2Distance(static_cast<const float*>(pVect1), static_cast<const float*>(pVect2),
-                      *static_cast<const unsigned*>(param));
-  }
-
-  static float IPDistanceStatic(const void* pVect1, const void* pVect2, const void* param) {
-    return IPDistance(static_cast<const float*>(pVect1), static_cast<const float*>(pVect2),
-                      *static_cast<const unsigned*>(param));
-  }
-
-  static float CosineDistanceStatic(const void* pVect1, const void* pVect2, const void* param) {
-    return CosineDistance(static_cast<const float*>(pVect1), static_cast<const float*>(pVect2),
-                          *static_cast<const unsigned*>(param));
+  // Distance between two native-width vector blobs; elements are widened to float internally.
+  static float DistStatic(const void* pVect1, const void* pVect2, const void* param) {
+    const auto* p = static_cast<const DistParams*>(param);
+    return VectorDistance(pVect1, pVect2, p->dim, p->sim, p->dt);
   }
 
  public:
-  explicit HnswSpace(size_t dim, VectorSimilarity sim) : dim_(dim), sim_(sim) {
+  HnswSpace(size_t dim, VectorSimilarity sim, VectorDataType dt) : params_{dim, sim, dt} {
   }
 
   size_t get_data_size() {
-    return dim_ * sizeof(float);
+    return params_.dim * ElementSize(params_.dt);
   }
 
   hnswlib::DISTFUNC<float> get_dist_func() {
-    if (sim_ == VectorSimilarity::L2) {
-      return L2DistanceStatic;
-    } else if (sim_ == VectorSimilarity::COSINE) {
-      return CosineDistanceStatic;
-    } else {
-      return IPDistanceStatic;
-    }
+    return DistStatic;
   }
 
   void* get_dist_func_param() {
-    return &dim_;
+    return &params_;
   }
 };
 }  // namespace
@@ -70,7 +61,7 @@ struct HnswlibAdapter {
   constexpr static size_t kSeed = 100;
 
   explicit HnswlibAdapter(const SchemaField::VectorParams& params, bool copy_vector)
-      : space_{params.dim, params.sim},
+      : space_{params.dim, params.sim, params.data_type},
         world_{&space_, params.capacity, params.hnsw_m, params.hnsw_ef_construction,
                kSeed,   copy_vector},
         copy_vector_{copy_vector},
@@ -79,8 +70,8 @@ struct HnswlibAdapter {
         ef_construction_{params.hnsw_ef_construction},
         ef_runtime_{params.hnsw_ef_runtime},
         epsilon_{params.hnsw_epsilon},
-        data_size_{params.dim * sizeof(float)},
-        stub_vector_(data_size_ / sizeof(float), 1.0f) {
+        data_size_{params.dim * ElementSize(params.data_type)},
+        stub_vector_(EncodeOnesVector(params.dim, params.data_type)) {
   }
 
   void Add(const void* data, GlobalDocId id) {
@@ -93,13 +84,13 @@ struct HnswlibAdapter {
     DoRemove(id);
   }
 
-  vector<pair<float, GlobalDocId>> Knn(float* target, size_t k, std::optional<uint32_t> ef) {
+  vector<pair<float, GlobalDocId>> Knn(const void* target, size_t k, std::optional<uint32_t> ef) {
     uint32_t ef_runtime = ef.value_or(ef_runtime_);
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
     return QueueToVec(world_.searchKnnWithEf(target, k, nullptr, ef_runtime));
   }
 
-  vector<pair<float, GlobalDocId>> Knn(float* target, size_t k, std::optional<uint32_t> ef,
+  vector<pair<float, GlobalDocId>> Knn(const void* target, size_t k, std::optional<uint32_t> ef,
                                        const vector<GlobalDocId>& allowed) {
     struct BinsearchFilter : hnswlib::BaseFilterFunctor {
       virtual bool operator()(hnswlib::labeltype id) {
@@ -119,7 +110,7 @@ struct HnswlibAdapter {
 
   // Brute-force KNN search over a specific subset of documents.
   // Computes distances for all provided document IDs and returns the k nearest neighbors.
-  vector<pair<float, GlobalDocId>> SubsetKnn(float* target, size_t k,
+  vector<pair<float, GlobalDocId>> SubsetKnn(const void* target, size_t k,
                                              const vector<GlobalDocId>& docs) {
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
     return QueueToVec(world_.subsetKnnSearch(target, k, docs));
@@ -128,7 +119,7 @@ struct HnswlibAdapter {
   // Returns all documents within the given radius, with their distances.
   // Uses dynamic-range exploration (searchRange) to correctly handle cases where
   // the entry point is farther than radius.
-  vector<pair<float, GlobalDocId>> RangeSearch(float* target, float radius,
+  vector<pair<float, GlobalDocId>> RangeSearch(const void* target, float radius,
                                                std::optional<double> epsilon) {
     double effective_epsilon = epsilon.value_or(epsilon_);
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
@@ -228,8 +219,8 @@ struct HnswlibAdapter {
     // In borrowed mode the node stays in the graph after markDelete and
     // traversal still computes distances for it.  Replace the external
     // pointer with stub_vector_ so the caller can free the original data.
-    // Uses 1.0f (not zero) because CosineDistance(v, 0) = 0 would bias
-    // traversal toward deleted nodes.
+    // Uses a native-encoded 1.0 (not zero) because a zero-norm vector yields
+    // cosine distance 0 and would bias traversal toward deleted nodes.
     if (it != world_.label_lookup_.end()) {
       const char* safe_ptr = reinterpret_cast<const char*>(stub_vector_.data());
       char* ptr_location = world_.getDataPtrByInternalId(it->second);
@@ -444,20 +435,21 @@ struct HnswlibAdapter {
   absl::Mutex resize_mutex_;
   mutable MRMWMutex mrmw_mutex_;
 
-  bool copy_vector_;                // Whether vectors are copied into hnswlib.
-  size_t capacity_;                 // Initial max_elements_ — used to reconstruct world_.
-  size_t M_;                        // hnsw_m — used to reconstruct world_.
-  size_t ef_construction_;          // hnsw_ef_construction — used to reconstruct world_.
-  uint32_t ef_runtime_;             // Default runtime search breadth.
-  double epsilon_;                  // Default range-search overscan.
-  size_t data_size_;                // Byte size of a single vector.
-  std::vector<float> stub_vector_;  // Non-zero data for deleted nodes in borrowed mode.
+  bool copy_vector_;                    // Whether vectors are copied into hnswlib.
+  size_t capacity_;                     // Initial max_elements_ — used to reconstruct world_.
+  size_t M_;                            // hnsw_m — used to reconstruct world_.
+  size_t ef_construction_;              // hnsw_ef_construction — used to reconstruct world_.
+  uint32_t ef_runtime_;                 // Default runtime search breadth.
+  double epsilon_;                      // Default range-search overscan.
+  size_t data_size_;                    // Byte size of a single vector.
+  std::vector<std::byte> stub_vector_;  // Native 1.0 data for deleted nodes in borrowed mode.
 };
 
 HnswVectorIndex::HnswVectorIndex(const SchemaField::VectorParams& params, bool copy_vector,
                                  PMR_NS::memory_resource*)
     : copy_vector_(copy_vector),
       dim_{params.dim},
+      data_type_{params.data_type},
       adapter_{make_unique<HnswlibAdapter>(params, copy_vector)} {
   DCHECK(params.use_hnsw);
   // TODO: Patch hnsw to use MR
@@ -467,7 +459,7 @@ HnswVectorIndex::~HnswVectorIndex() {
 }
 
 bool HnswVectorIndex::Add(GlobalDocId id, const DocumentAccessor& doc, std::string_view field) {
-  auto vector_ptr = doc.GetVector(field, dim_);
+  auto vector_ptr = doc.GetVector(field, dim_, data_type_);
 
   if (!vector_ptr) {
     return false;
@@ -488,24 +480,24 @@ bool HnswVectorIndex::Add(GlobalDocId id, const DocumentAccessor& doc, std::stri
   return true;
 }
 
-std::vector<std::pair<float, GlobalDocId>> HnswVectorIndex::Knn(float* target, size_t k,
+std::vector<std::pair<float, GlobalDocId>> HnswVectorIndex::Knn(const void* target, size_t k,
                                                                 std::optional<uint32_t> ef) const {
   return adapter_->Knn(target, k, ef);
 }
 
 std::vector<std::pair<float, GlobalDocId>> HnswVectorIndex::Knn(
-    float* target, size_t k, std::optional<uint32_t> ef,
+    const void* target, size_t k, std::optional<uint32_t> ef,
     const std::vector<GlobalDocId>& allowed) const {
   return adapter_->Knn(target, k, ef, allowed);
 }
 
 std::vector<std::pair<float, GlobalDocId>> HnswVectorIndex::SubsetKnn(
-    float* target, size_t k, const std::vector<GlobalDocId>& docs) const {
+    const void* target, size_t k, const std::vector<GlobalDocId>& docs) const {
   return adapter_->SubsetKnn(target, k, docs);
 }
 
 std::vector<std::pair<float, GlobalDocId>> HnswVectorIndex::RangeQuery(
-    float* target, float radius, std::optional<double> epsilon) const {
+    const void* target, float radius, std::optional<double> epsilon) const {
   return adapter_->RangeSearch(target, radius, epsilon);
 }
 
@@ -536,7 +528,7 @@ bool HnswVectorIndex::RestoreFromNodes(const std::vector<HnswNodeData>& nodes,
 
 bool HnswVectorIndex::UpdateVectorData(GlobalDocId id, const DocumentAccessor& doc,
                                        std::string_view field) {
-  auto vector_ptr = doc.GetVector(field, dim_);
+  auto vector_ptr = doc.GetVector(field, dim_, data_type_);
   if (!vector_ptr ||
       *vector_ptr == search::DocumentAccessor::VectorInfo(search::BorrowedFtVector(nullptr))) {
     // Document doesn't have the vector field - mark node as deleted to prevent

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -54,20 +54,24 @@ class HnswVectorIndex {
     return copy_vector_;
   }
 
-  std::vector<std::pair<float, GlobalDocId>> Knn(float* target, size_t k,
+  std::vector<std::pair<float, GlobalDocId>> Knn(const void* target, size_t k,
                                                  std::optional<uint32_t> ef) const;
-  std::vector<std::pair<float, GlobalDocId>> Knn(float* target, size_t k,
+  std::vector<std::pair<float, GlobalDocId>> Knn(const void* target, size_t k,
                                                  std::optional<uint32_t> ef,
                                                  const std::vector<GlobalDocId>& allowed) const;
-  std::vector<std::pair<float, GlobalDocId>> SubsetKnn(float* target, size_t k,
+  std::vector<std::pair<float, GlobalDocId>> SubsetKnn(const void* target, size_t k,
                                                        const std::vector<GlobalDocId>& docs) const;
 
   // Returns all documents within radius, with their distances.
-  std::vector<std::pair<float, GlobalDocId>> RangeQuery(float* target, float radius,
+  std::vector<std::pair<float, GlobalDocId>> RangeQuery(const void* target, float radius,
                                                         std::optional<double> epsilon) const;
 
   size_t GetDim() const {
     return dim_;
+  }
+
+  VectorDataType GetDataType() const {
+    return data_type_;
   }
 
   // Get metadata for serialization
@@ -105,6 +109,7 @@ class HnswVectorIndex {
  private:
   bool copy_vector_;
   size_t dim_;
+  VectorDataType data_type_;
   std::unique_ptr<HnswlibAdapter> adapter_;
 };
 

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -867,76 +867,77 @@ void TagIndex::Tokenize(std::string_view value, uint32_t* /*pos_counter*/,
   NormalizeTags(value, case_sensitive_, separator_, out);
 }
 
-BaseVectorIndex::BaseVectorIndex(size_t dim, VectorSimilarity sim) : dim_{dim}, sim_{sim} {
+BaseVectorIndex::BaseVectorIndex(size_t dim, VectorSimilarity sim, VectorDataType data_type)
+    : dim_{dim}, sim_{sim}, data_type_{data_type} {
 }
 
-std::pair<size_t /*dim*/, VectorSimilarity> BaseVectorIndex::Info() const {
-  return {dim_, sim_};
+VectorIndexInfo BaseVectorIndex::Info() const {
+  return {dim_, sim_, data_type_};
 }
 
 bool BaseVectorIndex::Add(DocId id, const DocumentAccessor& doc, std::string_view field) {
-  auto vector = doc.GetVector(field, dim_);
+  auto vector = doc.GetVector(field, dim_, data_type_);
 
   if (!vector)
     return false;
 
-  if (std::holds_alternative<OwnedFtVector>(*vector)) {
-    const auto& owned_vector = std::get<OwnedFtVector>(*vector);
-    AddVector(id, owned_vector.first.get());
-  } else {
-    const auto& borrowed_vector = std::get<BorrowedFtVector>(*vector);
-    AddVector(id, borrowed_vector);
-  }
+  if (std::holds_alternative<OwnedFtVector>(*vector))
+    AddVector(id, std::get<OwnedFtVector>(*vector).first.get());
+  else
+    AddVector(id, std::get<BorrowedFtVector>(*vector));
 
   return true;
 }
 
-// Each document occupies (dim_ + 1) floats in entries_: dim_ floats for the vector data,
-// followed by one float as a presence marker (1.0 = present, 0.0 = absent/removed).
-// This avoids the previous heuristic of treating all-zero vectors as null.
-static constexpr float kPresent = 1.0f;
-static constexpr float kAbsent = 0.0f;
-
 FlatVectorIndex::FlatVectorIndex(const SchemaField::VectorParams& params,
                                  PMR_NS::memory_resource* mr)
-    : BaseVectorIndex{params.dim, params.sim}, entries_{mr} {
+    : BaseVectorIndex{params.dim, params.sim, params.data_type},
+      stride_bytes_{params.dim * ElementSize(params.data_type)},
+      entries_{mr},
+      present_{mr} {
   DCHECK(!params.use_hnsw);
-  entries_.reserve(params.capacity * (params.dim + 1));
+  entries_.reserve(params.capacity * stride_bytes_);
+  present_.reserve((params.capacity + 63) / 64);
 }
 
 void FlatVectorIndex::AddVector(DocId id, const void* vector) {
-  const size_t stride = dim_ + 1;
-  DCHECK_LE(id * stride, entries_.size());
-  if (id * stride == entries_.size())
-    entries_.resize((id + 1) * stride, 0.0f);
+  const size_t need_bytes = (static_cast<size_t>(id) + 1) * stride_bytes_;
+  if (entries_.size() < need_bytes)
+    entries_.resize(need_bytes);
+
+  const size_t word = id / 64;
+  if (present_.size() <= word)
+    present_.resize(word + 1, 0);
 
   if (vector) {
-    memcpy(&entries_[id * stride], vector, dim_ * sizeof(float));
-    entries_[id * stride + dim_] = kPresent;
+    memcpy(entries_.data() + static_cast<size_t>(id) * stride_bytes_, vector, stride_bytes_);
+    present_[word] |= uint64_t{1} << (id % 64);
+  } else {
+    present_[word] &= ~(uint64_t{1} << (id % 64));
   }
 }
 
 void FlatVectorIndex::Remove(DocId id, const DocumentAccessor& doc, string_view field) {
-  const size_t stride = dim_ + 1;
-  if (id * stride + dim_ < entries_.size())
-    entries_[id * stride + dim_] = kAbsent;
+  const size_t word = id / 64;
+  if (word < present_.size())
+    present_[word] &= ~(uint64_t{1} << (id % 64));
 }
 
-const float* FlatVectorIndex::Get(DocId doc) const {
-  const size_t stride = dim_ + 1;
-  if (doc * stride + dim_ >= entries_.size() || entries_[doc * stride + dim_] != kPresent)
+const void* FlatVectorIndex::Get(DocId doc) const {
+  const size_t word = doc / 64;
+  if (word >= present_.size() || !((present_[word] >> (doc % 64)) & 1))
     return nullptr;
-  return &entries_[doc * stride];
+  return entries_.data() + static_cast<size_t>(doc) * stride_bytes_;
 }
 
 std::vector<DocId> FlatVectorIndex::GetAllDocsWithNonNullValues() const {
-  const size_t stride = dim_ + 1;
-  size_t num_slots = entries_.size() / stride;
   std::vector<DocId> result;
-  result.reserve(num_slots);
-  for (DocId id = 0; id < num_slots; ++id) {
-    if (entries_[id * stride + dim_] == kPresent)
-      result.push_back(id);
+  for (size_t word = 0; word < present_.size(); ++word) {
+    uint64_t bits = present_[word];
+    while (bits) {
+      result.push_back(static_cast<DocId>(word * 64 + __builtin_ctzll(bits)));
+      bits &= bits - 1;
+    }
   }
   return result;
 }

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -894,50 +894,42 @@ FlatVectorIndex::FlatVectorIndex(const SchemaField::VectorParams& params,
     : BaseVectorIndex{params.dim, params.sim, params.data_type},
       stride_bytes_{params.dim * ElementSize(params.data_type)},
       entries_{mr},
-      present_{mr} {
+      present_(mr) {
   DCHECK(!params.use_hnsw);
   entries_.reserve(params.capacity * stride_bytes_);
-  present_.reserve((params.capacity + 63) / 64);
+  present_.reserve(params.capacity);
 }
 
 void FlatVectorIndex::AddVector(DocId id, const void* vector) {
+  // Grow, never shrink: DocIds are recycled (see ShardDocIndex free_ids_), so `id` can be smaller
+  // than the current max — an unconditional resize would truncate and drop other docs' vectors.
   const size_t need_bytes = (static_cast<size_t>(id) + 1) * stride_bytes_;
   if (entries_.size() < need_bytes)
     entries_.resize(need_bytes);
+  if (present_.size() <= id)
+    present_.resize(id + 1, false);
 
-  const size_t word = id / 64;
-  if (present_.size() <= word)
-    present_.resize(word + 1, 0);
-
-  if (vector) {
+  present_[id] = vector != nullptr;
+  if (vector)
     memcpy(entries_.data() + static_cast<size_t>(id) * stride_bytes_, vector, stride_bytes_);
-    present_[word] |= uint64_t{1} << (id % 64);
-  } else {
-    present_[word] &= ~(uint64_t{1} << (id % 64));
-  }
 }
 
 void FlatVectorIndex::Remove(DocId id, const DocumentAccessor& doc, string_view field) {
-  const size_t word = id / 64;
-  if (word < present_.size())
-    present_[word] &= ~(uint64_t{1} << (id % 64));
+  if (id < present_.size())
+    present_[id] = false;
 }
 
 const void* FlatVectorIndex::Get(DocId doc) const {
-  const size_t word = doc / 64;
-  if (word >= present_.size() || !((present_[word] >> (doc % 64)) & 1))
+  if (doc >= present_.size() || !present_[doc])
     return nullptr;
   return entries_.data() + static_cast<size_t>(doc) * stride_bytes_;
 }
 
 std::vector<DocId> FlatVectorIndex::GetAllDocsWithNonNullValues() const {
   std::vector<DocId> result;
-  for (size_t word = 0; word < present_.size(); ++word) {
-    uint64_t bits = present_[word];
-    while (bits) {
-      result.push_back(static_cast<DocId>(word * 64 + __builtin_ctzll(bits)));
-      bits &= bits - 1;
-    }
+  for (size_t id = 0; id < present_.size(); ++id) {
+    if (present_[id])
+      result.push_back(static_cast<DocId>(id));
   }
   return result;
 }

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -19,6 +19,8 @@
 
 #include <absl/functional/function_ref.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -268,18 +270,25 @@ struct TagIndex : public BaseStringIndex<SortedVector<DocId>> {
   std::string next_defrag_suffix_entry_;
 };
 
+struct VectorIndexInfo {
+  size_t dim = 0;
+  VectorSimilarity sim = VectorSimilarity::L2;
+  VectorDataType data_type = VectorDataType::FLOAT32;
+};
+
 struct BaseVectorIndex : public BaseIndex {
-  std::pair<size_t /*dim*/, VectorSimilarity> Info() const;
+  VectorIndexInfo Info() const;
 
   bool Add(DocId id, const DocumentAccessor& doc, std::string_view field) override final;
 
  protected:
-  BaseVectorIndex(size_t dim, VectorSimilarity sim);
+  BaseVectorIndex(size_t dim, VectorSimilarity sim, VectorDataType data_type);
 
   virtual void AddVector(DocId id, const void* vector) = 0;
 
   size_t dim_;
   VectorSimilarity sim_;
+  VectorDataType data_type_;
 };
 
 // Index for vector fields.
@@ -289,7 +298,8 @@ struct FlatVectorIndex : public BaseVectorIndex {
 
   void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;
 
-  const float* Get(DocId doc) const;
+  // Pointer to the stored native-width vector bytes, or nullptr if the slot is empty.
+  const void* Get(DocId doc) const;
 
   // Return all documents that have vectors in this index
   std::vector<DocId> GetAllDocsWithNonNullValues() const override;
@@ -298,7 +308,9 @@ struct FlatVectorIndex : public BaseVectorIndex {
   void AddVector(DocId id, const void* vector) override;
 
  private:
-  PMR_NS::vector<float> entries_;
+  size_t stride_bytes_;                // dim_ * ElementSize(data_type_)
+  PMR_NS::vector<std::byte> entries_;  // contiguous native-width vectors
+  PMR_NS::vector<uint64_t> present_;   // presence bitmap, one bit per doc
 };
 
 struct GeoIndex : public BaseIndex {

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -310,7 +310,7 @@ struct FlatVectorIndex : public BaseVectorIndex {
  private:
   size_t stride_bytes_;                // dim_ * ElementSize(data_type_)
   PMR_NS::vector<std::byte> entries_;  // contiguous native-width vectors
-  PMR_NS::vector<uint64_t> present_;   // presence bitmap, one bit per doc
+  PMR_NS::vector<bool> present_;       // presence flag per doc (bit-packed)
 };
 
 struct GeoIndex : public BaseIndex {

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -165,14 +165,8 @@ knn_query:
       if (attrs.ef_runtime)
         ef = attrs.ef_runtime;
 
-      auto vec_result = BytesToFtVectorSafe($5);
-      if (!vec_result) {
-        // Create empty vector for invalid data - will return empty results during search
-        auto empty_vec = std::make_unique<float[]>(0);
-        $$ = AstKnnNode(knn_count, std::move(field), std::make_pair(std::move(empty_vec), size_t{0}), std::move(alias), ef);
-      } else {
-        $$ = AstKnnNode(knn_count, std::move(field), std::move(*vec_result), std::move(alias), ef);
-      }
+      // Raw query bytes are validated at search time against the field's declared dtype width.
+      $$ = AstKnnNode(knn_count, std::move(field), std::string{$5}, std::move(alias), ef);
     }
 
 opt_knn_alias:
@@ -234,30 +228,14 @@ vector_range_query:
       double radius = $5;
       auto field = std::move($1);
       auto attrs = std::move($8);
-      auto vec_result = BytesToFtVectorSafe($6);
-      if (!vec_result) {
-        auto empty_vec = std::make_unique<float[]>(0);
-        $$ = AstVectorRangeNode(std::move(field), radius,
-                                {std::move(empty_vec), size_t{0}}, std::move(attrs.score_alias),
-                                attrs.epsilon);
-      } else {
-        $$ = AstVectorRangeNode(std::move(field), radius, std::move(*vec_result),
-                                std::move(attrs.score_alias), attrs.epsilon);
-      }
+      $$ = AstVectorRangeNode(std::move(field), radius, std::string{$6},
+                              std::move(attrs.score_alias), attrs.epsilon);
     }
   | FIELD COLON LBRACKET VECTOR_RANGE vec_range_radius TERM RBRACKET %prec NO_YIELD
     {
       double radius = $5;
       auto field = std::move($1);
-      auto vec_result = BytesToFtVectorSafe($6);
-      if (!vec_result) {
-        auto empty_vec = std::make_unique<float[]>(0);
-        $$ = AstVectorRangeNode(std::move(field), radius,
-                                {std::move(empty_vec), size_t{0}}, std::string{}, std::nullopt);
-      } else {
-        $$ = AstVectorRangeNode(std::move(field), radius, std::move(*vec_result),
-                                std::string{}, std::nullopt);
-      }
+      $$ = AstVectorRangeNode(std::move(field), radius, std::string{$6}, std::string{}, std::nullopt);
     }
 
 vector_range_attrs_clause:

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -559,12 +559,12 @@ struct BasicSearch {
   void SearchKnnFlat(FlatVectorIndex* vec_index, const AstKnnNode& knn, IndexResult&& sub_results) {
     knn_distances_.reserve(sub_results.ApproximateSize());
     auto cb = [&](auto* set) {
-      auto [dim, sim] = vec_index->Info();
+      auto info = vec_index->Info();
       for (DocId matched_doc : *set) {
-        const float* vec = vec_index->Get(matched_doc);
+        const void* vec = vec_index->Get(matched_doc);
         if (!vec)
           continue;
-        float dist = VectorDistance(knn.vec.first.get(), vec, dim, sim);
+        float dist = VectorDistance(knn.blob.data(), vec, info.dim, info.sim, info.data_type);
         knn_distances_.emplace_back(dist, matched_doc);
       }
     };
@@ -579,12 +579,12 @@ struct BasicSearch {
   void SearchVectorRangeFlat(FlatVectorIndex* vec_index, const AstVectorRangeNode& node,
                              vector<DocId>* out) {
     const auto& all_docs = indices_->GetAllDocs();
-    auto [dim, sim] = vec_index->Info();
+    auto info = vec_index->Info();
     for (DocId doc : all_docs) {
-      const float* vec = vec_index->Get(doc);
+      const void* vec = vec_index->Get(doc);
       if (!vec)
         continue;
-      float dist = VectorDistance(node.vec.first.get(), vec, dim, sim);
+      float dist = VectorDistance(node.blob.data(), vec, info.dim, info.sim, info.data_type);
       if (dist <= static_cast<float>(node.radius)) {
         knn_scores_[doc] = dist;
         out->push_back(doc);
@@ -601,7 +601,12 @@ struct BasicSearch {
     if (!vec_index)
       return IndexResult{};
 
-    if (node.vec.second == 0)
+    auto info = vec_index->Info();
+    const size_t width = ElementSize(info.data_type);
+    if (node.blob.empty() || node.blob.size() % width != 0)
+      return IndexResult{};
+    const size_t qdim = node.blob.size() / width;
+    if (qdim == 0)
       return IndexResult{};
 
     if (!(node.radius >= 0) || !std::isfinite(node.radius)) {
@@ -613,9 +618,8 @@ struct BasicSearch {
       return IndexResult{};
     }
 
-    if (auto [dim, _] = vec_index->Info(); dim != node.vec.second) {
-      error_ = absl::StrCat("Wrong vector index dimensions, got: ", node.vec.second,
-                            ", expected: ", dim);
+    if (info.dim != qdim) {
+      error_ = absl::StrCat("Wrong vector index dimensions, got: ", qdim, ", expected: ", info.dim);
       return IndexResult{};
     }
 
@@ -639,14 +643,16 @@ struct BasicSearch {
     if (!vec_index)
       return IndexResult{};
 
-    // If vector dimension is 0, treat as placeholder/invalid - return empty results
-    // This allows tests to use dummy vector values like "<your_vector_blob>"
-    if (knn.vec.second == 0)
+    // A malformed/placeholder blob (empty or not a whole number of elements) yields no results
+    // instead of an error. This allows tests to use dummy values like "<your_vector_blob>".
+    auto info = vec_index->Info();
+    const size_t width = ElementSize(info.data_type);
+    if (knn.blob.empty() || knn.blob.size() % width != 0)
       return IndexResult{};
+    const size_t qdim = knn.blob.size() / width;
 
-    if (auto [dim, _] = vec_index->Info(); dim != knn.vec.second) {
-      error_ =
-          absl::StrCat("Wrong vector index dimensions, got: ", knn.vec.second, ", expected: ", dim);
+    if (info.dim != qdim) {
+      error_ = absl::StrCat("Wrong vector index dimensions, got: ", qdim, ", expected: ", info.dim);
       return IndexResult{};
     }
 

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -67,7 +67,8 @@ struct MockedDocument : public DocumentAccessor {
     return GetStrings(field);
   }
 
-  std::optional<VectorInfo> GetVector(string_view field, size_t dim) const override {
+  std::optional<VectorInfo> GetVector(string_view field, size_t dim,
+                                      VectorDataType dtype) const override {
     auto strings_list = GetStrings(field);
     if (!strings_list)
       return std::nullopt;
@@ -1440,7 +1441,7 @@ TEST(HnswBorrowedMode, DanglingPointerAfterRemove) {
     const char* data;
     explicit BorrowedDoc(const char* d) : data(d) {
     }
-    std::optional<VectorInfo> GetVector(string_view, size_t) const override {
+    std::optional<VectorInfo> GetVector(string_view, size_t, VectorDataType) const override {
       return BorrowedFtVector{data};
     }
     std::optional<StringList> GetStrings(string_view) const override {
@@ -2114,11 +2115,16 @@ TEST_F(SearchTest, VectorDistanceTypedDtypes) {
   EXPECT_FLOAT_EQ(HalfToFloat(0xC000), -2.0f);
   EXPECT_FLOAT_EQ(HalfToFloat(0x0000), 0.0f);
   EXPECT_FLOAT_EQ(HalfToFloat(0x4200), 3.0f);
-  EXPECT_FLOAT_EQ(HalfToFloat(0x0001), std::ldexp(1.0f, -24));  // smallest subnormal half
-  EXPECT_FLOAT_EQ(HalfToFloat(0x0200), std::ldexp(1.0f, -15));  // subnormal half
   EXPECT_FLOAT_EQ(Bf16ToFloat(0x3F80), 1.0f);
   EXPECT_FLOAT_EQ(Bf16ToFloat(0x4000), 2.0f);
   EXPECT_FLOAT_EQ(Bf16ToFloat(0x40C0), 6.0f);
+
+  // Encoders (float -> half), exact for representable values and round-trip.
+  EXPECT_EQ(FloatToHalf(1.0f), 0x3C00);
+  EXPECT_EQ(FloatToHalf(-2.0f), 0xC000);
+  EXPECT_EQ(FloatToBf16(1.0f), 0x3F80);
+  for (float x : {0.0f, 1.0f, -3.5f, 42.0f, 0.25f})
+    EXPECT_FLOAT_EQ(HalfToFloat(FloatToHalf(x)), x);
 
   // Every dtype holding {1,2,3} vs {4,5,6} must match the float32 reference under all metrics
   // (integers 1..6 are exactly representable in all six dtypes).
@@ -2145,6 +2151,57 @@ TEST_F(SearchTest, VectorDistanceTypedDtypes) {
   check(f64a, f64b, VectorDataType::FLOAT64);
   check(f16a, f16b, VectorDataType::FLOAT16);
   check(bf16a, bf16b, VectorDataType::BFLOAT16);
+}
+
+TEST_F(SearchTest, StubOnesVectorCosineWellDefined) {
+  // The HNSW deleted-node stub is EncodeOnesVector(...). Under COSINE it must have a nonzero norm,
+  // otherwise the distance degenerates to 0 (= maximally close) and biases traversal toward
+  // deleted nodes. Regresses for FLOAT32/BFLOAT16/FLOAT64 if the stub is a raw 0x01 byte fill,
+  // whose squared magnitude underflows the accumulator to zero.
+  const size_t dim = 3;
+  const float kExpected = 1.0f - 1.0f / std::sqrt(3.0f);  // cosine([1,0,0], [1,1,1])
+
+  auto check = [&](VectorDataType dt, const void* query) {
+    std::vector<std::byte> ones = EncodeOnesVector(dim, dt);
+    float d = VectorDistance(query, ones.data(), dim, VectorSimilarity::COSINE, dt);
+    EXPECT_NEAR(d, kExpected, 1e-3) << "dtype=" << VectorDataTypeToString(dt);
+    EXPECT_GT(d, 0.01f) << "degenerate zero-norm stub for dtype=" << VectorDataTypeToString(dt);
+  };
+
+  const float f32q[3] = {1, 0, 0};
+  const double f64q[3] = {1, 0, 0};
+  const uint16_t f16q[3] = {0x3C00, 0, 0};
+  const uint16_t bf16q[3] = {0x3F80, 0, 0};
+  const int8_t i8q[3] = {1, 0, 0};
+  const uint8_t u8q[3] = {1, 0, 0};
+
+  check(VectorDataType::FLOAT32, f32q);
+  check(VectorDataType::FLOAT64, f64q);
+  check(VectorDataType::FLOAT16, f16q);
+  check(VectorDataType::BFLOAT16, bf16q);
+  check(VectorDataType::INT8, i8q);
+  check(VectorDataType::UINT8, u8q);
+}
+
+TEST_F(SearchTest, HalfBf16SpecialValues) {
+  // Special-value branches of the half/bfloat converters (unexercised by the finite-normals test).
+  EXPECT_TRUE(std::isinf(HalfToFloat(0x7C00)));  // +inf
+  EXPECT_TRUE(std::isinf(HalfToFloat(0xFC00)) && HalfToFloat(0xFC00) < 0.0f);
+  EXPECT_TRUE(std::isnan(HalfToFloat(0x7E00)));
+  EXPECT_EQ(FloatToHalf(INFINITY), 0x7C00);
+  EXPECT_EQ(FloatToHalf(1e30f), 0x7C00);  // overflow -> inf
+  EXPECT_TRUE(std::isnan(HalfToFloat(FloatToHalf(std::nanf("")))));
+
+  EXPECT_TRUE(std::isinf(Bf16ToFloat(0x7F80)));
+  EXPECT_TRUE(std::isnan(Bf16ToFloat(0x7FC0)));
+  EXPECT_EQ(FloatToBf16(INFINITY), 0x7F80);
+  EXPECT_TRUE(std::isnan(Bf16ToFloat(FloatToBf16(std::nanf("")))));
+
+  // Smallest positive subnormal half round-trips and stays finite.
+  float sub = HalfToFloat(0x0001);
+  EXPECT_GT(sub, 0.0f);
+  EXPECT_LT(sub, 1e-6f);
+  EXPECT_EQ(FloatToHalf(sub), 0x0001);
 }
 
 TEST_F(SearchTest, VectorDistanceConsistency) {

--- a/src/core/search/vector_utils.cc
+++ b/src/core/search/vector_utils.cc
@@ -30,11 +30,9 @@ namespace {
 #endif
 
 OwnedFtVector ConvertToFtVector(string_view value) {
-  // Value cannot be casted directly as it might be not aligned as a float (4 bytes).
-  // Misaligned memory access is UB.
   size_t size = value.size() / sizeof(float);
-  auto out = make_unique<float[]>(size);
-  memcpy(out.get(), value.data(), size * sizeof(float));
+  auto out = make_unique<std::byte[]>(value.size());
+  memcpy(out.get(), value.data(), value.size());
 
   return OwnedFtVector{std::move(out), size};
 }
@@ -148,7 +146,119 @@ float Bf16ToFloat(uint16_t b) {
   return out;
 }
 
+uint16_t FloatToHalf(float f) {
+  uint32_t x;
+  memcpy(&x, &f, sizeof(x));
+  const uint32_t sign = (x >> 16) & 0x8000;
+  const uint32_t exp_field = (x >> 23) & 0xFF;
+  uint32_t mant = x & 0x7FFFFF;
+
+  if (exp_field == 0xFF)  // inf / nan
+    return static_cast<uint16_t>(sign | 0x7C00 | (mant ? 0x200 : 0));
+
+  int32_t exp = static_cast<int32_t>(exp_field) - 127 + 15;
+  if (exp >= 0x1F)  // overflow -> inf
+    return static_cast<uint16_t>(sign | 0x7C00);
+
+  if (exp <= 0) {  // subnormal or zero
+    if (exp < -10)
+      return static_cast<uint16_t>(sign);
+    mant |= 0x800000;
+    const int shift = 14 - exp;
+    uint32_t half_mant = mant >> shift;
+    const uint32_t remainder = mant & ((1u << shift) - 1);
+    const uint32_t halfway = 1u << (shift - 1);
+    if (remainder > halfway || (remainder == halfway && (half_mant & 1)))
+      half_mant++;
+    return static_cast<uint16_t>(sign | half_mant);
+  }
+
+  uint16_t half = static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) | (mant >> 13));
+  const uint32_t remainder = mant & 0x1FFF;  // round to nearest even
+  if (remainder > 0x1000 || (remainder == 0x1000 && (half & 1)))
+    half++;
+  return half;
+}
+
+uint16_t FloatToBf16(float f) {
+  uint32_t bits;
+  memcpy(&bits, &f, sizeof(bits));
+  if ((bits & 0x7FFFFFFF) > 0x7F800000)  // nan -> quiet nan
+    return static_cast<uint16_t>((bits >> 16) | 0x0040);
+  bits += 0x7FFF + ((bits >> 16) & 1);  // round to nearest even
+  return static_cast<uint16_t>(bits >> 16);
+}
+
+std::vector<std::byte> EncodeOnesVector(size_t dim, VectorDataType dt) {
+  const size_t width = ElementSize(dt);
+  std::byte elem[sizeof(double)] = {};
+  switch (dt) {
+    case VectorDataType::FLOAT32: {
+      float v = 1.0f;
+      memcpy(elem, &v, sizeof(v));
+    } break;
+    case VectorDataType::FLOAT64: {
+      double v = 1.0;
+      memcpy(elem, &v, sizeof(v));
+    } break;
+    case VectorDataType::FLOAT16: {
+      uint16_t v = FloatToHalf(1.0f);
+      memcpy(elem, &v, sizeof(v));
+    } break;
+    case VectorDataType::BFLOAT16: {
+      uint16_t v = FloatToBf16(1.0f);
+      memcpy(elem, &v, sizeof(v));
+    } break;
+    case VectorDataType::INT8: {
+      int8_t v = 1;
+      memcpy(elem, &v, sizeof(v));
+    } break;
+    case VectorDataType::UINT8: {
+      uint8_t v = 1;
+      memcpy(elem, &v, sizeof(v));
+    } break;
+  }
+  std::vector<std::byte> out(dim * width);
+  for (size_t i = 0; i < dim; i++)
+    memcpy(out.data() + i * width, elem, width);
+  return out;
+}
+
 namespace {
+
+#ifdef WITH_SIMSIMD
+
+// Distance between two native-width blobs of a given element type via simsimd, mapped to our
+// conventions: L2 = Euclidean distance, IP = 1 - dot product, COSINE = 1 - cosine similarity.
+// simsimd uses unaligned loads, so this is safe for unaligned query blobs and borrowed HNSW
+// storage; the raw bytes already match simsimd's element layout (fp16/bf16 as unsigned short).
+#define DFLY_DEFINE_SIMSIMD_DIST(suffix, elem_type)                                             \
+  float SimsimdDist_##suffix(const void* u, const void* v, size_t dims, VectorSimilarity sim) { \
+    const auto* a = reinterpret_cast<const elem_type*>(u);                                      \
+    const auto* b = reinterpret_cast<const elem_type*>(v);                                      \
+    simsimd_distance_t d = 0;                                                                   \
+    switch (sim) {                                                                              \
+      case VectorSimilarity::L2:                                                                \
+        simsimd_l2_##suffix(a, b, dims, &d);                                                    \
+        return static_cast<float>(d);                                                           \
+      case VectorSimilarity::IP:                                                                \
+        simsimd_dot_##suffix(a, b, dims, &d);                                                   \
+        return 1.0f - static_cast<float>(d);                                                    \
+      case VectorSimilarity::COSINE:                                                            \
+        simsimd_cos_##suffix(a, b, dims, &d);                                                   \
+        return static_cast<float>(d);                                                           \
+    }                                                                                           \
+    return 0.0f;                                                                                \
+  }
+DFLY_DEFINE_SIMSIMD_DIST(f32, simsimd_f32_t)
+DFLY_DEFINE_SIMSIMD_DIST(f64, simsimd_f64_t)
+DFLY_DEFINE_SIMSIMD_DIST(f16, simsimd_f16_t)
+DFLY_DEFINE_SIMSIMD_DIST(bf16, simsimd_bf16_t)
+DFLY_DEFINE_SIMSIMD_DIST(i8, simsimd_i8_t)
+DFLY_DEFINE_SIMSIMD_DIST(u8, simsimd_u8_t)
+#undef DFLY_DEFINE_SIMSIMD_DIST
+
+#else  // scalar fallback kernels, used when simsimd is not enabled
 
 uint16_t LoadU16(const void* base, size_t i) {
   uint16_t v;
@@ -227,11 +337,27 @@ float DistByMetric(const void* u, const void* v, size_t dims, VectorSimilarity s
   return 0.0f;
 }
 
+#endif  // WITH_SIMSIMD
+
 }  // namespace
 
 float VectorDistance(const void* u, const void* v, size_t dims, VectorSimilarity sim,
                      VectorDataType dt) {
   switch (dt) {
+#ifdef WITH_SIMSIMD
+    case VectorDataType::FLOAT32:
+      return SimsimdDist_f32(u, v, dims, sim);
+    case VectorDataType::FLOAT64:
+      return SimsimdDist_f64(u, v, dims, sim);
+    case VectorDataType::FLOAT16:
+      return SimsimdDist_f16(u, v, dims, sim);
+    case VectorDataType::BFLOAT16:
+      return SimsimdDist_bf16(u, v, dims, sim);
+    case VectorDataType::INT8:
+      return SimsimdDist_i8(u, v, dims, sim);
+    case VectorDataType::UINT8:
+      return SimsimdDist_u8(u, v, dims, sim);
+#else
     case VectorDataType::FLOAT32:
       return DistByMetric<ReaderF32>(u, v, dims, sim);
     case VectorDataType::FLOAT64:
@@ -244,6 +370,7 @@ float VectorDistance(const void* u, const void* v, size_t dims, VectorSimilarity
       return DistByMetric<ReaderI8>(u, v, dims, sim);
     case VectorDataType::UINT8:
       return DistByMetric<ReaderU8>(u, v, dims, sim);
+#endif
   }
   return 0.0f;
 }

--- a/src/core/search/vector_utils.cc
+++ b/src/core/search/vector_utils.cc
@@ -114,79 +114,19 @@ float VectorDistance(const float* u, const float* v, size_t dims, VectorSimilari
 }
 
 float HalfToFloat(uint16_t h) {
-  uint32_t sign = static_cast<uint32_t>(h & 0x8000) << 16;
-  uint32_t exp = (h >> 10) & 0x1F;
-  uint32_t mant = h & 0x3FF;
-  uint32_t bits;
-  if (exp == 0) {
-    if (mant == 0) {
-      bits = sign;  // +/- zero
-    } else {
-      // Normalize the subnormal: shift the mantissa left until bit 10 is set. `mant` is in
-      // [1, 0x3FF], so countl_zero is in [22, 31] and the shift in [1, 10].
-      int shift = std::countl_zero(mant) - 21;
-      exp = (127 - 15 + 1) - shift;
-      mant = (mant << shift) & 0x3FF;
-      bits = sign | (exp << 23) | (mant << 13);
-    }
-  } else if (exp == 0x1F) {
-    bits = sign | 0x7F800000u | (mant << 13);  // inf / nan
-  } else {
-    bits = sign | ((exp + 112) << 23) | (mant << 13);  // rebias 127 - 15 = 112
-  }
-  float out;
-  memcpy(&out, &bits, sizeof(out));
-  return out;
+  return static_cast<float>(std::bit_cast<_Float16>(h));
 }
 
 float Bf16ToFloat(uint16_t b) {
-  uint32_t bits = static_cast<uint32_t>(b) << 16;
-  float out;
-  memcpy(&out, &bits, sizeof(out));
-  return out;
+  return static_cast<float>(std::bit_cast<__bf16>(b));
 }
 
 uint16_t FloatToHalf(float f) {
-  uint32_t x;
-  memcpy(&x, &f, sizeof(x));
-  const uint32_t sign = (x >> 16) & 0x8000;
-  const uint32_t exp_field = (x >> 23) & 0xFF;
-  uint32_t mant = x & 0x7FFFFF;
-
-  if (exp_field == 0xFF)  // inf / nan
-    return static_cast<uint16_t>(sign | 0x7C00 | (mant ? 0x200 : 0));
-
-  int32_t exp = static_cast<int32_t>(exp_field) - 127 + 15;
-  if (exp >= 0x1F)  // overflow -> inf
-    return static_cast<uint16_t>(sign | 0x7C00);
-
-  if (exp <= 0) {  // subnormal or zero
-    if (exp < -10)
-      return static_cast<uint16_t>(sign);
-    mant |= 0x800000;
-    const int shift = 14 - exp;
-    uint32_t half_mant = mant >> shift;
-    const uint32_t remainder = mant & ((1u << shift) - 1);
-    const uint32_t halfway = 1u << (shift - 1);
-    if (remainder > halfway || (remainder == halfway && (half_mant & 1)))
-      half_mant++;
-    return static_cast<uint16_t>(sign | half_mant);
-  }
-
-  uint16_t half = static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) | (mant >> 13));
-  const uint32_t remainder = mant & 0x1FFF;  // round to nearest even
-  if (remainder > 0x1000 || (remainder == 0x1000 && (half & 1)))
-    half++;
-  return half;
+  return std::bit_cast<uint16_t>(static_cast<_Float16>(f));
 }
 
 uint16_t FloatToBf16(float f) {
-  uint32_t bits;
-  memcpy(&bits, &f, sizeof(bits));
-  if ((bits & 0x7FFFFFFF) > 0x7F800000)  // nan -> quiet nan
-    return static_cast<uint16_t>((bits >> 16) | 0x0040);
-  bits += 0x7FFF + ((bits >> 16) & 1);  // round to nearest even
-  return static_cast<uint16_t>(bits >> 16);
+  return std::bit_cast<uint16_t>(static_cast<__bf16>(f));
 }
 
 std::vector<std::byte> EncodeOnesVector(size_t dim, VectorDataType dt) {

--- a/src/core/search/vector_utils.h
+++ b/src/core/search/vector_utils.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <vector>
+
 #include "core/search/base.h"
 
 namespace dfly::search {
@@ -30,6 +33,13 @@ float VectorDistance(const void* u, const void* v, size_t dims, VectorSimilarity
 // Widen a half-precision (h) or bfloat16 (b) element, given as its raw 16-bit pattern, to float.
 float HalfToFloat(uint16_t h);
 float Bf16ToFloat(uint16_t b);
+
+// Narrow a float to half precision / bfloat16 (round to nearest even). Used to encode JSON numbers.
+uint16_t FloatToHalf(float f);
+uint16_t FloatToBf16(float f);
+
+// Builds a `dim`-element blob with every element set to 1.0 encoded in the given dtype.
+std::vector<std::byte> EncodeOnesVector(size_t dim, VectorDataType dt);
 
 std::string_view VectorSimilarityToString(VectorSimilarity sim);
 

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -15,6 +15,7 @@
 #include <absl/strings/str_join.h>
 
 #include <cmath>
+#include <type_traits>
 
 #include "base/flags.h"
 #include "core/detail/listpack_wrap.h"
@@ -42,6 +43,42 @@ namespace {
 
 string_view SdsToSafeSv(sds str) {
   return str != nullptr ? string_view{str, sdslen(str)} : ""sv;
+}
+
+// Encodes one JSON number `v` into `dst` at the native width of dtype DT. Returns false if the
+// value is out of range for an integer dtype. DT is a compile-time constant, so the per-dtype
+// branch is resolved at compile time and hoisted out of the caller's element loop.
+template <search::VectorDataType DT, typename JsonElem>
+bool EncodeJsonElement(const JsonElem& v, std::byte* dst) {
+  using VDT = search::VectorDataType;
+  if constexpr (DT == VDT::FLOAT32) {
+    float x = v.template as<float>();
+    memcpy(dst, &x, sizeof(x));
+  } else if constexpr (DT == VDT::FLOAT64) {
+    double x = v.template as<double>();
+    memcpy(dst, &x, sizeof(x));
+  } else if constexpr (DT == VDT::FLOAT16) {
+    uint16_t x = search::FloatToHalf(v.template as<float>());
+    memcpy(dst, &x, sizeof(x));
+  } else if constexpr (DT == VDT::BFLOAT16) {
+    uint16_t x = search::FloatToBf16(v.template as<float>());
+    memcpy(dst, &x, sizeof(x));
+  } else if constexpr (DT == VDT::INT8 || DT == VDT::UINT8) {
+    double d = v.template as<double>();
+    // Bound the magnitude before lrint (keeps it in-range for long), then round to nearest (ties
+    // to even, matching the fp16/bf16 encoders) and reject anything that rounds out of range.
+    constexpr double kLo = DT == VDT::INT8 ? -128.0 : 0.0;
+    constexpr double kHi = DT == VDT::INT8 ? 127.0 : 255.0;
+    if (!std::isfinite(d) || d < kLo - 1.0 || d > kHi + 1.0)
+      return false;
+    long r = std::lrint(d);
+    if (r < kLo || r > kHi)
+      return false;
+    using Int = std::conditional_t<DT == VDT::INT8, int8_t, uint8_t>;
+    auto x = static_cast<Int>(r);
+    memcpy(dst, &x, sizeof(x));
+  }
+  return true;
 }
 
 using FieldValue = std::optional<search::SortableValue>;
@@ -312,60 +349,41 @@ std::optional<BaseAccessor::VectorInfo> JsonAccessor::GetVector(
   const size_t width = search::ElementSize(dtype);
   auto bytes = make_unique<std::byte[]>(size * width);
 
-  size_t i = 0;
-  for (const auto& v : res[0].array_range()) {
-    if (!v.is_number())
-      return std::nullopt;
-    std::byte* dst = bytes.get() + i * width;
-    switch (dtype) {
-      case search::VectorDataType::FLOAT32: {
-        float x = v.as<float>();
-        memcpy(dst, &x, sizeof(x));
-        break;
-      }
-      case search::VectorDataType::FLOAT64: {
-        double x = v.as<double>();
-        memcpy(dst, &x, sizeof(x));
-        break;
-      }
-      case search::VectorDataType::FLOAT16: {
-        uint16_t x = search::FloatToHalf(v.as<float>());
-        memcpy(dst, &x, sizeof(x));
-        break;
-      }
-      case search::VectorDataType::BFLOAT16: {
-        uint16_t x = search::FloatToBf16(v.as<float>());
-        memcpy(dst, &x, sizeof(x));
-        break;
-      }
-      case search::VectorDataType::INT8: {
-        double d = v.as<double>();
-        // Bound the magnitude before lrint (keeps it in-range for long), then round to nearest
-        // (ties to even, matching the fp16/bf16 encoders) and reject anything that rounds outside
-        // int8 rather than wrapping.
-        if (!std::isfinite(d) || d < -129.0 || d > 128.0)
-          return std::nullopt;
-        long r = std::lrint(d);
-        if (r < -128 || r > 127)
-          return std::nullopt;
-        auto x = static_cast<int8_t>(r);
-        memcpy(dst, &x, sizeof(x));
-        break;
-      }
-      case search::VectorDataType::UINT8: {
-        double d = v.as<double>();
-        if (!std::isfinite(d) || d < -1.0 || d > 256.0)
-          return std::nullopt;
-        long r = std::lrint(d);
-        if (r < 0 || r > 255)
-          return std::nullopt;
-        auto x = static_cast<uint8_t>(r);
-        memcpy(dst, &x, sizeof(x));
-        break;
-      }
+  // Resolve the dtype once, then run a monomorphic encode loop for it.
+  auto encode_all = [&]<search::VectorDataType DT>() {
+    size_t i = 0;
+    for (const auto& v : res[0].array_range()) {
+      if (!v.is_number() || !EncodeJsonElement<DT>(v, bytes.get() + i * width))
+        return false;
+      ++i;
     }
-    i++;
+    return true;
+  };
+
+  using VDT = search::VectorDataType;
+  bool ok = false;
+  switch (dtype) {
+    case VDT::FLOAT32:
+      ok = encode_all.operator()<VDT::FLOAT32>();
+      break;
+    case VDT::FLOAT64:
+      ok = encode_all.operator()<VDT::FLOAT64>();
+      break;
+    case VDT::FLOAT16:
+      ok = encode_all.operator()<VDT::FLOAT16>();
+      break;
+    case VDT::BFLOAT16:
+      ok = encode_all.operator()<VDT::BFLOAT16>();
+      break;
+    case VDT::INT8:
+      ok = encode_all.operator()<VDT::INT8>();
+      break;
+    case VDT::UINT8:
+      ok = encode_all.operator()<VDT::UINT8>();
+      break;
   }
+  if (!ok)
+    return std::nullopt;
 
   return search::OwnedFtVector{std::move(bytes), size};
 }

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -14,6 +14,8 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 
+#include <cmath>
+
 #include "base/flags.h"
 #include "core/detail/listpack_wrap.h"
 #include "core/json/path.h"
@@ -112,13 +114,14 @@ SearchDocData BaseAccessor::Serialize(const search::Schema& schema,
   return out;
 }
 
-std::optional<BaseAccessor::VectorInfo> BaseAccessor::GetVector(std::string_view active_field,
-                                                                size_t dim) const {
+std::optional<BaseAccessor::VectorInfo> BaseAccessor::GetVector(
+    std::string_view active_field, size_t dim, search::VectorDataType dtype) const {
   auto strings_list = GetStrings(active_field);
   if (strings_list) {
     if (!strings_list->empty()) {
       auto value = strings_list->front();
-      if ((value.size() % sizeof(float)) || (value.size() / sizeof(float) != dim)) {
+      const size_t width = search::ElementSize(dtype);
+      if ((value.size() % width) || (value.size() / width != dim)) {
         return std::nullopt;
       }
       return value.data();
@@ -287,8 +290,8 @@ std::optional<BaseAccessor::StringList> JsonAccessor::GetStrings(std::string_vie
   return out;
 }
 
-std::optional<BaseAccessor::VectorInfo> JsonAccessor::GetVector(string_view active_field,
-                                                                size_t dim) const {
+std::optional<BaseAccessor::VectorInfo> JsonAccessor::GetVector(
+    string_view active_field, size_t dim, search::VectorDataType dtype) const {
   auto* path = GetPath(active_field);
   if (!path)
     return VectorInfo{};
@@ -305,17 +308,66 @@ std::optional<BaseAccessor::VectorInfo> JsonAccessor::GetVector(string_view acti
   if (size != dim)
     return std::nullopt;
 
-  auto ptr = make_unique<float[]>(size);
+  // JSON stores numbers, so quantize/encode each element to the field's declared native width.
+  const size_t width = search::ElementSize(dtype);
+  auto bytes = make_unique<std::byte[]>(size * width);
 
   size_t i = 0;
   for (const auto& v : res[0].array_range()) {
-    if (!v.is_number()) {
+    if (!v.is_number())
       return std::nullopt;
+    std::byte* dst = bytes.get() + i * width;
+    switch (dtype) {
+      case search::VectorDataType::FLOAT32: {
+        float x = v.as<float>();
+        memcpy(dst, &x, sizeof(x));
+        break;
+      }
+      case search::VectorDataType::FLOAT64: {
+        double x = v.as<double>();
+        memcpy(dst, &x, sizeof(x));
+        break;
+      }
+      case search::VectorDataType::FLOAT16: {
+        uint16_t x = search::FloatToHalf(v.as<float>());
+        memcpy(dst, &x, sizeof(x));
+        break;
+      }
+      case search::VectorDataType::BFLOAT16: {
+        uint16_t x = search::FloatToBf16(v.as<float>());
+        memcpy(dst, &x, sizeof(x));
+        break;
+      }
+      case search::VectorDataType::INT8: {
+        double d = v.as<double>();
+        // Bound the magnitude before lrint (keeps it in-range for long), then round to nearest
+        // (ties to even, matching the fp16/bf16 encoders) and reject anything that rounds outside
+        // int8 rather than wrapping.
+        if (!std::isfinite(d) || d < -129.0 || d > 128.0)
+          return std::nullopt;
+        long r = std::lrint(d);
+        if (r < -128 || r > 127)
+          return std::nullopt;
+        auto x = static_cast<int8_t>(r);
+        memcpy(dst, &x, sizeof(x));
+        break;
+      }
+      case search::VectorDataType::UINT8: {
+        double d = v.as<double>();
+        if (!std::isfinite(d) || d < -1.0 || d > 256.0)
+          return std::nullopt;
+        long r = std::lrint(d);
+        if (r < 0 || r > 255)
+          return std::nullopt;
+        auto x = static_cast<uint8_t>(r);
+        memcpy(dst, &x, sizeof(x));
+        break;
+      }
     }
-    ptr[i++] = v.as<float>();
+    i++;
   }
 
-  return search::OwnedFtVector{std::move(ptr), size};
+  return search::OwnedFtVector{std::move(bytes), size};
 }
 
 std::optional<BaseAccessor::NumsList> JsonAccessor::GetNumbers(string_view active_field) const {

--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -33,8 +33,8 @@ struct BaseAccessor : public search::DocumentAccessor {
                                   absl::Span<const FieldReference> fields) const;
 
   // Default implementation uses GetStrings
-  virtual std::optional<VectorInfo> GetVector(std::string_view active_field,
-                                              size_t dim) const override;
+  virtual std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim,
+                                              search::VectorDataType dtype) const override;
   virtual std::optional<NumsList> GetNumbers(std::string_view active_field) const override;
   virtual std::optional<StringList> GetTags(std::string_view active_field) const override;
 };
@@ -85,7 +85,8 @@ struct JsonAccessor : public BaseAccessor {
   }
 
   std::optional<StringList> GetStrings(std::string_view field) const override;
-  std::optional<VectorInfo> GetVector(std::string_view field, size_t dim) const override;
+  std::optional<VectorInfo> GetVector(std::string_view field, size_t dim,
+                                      search::VectorDataType dtype) const override;
   std::optional<NumsList> GetNumbers(std::string_view active_field) const override;
   std::optional<StringList> GetTags(std::string_view active_field) const override;
 

--- a/src/server/search/global_hnsw_index.cc
+++ b/src/server/search/global_hnsw_index.cc
@@ -49,7 +49,8 @@ bool GlobalHnswIndexRegistry::Create(std::string_view index_name, std::string_vi
   //    as listpack or StringMap. Problem with listpack encoding is that vector memory, if
   //    referenced, can have wrong alignment for vector distance operations.
   const bool copy_vector =
-      (data_type == DocIndex::JSON) || (params.dim * 4 < server.max_listpack_map_bytes);
+      (data_type == DocIndex::JSON) ||
+      (params.dim * search::ElementSize(params.data_type) < server.max_listpack_map_bytes);
 
   indices_[key] = std::make_shared<search::HnswVectorIndex>(params, copy_vector);
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -252,16 +252,18 @@ ParsedSchemaField ParseVector(CmdArgParser* parser) {
     return CreateSyntaxError("Knn vector dimension cannot be zero"sv);
   }
 
-  // Validate that the initial allocation (capacity * (dim+1) floats) cannot
-  // overflow size_t or request an unreasonable amount of memory.  Without this
-  // check FlatVectorIndex::FlatVectorIndex() would throw std::bad_alloc,
-  // leaving a half-initialised index registered in ShardDocIndices.
-  static constexpr size_t kMaxFlatBufEntries = size_t{1} << 30;  // ~4 GiB of floats
-  if (vector_params.dim >= kMaxFlatBufEntries) {
+  // Cap the initial allocation (capacity * dim * element_width bytes, plus a small presence bitmap)
+  // so it cannot overflow size_t or request an unreasonable amount of memory. Without this check
+  // FlatVectorIndex::FlatVectorIndex() would throw std::bad_alloc, leaving a half-initialised index
+  // registered in ShardDocIndices.
+  static constexpr size_t kMaxFlatBufBytes = size_t{1} << 32;  // 4 GiB
+  const size_t width =
+      search::ElementSize(vector_params.data_type);  // dim already checked non-zero
+  if (vector_params.dim > kMaxFlatBufBytes / width) {
     return CreateSyntaxError("Vector index initial allocation is too large"sv);
   }
-  size_t dim_plus1 = vector_params.dim + 1;
-  if (vector_params.capacity > kMaxFlatBufEntries / dim_plus1) {
+  const size_t stride_bytes = vector_params.dim * width;
+  if (vector_params.capacity > kMaxFlatBufBytes / stride_bytes) {
     return CreateSyntaxError("Vector index initial allocation is too large"sv);
   }
 
@@ -1476,23 +1478,42 @@ vector<SearchResult> LoadHnswSearchDocs(
   return results;
 }
 
+// Validates that a KNN query blob matches the index's dim * element width. Returns an error
+// message on mismatch (mirrors the FLAT and FT.AGGREGATE paths), else nullopt.
+std::optional<std::string> ValidateHnswKnnBlob(const search::AstKnnNode* knn,
+                                               const search::HnswVectorIndex& index) {
+  size_t width = search::ElementSize(index.GetDataType());
+  if (knn->blob.empty() || knn->blob.size() % width != 0)
+    return "Parse error of vector parameters";
+  if (knn->blob.size() != index.GetDim() * width)
+    return absl::StrCat("Wrong vector index dimensions, got: ", knn->blob.size() / width,
+                        ", expected: ", index.GetDim());
+  return std::nullopt;
+}
+
 std::vector<std::pair<float, search::GlobalDocId>> SearchHnswWithPrefilter(
     const search::AstKnnNode* knn, const shared_ptr<search::HnswVectorIndex>& index,
     std::optional<std::vector<search::GlobalDocId>> prefilter_global_docs_ids) {
+  // Callers validate the blob width and surface an error (ValidateHnswKnnBlob). This guard is a
+  // release-safety net against OOB reads if a future call site forgets; DCHECK flags that misuse.
+  DCHECK_EQ(knn->blob.size(), index->GetDim() * search::ElementSize(index->GetDataType()));
+  if (knn->blob.size() != index->GetDim() * search::ElementSize(index->GetDataType()))
+    return {};
+
   if (!prefilter_global_docs_ids)
-    return index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime);
+    return index->Knn(knn->blob.data(), knn->limit, knn->ef_runtime);
 
   auto& ids = *prefilter_global_docs_ids;
   VLOG(1) << "Searching HNSW index with prefilter size: " << ids.size();
 
   if (ids.size() < absl::GetFlag(FLAGS_subset_knn_search_threshold))
-    return index->SubsetKnn(knn->vec.first.get(), knn->limit, ids);
+    return index->SubsetKnn(knn->blob.data(), knn->limit, ids);
 
   // HnswVectorIndex::Knn(... allowed) uses binary_search for membership.
   if (!is_sorted(ids.begin(), ids.end()))
     sort(ids.begin(), ids.end());
 
-  return index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime, ids);
+  return index->Knn(knn->blob.data(), knn->limit, knn->ef_runtime, ids);
 }
 
 vector<SearchResult> SearchGlobalHnswIndex(
@@ -1571,7 +1592,7 @@ vector<SearchResult> SearchGlobalHnswIndexRange(
   const ShardId shard_size = shard_set->size();
 
   auto range_results =
-      index->RangeQuery(range->vec.first.get(), static_cast<float>(range->radius), range->epsilon);
+      index->RangeQuery(range->blob.data(), static_cast<float>(range->radius), range->epsilon);
 
   std::vector<std::vector<SerializedSearchDoc>> shard_docs(shard_size);
   for (const auto& [score, global_doc_id] : range_results) {
@@ -1636,7 +1657,7 @@ vector<SearchResult> SearchGlobalHnswIndexRangePrefiltered(
         [](const SerializedSearchDoc& a, const SerializedSearchDoc& b) { return a.id < b.id; });
 
   auto range_results =
-      index->RangeQuery(range->vec.first.get(), static_cast<float>(range->radius), range->epsilon);
+      index->RangeQuery(range->blob.data(), static_cast<float>(range->radius), range->epsilon);
 
   std::vector<SerializedSearchDoc> out;
   out.reserve(range_results.size());
@@ -1693,7 +1714,8 @@ std::shared_ptr<search::HnswVectorIndex> GetValidatedHnswRangeIndex(
     builder->SendError(string{index_name} + ": no such global hnsw index");
     return nullptr;
   }
-  if (hnsw_range->vec.second == 0) {
+  const size_t width = search::ElementSize(hnsw_index->GetDataType());
+  if (hnsw_range->blob.empty() || hnsw_range->blob.size() % width != 0) {
     builder->SendError("Parse error of vector parameters");
     return nullptr;
   }
@@ -1707,9 +1729,10 @@ std::shared_ptr<search::HnswVectorIndex> GetValidatedHnswRangeIndex(
     builder->SendError("VECTOR_RANGE EPSILON must be greater than zero");
     return nullptr;
   }
-  if (hnsw_index->GetDim() != hnsw_range->vec.second) {
-    builder->SendError(absl::StrCat("Wrong vector index dimensions, got: ", hnsw_range->vec.second,
-                                    ", expected: ", hnsw_index->GetDim()));
+  if (hnsw_index->GetDim() * width != hnsw_range->blob.size()) {
+    builder->SendError(
+        absl::StrCat("Wrong vector index dimensions, got: ", hnsw_range->blob.size() / width,
+                     ", expected: ", hnsw_index->GetDim()));
     return nullptr;
   }
   return hnsw_index;
@@ -2097,21 +2120,18 @@ bool CollectGlobalScoringStats(string_view index_name, search::SearchAlgorithm& 
 
 std::optional<string> ValidateAndExtractHnswVector(const search::HnswVectorIndex& hnsw_index,
                                                    const HybridSearchParams& params,
-                                                   search::OwnedFtVector* out_vec) {
+                                                   std::string_view* out_blob) {
   auto vec_bytes = params.query_params[params.vsim_param];
   if (vec_bytes.empty())
     return absl::StrCat("Vector parameter not found: $", params.vsim_param);
 
-  auto vec = search::BytesToFtVectorSafe(vec_bytes);
-  if (!vec)
-    return absl::StrCat("Invalid vector bytes for parameter: $", params.vsim_param);
+  const size_t width = search::ElementSize(hnsw_index.GetDataType());
+  if (vec_bytes.size() != hnsw_index.GetDim() * width)
+    return absl::StrCat("Query vector blob size (", vec_bytes.size(),
+                        ") does not match index's expected size (", hnsw_index.GetDim() * width,
+                        ")");
 
-  if (vec->second != hnsw_index.GetDim())
-    return absl::StrCat("Query vector blob size (", vec->second * sizeof(float),
-                        ") does not match index's expected size (",
-                        hnsw_index.GetDim() * sizeof(float), ")");
-
-  *out_vec = std::move(*vec);
+  *out_blob = vec_bytes;
   return std::nullopt;
 }
 
@@ -2122,8 +2142,8 @@ std::optional<string> RunHnswPreSearch(string_view index_name, const HybridSearc
   if (!hnsw_index)
     return absl::StrCat("No HNSW index for field: ", params.vsim_field);
 
-  search::OwnedFtVector vec;
-  if (auto err = ValidateAndExtractHnswVector(*hnsw_index, params, &vec))
+  std::string_view blob;
+  if (auto err = ValidateAndExtractHnswVector(*hnsw_index, params, &blob))
     return err;
 
   auto populate = [&](const vector<pair<float, search::GlobalDocId>>& results) {
@@ -2137,9 +2157,9 @@ std::optional<string> RunHnswPreSearch(string_view index_name, const HybridSearc
   };
 
   if (params.use_range)
-    populate(hnsw_index->RangeQuery(vec.first.get(), params.range_radius, params.range_epsilon));
+    populate(hnsw_index->RangeQuery(blob.data(), params.range_radius, params.range_epsilon));
   else
-    populate(hnsw_index->Knn(vec.first.get(), params.num_candidates, params.ef_runtime));
+    populate(hnsw_index->Knn(blob.data(), params.num_candidates, params.ef_runtime));
   return std::nullopt;
 }
 
@@ -2152,8 +2172,8 @@ std::optional<string> RunHnswFilteredSearch(string_view index_name,
   if (!hnsw_index)
     return absl::StrCat("No HNSW index for field: ", params.vsim_field);
 
-  search::OwnedFtVector vec;
-  if (auto err = ValidateAndExtractHnswVector(*hnsw_index, params, &vec))
+  std::string_view blob;
+  if (auto err = ValidateAndExtractHnswVector(*hnsw_index, params, &blob))
     return err;
 
   vector<search::GlobalDocId> prefilter_ids;
@@ -2168,9 +2188,8 @@ std::optional<string> RunHnswFilteredSearch(string_view index_name,
 
   auto knn_results =
       prefilter_ids.size() < absl::GetFlag(FLAGS_subset_knn_search_threshold)
-          ? hnsw_index->SubsetKnn(vec.first.get(), params.num_candidates, prefilter_ids)
-          : hnsw_index->Knn(vec.first.get(), params.num_candidates, params.ef_runtime,
-                            prefilter_ids);
+          ? hnsw_index->SubsetKnn(blob.data(), params.num_candidates, prefilter_ids)
+          : hnsw_index->Knn(blob.data(), params.num_candidates, params.ef_runtime, prefilter_ids);
 
   for (const auto& [dist, global_id] : knn_results) {
     auto it = prefilter_map.find(global_id);
@@ -2363,8 +2382,8 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
       rb->SendError(absl::StrCat("No HNSW index for field: ", params->vsim_field));
       return false;
     }
-    search::OwnedFtVector vec_ignored;
-    if (auto err = ValidateAndExtractHnswVector(*hnsw_index, *params, &vec_ignored)) {
+    std::string_view blob_ignored;
+    if (auto err = ValidateAndExtractHnswVector(*hnsw_index, *params, &blob_ignored)) {
       rb->SendError(*err);
       return false;
     }
@@ -2397,7 +2416,7 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
   std::once_flag schema_validated;
   bool vsim_not_vector = false;
   bool vsim_dim_mismatch = false;
-  size_t vsim_query_dim = 0, vsim_index_dim = 0;
+  size_t vsim_query_dim = 0, vsim_index_dim = 0, vsim_width = sizeof(float);
   search::VectorSimilarity captured_metric = search::VectorSimilarity::L2;
 
   vector<SearchResult> text_docs(shard_count);
@@ -2426,10 +2445,11 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
       captured_metric = vp.sim;
       if (!use_hnsw) {
         auto vec_bytes = params->query_params[params->vsim_param];
-        if (!vec_bytes.empty() && vec_bytes.size() != vp.dim * sizeof(float)) {
+        vsim_width = search::ElementSize(vp.data_type);
+        if (!vec_bytes.empty() && vec_bytes.size() != vp.dim * vsim_width) {
           vsim_dim_mismatch = true;
           vsim_index_dim = vp.dim;
-          vsim_query_dim = vec_bytes.size() / sizeof(float);
+          vsim_query_dim = vec_bytes.size() / vsim_width;
         }
       }
     });
@@ -2480,9 +2500,9 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
     return false;
   }
   if (vsim_dim_mismatch) {
-    rb->SendError(absl::StrCat("Query vector blob size (", vsim_query_dim * sizeof(float),
+    rb->SendError(absl::StrCat("Query vector blob size (", vsim_query_dim * vsim_width,
                                ") does not match index's expected size (",
-                               vsim_index_dim * sizeof(float), ")"));
+                               vsim_index_dim * vsim_width, ")"));
     return false;
   }
 
@@ -3186,6 +3206,11 @@ void CmdFtSearch(CmdArgParser parser, CommandContext* cmd_cntx) {
         cmd_cntx->tx()->Conclude();
       return builder->SendError(string{index_name} + ": no such global hnsw index");
     }
+    if (auto err = ValidateHnswKnnBlob(knn, *hnsw_index)) {
+      if (knn_has_prefilter)
+        cmd_cntx->tx()->Conclude();
+      return builder->SendError(*err);
+    }
     if (knn_has_prefilter) {
       docs = SearchGlobalHnswIndex(knn, hnsw_index, index_name, search_algo.GetKnnScoreSortOption(),
                                    knn_prefilter_docs, *params, *cmd_cntx);
@@ -3395,6 +3420,8 @@ void CmdFtProfile(CmdArgParser parser, CommandContext* cmd_cntx) {
     auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(index_name, profile_knn->field);
     if (!hnsw_index)
       return rb->SendError(std::string{index_name} + ": no such global hnsw index");
+    if (auto err = ValidateHnswKnnBlob(profile_knn, *hnsw_index))
+      return rb->SendError(*err);
 
     std::vector<SearchResult> search_results(shards_count);
     std::vector<SearchResult> profile_search_results(shards_count);
@@ -3744,6 +3771,18 @@ static bool AggregateHnswKnn(CommandContext* cmd_cntx, AggregateParams& params,
     return false;
   }
 
+  const size_t hnsw_width = search::ElementSize(hnsw_index->GetDataType());
+  if (knn->blob.empty() || knn->blob.size() % hnsw_width != 0) {
+    cmd_cntx->rb()->SendError("Parse error of vector parameters");
+    return false;
+  }
+  if (knn->blob.size() != hnsw_index->GetDim() * hnsw_width) {
+    cmd_cntx->rb()->SendError(
+        absl::StrCat("Wrong vector index dimensions, got: ", knn->blob.size() / hnsw_width,
+                     ", expected: ", hnsw_index->GetDim()));
+    return false;
+  }
+
   const bool has_prefilter = knn->HasPreFilter();
   std::vector<absl::flat_hash_map<search::DocId, float>> text_scores(shard_set->size());
   std::optional<std::vector<search::GlobalDocId>> prefilter_ids;
@@ -3751,9 +3790,8 @@ static bool AggregateHnswKnn(CommandContext* cmd_cntx, AggregateParams& params,
     prefilter_ids = RunAggregatePrefilter(cmd_cntx, params, search_algo, text_scores);
 
   auto knn_results =
-      prefilter_ids
-          ? hnsw_index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime, *prefilter_ids)
-          : hnsw_index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime);
+      prefilter_ids ? hnsw_index->Knn(knn->blob.data(), knn->limit, knn->ef_runtime, *prefilter_ids)
+                    : hnsw_index->Knn(knn->blob.data(), knn->limit, knn->ef_runtime);
   auto shard_docs = GroupByShardId(knn_results, shard_set->size());
   RunHnswAggregateLoad(cmd_cntx, params, query_results, shard_docs, knn->score_alias, text_scores,
                        has_prefilter);
@@ -3795,7 +3833,7 @@ static bool AggregateHnswRange(CommandContext* cmd_cntx, AggregateParams& params
   // Intersect the range hits with the filter matches: keep only range results whose global id is
   // in the sorted prefilter id set. Memory is O(filter matches) of ids plus O(range hits).
   auto range_results = hnsw_index->RangeQuery(
-      hnsw_range->vec.first.get(), static_cast<float>(hnsw_range->radius), hnsw_range->epsilon);
+      hnsw_range->blob.data(), static_cast<float>(hnsw_range->radius), hnsw_range->epsilon);
   if (prefilter_ids) {
     erase_if(range_results, [&](const auto& r) {
       return !std::binary_search(prefilter_ids->begin(), prefilter_ids->end(), r.second);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1317,6 +1317,278 @@ TEST_F(SearchFamilyTest, HashKnnReturnsImplicitVectorScore) {
   EXPECT_THAT(resp, MatchEntry("d:a", "__v_score", "0", "v", va));
 }
 
+TEST_F(SearchFamilyTest, HashKnnInt8) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "FLAT", "6",
+       "TYPE", "INT8", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto Int8Vec = [](std::initializer_list<int> vals) {
+    string s;
+    for (int v : vals)
+      s.push_back(static_cast<char>(static_cast<int8_t>(v)));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", Int8Vec({1, 2, 3})});
+  Run({"HSET", "d:b", "v", Int8Vec({40, 50, 60})});
+
+  const string q = Int8Vec({1, 2, 3});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, HashKnnFloat64) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "FLAT", "6",
+       "TYPE", "FLOAT64", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto F64 = [](std::initializer_list<double> vals) {
+    string s;
+    for (double v : vals)
+      s.append(reinterpret_cast<const char*>(&v), sizeof(v));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", F64({1.5, 2.5, 3.5})});
+  Run({"HSET", "d:b", "v", F64({-1.0, -2.0, -3.0})});
+
+  const string q = F64({1.5, 2.5, 3.5});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, HashKnnFloat16) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "FLAT", "6",
+       "TYPE", "FLOAT16", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto F16 = [](std::initializer_list<uint16_t> vals) {
+    string s;
+    for (uint16_t v : vals)
+      s.append(reinterpret_cast<const char*>(&v), sizeof(v));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", F16({0x3C00, 0x4000, 0x4200})});  // 1, 2, 3
+  Run({"HSET", "d:b", "v", F16({0x4400, 0x4500, 0x4600})});  // 4, 5, 6
+
+  const string q = F16({0x3C00, 0x4000, 0x4200});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, HnswKnnInt8) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "HNSW", "6",
+       "TYPE", "INT8", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto Int8Vec = [](std::initializer_list<int> vals) {
+    string s;
+    for (int v : vals)
+      s.push_back(static_cast<char>(static_cast<int8_t>(v)));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", Int8Vec({1, 2, 3})});
+  Run({"HSET", "d:b", "v", Int8Vec({40, 50, 60})});
+
+  const string q = Int8Vec({1, 2, 3});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, HnswKnnFloat16) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "HNSW", "6",
+       "TYPE", "FLOAT16", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto F16 = [](std::initializer_list<uint16_t> vals) {
+    string s;
+    for (uint16_t v : vals)
+      s.append(reinterpret_cast<const char*>(&v), sizeof(v));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", F16({0x3C00, 0x4000, 0x4200})});
+  Run({"HSET", "d:b", "v", F16({0x4400, 0x4500, 0x4600})});
+
+  const string q = F16({0x3C00, 0x4000, 0x4200});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, JsonKnnInt8) {
+  Run({"FT.CREATE", "idx",  "ON",  "JSON", "PREFIX",          "1",    "d:",
+       "SCHEMA",    "$.v",  "AS",  "v",    "VECTOR",          "FLAT", "6",
+       "TYPE",      "INT8", "DIM", "3",    "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  Run({"JSON.SET", "d:a", "$", R"({"v":[1,2,3]})"});
+  Run({"JSON.SET", "d:b", "$", R"({"v":[40,50,60]})"});
+
+  auto Int8Vec = [](std::initializer_list<int> vals) {
+    string s;
+    for (int v : vals)
+      s.push_back(static_cast<char>(static_cast<int8_t>(v)));
+    return s;
+  };
+  const string q = Int8Vec({1, 2, 3});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, JsonKnnFloat16) {
+  Run({"FT.CREATE", "idx",     "ON",  "JSON", "PREFIX",          "1",    "d:",
+       "SCHEMA",    "$.v",     "AS",  "v",    "VECTOR",          "FLAT", "6",
+       "TYPE",      "FLOAT16", "DIM", "3",    "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  Run({"JSON.SET", "d:a", "$", R"({"v":[1,2,3]})"});
+  Run({"JSON.SET", "d:b", "$", R"({"v":[4,5,6]})"});
+
+  auto F16 = [](std::initializer_list<uint16_t> vals) {
+    string s;
+    for (uint16_t v : vals)
+      s.append(reinterpret_cast<const char*>(&v), sizeof(v));
+    return s;
+  };
+  const string q = F16({0x3C00, 0x4000, 0x4200});  // 1, 2, 3
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, HnswKnnWrongDimReturnsError) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "HNSW", "6",
+       "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto F32 = [](std::initializer_list<float> vals) {
+    string s;
+    for (float v : vals)
+      s.append(reinterpret_cast<const char*>(&v), sizeof(v));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", F32({1, 2, 3})});
+
+  // Query blob carries 2 elements, index expects 3 -> explicit error, not a silent empty result.
+  const string q = F32({1, 2});
+  auto resp =
+      Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "PARAMS", "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, ErrArg("Wrong vector index dimensions"));
+}
+
+TEST_F(SearchFamilyTest, HnswKnnNonMultipleBlobReturnsError) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "HNSW", "6",
+       "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  // Blob size (5 bytes) is not a whole number of float32 elements -> parse error, and the reported
+  // dimension must not be a truncated size / width.
+  const string q = "abcde";
+  auto resp =
+      Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "PARAMS", "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, ErrArg("Parse error of vector parameters"));
+}
+
+TEST_F(SearchFamilyTest, JsonKnnInt8OutOfRange) {
+  Run({"FT.CREATE", "idx",  "ON",  "JSON", "PREFIX",          "1",    "d:",
+       "SCHEMA",    "$.v",  "AS",  "v",    "VECTOR",          "FLAT", "6",
+       "TYPE",      "INT8", "DIM", "3",    "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  Run({"JSON.SET", "d:ok", "$", R"({"v":[1,2,3]})"});
+  Run({"JSON.SET", "d:round", "$", R"({"v":[1,2,3.4]})"});  // 3.4 rounds to 3
+  Run({"JSON.SET", "d:hi", "$", R"({"v":[1,2,999]})"});     // out of int8 range -> doc skipped
+  Run({"JSON.SET", "d:lo", "$", R"({"v":[1,2,-200]})"});    // out of int8 range -> doc skipped
+
+  // Only the two in-range docs are indexed; the out-of-range ones are dropped (not wrapped).
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "*"}), AreDocIds("d:ok", "d:round"));
+
+  // 3.4 rounded to 3, so d:round matches the [1,2,3] query exactly (distance 0).
+  Run({"JSON.DEL", "d:ok"});
+  auto Int8Vec = [](std::initializer_list<int> vals) {
+    string s;
+    for (int v : vals)
+      s.push_back(static_cast<char>(static_cast<int8_t>(v)));
+    return s;
+  };
+  const string q = Int8Vec({1, 2, 3});
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:round", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, HnswKnnFloat64LargeDim) {
+  // dim*8 = 2048 bytes exceeds the listpack threshold -> borrowed keyspace storage, whose sds
+  // data pointer is unaligned. Exercises the memcpy-based FLOAT64 reader (would trip
+  // -fsanitize=alignment before the byte-safe-load fix).
+  const int kDim = 256;
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "HNSW", "6",
+       "TYPE", "FLOAT64", "DIM", absl::StrCat(kDim), "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  auto F64 = [](double fill, int dim) {
+    string s;
+    for (int i = 0; i < dim; i++)
+      s.append(reinterpret_cast<const char*>(&fill), sizeof(fill));
+    return s;
+  };
+  Run({"HSET", "d:a", "v", F64(1.0, kDim)});
+  Run({"HSET", "d:b", "v", F64(5.0, kDim)});
+
+  const string q = F64(1.0, kDim);
+  auto resp = Run({"FT.SEARCH", "idx", "*=>[KNN 1 @v $q AS dist]", "RETURN", "1", "dist", "PARAMS",
+                   "2", "q", q, "DIALECT", "2"});
+  EXPECT_THAT(resp, MatchEntry("d:a", "dist", "0"));
+}
+
+TEST_F(SearchFamilyTest, VectorUnknownTypeRejected) {
+  // A non-standard TYPE is rejected on a normal FT.CREATE (the replay-only coerce does not apply).
+  for (string_view bogus : {"BOGUS", "FP32", "FLOAT8", ""}) {
+    EXPECT_THAT(Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "v", "VECTOR", "FLAT", "6", "TYPE",
+                     bogus, "DIM", "3", "DISTANCE_METRIC", "L2"}),
+                ErrArg("Parse error of vector parameters"))
+        << "TYPE=" << bogus;
+  }
+}
+
+TEST_F(SearchFamilyTest, HnswVectorRangeInt8) {
+  // VECTOR_RANGE on a non-float dtype: exercises the width-aware range validation/decode seam.
+  auto Int8Bytes = [](int v) { return string(1, static_cast<char>(static_cast<int8_t>(v))); };
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "INT8",
+       "DIM", "1", "DISTANCE_METRIC", "L2"});
+  for (int i = 0; i < 10; i++)
+    Run({"HSET", absl::StrFormat("k%d", i), "pos", Int8Bytes(i)});
+
+  const string q = Int8Bytes(5);
+  auto resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $vec]=>{$YIELD_DISTANCE_AS: dist}",
+                   "PARAMS", "2", "vec", q, "LIMIT", "0", "10"});
+  EXPECT_THAT(resp, AreDocIds("k4", "k5", "k6"));
+}
+
+TEST_F(SearchFamilyTest, FtHybridInt8) {
+  // FT.HYBRID has its own vector-width validation, separate from the plain KNN path.
+  auto Int8Vec = [](std::initializer_list<int> vals) {
+    string s;
+    for (int v : vals)
+      s.push_back(static_cast<char>(static_cast<int8_t>(v)));
+    return s;
+  };
+  EXPECT_EQ(Run({"FT.CREATE", "vidx", "ON", "HASH", "SCHEMA", "t", "TEXT", "v", "VECTOR", "FLAT",
+                 "6", "TYPE", "INT8", "DIM", "3", "DISTANCE_METRIC", "L2"}),
+            "OK");
+  Run({"HSET", "d:a", "t", "hello world", "v", Int8Vec({1, 2, 3})});
+  Run({"HSET", "d:b", "t", "hello there", "v", Int8Vec({40, 50, 60})});
+
+  auto resp = Run({"FT.HYBRID", "vidx", "SEARCH", "hello", "VSIM", "@v", "$b", "KNN", "5", "PARAMS",
+                   "2", "b", Int8Vec({1, 2, 3})});
+  ASSERT_HYBRID_RESP(resp);
+  EXPECT_EQ(HybridTotal(resp), 2);
+  EXPECT_THAT(HybridKeys(resp), UnorderedElementsAre("d:a", "d:b"));
+}
+
 TEST_F(SearchFamilyTest, HashHnswKnnReturnsImplicitVectorScore) {
   Run({"FT.CREATE", "idx",  "ON", "HASH", "PREFIX",  "1",   "d:", "SCHEMA",          "v",
        "VECTOR",    "HNSW", "8",  "TYPE", "FLOAT32", "DIM", "3",  "DISTANCE_METRIC", "L2",
@@ -1833,16 +2105,6 @@ TEST_F(SearchFamilyTest, AggregateLoad) {
   resp = Run({"ft.aggregate", "index", "*", "GROUPBY", "1", "@word", "REDUCE", "SUM", "1", "@foo",
               "AS", "foo_total", "LOAD", "1", "foo_total"});
   EXPECT_THAT(resp, ErrArg("LOAD cannot be applied after projectors or reducers"));
-}
-
-TEST_F(SearchFamilyTest, VectorUnknownTypeRejected) {
-  // A non-standard TYPE is rejected on a normal FT.CREATE (the replay-only coerce does not apply).
-  for (string_view bogus : {"BOGUS", "FP32", "FLOAT8", ""}) {
-    EXPECT_THAT(Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "v", "VECTOR", "FLAT", "6", "TYPE",
-                     bogus, "DIM", "3", "DISTANCE_METRIC", "L2"}),
-                ErrArg("Parse error of vector parameters"))
-        << "TYPE=" << bogus;
-  }
 }
 
 TEST_F(SearchFamilyTest, Vector) {
@@ -6840,6 +7102,18 @@ TEST_F(SearchFamilyTest, SearchOnIndexWithHugeVectorDim) {
 
   // Index must not be registered — FT.SEARCH must report "no such index".
   resp = Run({"FT.SEARCH", "idx", "hello"});
+  EXPECT_THAT(resp, ErrArg("idx: no such index"));
+}
+
+// The allocation guard must account for the element width, not a fixed float32 layout.
+// dim=1000 / capacity=1e6 slips under the old "capacity * (dim+1) floats" bound, yet allocates
+// ~8 GiB as FLOAT64 — which used to throw std::bad_alloc and leave a broken ShardDocIndex.
+TEST_F(SearchFamilyTest, FlatWideDtypeAllocationGuard) {
+  auto resp = Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "v", "VECTOR", "FLAT", "8", "TYPE",
+                   "FLOAT64", "DIM", "1000", "INITIAL_CAP", "1000000", "DISTANCE_METRIC", "L2"});
+  EXPECT_THAT(resp, ErrArg("Vector index initial allocation is too large"));
+
+  resp = Run({"FT.SEARCH", "idx", "*"});
   EXPECT_THAT(resp, ErrArg("idx: no such index"));
 }
 


### PR DESCRIPTION
Builds on #7839. Stores and queries vector fields at their declared native width (FLOAT32/FLOAT64/FLOAT16/BFLOAT16/INT8/UINT8) end-to-end across FLAT and HNSW, on both HASH and JSON storage.

Changes:
- Query vector is now a raw byte blob on the AST, decoded per-dtype at search time (the parser is schema-agnostic and cannot know the element width).
- OwnedFtVector holds native-width bytes; GetVector takes the field dtype.
- FLAT index stores native-width vectors with a presence bitmap.
- HNSW space uses one typed distance kernel; data size and the deleted-node stub (native-encoded 1.0) follow the dtype.
- HASH borrows client bytes as-is (width-validated); JSON quantizes each number to the native width (round-to-nearest-even; int types reject out-of-range).
- All KNN/RANGE/HYBRID/AGGREGATE paths validate dim via blob_size / width.

Tests: +13 dtype integration tests (HASH/HNSW/JSON x INT8/FP16/FP64, wrong-dim, out-of-range, vector-range, hybrid) and +2 kernel tests. FLOAT32 path unchanged.