### PR TITLE
build(cmake): add retry to third-party tarball downloads, bump helio

### DIFF
--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -79,7 +79,10 @@ ExternalProject_Add(mimalloc2_project
       -DEXTRACT_DIR=${THIRD_PARTY_DIR}/mimalloc2
       -DEXPECTED_HASH=${MIMALLOC_SHA256}
       -P ${HELIO_CMAKE_DIR}/download_retry.cmake
-  DOWNLOAD_DIR ${THIRD_PARTY_DIR}/mimalloc2
+  # DOWNLOAD_DIR (the download step's working dir) must differ from the source
+  # dir: download_retry.cmake removes EXTRACT_DIR (=the source dir) before
+  # moving the extracted tree into place, so it must not be the step's own CWD.
+  DOWNLOAD_DIR ${THIRD_PARTY_DIR}
   SOURCE_DIR ${THIRD_PARTY_DIR}/mimalloc2
   # INSTALL_DIR ${MIMALLOC_ROOT_DIR}
   UPDATE_COMMAND ""

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -58,14 +58,27 @@ add_third_party(
   INSTALL_COMMAND ${DFLY_TOOLS_MAKE} install BUILD_SHARED=no PREFIX=${THIRD_PARTY_LIB_DIR}/lz4
 )
 
+# MiMalloc is built with a raw ExternalProject_Add rather than add_third_party:
+# its build needs custom patches, bespoke -DMI_* CMAKE_ARGS, non-standard output dirs, extra header copying, and a
+# hand-declared imported target - none of which fit add_third_party's conventional layout. It still downloads a URL
+# tarball, so it reuses the shared retry policy (see third_party.cmake) via DOWNLOAD_COMMAND (see below).
 set(MIMALLOC_ROOT_DIR ${THIRD_PARTY_LIB_DIR}/mimalloc2)
 set(MIMALLOC_INCLUDE_DIR ${MIMALLOC_ROOT_DIR}/include)
 set(MIMALLOC_PATCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.2.4)
 set(MIMALLOC_C_FLAGS "-O3 -g -DMI_STAT=0 -DNDEBUG")
+set(MIMALLOC_URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.2.4.tar.gz)
+set(MIMALLOC_SHA256 754a98de5e2912fddbeaf24830f982b4540992f1bab4a0a8796ee118e0752bda)
 file(MAKE_DIRECTORY ${MIMALLOC_INCLUDE_DIR})
 
 ExternalProject_Add(mimalloc2_project
-  URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.2.4.tar.gz
+  # Download via the shared retry policy (see note above). HELIO_CMAKE_DIR is
+  # exported by helio/cmake/third_party.cmake.
+  DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DURL=${MIMALLOC_URL}
+      -DDEST=${THIRD_PARTY_DIR}/mimalloc2-src-archive
+      -DEXTRACT_DIR=${THIRD_PARTY_DIR}/mimalloc2
+      -DEXPECTED_HASH=${MIMALLOC_SHA256}
+      -P ${HELIO_CMAKE_DIR}/download_retry.cmake
   DOWNLOAD_DIR ${THIRD_PARTY_DIR}/mimalloc2
   SOURCE_DIR ${THIRD_PARTY_DIR}/mimalloc2
   # INSTALL_DIR ${MIMALLOC_ROOT_DIR}
@@ -89,7 +102,6 @@ ExternalProject_Add(mimalloc2_project
   LOG_BUILD ON
   LOG_PATCH ON
   LOG_UPDATE ON
-  DOWNLOAD_EXTRACT_TIMESTAMP YES
 
   CMAKE_GENERATOR "Unix Makefiles"
 


### PR DESCRIPTION
Bump the helio submodule to pull in the shared download_retry.cmake policy (retries with backoff, verifies hashes, extracts). With it, add_third_party now implicitly routes every URL/tarball dependency through the retrying downloader instead of ExternalProject's single-shot download.

mimalloc keeps its raw ExternalProject_Add (its build is too custom for add_third_party) but opts into the same policy via a custom DOWNLOAD_COMMAND.

In total, ~9 deps now use it (in Dragonfly): 

- The 8 URL add_third_party targets plus mimalloc;
- The 5 GIT_REPOSITORY deps (14 - 5) are unchanged, since git clone is a separate path.
- ~3 more use it at helio

Drop DOWNLOAD_EXTRACT_TIMESTAMP from mimalloc: it only affects ExternalProject's built-in URL extract, which DOWNLOAD_COMMAND bypasses, so it was a no-op (our script preserves archive mtimes, matching the old behavior).
