### PR TITLE
fix(core): Fix segment dangle

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -462,14 +462,40 @@ class DashTable<_Key, _Value, Policy>::Iterator {
   uint8_t slot_id_;
   bool done_;
 
+  // For single bucket iterators we pin the segment to its pointer. Because the iterators are held
+  // across suspension points during concurrent modifications, growing the dashtable will displace
+  // the seg_id_ pointing it to a different bucket.
+  using PinnedType = std::conditional_t<IsSingleBucket, SegmentType*, std::nullptr_t>;
+  PinnedType pinned_seg_ = {};
+
   friend class DashTable;
+
+  // Resolves the segment backing this iterator. Single-bucket iterators use the pinned pointer;
+  // multi-bucket iterators always read the live directory entry.
+  SegmentType* GetSegment() const {
+    if constexpr (IsSingleBucket) {
+      return pinned_seg_;
+    } else {
+      return owner_->segment_[seg_id_];
+    }
+  }
+
+  // Pins the segment pointer from the current directory index (single-bucket iterators only).
+  void PinSegment() {
+    if constexpr (IsSingleBucket) {
+      pinned_seg_ =
+          (owner_ && seg_id_ < owner_->segment_.size()) ? owner_->segment_[seg_id_] : nullptr;
+    }
+  }
 
   Iterator(Owner* me, uint32_t seg_id, detail::PhysicalBid bid, uint8_t sid)
       : owner_(me), seg_id_(seg_id), bucket_id_(bid), slot_id_(sid), done_(false) {
+    PinSegment();
   }
 
   Iterator(Owner* me, uint32_t seg_id, detail::PhysicalBid bid)
       : owner_(me), seg_id_(seg_id), bucket_id_(bid), slot_id_(0), done_(false) {
+    PinSegment();
     Seek2Occupied();
   }
 
@@ -489,6 +515,7 @@ class DashTable<_Key, _Value, Policy>::Iterator {
         bucket_id_(other.bucket_id_),
         slot_id_(other.slot_id_),
         done_(other.done_) {
+    PinSegment();
   }
 
   // Copy constructor from iterator to bucket_iterator and vice versa.
@@ -499,6 +526,7 @@ class DashTable<_Key, _Value, Policy>::Iterator {
         bucket_id_(other.bucket_id_),
         slot_id_(IsSingleBucket ? 0 : other.slot_id_),
         done_(other.done_) {
+    PinSegment();
     // if this - is a bucket_iterator - we reset slot_id to the first occupied space.
     if constexpr (IsSingleBucket) {
       Seek2Occupied();
@@ -515,20 +543,21 @@ class DashTable<_Key, _Value, Policy>::Iterator {
   Iterator& operator=(const Iterator& other) = default;
   Iterator& operator=(Iterator&& other) = default;
 
-  // pre
-  Iterator& operator++() {
+  // Advancing is restricted to single-bucket iterators. A multi-bucket iterator may easily be
+  // invalidated across suspension points, so the cursors and the Traverse function should be used
+  Iterator& operator++() requires IsSingleBucket {
     ++slot_id_;
     Seek2Occupied();
     return *this;
   }
 
-  Iterator& operator+=(int delta) {
+  Iterator& operator+=(int delta) requires IsSingleBucket {
     slot_id_ += delta;
     Seek2Occupied();
     return *this;
   }
 
-  Iterator& AdvanceIfNotOccupied() {
+  Iterator& AdvanceIfNotOccupied() requires IsSingleBucket {
     if (!IsOccupied()) {
       this->operator++();
     }
@@ -536,7 +565,7 @@ class DashTable<_Key, _Value, Policy>::Iterator {
   }
 
   IteratorPairType operator->() const {
-    auto* seg = owner_->segment_[seg_id_];
+    auto* seg = GetSegment();
     return {seg->Key(bucket_id_, slot_id_), seg->Value(bucket_id_, slot_id_)};
   }
 
@@ -546,8 +575,12 @@ class DashTable<_Key, _Value, Policy>::Iterator {
   }
 
   bool IsOccupied() const {
-    return (seg_id_ < owner_->segment_.size()) &&
-           ((owner_->segment_[seg_id_]->IsBusy(bucket_id_, slot_id_)));
+    if constexpr (IsSingleBucket) {
+      return pinned_seg_ && pinned_seg_->IsBusy(bucket_id_, slot_id_);
+    } else {
+      return (seg_id_ < owner_->segment_.size()) &&
+             ((owner_->segment_[seg_id_]->IsBusy(bucket_id_, slot_id_)));
+    }
   }
 
   Owner& owner() const {
@@ -558,12 +591,12 @@ class DashTable<_Key, _Value, Policy>::Iterator {
   requires B uint64_t GetVersion()
   const {
     assert(owner_ && seg_id_ < owner_->segment_.size());
-    return owner_->segment_[seg_id_]->GetVersion(bucket_id_);
+    return GetSegment()->GetVersion(bucket_id_);
   }
 
   template <bool B = Policy::kUseVersion>
   requires B void SetVersion(uint64_t v) {
-    return owner_->segment_[seg_id_]->SetVersion(bucket_id_, v);
+    return GetSegment()->SetVersion(bucket_id_, v);
   }
 
   friend bool operator==(const Iterator& lhs, const Iterator& rhs) {
@@ -594,7 +627,7 @@ class DashTable<_Key, _Value, Policy>::Iterator {
   // segment splits are blocked while a snapshot version is registered).
   uintptr_t bucket_address() const {
     assert(owner_ && seg_id_ < owner_->segment_.size());
-    return reinterpret_cast<uintptr_t>(&owner_->segment_[seg_id_]->GetBucket(bucket_id_));
+    return reinterpret_cast<uintptr_t>(&GetSegment()->GetBucket(bucket_id_));
   }
 
   unsigned slot_id() const {
@@ -666,7 +699,7 @@ void DashTable<_Key, _Value, Policy>::Iterator<IsConst, IsSingleBucket>::Seek2Oc
   assert(seg_id_ < owner_->segment_.size());
 
   if constexpr (IsSingleBucket) {
-    const auto& b = owner_->segment_[seg_id_]->GetBucket(bucket_id_);
+    const auto& b = GetSegment()->GetBucket(bucket_id_);
     uint32_t mask = b.GetBusy() >> slot_id_;
     if (mask) {
       int slot = __builtin_ctz(mask);

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -1445,12 +1445,15 @@ TEST_F(DashTest, Version) {
   }
 
   unsigned items = 0;
-  for (auto it = dt.begin(); it != dt.end(); ++it) {
-    ASSERT_FALSE(it.is_done());
-    ASSERT_GE(it.GetVersion(), it->first + 65000)
-        << it.segment_id() << " " << it.bucket_id() << " " << it.slot_id();
-    ++items;
-  }
+  VersionDT::Cursor cursor;
+  do {
+    cursor = dt.Traverse(cursor, [&](VersionDT::iterator it) {
+      ASSERT_FALSE(it.is_done());
+      ASSERT_GE(it.GetVersion(), it->first + 65000)
+          << it.segment_id() << " " << it.bucket_id() << " " << it.slot_id();
+      ++items;
+    });
+  } while (cursor);
   ASSERT_EQ(kNum, items);
 }
 

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -142,7 +142,7 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
 
   void RecordSerialized(std::string key) {
     // Simulate occasional yields due to big value flushes
-    while (absl::Bernoulli(bg_, 0.3)) {
+    while (absl::Bernoulli(bg_, 0.4)) {
       for (unsigned it = absl::Uniform(bg_, 1, 10); it > 0; it--)
         util::ThisFiber::Yield();
     }
@@ -348,7 +348,7 @@ TEST_F(SerializerBaseTest, IncreasingLists) {
   // Select keys in range [0, 2 * kKeys] to have a balance of new and existing keys
   std::atomic_bool running = true;
   std::vector<util::fb2::Fiber> workers;
-  for (size_t w = 0; w < 3; w++) {
+  for (size_t w = 0; w < 5; w++) {
     auto worker = pp_->at(w % pp_->size())->LaunchFiber([&, w] {
       std::string id = absl::StrCat("w", w);
       absl::InsecureBitGen bg;


### PR DESCRIPTION
With out changes in serialization code, bucket modifications can now happen concurrently. Previously, the single mutex introduced a thread-global linear ordering. When modifications happen concurrently, the dash table can grow, "invalidating" all suspended bucket iterators held by the serialization process. 

The solution is to use segment pointers instead of the segment ids, so when the table grows we still point to the last segment

Fixes #7795