### PR TITLE
feat: add new size format for OAHPair

### DIFF
--- a/src/core/oah_base.h
+++ b/src/core/oah_base.h
@@ -67,12 +67,6 @@ inline uint32_t FieldSize(size_t size) {
                                     : kLargeFieldSize;
 }
 
-inline uint32_t FieldSizeFromControl(uint8_t control) {
-  return (control & kBigSizeBit) == 0 ? kInlineFieldSize
-         : control & kThreeBytesBit   ? kLargeFieldSize
-                                      : kMediumFieldSize;
-}
-
 inline void Write(size_t size, uint32_t field_size, char* dest) {
   assert(field_size == FieldSize(size));
   uint8_t control;
@@ -104,15 +98,6 @@ inline Decoded Read(const char* src) {
   }
   const uint32_t size = (control & kLowSizeMask) | (extra << kLowSizeBits);
   return {size, three_bytes ? kLargeFieldSize : kMediumFieldSize};
-}
-
-inline uint32_t ReadLarge(const char* src) {
-  const uint8_t control = static_cast<uint8_t>(src[0]);
-  assert(FieldSizeFromControl(control) == kLargeFieldSize);
-  uint32_t extra = static_cast<uint8_t>(src[1]);
-  extra |= static_cast<uint32_t>(static_cast<uint8_t>(src[2])) << 8;
-  extra |= static_cast<uint32_t>(static_cast<uint8_t>(src[3])) << 16;
-  return (control & kLowSizeMask) | (extra << kLowSizeBits);
 }
 
 }  // namespace size

--- a/src/core/oah_base.h
+++ b/src/core/oah_base.h
@@ -1,0 +1,120 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+namespace dfly {
+
+// Shared building blocks for the open-addressing hash containers (OAHEntry/OAHPair/OAHTable).
+namespace oah {
+
+// A uint64_t that packs a heap pointer together with tag/flag bits in its unused low/high bits.
+using TaggedPtr = uint64_t;
+
+// Pointer tags shared by OAHEntry and OAHPair. Bit 0 is reserved for OAHPtr's vector tag, bit 1
+// marks an expiry field, and bits 52-63 hold the cached hash. All three low bits are masked when
+// recovering the allocation pointer so an entry type can use bit 2 for its own metadata.
+inline constexpr size_t kVectorBit = 1ULL << 0;
+inline constexpr size_t kExpiryBit = 1ULL << 1;
+inline constexpr size_t kExtHashShift = 52;
+inline constexpr uint32_t kExtHashSize = 12;
+inline constexpr size_t kExtHashMask = 0xFFFULL;
+inline constexpr size_t kExtHashShiftedMask = kExtHashMask << kExtHashShift;
+inline constexpr size_t kLowTagMask = 7;
+inline constexpr size_t kTagMask = kExtHashShiftedMask | kLowTagMask;
+
+inline void PrefetchRead(const void* ptr) noexcept {
+  __builtin_prefetch(ptr, 0, 1);
+}
+
+// Variable-width size field shared by OAHEntry and OAHPair.
+//
+// Control-byte layout:
+//   bit 7    : reserved ASCII/raw encoding flag (currently always 0)
+//   bit 6    : kBigSizeBit    - size doesn't fit in 6 bits, extra bytes follow
+//   bit 5    : kThreeBytesBit - when kBigSizeBit is set: 3 extra bytes (otherwise 1)
+//   bits 0-5 : inline size (< 64B); or bits 0-4 hold the low 5 bits of a larger size
+namespace size {
+
+inline constexpr uint8_t kEncodingBit = 1u << 7;
+inline constexpr uint8_t kBigSizeBit = 1u << 6;
+inline constexpr uint8_t kThreeBytesBit = 1u << 5;
+inline constexpr uint8_t kInlineSizeMask = 0x3F;
+inline constexpr uint8_t kLowSizeMask = 0x1F;
+inline constexpr uint32_t kLowSizeBits = 5;
+inline constexpr uint32_t kInlineSizeMax = kInlineSizeMask;
+inline constexpr uint32_t kOneExtraByteMax = (1u << 13) - 1;
+inline constexpr uint32_t kMaxSize = (1u << 29) - 1;
+
+inline constexpr uint32_t kInlineFieldSize = 1;
+inline constexpr uint32_t kMediumFieldSize = 2;
+inline constexpr uint32_t kLargeFieldSize = 4;
+
+struct Decoded {
+  uint32_t size;
+  uint32_t field_size;
+};
+
+inline uint32_t FieldSize(size_t size) {
+  assert(size <= kMaxSize);
+  return size <= kInlineSizeMax     ? kInlineFieldSize
+         : size <= kOneExtraByteMax ? kMediumFieldSize
+                                    : kLargeFieldSize;
+}
+
+inline uint32_t FieldSizeFromControl(uint8_t control) {
+  return (control & kBigSizeBit) == 0 ? kInlineFieldSize
+         : control & kThreeBytesBit   ? kLargeFieldSize
+                                      : kMediumFieldSize;
+}
+
+inline void Write(size_t size, uint32_t field_size, char* dest) {
+  assert(field_size == FieldSize(size));
+  uint8_t control;
+  if (field_size == kInlineFieldSize) {
+    control = static_cast<uint8_t>(size);
+  } else if (field_size == kMediumFieldSize) {
+    control = static_cast<uint8_t>(kBigSizeBit | (size & kLowSizeMask));
+  } else {
+    control = static_cast<uint8_t>(kBigSizeBit | kThreeBytesBit | (size & kLowSizeMask));
+  }
+
+  *dest++ = static_cast<char>(control);
+  size_t extra = size >> kLowSizeBits;
+  for (uint32_t i = 1; i < field_size; ++i, extra >>= 8) {
+    *dest++ = static_cast<char>(extra & 0xFF);
+  }
+}
+
+inline Decoded Read(const char* src) {
+  const uint8_t control = static_cast<uint8_t>(*src);
+  if ((control & kBigSizeBit) == 0)
+    return {static_cast<uint32_t>(control & kInlineSizeMask), kInlineFieldSize};
+
+  const bool three_bytes = control & kThreeBytesBit;
+  uint32_t extra = static_cast<uint8_t>(src[1]);
+  if (three_bytes) {
+    extra |= static_cast<uint32_t>(static_cast<uint8_t>(src[2])) << 8;
+    extra |= static_cast<uint32_t>(static_cast<uint8_t>(src[3])) << 16;
+  }
+  const uint32_t size = (control & kLowSizeMask) | (extra << kLowSizeBits);
+  return {size, three_bytes ? kLargeFieldSize : kMediumFieldSize};
+}
+
+inline uint32_t ReadLarge(const char* src) {
+  const uint8_t control = static_cast<uint8_t>(src[0]);
+  assert(FieldSizeFromControl(control) == kLargeFieldSize);
+  uint32_t extra = static_cast<uint8_t>(src[1]);
+  extra |= static_cast<uint32_t>(static_cast<uint8_t>(src[2])) << 8;
+  extra |= static_cast<uint32_t>(static_cast<uint8_t>(src[3])) << 16;
+  return (control & kLowSizeMask) | (extra << kLowSizeBits);
+}
+
+}  // namespace size
+}  // namespace oah
+}  // namespace dfly

--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -4,29 +4,20 @@
 
 #include "core/oah_entry.h"
 
+#include "base/logging.h"
 #include "core/page_usage/page_usage_stats.h"
 
 namespace dfly {
 
-OAHEntry::TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
-  const uint32_t key_size = key.size();
-  assert(key_size <= kMaxKeySize);
-  uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
+using namespace oah;
 
-  uint8_t control;
-  uint32_t size_field_len;  // control byte + trailing extra size bytes
-  if (key_size <= kInlineSizeMax) {
-    control = static_cast<uint8_t>(key_size);
-    size_field_len = 1;
-  } else if (key_size <= kOneExtraByteMax) {
-    control = static_cast<uint8_t>(kBigSizeBit | (key_size & kLowSizeMask));
-    size_field_len = 2;
-  } else {
-    control = static_cast<uint8_t>(kBigSizeBit | kThreeBytesBit | (key_size & kLowSizeMask));
-    size_field_len = 4;
-  }
+TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
+  const size_t key_size = key.size();
+  assert(key_size <= size::kMaxSize);
+  const uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
+  const uint32_t key_size_field = size::FieldSize(key_size);
 
-  auto* blob = (char*)zmalloc(expiry_size + size_field_len + key_size);
+  auto* blob = (char*)zmalloc(expiry_size + key_size_field + key_size);
   TaggedPtr tagged_ptr = reinterpret_cast<TaggedPtr>(blob);
   if (expiry_size) {
     tagged_ptr |= kExpiryBit;
@@ -34,9 +25,9 @@ OAHEntry::TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
   }
 
   char* p = blob + expiry_size;
-  *p++ = static_cast<char>(control);
-  for (uint32_t extra = key_size >> kLowSizeBits, i = 1; i < size_field_len; ++i, extra >>= 8)
-    *p++ = static_cast<char>(extra & 0xFF);
+  size::Write(key_size, key_size_field, p);
+  p += key_size_field;
+  DCHECK(key.data());  // args are never null, even when empty (see CmdArgParser::SafeSV)
   std::memcpy(p, key.data(), key_size);
   return tagged_ptr;
 }
@@ -83,7 +74,7 @@ void OAHEntry::ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* all
   }
 }
 
-ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+int64_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   *realloced = false;
   if (Empty())
     return 0;
@@ -93,20 +84,7 @@ ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   const size_t old_alloc = AllocSize();
   Rebuild(HasExpiry() ? GetExpiry() : UINT32_MAX);
   *realloced = true;
-  return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
-}
-
-std::string_view OAHEntry::KeyBig(const char* p, uint8_t control) const {
-  uint32_t size = control & kLowSizeMask;
-  uint32_t extra = static_cast<uint8_t>(p[1]);
-  const char* key = p + 2;  // control byte + 1 extra size byte
-  if (control & kThreeBytesBit) {
-    extra |= static_cast<uint32_t>(static_cast<uint8_t>(p[2])) << 8;
-    extra |= static_cast<uint32_t>(static_cast<uint8_t>(p[3])) << 16;
-    key = p + 4;  // control byte + 3 extra size bytes
-  }
-  size |= extra << kLowSizeBits;
-  return {key, size};
+  return static_cast<int64_t>(AllocSize()) - static_cast<int64_t>(old_alloc);
 }
 
 }  // namespace dfly

