### PR TITLE
ci: bump test-fakeredis image to ubuntu-dev:24

### DIFF
--- a/.github/workflows/test-fakeredis.yml
+++ b/.github/workflows/test-fakeredis.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/romange/ubuntu-dev:22
+      image: ghcr.io/romange/ubuntu-dev:24
       options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
     strategy:
       fail-fast: false
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         working-directory: tests/fakeredis
         run: |
-          pip install poetry
+          pip install --break-system-packages poetry
           echo "$HOME/.poetry/bin" >> $GITHUB_PATH
           poetry install
       - name: Configure CMake


### PR DESCRIPTION
The fakeredis test job was the only builder still pinned to ubuntu-dev:22 (GCC 11); bump it to ubuntu-dev:24 (GCC 13) to align with the ci.yml / release.yml build matrix.

Why:
- GCC 11 lacks native `_Float16` / `__bf16`, which the search vector code relies on.
- Every other build image is already GCC 13/14 (ubuntu-dev:24, ubuntu-dev:20-gcc14).

The newer image ships Python 3.12 (PEP 668), so the poetry bootstrap needs --break-system-packages.

Changes:
- test-fakeredis.yml: container image ghcr.io/romange/ubuntu-dev:22 -> :24
- test-fakeredis.yml: pip install --break-system-packages poetry (Python 3.12 / PEP 668)