--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -74,7 +74,7 @@ void OAHEntry::ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* all
   }
 }
 
-int64_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   *realloced = false;
   if (Empty())
     return 0;
@@ -84,7 +84,7 @@ int64_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   const size_t old_alloc = AllocSize();
   Rebuild(HasExpiry() ? GetExpiry() : UINT32_MAX);
   *realloced = true;
-  return static_cast<int64_t>(AllocSize()) - static_cast<int64_t>(old_alloc);
+  return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
 }
 
 }  // namespace dfly

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -4,13 +4,11 @@
 
 #pragma once
 
-#include <sys/types.h>
-
 #include <cassert>
 #include <cstdint>
-#include <cstring>
-#include <limits>
 #include <string_view>
+
+#include "core/oah_base.h"
 
 extern "C" {
 #include "redis/zmalloc.h"
@@ -20,8 +18,6 @@ namespace dfly {
 
 class PageUsage;
 
-#define PREFETCH_READ(x) __builtin_prefetch(x, 0, 1)
-
 // oah_entry.h - a single set member: a string key plus its expiry and cached hash.
 //
 // OAHEntry is a non-owning accessor over a TaggedPtr that points at a [expiry?, control, key] heap
@@ -30,38 +26,11 @@ class PageUsage;
 // pointer are always free (user addresses are <= 52 bits), so flags live there: bit 0 stays clear
 // for OAHPtr's entry/vector tag, OAHEntry uses bit 1 (expiry) and 52-63 (cached hash).
 //
-// The blob begins with an optional 4-byte expiry, then a control byte encoding the key size (see
-// the kBigSizeBit/kThreeBytesBit block): keys < 64B store the size inline in the low 6 bits; larger
-// keys keep 5 low bits in the control byte plus 1 extra byte (< 8KB) or 3 extra bytes (< 0.5GB).
-// The control byte's top bit is a reserved ASCII/raw encoding flag, currently always 0.
+// The blob begins with an optional 4-byte expiry, then an oah::size-encoded key size followed by
+// the key bytes. See oah::size (core/oah_base.h) for the size encoding.
 class OAHEntry {
  public:
-  // A uint64_t packing the heap pointer together with tag/flag bits in its free low/high bits.
-  using TaggedPtr = uint64_t;
-
-  static constexpr size_t kExpiryBit = 1ULL << 1;
-
-  static constexpr size_t kExtHashShift = 52;
-  static constexpr uint32_t kExtHashSize = 12;
-  static constexpr size_t kExtHashMask = 0xFFFULL;
-  static constexpr size_t kExtHashShiftedMask = kExtHashMask << kExtHashShift;
-
-  static constexpr size_t kTagMask = (4095ULL << 52) | 7;  // 12 high + 3 low tag bits
-
-  // Control-byte layout (the first blob byte after the optional expiry):
-  //   bit 7    : reserved ASCII/raw encoding flag (currently always 0)
-  //   bit 6    : kBigSizeBit    - size doesn't fit in 6 bits, extra bytes follow
-  //   bit 5    : kThreeBytesBit - when kBigSizeBit set: 3 extra size bytes (else 1)
-  //   bits 0-5 : inline size (< 64B); or bits 0-4 hold the low 5 bits of a larger size
-  static constexpr uint8_t kEncodingBit = 1u << 7;  // reserved, kept 0 for now
-  static constexpr uint8_t kBigSizeBit = 1u << 6;
-  static constexpr uint8_t kThreeBytesBit = 1u << 5;
-  static constexpr uint8_t kInlineSizeMask = 0x3F;              // 6-bit inline size
-  static constexpr uint8_t kLowSizeMask = 0x1F;                 // 5 low size bits for larger keys
-  static constexpr uint32_t kLowSizeBits = 5;                   // bits taken from the control byte
-  static constexpr uint32_t kInlineSizeMax = kInlineSizeMask;   // 63
-  static constexpr uint32_t kOneExtraByteMax = (1u << 13) - 1;  // 8191 (5 + 8 bits)
-  static constexpr uint32_t kMaxKeySize = (1u << 29) - 1;       // 5 + 24 bits (< 0.5GB)
+  using TaggedPtr = oah::TaggedPtr;
 
   static TaggedPtr Create(std::string_view key, uint32_t expiry = UINT32_MAX);
   static void Destroy(TaggedPtr tagged_ptr);
@@ -84,21 +53,19 @@ class OAHEntry {
 
   std::string_view Key() const {
     const char* p = Raw() + GetExpirySize();
-    uint8_t control = static_cast<uint8_t>(*p);
-    if ((control & kBigSizeBit) == 0)
-      return {p + 1, static_cast<size_t>(control & kInlineSizeMask)};
-    return KeyBig(p, control);
+    const oah::size::Decoded key = oah::size::Read(p);
+    return {p + key.field_size, key.size};
   }
 
   bool HasExpiry() const {
-    return (GetTaggedPtr() & kExpiryBit) != 0;
+    return (GetTaggedPtr() & oah::kExpiryBit) != 0;
   }
   uint32_t GetExpiry() const;
   void SetExpiry(uint32_t at_sec);
   void ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used);
 
   uint64_t GetHash() const {
-    return (GetTaggedPtr() & kExtHashShiftedMask) >> kExtHashShift;
+    return (GetTaggedPtr() & oah::kExtHashShiftedMask) >> oah::kExtHashShift;
   }
   void SetExtHash(uint64_t ext_hash);
 
@@ -106,16 +73,16 @@ class OAHEntry {
   // directly, no read-mask. `shifted_ext_hash` must carry bits only in [kExtHashShift, 64); use
   // SetExtHash if the entry may already hold a fingerprint.
   void SetShiftedExtHash(uint64_t shifted_ext_hash) {
-    assert((shifted_ext_hash & ~kExtHashShiftedMask) == 0);
+    assert((shifted_ext_hash & ~oah::kExtHashShiftedMask) == 0);
     SetTaggedPtr(GetTaggedPtr() | shifted_ext_hash);
   }
 
   // Reallocates the key blob if its page is underutilized; returns the usable-size delta and sets
   // *realloced when the buffer moved.
-  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
+  int64_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   char* Raw() const {
-    return (char*)(GetTaggedPtr() & ~kTagMask);
+    return (char*)(GetTaggedPtr() & ~oah::kTagMask);
   }
 
   // Returns the control word and zeroes the slot, transferring ownership to the caller.
@@ -131,10 +98,6 @@ class OAHEntry {
   }
 
  protected:
-  // Slow path of Key() for keys >= 64B: decodes the multibyte size field starting at control
-  // byte `p` (already read into `control`) and returns the key view.
-  std::string_view KeyBig(const char* p, uint8_t control) const;
-
   // Reallocates the key blob with `expiry`, preserving the key and stored ext-hash.
   void Rebuild(uint32_t expiry);
 

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/types.h>
+
 #include <cassert>
 #include <cstdint>
 #include <string_view>
@@ -79,7 +81,7 @@ class OAHEntry {
 
   // Reallocates the key blob if its page is underutilized; returns the usable-size delta and sets
   // *realloced when the buffer moved.
-  int64_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   char* Raw() const {
     return (char*)(GetTaggedPtr() & ~oah::kTagMask);

--- a/src/core/oah_map.h
+++ b/src/core/oah_map.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <optional>
@@ -12,6 +11,7 @@
 #include <string_view>
 #include <vector>
 
+#include "core/oah_base.h"
 #include "core/oah_pair.h"
 #include "core/oah_table.h"
 
@@ -55,7 +55,7 @@ class OAHMap : public OAHTable<OAHPair> {
     const uint64_t hash = Hash(field);
     const uint32_t bid = BucketId(hash, capacity_log_);
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-    const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << OAHPair::kExtHashShift);
+    const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << oah::kExtHashShift);
 
     TaggedPtr* matched = nullptr;
     TaggedPtr* base = entries_.data();
@@ -149,15 +149,15 @@ class OAHMap : public OAHTable<OAHPair> {
 
     uint64_t hash = Hash(field);
     auto bucket_id = BucketId(hash, capacity_log_);
-    PREFETCH_READ(entries_.data() + bucket_id);
+    oah::PrefetchRead(entries_.data() + bucket_id);
 
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-    const uint64_t shifted_ext_hash = ext_hash << OAHPair::kExtHashShift;
+    const uint64_t shifted_ext_hash = ext_hash << oah::kExtHashShift;
     OAHPair(new_tp).SetShiftedExtHash(shifted_ext_hash);
     const size_t entry_alloc_size = OAHPair(new_tp).AllocSize();
 
     const uint32_t ext_bid = GetExtensionPoint(bucket_id);
-    PREFETCH_READ(At(ext_bid).Raw());
+    oah::PrefetchRead(At(ext_bid).Raw());
 
     const LaneMasks masks = ProbeWindowShifted(&entries_[bucket_id], shifted_ext_hash);
 

--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -326,11 +326,11 @@ TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   size_t old_alloc = pair.AllocSize();
   SelectivePageUsage value_only(const_cast<char*>(old_value));
   bool realloced = false;
-  int64_t delta = pair.ReallocIfNeeded(&value_only, &realloced);
+  ssize_t delta = pair.ReallocIfNeeded(&value_only, &realloced);
   EXPECT_TRUE(realloced);
   EXPECT_EQ(pair.Raw(), old_raw);
   EXPECT_NE(pair.Value().data(), old_value);
-  EXPECT_EQ(delta, static_cast<int64_t>(pair.AllocSize()) - static_cast<int64_t>(old_alloc));
+  EXPECT_EQ(delta, static_cast<ssize_t>(pair.AllocSize()) - static_cast<ssize_t>(old_alloc));
   EXPECT_EQ(pair.Key(), key);
   EXPECT_EQ(pair.Value(), value);
   EXPECT_EQ(pair.GetExpiry(), 11u);
@@ -346,7 +346,7 @@ TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   EXPECT_TRUE(realloced);
   EXPECT_NE(pair.Raw(), old_raw);
   EXPECT_EQ(pair.Value().data(), old_value);
-  EXPECT_EQ(delta, static_cast<int64_t>(pair.AllocSize()) - static_cast<int64_t>(old_alloc));
+  EXPECT_EQ(delta, static_cast<ssize_t>(pair.AllocSize()) - static_cast<ssize_t>(old_alloc));
   EXPECT_EQ(pair.Key(), key);
   EXPECT_EQ(pair.Value(), value);
   EXPECT_EQ(pair.GetExpiry(), 11u);
@@ -361,7 +361,7 @@ TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   EXPECT_TRUE(realloced);
   EXPECT_NE(pair.Raw(), old_raw);
   EXPECT_NE(pair.Value().data(), old_value);
-  EXPECT_EQ(delta, static_cast<int64_t>(pair.AllocSize()) - static_cast<int64_t>(old_alloc));
+  EXPECT_EQ(delta, static_cast<ssize_t>(pair.AllocSize()) - static_cast<ssize_t>(old_alloc));
   EXPECT_EQ(pair.Key(), key);
   EXPECT_EQ(pair.Value(), value);
   EXPECT_EQ(pair.GetExpiry(), 11u);

--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -8,6 +8,7 @@
 #include <absl/strings/str_cat.h>
 #include <mimalloc.h>
 
+#include <cstring>
 #include <random>
 #include <string>
 
@@ -61,6 +62,37 @@ static string random_string(mt19937& rand, unsigned len) {
   return ret;
 }
 
+static string sized_string(size_t len, char fill) {
+  string result(len, fill);
+  if (len > 2)
+    result[len / 2] = '\0';
+  if (len)
+    result.back() = static_cast<char>(fill + 1);
+  return result;
+}
+
+class SelectivePageUsage : public PageUsage {
+ public:
+  explicit SelectivePageUsage(void* target, void* second_target = nullptr)
+      : PageUsage(CollectPageStats::NO, 0), target_(target), second_target_(second_target) {
+  }
+
+  bool IsPageForObjectUnderUtilized(void* object) override {
+    return object == target_ || object == second_target_;
+  }
+
+ private:
+  void* target_;
+  void* second_target_;
+};
+
+static size_t SumEntryAlloc(OAHMap& map) {
+  size_t result = 0;
+  for (OAHPair pair : map)
+    result += pair.AllocSize();
+  return result;
+}
+
 TEST_F(OAHMapTest, Basic) {
   EXPECT_TRUE(m_->AddOrUpdate("foo", "bar"));
   EXPECT_TRUE(m_->Contains("foo"));
@@ -85,6 +117,302 @@ TEST_F(OAHMapTest, Basic) {
 
   EXPECT_FALSE(m_->AddOrSkip("foo", "bar2"));
   EXPECT_EQ(m_->Find("foo")->Value(), "baraaaaaaaaaaaa2"sv);
+
+  auto value = m_->GetValue("foo");
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(*value, "baraaaaaaaaaaaa2"sv);
+  EXPECT_FALSE(m_->GetValue("missing").has_value());
+}
+
+TEST_F(OAHMapTest, EmptyKeyAndValue) {
+  // Empty members arrive as non-null empty views (""sv), never a null std::string_view{} -- see
+  // CmdArgParser::SafeSV. OAHPair::Create relies on that invariant (DCHECK on the data pointers).
+  uint64_t bits = OAHPair::Create(""sv, ""sv);
+  OAHPair pair(bits);
+  EXPECT_TRUE(pair.Key().empty());
+  EXPECT_TRUE(pair.Value().empty());
+  OAHPair::Destroy(pair.Release());
+
+  EXPECT_TRUE(m_->AddOrUpdate("", ""));
+  auto value = m_->GetValue("");
+  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value->empty());
+  auto it = m_->Find("");
+  ASSERT_NE(it, m_->end());
+  EXPECT_TRUE(it->Key().empty());
+  EXPECT_TRUE(it->Value().empty());
+  EXPECT_TRUE(m_->Erase(""));
+  EXPECT_FALSE(m_->GetValue("").has_value());
+}
+
+TEST_F(OAHMapTest, OAHPairSizeEncoding) {
+  for (uint32_t key_size : {0u, 1u, 31u, 32u, 63u, 64u, 255u, 8191u, 8192u, 100000u}) {
+    const string key = sized_string(key_size, 'k');
+    for (uint32_t value_size : {0u, 1u, 31u, 32u, 63u, 64u, 255u, 8191u, 8192u, 100000u}) {
+      const string value = sized_string(value_size, 'v');
+      for (uint32_t expiry : {UINT32_MAX, 7u}) {
+        const size_t used_before = zmalloc_used_memory_tl;
+        uint64_t bits = OAHPair::Create(key, value, expiry);
+        OAHPair pair(bits);
+
+        EXPECT_EQ(pair.Key(), key);
+        EXPECT_EQ(pair.Value(), value);
+        EXPECT_EQ(pair.KeyValue(), make_pair(string_view(key), string_view(value)));
+        EXPECT_EQ(pair.HasExpiry(), expiry != UINT32_MAX);
+        EXPECT_EQ(pair.GetExpiry(), expiry);
+        EXPECT_EQ(pair.AllocSize(), zmalloc_used_memory_tl - used_before);
+
+        // Decode the fields directly from the blob: [expiry?, key_size, value_size, value_ptr:8B].
+        const char* key_size_field = pair.Raw() + (expiry != UINT32_MAX) * sizeof(expiry);
+        const oah::size::Decoded decoded_key_size = oah::size::Read(key_size_field);
+        const char* value_size_field = key_size_field + decoded_key_size.field_size;
+        const oah::size::Decoded decoded_value_size = oah::size::Read(value_size_field);
+        const char* value_ptr_field = value_size_field + decoded_value_size.field_size;
+        EXPECT_EQ(decoded_key_size.size, key_size);
+        EXPECT_EQ(decoded_value_size.size, value_size);
+
+        char* stored_value = nullptr;
+        std::memcpy(&stored_value, value_ptr_field, sizeof(stored_value));
+        EXPECT_EQ(stored_value, pair.Value().data());
+        EXPECT_EQ(pair.Key().data(), value_ptr_field + sizeof(stored_value));
+
+        const uintptr_t raw = reinterpret_cast<uintptr_t>(pair.Raw());
+        const uintptr_t raw_end = raw + zmalloc_usable_size(pair.Raw());
+        const uintptr_t value_data = reinterpret_cast<uintptr_t>(pair.Value().data());
+        if (value_size == 0) {
+          EXPECT_EQ(pair.Value().data(), nullptr);  // empty value: no buffer
+        } else {
+          EXPECT_TRUE(value_data < raw || value_data >= raw_end);  // outside the blob
+          EXPECT_EQ(value_data % 8, 0u);  // separate zmalloc buffer is >=8-byte aligned
+        }
+
+        OAHPair::Destroy(pair.Release());
+        EXPECT_EQ(zmalloc_used_memory_tl, used_before);
+      }
+    }
+  }
+}
+
+TEST_F(OAHMapTest, OAHSizeFieldEncoding) {
+  for (auto [size, expected_field_size] :
+       {pair{0u, 1u}, pair{63u, 1u}, pair{64u, 2u}, pair{8191u, 2u}, pair{8192u, 4u},
+        pair{100000u, 4u}, pair{oah::size::kMaxSize, 4u}}) {
+    char field[oah::size::kLargeFieldSize] = {};
+    EXPECT_EQ(oah::size::FieldSize(size), expected_field_size);
+    oah::size::Write(size, expected_field_size, field);
+    const oah::size::Decoded decoded = oah::size::Read(field);
+    EXPECT_EQ(decoded.size, size);
+    EXPECT_EQ(decoded.field_size, expected_field_size);
+  }
+}
+
+TEST_F(OAHMapTest, ExternalValueOwnership) {
+  const string key = sized_string(8192, 'k');
+  const string inline_value = sized_string(8191, 'a');
+  const string external_value = sized_string(8192, 'b');
+  const string replacement = sized_string(8192, 'c');
+
+  EXPECT_TRUE(m_->AddOrUpdate(key, inline_value));
+  ASSERT_NE(m_->Find(key), m_->end());
+  EXPECT_EQ(m_->ObjMallocUsed(), m_->Find(key)->AllocSize());
+
+  const size_t used_before_skip = zmalloc_used_memory_tl;
+  const size_t obj_before_skip = m_->ObjMallocUsed();
+  EXPECT_FALSE(m_->AddOrSkip(key, external_value));
+  EXPECT_EQ(zmalloc_used_memory_tl, used_before_skip);
+  EXPECT_EQ(m_->ObjMallocUsed(), obj_before_skip);
+
+  size_t used_with_owner = 0;
+  size_t owner_alloc = 0;
+  {
+    auto previous = m_->AddOrExchange(key, external_value);
+    ASSERT_TRUE(previous);
+    EXPECT_EQ(previous.pair().Value(), inline_value);
+    EXPECT_EQ(m_->Find(key)->Value(), external_value);
+    EXPECT_EQ(m_->ObjMallocUsed(), m_->Find(key)->AllocSize());
+    owner_alloc = previous.pair().AllocSize();
+    used_with_owner = zmalloc_used_memory_tl;
+  }
+  EXPECT_EQ(zmalloc_used_memory_tl, used_with_owner - owner_alloc);
+
+  EXPECT_FALSE(m_->AddOrUpdate(key, replacement, 100));
+  EXPECT_EQ(m_->ObjMallocUsed(), m_->Find(key)->AllocSize());
+
+  {
+    auto previous = m_->AddOrExchange(key, inline_value, 200);
+    ASSERT_TRUE(previous);
+    EXPECT_EQ(previous.pair().Value(), replacement);
+    EXPECT_EQ(previous.pair().GetExpiry(), 100u);
+    EXPECT_EQ(m_->Find(key)->Value(), inline_value);
+    EXPECT_EQ(m_->Find(key).ExpiryTime(), 200u);
+    EXPECT_EQ(m_->ObjMallocUsed(), m_->Find(key)->AllocSize());
+  }
+
+  EXPECT_FALSE(m_->AddOrUpdate(key, replacement));
+
+  const size_t used_before_extract = zmalloc_used_memory_tl;
+  size_t extracted_alloc = 0;
+  {
+    auto extracted = m_->Extract(key);
+    ASSERT_TRUE(extracted);
+    EXPECT_EQ(extracted.pair().Key(), key);
+    EXPECT_EQ(extracted.pair().Value(), replacement);
+    EXPECT_EQ(m_->ObjMallocUsed(), 0u);
+    EXPECT_EQ(zmalloc_used_memory_tl, used_before_extract);
+    extracted_alloc = extracted.pair().AllocSize();
+  }
+  EXPECT_EQ(zmalloc_used_memory_tl, used_before_extract - extracted_alloc);
+}
+
+TEST_F(OAHMapTest, ExtractExpiredExternalValue) {
+  const string key = sized_string(8192, 'k');
+  const string value = sized_string(8192, 'v');
+  EXPECT_TRUE(m_->AddOrUpdate(key, value, 1));
+  const size_t pair_alloc = m_->Find(key)->AllocSize();
+  const size_t used_before = zmalloc_used_memory_tl;
+
+  m_->set_time(1);
+  EXPECT_FALSE(m_->Extract(key));
+  EXPECT_EQ(m_->UpperBoundSize(), 0u);
+  EXPECT_EQ(m_->ObjMallocUsed(), 0u);
+  EXPECT_EQ(zmalloc_used_memory_tl, used_before - pair_alloc);
+}
+
+TEST_F(OAHMapTest, ExternalValueExpiryRebuild) {
+  const string key = sized_string(8192, 'k');
+  const string value = sized_string(8192, 'v');
+  EXPECT_TRUE(m_->AddOrUpdate(key, value));
+
+  auto it = m_->Find(key);
+  ASSERT_NE(it, m_->end());
+  char* old_raw = it->Raw();
+  const char* old_value = it->Value().data();
+  const uint64_t old_hash = it->GetHash();
+
+  it.SetExpiryTime(7);
+  it = m_->Find(key);
+  ASSERT_NE(it, m_->end());
+  EXPECT_NE(it->Raw(), old_raw);
+  EXPECT_EQ(it->Value().data(), old_value);
+  EXPECT_EQ(it->Key(), key);
+  EXPECT_EQ(it->Value(), value);
+  EXPECT_EQ(it->GetHash(), old_hash);
+  EXPECT_EQ(it.ExpiryTime(), 7u);
+  EXPECT_EQ(m_->ObjMallocUsed(), it->AllocSize());
+
+  old_raw = it->Raw();
+  old_value = it->Value().data();
+  it.SetExpiryTime(9);
+  EXPECT_EQ(it->Raw(), old_raw);
+  EXPECT_EQ(it->Value().data(), old_value);
+  EXPECT_EQ(it.ExpiryTime(), 9u);
+
+  m_->set_time(9);
+  EXPECT_FALSE(m_->Contains(key));
+  EXPECT_EQ(m_->UpperBoundSize(), 0u);
+  EXPECT_EQ(m_->ObjMallocUsed(), 0u);
+}
+
+TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
+  const string key = sized_string(8192, 'k');
+  const string value = sized_string(8192, 'v');
+  uint64_t bits = OAHPair::Create(key, value, 11);
+  OAHPair pair(bits);
+  pair.SetExtHash(123);
+
+  // Only the value's page is flagged: the value buffer is relocated, the blob stays put.
+  char* old_raw = pair.Raw();
+  const char* old_value = pair.Value().data();
+  size_t old_alloc = pair.AllocSize();
+  SelectivePageUsage value_only(const_cast<char*>(old_value));
+  bool realloced = false;
+  int64_t delta = pair.ReallocIfNeeded(&value_only, &realloced);
+  EXPECT_TRUE(realloced);
+  EXPECT_EQ(pair.Raw(), old_raw);
+  EXPECT_NE(pair.Value().data(), old_value);
+  EXPECT_EQ(delta, static_cast<int64_t>(pair.AllocSize()) - static_cast<int64_t>(old_alloc));
+  EXPECT_EQ(pair.Key(), key);
+  EXPECT_EQ(pair.Value(), value);
+  EXPECT_EQ(pair.GetExpiry(), 11u);
+  EXPECT_EQ(pair.GetHash(), 123u);
+
+  // Only the blob's page is flagged: the blob is rebuilt, the value buffer is transferred
+  // unchanged.
+  old_raw = pair.Raw();
+  old_value = pair.Value().data();
+  old_alloc = pair.AllocSize();
+  SelectivePageUsage raw_only(old_raw);
+  delta = pair.ReallocIfNeeded(&raw_only, &realloced);
+  EXPECT_TRUE(realloced);
+  EXPECT_NE(pair.Raw(), old_raw);
+  EXPECT_EQ(pair.Value().data(), old_value);
+  EXPECT_EQ(delta, static_cast<int64_t>(pair.AllocSize()) - static_cast<int64_t>(old_alloc));
+  EXPECT_EQ(pair.Key(), key);
+  EXPECT_EQ(pair.Value(), value);
+  EXPECT_EQ(pair.GetExpiry(), 11u);
+  EXPECT_EQ(pair.GetHash(), 123u);
+
+  // Both pages flagged: the blob and the value buffer both move.
+  old_raw = pair.Raw();
+  old_value = pair.Value().data();
+  old_alloc = pair.AllocSize();
+  SelectivePageUsage both(old_raw, const_cast<char*>(old_value));
+  delta = pair.ReallocIfNeeded(&both, &realloced);
+  EXPECT_TRUE(realloced);
+  EXPECT_NE(pair.Raw(), old_raw);
+  EXPECT_NE(pair.Value().data(), old_value);
+  EXPECT_EQ(delta, static_cast<int64_t>(pair.AllocSize()) - static_cast<int64_t>(old_alloc));
+  EXPECT_EQ(pair.Key(), key);
+  EXPECT_EQ(pair.Value(), value);
+  EXPECT_EQ(pair.GetExpiry(), 11u);
+  EXPECT_EQ(pair.GetHash(), 123u);
+
+  OAHPair::Destroy(pair.Release());
+}
+
+TEST_F(OAHMapTest, ExternalValueMapReallocAccounting) {
+  vector<pair<string, string>> entries;
+  for (unsigned i = 0; i < 8; ++i) {
+    string key = sized_string(8192, static_cast<char>('a' + i));
+    key.replace(0, 1, to_string(i));
+    string value = sized_string(8192, static_cast<char>('k' + i));
+    entries.emplace_back(std::move(key), std::move(value));
+    EXPECT_TRUE(m_->AddOrUpdate(entries.back().first, entries.back().second, 100 + i));
+  }
+  EXPECT_EQ(m_->ObjMallocUsed(), SumEntryAlloc(*m_));
+
+  auto first = m_->Find(entries.front().first);
+  ASSERT_NE(first, m_->end());
+  char* first_raw = first->Raw();
+  const char* first_value = first->Value().data();
+  // Flagging only the value's page relocates the value buffer; the blob stays put.
+  SelectivePageUsage value_only(const_cast<char*>(first_value));
+  EXPECT_TRUE(first.ReallocIfNeeded(&value_only));
+  first = m_->Find(entries.front().first);
+  ASSERT_NE(first, m_->end());
+  EXPECT_EQ(first->Raw(), first_raw);
+  EXPECT_NE(first->Value().data(), first_value);
+  EXPECT_EQ(m_->ObjMallocUsed(), SumEntryAlloc(*m_));
+
+  PageUsage page_usage{CollectPageStats::NO, 0.9};
+  page_usage.SetForceReallocate(true);
+  for (auto it = m_->begin(); it != m_->end(); ++it)
+    EXPECT_TRUE(it.ReallocIfNeeded(&page_usage));
+
+  EXPECT_EQ(m_->ObjMallocUsed(), SumEntryAlloc(*m_));
+  for (unsigned i = 0; i < entries.size(); ++i) {
+    auto it = m_->Find(entries[i].first);
+    ASSERT_NE(it, m_->end());
+    EXPECT_EQ(it->Value(), entries[i].second);
+    EXPECT_EQ(it.ExpiryTime(), 100u + i);
+  }
+
+  for (unsigned i = 0; i < entries.size(); i += 2)
+    EXPECT_TRUE(m_->Erase(entries[i].first));
+  EXPECT_EQ(m_->ObjMallocUsed(), SumEntryAlloc(*m_));
+
+  m_->Clear();
+  EXPECT_EQ(m_->ObjMallocUsed(), 0u);
 }
 
 TEST_F(OAHMapTest, EmptyFind) {
@@ -109,31 +437,23 @@ TEST_F(OAHMapTest, Ttl) {
   EXPECT_TRUE(it == m_->end());
 }
 
-TEST_F(OAHMapTest, IterateExpired) {
-  EXPECT_TRUE(m_->AddOrUpdate("k1", "v1", 1));
-  EXPECT_TRUE(m_->AddOrUpdate("k2", "v2", 1));
-  m_->set_time(1);
-  auto it = m_->begin();
-  EXPECT_EQ(it, m_->end());
-}
-
-TEST_F(OAHMapTest, SetFieldExpireHasExpiry) {
+TEST_F(OAHMapTest, SetFieldExpire) {
+  // Field created with an expiry: SetExpiryTime overwrites it.
   EXPECT_TRUE(m_->AddOrUpdate("k1", "v1", 5));
-  auto k = m_->Find("k1");
-  EXPECT_TRUE(k.HasExpiry());
-  EXPECT_EQ(k.ExpiryTime(), 5);
-  k.SetExpiryTime(1);
-  EXPECT_TRUE(k.HasExpiry());
-  EXPECT_EQ(k.ExpiryTime(), 1);
-}
+  auto k1 = m_->Find("k1");
+  EXPECT_TRUE(k1.HasExpiry());
+  EXPECT_EQ(k1.ExpiryTime(), 5);
+  k1.SetExpiryTime(1);
+  EXPECT_TRUE(k1.HasExpiry());
+  EXPECT_EQ(k1.ExpiryTime(), 1);
 
-TEST_F(OAHMapTest, SetFieldExpireNoHasExpiry) {
-  EXPECT_TRUE(m_->AddOrUpdate("k1", "v1"));
-  auto k = m_->Find("k1");
-  EXPECT_FALSE(k.HasExpiry());
-  k.SetExpiryTime(1);
-  EXPECT_TRUE(k.HasExpiry());
-  EXPECT_EQ(k.ExpiryTime(), 1);
+  // Field created without an expiry: SetExpiryTime adds one.
+  EXPECT_TRUE(m_->AddOrUpdate("k2", "v2"));
+  auto k2 = m_->Find("k2");
+  EXPECT_FALSE(k2.HasExpiry());
+  k2.SetExpiryTime(1);
+  EXPECT_TRUE(k2.HasExpiry());
+  EXPECT_EQ(k2.ExpiryTime(), 1);
 }
 
 TEST_F(OAHMapTest, ManyFieldsSetExpiry) {
@@ -172,7 +492,7 @@ TEST_F(OAHMapTest, UpdateAfterSetExpiry) {
 TEST_F(OAHMapTest, ExpiryChangesSize) {
   // Value sized so the +4 expiry bytes push the blob across a mimalloc size class (48 -> 64),
   // making the growth observable in ObjMallocUsed.
-  const string value(35, 'x');
+  const string value(38, 'x');
   m_->AddOrUpdate("field", value);
   const size_t old_size = m_->ObjMallocUsed();
 
@@ -215,115 +535,91 @@ TEST_F(OAHMapTest, ExpiryWithMaxAndKeepTTL) {
   EXPECT_FALSE(k.HasExpiry());
 }
 
-TEST_F(OAHMapTest, AddOrExchangeNew) {
-  // Adding a new field returns an empty owner (no previous entry).
-  auto prev = m_->AddOrExchange("f1", "v1");
-  EXPECT_FALSE(prev);
+TEST_F(OAHMapTest, AddOrExchange) {
+  // New field: empty owner, no previous entry.
+  auto added = m_->AddOrExchange("f1", "v1");
+  EXPECT_FALSE(added);
   EXPECT_TRUE(m_->Contains("f1"));
   EXPECT_EQ(m_->Find("f1")->Value(), "v1"sv);
-}
-
-TEST_F(OAHMapTest, AddOrExchangeReplace) {
-  m_->AddOrUpdate("f1", "old_value");
   EXPECT_EQ(m_->UpperBoundSize(), 1u);
 
-  auto prev = m_->AddOrExchange("f1", "new_value");
-  ASSERT_TRUE(prev);
-  EXPECT_EQ(prev.pair().Value(), "old_value"sv);  // freed automatically on scope exit
-
+  // Replace: the owner holds the previous value (freed on scope exit).
+  auto replaced = m_->AddOrExchange("f1", "new_value");
+  ASSERT_TRUE(replaced);
+  EXPECT_EQ(replaced.pair().Value(), "v1"sv);
   EXPECT_EQ(m_->Find("f1")->Value(), "new_value"sv);
   EXPECT_EQ(m_->UpperBoundSize(), 1u);
-}
 
-TEST_F(OAHMapTest, AddOrExchangeWithTtl) {
-  m_->AddOrUpdate("f1", "v1", 100);
-
-  auto prev = m_->AddOrExchange("f1", "v2", 200);
-  ASSERT_TRUE(prev);
-  EXPECT_EQ(prev.pair().Value(), "v1"sv);
-
+  // Replace with a TTL: the new expiry is applied.
+  auto with_ttl = m_->AddOrExchange("f1", "v2", 200);
+  ASSERT_TRUE(with_ttl);
+  EXPECT_EQ(with_ttl.pair().Value(), "new_value"sv);
   auto it = m_->Find("f1");
   EXPECT_EQ(it->Value(), "v2"sv);
   EXPECT_TRUE(it.HasExpiry());
   EXPECT_EQ(it.ExpiryTime(), 200u);
 }
 
-TEST_F(OAHMapTest, GetValue) {
+TEST_F(OAHMapTest, Extract) {
+  // Non-existing key: empty owner, map unchanged.
   m_->AddOrUpdate("f1", "v1");
-  auto v = m_->GetValue("f1");
-  ASSERT_TRUE(v.has_value());
-  EXPECT_EQ(*v, "v1"sv);
-  EXPECT_FALSE(m_->GetValue("missing").has_value());
-}
+  EXPECT_FALSE(m_->Extract("no_such_key"));
+  EXPECT_EQ(m_->UpperBoundSize(), 1u);
 
-TEST_F(OAHMapTest, ExtractExisting) {
-  m_->AddOrUpdate("f1", "v1");
+  // Existing key: the owner holds the removed pair; other keys remain.
   m_->AddOrUpdate("f2", "v2");
-  EXPECT_EQ(m_->UpperBoundSize(), 2u);
-
-  auto entry = m_->Extract("f1");
-  ASSERT_TRUE(entry);
-  EXPECT_EQ(entry.pair().Key(), "f1"sv);
-  EXPECT_EQ(entry.pair().Value(), "v1"sv);
-
+  {
+    auto entry = m_->Extract("f1");
+    ASSERT_TRUE(entry);
+    EXPECT_EQ(entry.pair().Key(), "f1"sv);
+    EXPECT_EQ(entry.pair().Value(), "v1"sv);
+  }
   EXPECT_EQ(m_->UpperBoundSize(), 1u);
   EXPECT_FALSE(m_->Contains("f1"));
   EXPECT_TRUE(m_->Contains("f2"));
-}
 
-TEST_F(OAHMapTest, ExtractNonExisting) {
-  m_->AddOrUpdate("f1", "v1");
-  auto entry = m_->Extract("no_such_key");
-  EXPECT_FALSE(entry);
-  EXPECT_EQ(m_->UpperBoundSize(), 1u);
-}
-
-TEST_F(OAHMapTest, ExtractMultiple) {
+  // Extract half of many entries (exercises rehash-sized tables).
+  m_->Clear();
   for (unsigned i = 0; i < 20; i++)
     m_->AddOrUpdate(to_string(i), "val" + to_string(i));
   EXPECT_EQ(m_->UpperBoundSize(), 20u);
-
   for (unsigned i = 0; i < 20; i += 2) {
     auto entry = m_->Extract(to_string(i));
     ASSERT_TRUE(entry);
     EXPECT_EQ(entry.pair().Value(), ("val" + to_string(i)));
   }
-
   EXPECT_EQ(m_->UpperBoundSize(), 10u);
   for (unsigned i = 1; i < 20; i += 2)
     EXPECT_TRUE(m_->Contains(to_string(i)));
 }
 
-TEST_F(OAHMapTest, RandomPairsUniqueAfterSetExpiryTime) {
+TEST_F(OAHMapTest, RandomPairs) {
   m_->Reserve(1024);
   for (unsigned i = 0; i < 20; i++)
-    EXPECT_TRUE(m_->AddOrUpdate(to_string(i), "v"));
+    EXPECT_TRUE(m_->AddOrUpdate(to_string(i), "val" + to_string(i)));
   EXPECT_FALSE(m_->ExpirationUsed());
 
-  for (unsigned i = 0; i < 10; i++) {
-    auto it = m_->Find(to_string(i));
-    ASSERT_FALSE(it.HasExpiry());
-    it.SetExpiryTime(1);
-  }
-  EXPECT_TRUE(m_->ExpirationUsed());
-
-  m_->set_time(2);
-
-  vector<string> keys, vals;
-  m_->RandomPairsUnique(20, keys, vals, false);
-  EXPECT_EQ(keys.size(), 10u);
-}
-
-TEST_F(OAHMapTest, RandomPairsWithValues) {
-  for (unsigned i = 0; i < 20; i++)
-    m_->AddOrUpdate(to_string(i), "val" + to_string(i));
-
+  // With values requested, keys and values are returned in matching order.
   vector<string> keys, vals;
   m_->RandomPairsUnique(5, keys, vals, true);
   ASSERT_EQ(keys.size(), 5u);
   ASSERT_EQ(vals.size(), 5u);
   for (size_t i = 0; i < keys.size(); ++i)
     EXPECT_EQ(vals[i], "val" + keys[i]);
+
+  // Expired fields are skipped after setting expiry on half and advancing time.
+  for (unsigned i = 0; i < 10; i++) {
+    auto it = m_->Find(to_string(i));
+    ASSERT_FALSE(it.HasExpiry());
+    it.SetExpiryTime(1);
+  }
+  EXPECT_TRUE(m_->ExpirationUsed());
+  m_->set_time(2);
+
+  keys.clear();
+  vals.clear();
+  m_->RandomPairsUnique(20, keys, vals, false);
+  EXPECT_EQ(keys.size(), 10u);
 }
 
 TEST_F(OAHMapTest, ReallocIfNeeded) {

--- a/src/core/oah_pair.cc
+++ b/src/core/oah_pair.cc
@@ -4,38 +4,61 @@
 
 #include "core/oah_pair.h"
 
+#include "base/logging.h"
 #include "core/page_usage/page_usage_stats.h"
 
 namespace dfly {
 
-OAHPair::TaggedPtr OAHPair::Create(std::string_view key, std::string_view value, uint32_t expiry) {
-  const uint32_t key_size = key.size();
-  const uint32_t val_size = value.size();
-  const uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
+using namespace oah;
 
-  char* blob =
-      (char*)zmalloc(expiry_size + sizeof(key_size) + key_size + sizeof(val_size) + val_size);
+TaggedPtr OAHPair::BuildBlob(std::string_view key, char* value_ptr, size_t value_size,
+                             uint32_t expiry) {
+  const size_t key_size = key.size();
+  assert(key_size <= size::kMaxSize);
+  assert(value_size <= size::kMaxSize);
+  const uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
+  const uint32_t key_size_field = size::FieldSize(key_size);
+  const uint32_t val_size_field = size::FieldSize(value_size);
+
+  const size_t blob_size = expiry_size + key_size_field + val_size_field + sizeof(char*) + key_size;
+  char* blob = (char*)zmalloc(blob_size);
   TaggedPtr tagged_ptr = reinterpret_cast<TaggedPtr>(blob);
   if (expiry_size) {
-    OAHPair(tagged_ptr).SetExpiryBit(true);
+    tagged_ptr |= kExpiryBit;
     std::memcpy(blob, &expiry, sizeof(expiry));
   }
 
   char* p = blob + expiry_size;
-  std::memcpy(p, &key_size, sizeof(key_size));
-  p += sizeof(key_size);
+  size::Write(key_size, key_size_field, p);
+  p += key_size_field;
+  size::Write(value_size, val_size_field, p);
+  p += val_size_field;
+
+  std::memcpy(p, &value_ptr, sizeof(value_ptr));
+  p += sizeof(value_ptr);
+
+  // args are never null, even when empty (see CmdArgParser::SafeSV), so memcpy needs no size guard.
+  DCHECK(key.data());
   std::memcpy(p, key.data(), key_size);
-  p += key_size;
-  std::memcpy(p, &val_size, sizeof(val_size));
-  p += sizeof(val_size);
-  std::memcpy(p, value.data(), val_size);
   return tagged_ptr;
+}
+
+TaggedPtr OAHPair::Create(std::string_view key, std::string_view value, uint32_t expiry) {
+  char* value_ptr = nullptr;
+  if (!value.empty()) {
+    value_ptr = (char*)zmalloc(value.size());
+    std::memcpy(value_ptr, value.data(), value.size());
+  }
+  return BuildBlob(key, value_ptr, value.size(), expiry);
 }
 
 void OAHPair::Destroy(TaggedPtr tagged_ptr) {
   if (tagged_ptr == 0)
     return;
-  zfree(reinterpret_cast<void*>(tagged_ptr & ~kTagMask));
+  OAHPair pair(tagged_ptr);
+  if (char* value = pair.ValuePtr())
+    zfree(value);
+  zfree(pair.Raw());
 }
 
 uint32_t OAHPair::GetExpiry() const {
@@ -52,10 +75,12 @@ void OAHPair::SetExtHash(uint64_t ext_hash) {
 
 void OAHPair::Rebuild(uint32_t expiry) {
   const uint64_t saved_hash = GetHash();
-  auto [key, value] = KeyValue();  // views into the old blob; Create copies them before Destroy
-  TaggedPtr rebuilt = Create(key, value, expiry);
+  const Header header = ParseHeader();
+  // The rebuilt blob references the same value buffer, so only the old blob is freed.
+  TaggedPtr rebuilt =
+      BuildBlob({header.key, header.key_size}, ReadValuePtr(header), header.value_size, expiry);
   OAHPair(rebuilt).SetExtHash(saved_hash);
-  Destroy(Release());
+  zfree(Raw());
   SetTaggedPtr(rebuilt);
 }
 
@@ -63,7 +88,7 @@ void OAHPair::SetExpiry(uint32_t at_sec) {
   if (HasExpiry()) {
     std::memcpy(Raw(), &at_sec, sizeof(at_sec));
   } else {
-    Rebuild(at_sec);  // no expiry field yet: rebuild the blob with room for one
+    Rebuild(at_sec);
   }
 }
 
@@ -75,24 +100,34 @@ void OAHPair::ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* allo
   }
 }
 
-ssize_t OAHPair::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+int64_t OAHPair::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   *realloced = false;
   if (Empty())
     return 0;
-  if (!page_usage->IsPageForObjectUnderUtilized(Raw()))
+
+  // Relocate the blob and its separate value buffer independently: each moves only when its own
+  // page is underutilized (a large value on a fully-used page stays put).
+  char* value_buffer = ValuePtr();
+  const bool realloc_blob = page_usage->IsPageForObjectUnderUtilized(Raw());
+  const bool realloc_value = value_buffer && page_usage->IsPageForObjectUnderUtilized(value_buffer);
+  if (!realloc_blob && !realloc_value)
     return 0;
 
   const size_t old_alloc = AllocSize();
-  Rebuild(HasExpiry() ? GetExpiry() : UINT32_MAX);
-  *realloced = true;
-  return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
-}
+  if (realloc_blob)
+    Rebuild(HasExpiry() ? GetExpiry() : UINT32_MAX);
 
-void OAHPair::SetExpiryBit(bool b) {
-  if (b)
-    SetTaggedPtr(GetTaggedPtr() | kExpiryBit);
-  else
-    SetTaggedPtr(GetTaggedPtr() & ~kExpiryBit);
+  if (realloc_value) {
+    const Header header = ParseHeader();
+    char* old_value = ReadValuePtr(header);
+    char* new_value = (char*)zmalloc(header.value_size);
+    std::memcpy(new_value, old_value, header.value_size);
+    std::memcpy(header.value_ptr_field, &new_value, sizeof(new_value));
+    zfree(old_value);
+  }
+
+  *realloced = true;
+  return static_cast<int64_t>(AllocSize()) - static_cast<int64_t>(old_alloc);
 }
 
 }  // namespace dfly

--- a/src/core/oah_pair.cc
+++ b/src/core/oah_pair.cc
@@ -100,7 +100,7 @@ void OAHPair::ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* allo
   }
 }
 
-int64_t OAHPair::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+ssize_t OAHPair::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   *realloced = false;
   if (Empty())
     return 0;
@@ -127,7 +127,7 @@ int64_t OAHPair::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   }
 
   *realloced = true;
-  return static_cast<int64_t>(AllocSize()) - static_cast<int64_t>(old_alloc);
+  return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
 }
 
 }  // namespace dfly

--- a/src/core/oah_pair.h
+++ b/src/core/oah_pair.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/types.h>
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -85,7 +87,7 @@ class OAHPair {
     SetTaggedPtr(GetTaggedPtr() | shifted_ext_hash);
   }
 
-  int64_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   char* Raw() const {
     return (char*)(GetTaggedPtr() & ~oah::kTagMask);

--- a/src/core/oah_pair.h
+++ b/src/core/oah_pair.h
@@ -4,33 +4,31 @@
 
 #pragma once
 
-#include <sys/types.h>
-
+#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <string_view>
 #include <utility>
 
-#include "core/oah_entry.h"
+#include "core/oah_base.h"
+
+extern "C" {
+#include "redis/zmalloc.h"
+}
 
 namespace dfly {
 
 class PageUsage;
 
 // oah_pair.h - a map member (key + value, plus expiry and cached hash), the map counterpart of
-// OAHEntry. It shares OAHEntry's pointer-tag layout so the OAHTable SIMD probes stay
-// entry-agnostic. Heap blob: [expiry?, key_size:4B, key, value_size:4B, value].
+// OAHEntry, sharing its pointer-tag layout so OAHTable SIMD probes stay entry-agnostic. Blob
+// layout:
+//   [expiry?, key_size, value_size, value_ptr:8B, key]      (sizes use variable-width oah::size)
+// The value always lives in its own zmalloc buffer, so its bytes stay >=8-byte aligned for typed
+// reinterpretation (e.g. vector search). An empty value stores a null value_ptr and no buffer.
 class OAHPair {
  public:
-  using TaggedPtr = uint64_t;
-
-  // The tag lives in the TaggedPtr (not the blob), so it must match OAHEntry's for shared probes.
-  static constexpr size_t kExpiryBit = OAHEntry::kExpiryBit;
-  static constexpr size_t kExtHashShift = OAHEntry::kExtHashShift;
-  static constexpr uint32_t kExtHashSize = OAHEntry::kExtHashSize;
-  static constexpr size_t kExtHashMask = OAHEntry::kExtHashMask;
-  static constexpr size_t kExtHashShiftedMask = OAHEntry::kExtHashShiftedMask;
-  static constexpr size_t kTagMask = OAHEntry::kTagMask;
+  using TaggedPtr = oah::TaggedPtr;
 
   static TaggedPtr Create(std::string_view key, std::string_view value,
                           uint32_t expiry = UINT32_MAX);
@@ -49,47 +47,48 @@ class OAHPair {
   }
 
   size_t AllocSize() const {
-    return zmalloc_usable_size(Raw());
+    size_t result = zmalloc_usable_size(Raw());
+    if (char* value = ValuePtr())
+      result += zmalloc_usable_size(value);
+    return result;
   }
 
   std::string_view Key() const {
-    const char* p = Raw() + GetExpirySize();
-    uint32_t key_size;
-    std::memcpy(&key_size, p, sizeof(key_size));
-    return {p + sizeof(key_size), key_size};
+    const Header header = ParseHeader();
+    return {header.key, header.key_size};
   }
 
   std::string_view Value() const {
-    return KeyValue().second;
+    const Header header = ParseHeader();
+    return {ReadValuePtr(header), header.value_size};
   }
 
   std::pair<std::string_view, std::string_view> KeyValue() const {
-    const char* val = nullptr;
-    std::string_view key = KeyInternal(&val);
-    return {key, ValueFrom(val)};
+    const Header header = ParseHeader();
+    return {{header.key, header.key_size}, {ReadValuePtr(header), header.value_size}};
   }
 
   bool HasExpiry() const {
-    return (GetTaggedPtr() & kExpiryBit) != 0;
+    return (GetTaggedPtr() & oah::kExpiryBit) != 0;
   }
   uint32_t GetExpiry() const;
   void SetExpiry(uint32_t at_sec);
   void ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used);
 
   uint64_t GetHash() const {
-    return (GetTaggedPtr() & kExtHashShiftedMask) >> kExtHashShift;
+    return (GetTaggedPtr() & oah::kExtHashShiftedMask) >> oah::kExtHashShift;
   }
   void SetExtHash(uint64_t ext_hash);
 
   void SetShiftedExtHash(uint64_t shifted_ext_hash) {
-    assert((shifted_ext_hash & ~kExtHashShiftedMask) == 0);
+    assert((shifted_ext_hash & ~oah::kExtHashShiftedMask) == 0);
     SetTaggedPtr(GetTaggedPtr() | shifted_ext_hash);
   }
 
-  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
+  int64_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   char* Raw() const {
-    return (char*)(GetTaggedPtr() & ~kTagMask);
+    return (char*)(GetTaggedPtr() & ~oah::kTagMask);
   }
 
   TaggedPtr Release() {
@@ -103,25 +102,38 @@ class OAHPair {
   }
 
  protected:
-  // Returns the key and, via out_val, the pointer to the following value_size field.
-  std::string_view KeyInternal(const char** out_val) const {
-    const char* p = Raw() + GetExpirySize();
+  struct Header {
+    char* value_ptr_field;
+    char* key;
     uint32_t key_size;
-    std::memcpy(&key_size, p, sizeof(key_size));
-    const char* key = p + sizeof(key_size);
-    *out_val = key + key_size;
-    return {key, key_size};
+    uint32_t value_size;
+  };
+
+  Header ParseHeader() const {
+    char* p = Raw() + GetExpirySize();
+    const oah::size::Decoded key = oah::size::Read(p);
+    p += key.field_size;
+    const oah::size::Decoded value = oah::size::Read(p);
+    p += value.field_size;
+    return {p, p + sizeof(char*), key.size, value.size};
   }
 
-  static std::string_view ValueFrom(const char* val) {
-    uint32_t val_size;
-    std::memcpy(&val_size, val, sizeof(val_size));
-    return {val + sizeof(val_size), val_size};
+  static char* ReadValuePtr(const Header& header) {
+    char* value = nullptr;
+    std::memcpy(&value, header.value_ptr_field, sizeof(value));
+    return value;
   }
 
-  void SetExpiryBit(bool b);
+  char* ValuePtr() const {
+    return ReadValuePtr(ParseHeader());
+  }
 
-  // Reallocates the blob with `expiry`, preserving key, value and stored ext-hash.
+  // Builds a blob that takes ownership of `value_ptr` (null for an empty value): Create allocates a
+  // fresh value buffer, Rebuild passes the existing one through unchanged.
+  static TaggedPtr BuildBlob(std::string_view key, char* value_ptr, size_t value_size,
+                             uint32_t expiry);
+
+  // Reallocates the blob with `expiry`, preserving key, value and the cached ext-hash.
   void Rebuild(uint32_t expiry);
 
   std::uint32_t GetExpirySize() const {
@@ -138,12 +150,12 @@ class OAHPair {
   TaggedPtr* slot_;
 };
 
-// RAII owner of an OAHPair blob handed out by OAHMap::Extract / AddOrExchange. Frees it on
-// destruction; move-only. Read the key/value through pair(); empty when the operation returned
+// RAII owner of an OAHPair blob handed out by OAHMap::Extract / AddOrExchange; move-only, frees the
+// blob on destruction. Read the key/value through pair(); empty when the operation returned
 // nothing.
 class OwnedOAHPair {
  public:
-  using TaggedPtr = OAHPair::TaggedPtr;
+  using TaggedPtr = oah::TaggedPtr;
 
   OwnedOAHPair() = default;
   explicit OwnedOAHPair(TaggedPtr tp) : tp_(tp) {
@@ -168,7 +180,6 @@ class OwnedOAHPair {
     return tp_ != 0;
   }
 
-  // Non-owning view over the owned blob, for reading the key/value.
   OAHPair pair() {
     return OAHPair(tp_);
   }

--- a/src/core/oah_ptr.h
+++ b/src/core/oah_ptr.h
@@ -120,14 +120,14 @@ template <typename Entry> class OAHPtr {
   // Defragments fragmented buffers under this slot: the entry's string, or for a vector every inner
   // entry plus the array. Returns the cumulative usable-size delta; *realloced is set if anything
   // moved.
-  int64_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
     *realloced = false;
     if (Empty())
       return 0;
     if (!IsVector())
       return Entry(*slot_).ReallocIfNeeded(page_usage, realloced);
 
-    int64_t obj_alloc_delta = 0;
+    ssize_t obj_alloc_delta = 0;
     Vector vec = AsVector();
     for (TaggedPtr& cell : vec) {
       Entry entry(cell);

--- a/src/core/oah_ptr.h
+++ b/src/core/oah_ptr.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
-#include "core/oah_entry.h"
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "core/oah_base.h"
 #include "core/page_usage/page_usage_stats.h"
 #include "core/ptr_vector.h"
 
@@ -18,11 +22,10 @@ namespace dfly {
 // owns the lifetime logic (promote-to-vector, grow, clear) via the Entry and PtrVector
 // Create()/Destroy() factories.
 template <typename Entry> class OAHPtr {
+  using TaggedPtr = oah::TaggedPtr;
   using Vector = PtrVector<TaggedPtr>;
 
  public:
-  static constexpr TaggedPtr kVectorBit = 1ULL << 0;
-
   explicit OAHPtr(TaggedPtr& slot) : slot_(&slot) {
   }
 
@@ -33,7 +36,7 @@ template <typename Entry> class OAHPtr {
     return !Empty();
   }
   bool IsVector() const {
-    return (*slot_ & kVectorBit) != 0;
+    return (*slot_ & oah::kVectorBit) != 0;
   }
 
   Vector AsVector() {
@@ -117,14 +120,14 @@ template <typename Entry> class OAHPtr {
   // Defragments fragmented buffers under this slot: the entry's string, or for a vector every inner
   // entry plus the array. Returns the cumulative usable-size delta; *realloced is set if anything
   // moved.
-  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+  int64_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
     *realloced = false;
     if (Empty())
       return 0;
     if (!IsVector())
       return Entry(*slot_).ReallocIfNeeded(page_usage, realloced);
 
-    ssize_t obj_alloc_delta = 0;
+    int64_t obj_alloc_delta = 0;
     Vector vec = AsVector();
     for (TaggedPtr& cell : vec) {
       Entry entry(cell);
@@ -142,7 +145,7 @@ template <typename Entry> class OAHPtr {
   }
 
   char* Raw() const {
-    return reinterpret_cast<char*>(*slot_ & ~Entry::kTagMask);
+    return reinterpret_cast<char*>(*slot_ & ~oah::kTagMask);
   }
 
   // Replaces the slot's contents with the single entry `tagged_ptr`, freeing the old contents.

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -69,7 +69,7 @@ class OAHSet : public OAHTable<OAHEntry> {
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
     const uint64_t shifted_ext_hash = ext_hash << oah::kExtHashShift;
 
-    const int64_t mem_before = zmalloc_used_memory_tl;
+    const ssize_t mem_before = zmalloc_used_memory_tl;
     TaggedPtr entry_tagged_ptr = OAHEntry::Create(str, EntryTTL(ttl_sec));
     OAHEntry(entry_tagged_ptr).SetShiftedExtHash(shifted_ext_hash);  // reuse the shifted value
     if (ttl_sec != UINT32_MAX)

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -10,6 +10,8 @@
 #include <cassert>
 #include <string_view>
 
+#include "core/oah_base.h"
+#include "core/oah_entry.h"
 #include "core/oah_table.h"
 #include "core/string_set.h"
 
@@ -62,12 +64,12 @@ class OAHSet : public OAHTable<OAHEntry> {
 
     uint64_t hash = Hash(str);
     auto bucket_id = BucketId(hash, capacity_log_);
-    PREFETCH_READ(entries_.data() + bucket_id);
+    oah::PrefetchRead(entries_.data() + bucket_id);
 
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-    const uint64_t shifted_ext_hash = ext_hash << OAHEntry::kExtHashShift;
+    const uint64_t shifted_ext_hash = ext_hash << oah::kExtHashShift;
 
-    const ssize_t mem_before = zmalloc_used_memory_tl;
+    const int64_t mem_before = zmalloc_used_memory_tl;
     TaggedPtr entry_tagged_ptr = OAHEntry::Create(str, EntryTTL(ttl_sec));
     OAHEntry(entry_tagged_ptr).SetShiftedExtHash(shifted_ext_hash);  // reuse the shifted value
     if (ttl_sec != UINT32_MAX)
@@ -75,7 +77,7 @@ class OAHSet : public OAHTable<OAHEntry> {
     const size_t entry_alloc_size = zmalloc_used_memory_tl - mem_before;
 
     const uint32_t ext_bid = GetExtensionPoint(bucket_id);
-    PREFETCH_READ(At(ext_bid).Raw());
+    oah::PrefetchRead(At(ext_bid).Raw());
 
     const LaneMasks masks = ProbeWindowShifted(&entries_[bucket_id], shifted_ext_hash);
 

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -144,18 +144,20 @@ TEST_F(OAHSetTest, OAHEntryTest) {
   OAHEntry::Destroy(test.Release());
 }
 
-TEST_F(OAHSetTest, OAHEntryKeySizes) {
-  // Round-trips the control-byte size encoding across its boundaries: inline (< 64B),
-  // 1 extra byte (< 8KB) and 3 extra bytes (larger), with and without an expiry.
-  for (uint32_t sz : {0u, 1u, 63u, 64u, 255u, 8191u, 8192u, 100000u}) {
+TEST_F(OAHSetTest, KeySizeEncoding) {
+  // Round-trips the size encoding across its field-width boundaries -- inline (< 64B), 1 extra
+  // byte (< 8KB) and 3 extra bytes (larger) -- both at the OAHEntry level (with/without expiry)
+  // and through the full Add/Find/Erase path, whose duplicate detection relies on Key() decoding.
+  vector<string> keys;
+  for (uint32_t sz : {0u, 63u, 64u, 8191u, 8192u, 100000u}) {
     string key(sz, 'x');
     if (sz)
       key[sz - 1] = 'z';  // make the tail byte observable
+    keys.push_back(key);
 
     for (uint32_t expiry : {UINT32_MAX, 7u}) {
       uint64_t bits = OAHEntry::Create(key, expiry);
       OAHEntry e(bits);
-      EXPECT_EQ(e.Key().size(), sz);
       EXPECT_EQ(e.Key(), key);
       EXPECT_EQ(e.HasExpiry(), expiry != UINT32_MAX);
       if (expiry != UINT32_MAX) {
@@ -164,12 +166,7 @@ TEST_F(OAHSetTest, OAHEntryKeySizes) {
       OAHEntry::Destroy(e.Release());
     }
   }
-}
 
-TEST_F(OAHSetTest, LargeKeys) {
-  // The size encoding must round-trip through the full Add/Find/Erase path, not just OAHEntry.
-  vector<string> keys = {string(10, 'a'), string(63, 'b'), string(64, 'c'), string(8192, 'd'),
-                         string(70000, 'e')};
   for (const auto& k : keys)
     EXPECT_TRUE(ss_->Add(k));
   for (const auto& k : keys)

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -17,6 +17,7 @@
 
 #include "common/rapidhash.h"
 #include "core/detail/stateless_allocator.h"
+#include "core/oah_base.h"
 #include "core/oah_ptr.h"
 #include "core/simd_op.h"
 
@@ -34,6 +35,10 @@ namespace dfly {
 // entry-specific (a set adds a key, a map a key+value with replace/exchange semantics), so it lives
 // in the derived OAHSet / OAHMap where each keeps its own tight, separately optimized code path.
 template <typename Entry> class OAHTable {  // Open Addressing Hash table
+ protected:
+  using TaggedPtr = oah::TaggedPtr;
+
+ private:
   using Buckets = std::vector<TaggedPtr, StatelessAllocator<TaggedPtr>>;
 
  public:
@@ -108,9 +113,9 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     bool ReallocIfNeeded(PageUsage* page_usage) {
       auto bucket = owner_->At(bucket_);
       bool realloced = false;
-      ssize_t delta = bucket.ReallocIfNeeded(page_usage, &realloced);
+      int64_t delta = bucket.ReallocIfNeeded(page_usage, &realloced);
       // delta can be negative if a realloc lands in a smaller mimalloc usable-size
-      // bucket; route the signed update through ssize_t to avoid size_t underflow.
+      // bucket; route the signed update through int64_t to avoid size_t underflow.
       if (delta >= 0) {
         owner_->obj_alloc_used_ += static_cast<size_t>(delta);
       } else {
@@ -304,7 +309,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     const uint64_t hash = Hash(str);
     const uint32_t bid = BucketId(hash, capacity_log_);
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-    const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << Entry::kExtHashShift);
+    const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << oah::kExtHashShift);
 
     // Erase keeps the matched cell (to free it) and whether the hit lives in an extension vector.
     TaggedPtr* matched = nullptr;
@@ -614,7 +619,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     auto data_v = Wide::Load(base);
     // Mask covers the vector bit so vector slots never match a candidate (window probes then need
     // no per-candidate IsVector test); ext-hash is never 0, so empty lanes can't match the query.
-    auto stored = data_v & Wide::Fill(Entry::kExtHashShiftedMask | OAHPtr<Entry>::kVectorBit);
+    auto stored = data_v & Wide::Fill(oah::kExtHashShiftedMask | oah::kVectorBit);
     auto is_empty = data_v == uint64_t(0);
     auto candidate = stored == shifted_ext_hash;
     return {candidate.GetMSBs(), is_empty.GetMSBs()};
@@ -641,8 +646,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
       const EntryWide data = EntryWide::Load(base + off);
       const uint32_t isvec =
-          ((data & EntryWide::Fill(OAHPtr<Entry>::kVectorBit)) == OAHPtr<Entry>::kVectorBit)
-              .GetMSBs();
+          ((data & EntryWide::Fill(oah::kVectorBit)) == oah::kVectorBit).GetMSBs();
       const uint32_t matched = ((data >> shift) == target).GetMSBs();
       // target == 0 also matches all-zero empties; drop them here (cheaper than a scalar re-read).
       const uint32_t is_empty = (data == uint64_t(0)).GetMSBs();
@@ -677,7 +681,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     // Prefetch every window slot's blob to overlap the loads with the SIMD mask below (an empty
     // slot prefetches null, a no-op).
     for (uint32_t i = 0; i < kDisplacementSize; ++i)
-      PREFETCH_READ(reinterpret_cast<const char*>(base[i] & ~Entry::kTagMask));
+      oah::PrefetchRead(reinterpret_cast<const char*>(base[i] & ~oah::kTagMask));
 
     uint32_t vec_mask = 0;
     uint32_t cand = ScanWindowMask(base, target, shift, &vec_mask);
@@ -732,7 +736,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     assert(size >= size_t(kVectorLaneStep));
     assert(size % kVectorLaneStep == 0u);
 
-    const uint64_t shifted_ext_hash = ext_hash << Entry::kExtHashShift;
+    const uint64_t shifted_ext_hash = ext_hash << oah::kExtHashShift;
     for (size_t base = 0; base < size; base += kVectorLaneStep) {
       auto cand_bits = ProbeLanes<VectorWide>(reinterpret_cast<const uint64_t*>(&raw_arr[base]),
                                               shifted_ext_hash)
@@ -751,7 +755,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   // Expire: when no TTLs exist a key match is provably live, so the empty re-check is dropped.
   template <bool Expire> iterator FindInternal(uint32_t bid, std::string_view str, uint64_t hash) {
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-    const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << Entry::kExtHashShift);
+    const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << oah::kExtHashShift);
 
     // Find returns an iterator built straight from the match. With no TTLs a key match is always
     // live, so ExpireIfNeeded and the resulting empty re-check are compiled out.
@@ -785,8 +789,8 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
 
   static uint64_t CalcExtHash(uint64_t hash, uint32_t capacity_log) {
     const uint32_t start_hash_bit = capacity_log > kShiftLog ? capacity_log - kShiftLog : 0;
-    const uint32_t ext_hash_shift = 64 - start_hash_bit - Entry::kExtHashSize;
-    const uint64_t h = (hash >> ext_hash_shift) & Entry::kExtHashMask;
+    const uint32_t ext_hash_shift = 64 - start_hash_bit - oah::kExtHashSize;
+    const uint64_t h = (hash >> ext_hash_shift) & oah::kExtHashMask;
     // Remap the rare all-zero fingerprint to 1 so empty (all-zero) slots never match a real
     // entry, letting the SIMD probes drop the empty mask. Full entropy otherwise; home-prefix
     // bits stay 0.

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -113,9 +113,9 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     bool ReallocIfNeeded(PageUsage* page_usage) {
       auto bucket = owner_->At(bucket_);
       bool realloced = false;
-      int64_t delta = bucket.ReallocIfNeeded(page_usage, &realloced);
+      ssize_t delta = bucket.ReallocIfNeeded(page_usage, &realloced);
       // delta can be negative if a realloc lands in a smaller mimalloc usable-size
-      // bucket; route the signed update through int64_t to avoid size_t underflow.
+      // bucket; route the signed update through ssize_t to avoid size_t underflow.
       if (delta >= 0) {
         owner_->obj_alloc_used_ += static_cast<size_t>(delta);
       } else {

--- a/src/core/ptr_vector.h
+++ b/src/core/ptr_vector.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-
 #include <algorithm>
 #include <bit>
 #include <cassert>
@@ -13,14 +11,13 @@
 #include <new>
 #include <type_traits>
 
+#include "core/oah_base.h"
+
 extern "C" {
 #include "redis/zmalloc.h"
 }
 
 namespace dfly {
-
-// A uint64_t that packs a heap pointer together with tag/flag bits in its unused low/high bits.
-using TaggedPtr = uint64_t;
 
 // ptr_vector.h - a growable heap array of T addressed through a single TaggedPtr.
 //
@@ -30,8 +27,7 @@ using TaggedPtr = uint64_t;
 // stay even for the 2-lane SIMD probe; the 11-bit size field holds the count, or its base-2 log
 // when kLogModeBit is set (power-of-two sizes).
 template <class T> class PtrVector {
-  static constexpr size_t kVectorBit = 1ULL << 0;
-  static constexpr size_t kTagMask = (4095ULL << 52) | 7;
+  using TaggedPtr = oah::TaggedPtr;
   static constexpr size_t kSizeShift = 52;
   static constexpr size_t kSizeMask = 0x7FFULL;
   static constexpr size_t kLogModeBit = 1ULL << 63;
@@ -118,7 +114,7 @@ template <class T> class PtrVector {
 
  private:
   static T* RawOf(TaggedPtr tagged_ptr) {
-    return reinterpret_cast<T*>(tagged_ptr & ~kTagMask);
+    return reinterpret_cast<T*>(tagged_ptr & ~oah::kTagMask);
   }
 
   static size_t SizeOf(TaggedPtr tagged_ptr) {
@@ -133,7 +129,7 @@ template <class T> class PtrVector {
     assert(!log_mode || std::has_single_bit(count));
     const uint64_t field = log_mode ? std::countr_zero(count) : count;
     assert(field <= kSizeMask);
-    return (tagged_ptr & ~kSizeFieldMask) | kVectorBit | (field << kSizeShift) |
+    return (tagged_ptr & ~kSizeFieldMask) | oah::kVectorBit | (field << kSizeShift) |
            (log_mode ? kLogModeBit : 0);
   }
 

--- a/src/core/ptr_vector.h
+++ b/src/core/ptr_vector.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/types.h>
+
 #include <algorithm>
 #include <bit>
 #include <cassert>


### PR DESCRIPTION
## Summary

OAHPair (the OAHMap member) now uses the same variable-width size encoding as OAHEntry and always
stores its value in a separate, 8-byte-aligned allocation so values can be reinterpreted as typed
arrays (e.g. by vector search). The shared size codec and pointer-tag layout are extracted into a
new `oah_base.h`, so OAHEntry and OAHPair no longer duplicate them.

## Changes

- Add `src/core/oah_base.h` with a shared `dfly::oah` namespace: `TaggedPtr`, the pointer
  tag/flag constants, `PrefetchRead`, and the `oah::size` variable-width size codec (1/2/4-byte
  fields, sizes up to ~0.5 GB).
- Reencode OAHPair key and value sizes with `oah::size`; the blob layout is now
  `[expiry?, key_size, value_size, value_ptr:8B, key]`.
- Always store the OAHPair value in its own zmalloc buffer (>= 8-byte aligned); an empty value
  stores a null pointer and allocates no buffer.
- Relocate the blob and the external value buffer independently in `ReallocIfNeeded`, so defrag
  moves only the under-utilized allocation while accounting for both.
- Refactor OAHEntry to consume the shared `oah` / `oah::size` definitions instead of its own
  copies; replace the `PREFETCH_READ` macro with `oah::PrefetchRead` and drop `<sys/types.h>`.
- Give each accessor a class-scope `using TaggedPtr = oah::TaggedPtr;` to keep names local
  without polluting the enclosing namespace.
- Extend `oah_map_test` and `oah_set_test` to cover the new encoding, external-value ownership,
  expiry rebuilds, and selective realloc/defrag accounting.