### PR TITLE
fix(tiering): Fix offloading cooling

### DIFF
--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -212,13 +212,13 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   // Load all values from bin by their hashes
   void Defragment(tiering::DiskSegment segment, string_view value);
 
-  void NotifyStashed(const OwnedEntryId& id,
-                     const io::Result<tiering::DiskSegment>& segment) override {
+  void NotifyStashed(const OwnedEntryId& id, const io::Result<tiering::DiskSegment>& segment,
+                     uint8_t flags) override {
     if (!segment) {
       VLOG(1) << "Stash failed " << segment.error().message();
       visit([this](auto id) { ClearStashPending(id); }, id);
     } else {
-      visit([this, segment](auto id) { SetExternal(id, *segment); }, id);
+      visit([this, segment, flags](auto id) { SetExternal(id, *segment, flags); }, id);
     }
   }
 
@@ -258,7 +258,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   // Find entry by key in db_slice and store external segment in place of original value.
   // Update memory stats
-  void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment) {
+  void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment, uint8_t flags) {
     UnblockBackpressure(key, true);
     if (auto* pv = Find(key.first, key.second); pv) {
       auto* stats = GetDbTableStats(key.first);
@@ -269,7 +269,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       stats_.total_stashes++;
 
       StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
-      if (ts_->config_.experimental_cooling) {
+      if (ts_->config_.experimental_cooling && (flags & TieredStorage::kWasClientWrite)) {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
       } else {
@@ -282,13 +282,13 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   // Find bin by id and call SetExternal for all contained entries
-  void SetExternal(tiering::SmallBins::BinId id, tiering::DiskSegment segment) {
+  void SetExternal(tiering::SmallBins::BinId id, tiering::DiskSegment segment, uint8_t flags) {
     for (const auto& [sub_dbid, sub_key, sub_segment] : ts_->bins_->ReportStashed(id, segment))
-      SetExternal({sub_dbid, sub_key}, sub_segment);
+      SetExternal({sub_dbid, sub_key}, sub_segment, flags);
   }
 
   // Finalize stash for a fragments identified by pointer
-  void SetExternal(tiering::ListNodeId id, tiering::DiskSegment segment) {
+  void SetExternal(tiering::ListNodeId id, tiering::DiskSegment segment, uint8_t /*flags*/) {
     auto* stats = GetDbTableStats(std::get<0>(id));
 
     stats->tiered_entries++;
@@ -510,7 +510,7 @@ void TieredStorage::ReadInternal(tiering::ReadId id, const tiering::DiskSegment&
 }
 
 void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDescriptor& blobs,
-                                    BackPressureFuture* backpressure) {
+                                    BackPressureFuture* backpressure, uint8_t flags) {
   CHECK(!bins_->IsPending(dbid, key));  // Because has stash pending is false (ShouldStash checks)
 
   size_t est_size = blobs.EstimatedSerializedSize();
@@ -522,11 +522,13 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
   if (OccupiesWholePages(est_size)) {  // large enough for own page
     id = KeyRef(dbid, key);
     auto serialize = absl::bind_front(&StashDescriptor::Serialize, &blobs);
-    ec = op_manager_->PrepareAndStash(id, est_size, serialize);
-  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs)); bin) {
+    ec = op_manager_->PrepareAndStash(id, est_size, serialize, flags);
+  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs), flags); bin) {
     id = bin->id;
     auto serialize = absl::bind_front(&tiering::SmallBins::SerializeBin, bins_.get(), &*bin);
-    ec = op_manager_->PrepareAndStash(id, 4_KB, serialize);
+    // The flushed bin may aggregate entries from several stashes; keep it cool if any of them
+    // requested it (see SmallBins::FilledBin::Flags).
+    ec = op_manager_->PrepareAndStash(id, 4_KB, serialize, bin->flags);
   } else {
     return;  // added to bin, no operations pending
   }
@@ -689,7 +691,9 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
       } else {
         stats_.offloading_stashes++;
         it->second.SetStashPending(true);
-        StashPrimeValue(dbid, it->first.GetSlice(&tmp), *blobs, nullptr);
+        // Background cold-scan offload: this value already lost a second chance, so do not keep
+        // it in the cooling layer.
+        StashPrimeValue(dbid, it->first.GetSlice(&tmp), *blobs, nullptr, /*flags=*/0);
       }
     }
   };
@@ -858,7 +862,8 @@ void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, Pri
           ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk.GetExpireTime()});
       blobs) {
     pv->SetStashPending(true);
-    ts->StashPrimeValue(dbid, key, *blobs, backpressure);
+    // Write/load-driven offload: keep the value in the cooling layer to serve read-after-write.
+    ts->StashPrimeValue(dbid, key, *blobs, backpressure, TieredStorage::kWasClientWrite);
   }
 }
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -45,6 +45,12 @@ ABSL_FLAG(bool, tiered_experimental_cooling, true,
           "If true, uses intermediate cooling layer "
           "when offloading values to storage");
 
+ABSL_FLAG(bool, tiered_offload_cooling, true,
+          "If true, values offloaded by background offloading are cooled like client writes. If "
+          "false, such values (already proven cold) are only kept in the cooling layer when there "
+          "is spare memory (no eviction needed) and are then inserted at the reclaim end of the "
+          "cool queue so they are evicted first; otherwise they go straight to disk");
+
 ABSL_RETIRED_FLAG(unsigned, tiered_storage_write_depth, 200,
                   "Maximum number of concurrent stash requests issued by background offload. "
                   "Deprecated: prefer tiered_max_pending_stash_bytes.");
@@ -213,12 +219,12 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   void Defragment(tiering::DiskSegment segment, string_view value);
 
   void NotifyStashed(const OwnedEntryId& id, const io::Result<tiering::DiskSegment>& segment,
-                     uint8_t flags) override {
+                     tiering::StashSource source) override {
     if (!segment) {
       VLOG(1) << "Stash failed " << segment.error().message();
       visit([this](auto id) { ClearStashPending(id); }, id);
     } else {
-      visit([this, segment, flags](auto id) { SetExternal(id, *segment, flags); }, id);
+      visit([this, segment, source](auto id) { SetExternal(id, *segment, source); }, id);
     }
   }
 
@@ -258,37 +264,58 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   // Find entry by key in db_slice and store external segment in place of original value.
   // Update memory stats
-  void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment, uint8_t flags) {
+  void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment,
+                   tiering::StashSource source) {
     UnblockBackpressure(key, true);
-    if (auto* pv = Find(key.first, key.second); pv) {
-      auto* stats = GetDbTableStats(key.first);
 
-      pv->SetStashPending(false);
-      stats->tiered_entries++;
-      stats->tiered_used_bytes += segment.length;
-      stats_.total_stashes++;
+    auto* pv = Find(key.first, key.second);
+    if (!pv) {
+      LOG(DFATAL) << "Value not found";
+      return;
+    }
 
-      StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
-      if (ts_->config_.experimental_cooling && (flags & TieredStorage::kWasClientWrite)) {
-        RetireColdEntries(pv->MallocUsed());
-        ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
-      } else {
-        stats->AddTypeMemoryUsage(pv->ObjType(), -pv->MallocUsed());
-        pv->SetExternal(segment.offset, segment.length, blobs.rep);
+    auto* stats = GetDbTableStats(key.first);
+
+    pv->SetStashPending(false);
+    stats->tiered_entries++;
+    stats->tiered_used_bytes += segment.length;
+    stats_.total_stashes++;
+
+    StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
+
+    // Client writes are always cooled down.
+    // Offloaded are cooled down if enabled or otherwise placed at the head of the cool qeueue
+    // (lowest prio) and only if memory is available - so not to disrupt client writes at all
+    bool should_cool = false, low_prio = false;
+    if (ts_->config_.experimental_cooling) {
+      if (source == tiering::StashSource::kClient || ts_->config_.offload_cooling) {
+        should_cool = true;
+      } else if (ts_->UploadBudget() > int64_t(pv->MallocUsed())) {
+        should_cool = true;
+        low_prio = true;
       }
+    }
+
+    if (should_cool) {
+      if (!low_prio)
+        RetireColdEntries(pv->MallocUsed());
+      ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv, low_prio);
     } else {
-      LOG(DFATAL) << "Should not reach here";
+      stats->AddTypeMemoryUsage(pv->ObjType(), -pv->MallocUsed());
+      pv->SetExternal(segment.offset, segment.length, blobs.rep);
     }
   }
 
   // Find bin by id and call SetExternal for all contained entries
-  void SetExternal(tiering::SmallBins::BinId id, tiering::DiskSegment segment, uint8_t flags) {
+  void SetExternal(tiering::SmallBins::BinId id, tiering::DiskSegment segment,
+                   tiering::StashSource source) {
     for (const auto& [sub_dbid, sub_key, sub_segment] : ts_->bins_->ReportStashed(id, segment))
-      SetExternal({sub_dbid, sub_key}, sub_segment, flags);
+      SetExternal({sub_dbid, sub_key}, sub_segment, source);
   }
 
   // Finalize stash for a fragments identified by pointer
-  void SetExternal(tiering::ListNodeId id, tiering::DiskSegment segment, uint8_t /*flags*/) {
+  void SetExternal(tiering::ListNodeId id, tiering::DiskSegment segment,
+                   tiering::StashSource /*source*/) {
     auto* stats = GetDbTableStats(std::get<0>(id));
 
     stats->tiered_entries++;
@@ -510,7 +537,7 @@ void TieredStorage::ReadInternal(tiering::ReadId id, const tiering::DiskSegment&
 }
 
 void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDescriptor& blobs,
-                                    BackPressureFuture* backpressure, uint8_t flags) {
+                                    BackPressureFuture* backpressure, tiering::StashSource source) {
   CHECK(!bins_->IsPending(dbid, key));  // Because has stash pending is false (ShouldStash checks)
 
   size_t est_size = blobs.EstimatedSerializedSize();
@@ -522,13 +549,13 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
   if (OccupiesWholePages(est_size)) {  // large enough for own page
     id = KeyRef(dbid, key);
     auto serialize = absl::bind_front(&StashDescriptor::Serialize, &blobs);
-    ec = op_manager_->PrepareAndStash(id, est_size, serialize, flags);
-  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs), flags); bin) {
+    ec = op_manager_->PrepareAndStash(id, est_size, serialize, source);
+  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs), source); bin) {
     id = bin->id;
     auto serialize = absl::bind_front(&tiering::SmallBins::SerializeBin, bins_.get(), &*bin);
-    // The flushed bin may aggregate entries from several stashes; keep it cool if any of them
-    // requested it (see SmallBins::FilledBin::Flags).
-    ec = op_manager_->PrepareAndStash(id, 4_KB, serialize, bin->flags);
+    // The flushed bin may aggregate entries from several stashes; it counts as a client stash if
+    // any of them was one (see SmallBins::FilledBin::source).
+    ec = op_manager_->PrepareAndStash(id, 4_KB, serialize, bin->source);
   } else {
     return;  // added to bin, no operations pending
   }
@@ -631,6 +658,7 @@ void TieredStorage::UpdateFromFlags() {
   config_ = {
       .min_value_size = absl::GetFlag(FLAGS_tiered_min_value_size),
       .experimental_cooling = absl::GetFlag(FLAGS_tiered_experimental_cooling),
+      .offload_cooling = absl::GetFlag(FLAGS_tiered_offload_cooling),
       .max_pending_stash_bytes = absl::GetFlag(FLAGS_tiered_max_pending_stash_bytes),
       .offload_threshold = absl::GetFlag(FLAGS_tiered_offload_threshold),
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
@@ -645,11 +673,11 @@ void TieredStorage::UpdateFromFlags() {
 }
 
 std::vector<std::string> TieredStorage::GetMutableFlagNames() {
-  return base::GetFlagNames(FLAGS_tiered_min_value_size, FLAGS_tiered_experimental_cooling,
-                            FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
-                            FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
-                            FLAGS_tiered_experimental_list_support,
-                            FLAGS_tiered_min_ttl_to_offload_ms);
+  return base::GetFlagNames(
+      FLAGS_tiered_min_value_size, FLAGS_tiered_experimental_cooling, FLAGS_tiered_offload_cooling,
+      FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
+      FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
+      FLAGS_tiered_experimental_list_support, FLAGS_tiered_min_ttl_to_offload_ms);
 }
 
 bool TieredStorage::ShouldOffload() const {
@@ -691,9 +719,8 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
       } else {
         stats_.offloading_stashes++;
         it->second.SetStashPending(true);
-        // Background cold-scan offload: this value already lost a second chance, so do not keep
-        // it in the cooling layer.
-        StashPrimeValue(dbid, it->first.GetSlice(&tmp), *blobs, nullptr, /*flags=*/0);
+        StashPrimeValue(dbid, it->first.GetSlice(&tmp), *blobs, nullptr,
+                        tiering::StashSource::kOffloading);
       }
     }
   };
@@ -814,9 +841,13 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref,
 
 void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
                              const tiering::DiskSegment& segment, CompactObj::ExternalRep rep,
-                             PrimeValue* pv) {
+                             PrimeValue* pv, bool insert_at_end) {
   TieredCoolRecord* record = CompactObj::AllocateMR<TieredCoolRecord>();
-  cool_queue_.push_front(*record);
+
+  if (insert_at_end)
+    cool_queue_.push_back(*record);
+  else
+    cool_queue_.push_front(*record);
   stats_.cool_memory_used += (sizeof(TieredCoolRecord) + pv->MallocUsed());
 
   record->key_hash = CompactObj::HashCode(str);
@@ -862,8 +893,7 @@ void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, Pri
           ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk.GetExpireTime()});
       blobs) {
     pv->SetStashPending(true);
-    // Write/load-driven offload: keep the value in the cooling layer to serve read-after-write.
-    ts->StashPrimeValue(dbid, key, *blobs, backpressure, TieredStorage::kWasClientWrite);
+    ts->StashPrimeValue(dbid, key, *blobs, backpressure, tiering::StashSource::kClient);
   }
 }
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -66,12 +66,6 @@ class TieredStorage : public TieredStorageBase {
   std::error_code Open(std::string_view path);
   void Close();
 
-  // Stash flags below:
-  //
-  // Set if the stash was issued by a client write (and not background offloading).
-  // Such writes can be "cooled down" as we don't yet know the access frequency of the value
-  static constexpr uint8_t kWasClientWrite = 1;
-
   // Enqueue read external value with generic decoder.
   template <typename D, typename F>
   void Read(tiering::ReadId id, const tiering::DiskSegment& segment, const D& decoder, F&& f,
@@ -89,10 +83,10 @@ class TieredStorage : public TieredStorageBase {
                                              const StashContext& stash_ctx) const;
 
   // Stash value identified by (dbid, key), returns optional future for backpressure is not null.
-  // if `provide_bp` is set and conditions are met. `flags` (see kKeepCool) are carried through
-  // to stash completion.
+  // if `provide_bp` is set and conditions are met. `source` records who issued the stash and is
+  // carried through to stash completion to decide whether the value is cooled.
   void StashPrimeValue(DbIndex dbid, std::string_view key, const StashDescriptor& blobs,
-                       BackPressureFuture* backpressure, uint8_t flags);
+                       BackPressureFuture* backpressure, tiering::StashSource source);
 
   // Stash partial value identified by pointer.
   void StashPartialValue(tiering::PendingId id, const StashDescriptor& blobs,
@@ -139,9 +133,10 @@ class TieredStorage : public TieredStorageBase {
                     const tiering::Decoder& decoder,
                     std::function<void(io::Result<tiering::Decoder*>)> cb, bool read_only);
 
-  // Moves pv contents to the cool storage and updates pv to point to it.
+  // Moves pv contents to the cool storage and updates pv to point to it. Inserts at front by
+  // default or at back if `insert_at_end` is set (first to be evicted, lowest priority)
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
-                CompactObj::ExternalRep rep, PrimeValue* pv);
+                CompactObj::ExternalRep rep, PrimeValue* pv, bool insert_at_end = false);
 
   void ProcessDelayedDeframents();
 
@@ -164,6 +159,7 @@ class TieredStorage : public TieredStorageBase {
   struct {
     size_t min_value_size;
     bool experimental_cooling;
+    bool offload_cooling;
     size_t max_pending_stash_bytes;
     float offload_threshold;
     float upload_threshold;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -66,6 +66,12 @@ class TieredStorage : public TieredStorageBase {
   std::error_code Open(std::string_view path);
   void Close();
 
+  // Stash flags below:
+  //
+  // Set if the stash was issued by a client write (and not background offloading).
+  // Such writes can be "cooled down" as we don't yet know the access frequency of the value
+  static constexpr uint8_t kWasClientWrite = 1;
+
   // Enqueue read external value with generic decoder.
   template <typename D, typename F>
   void Read(tiering::ReadId id, const tiering::DiskSegment& segment, const D& decoder, F&& f,
@@ -83,9 +89,10 @@ class TieredStorage : public TieredStorageBase {
                                              const StashContext& stash_ctx) const;
 
   // Stash value identified by (dbid, key), returns optional future for backpressure is not null.
-  // if `provide_bp` is set and conditions are met.
+  // if `provide_bp` is set and conditions are met. `flags` (see kKeepCool) are carried through
+  // to stash completion.
   void StashPrimeValue(DbIndex dbid, std::string_view key, const StashDescriptor& blobs,
-                       BackPressureFuture* backpressure);
+                       BackPressureFuture* backpressure, uint8_t flags);
 
   // Stash partial value identified by pointer.
   void StashPartialValue(tiering::PendingId id, const StashDescriptor& blobs,

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -28,6 +28,8 @@ ABSL_DECLARE_FLAG(float, tiered_offload_threshold);
 ABSL_DECLARE_FLAG(float, tiered_upload_threshold);
 ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
+ABSL_DECLARE_FLAG(bool, tiered_offload_cooling);
+ABSL_DECLARE_FLAG(uint32_t, tiered_min_ttl_to_offload_ms);
 ABSL_DECLARE_FLAG(uint64_t, registered_buffer_size);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_hash_support);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_list_support);
@@ -71,6 +73,26 @@ class TieredStorageTest : public BaseFamilyTest {
 
   void UpdateFromFlags() {
     pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->UpdateFromFlags(); });
+  }
+
+  // Writes `num` large values that stay hot (nothing is stashed on the write path), then enables
+  // background offloading. Callers wait for and assert the outcome they expect.
+  void PrimeHotValuesAndEnableOffloading(size_t num) {
+    string value = BuildString(3000);
+    max_memory_limit = num * 8192;  // headroom so writes stay hot (no eager stash)
+
+    // Write everything with offloading off. Give keys a TTL below min_ttl_to_offload_ms so the
+    // write path does not eagerly stash (and cool) them; they stay hot in memory.
+    SetFlag(&FLAGS_tiered_offload_threshold, 0.0f);
+    SetFlag(&FLAGS_tiered_min_ttl_to_offload_ms, 3600'000);  // 1h: covers our 100s key TTL
+    UpdateFromFlags();
+    for (size_t i = 0; i < num; i++)
+      Run({"SET", absl::StrCat("k", i), value, "EX", "100"});
+    EXPECT_EQ(GetMetrics().tiered_stats.total_stashes, 0u);
+
+    // Enable offloading so the background cold-scan drains the (now cold) values.
+    SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+    UpdateFromFlags();
   }
 
   // A single huge PFADD stays sparse and too small to offload; batch to force dense.
@@ -498,6 +520,66 @@ TEST_F(PureDiskTSTest, OffloadingStrategy) {
     EXPECT_EQ(metrics.tiered_stats.total_offloading_stashes, i);
     EXPECT_EQ(metrics.tiered_stats.total_stashes, i + 1);
   }
+}
+
+// With tiered_offload_cooling=false and spare memory, a background-offloaded value (proven cold)
+// is kept in the cooling layer as an opportunistic cache instead of going straight to disk.
+TEST_F(TieredStorageTest, BackgroundOffloadingCoolsWhenRoom) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  SetFlag(&FLAGS_tiered_offload_cooling, false);
+  // Default upload_threshold (0.1) leaves headroom, so cooling won't evict anything.
+
+  PrimeHotValuesAndEnableOffloading(200);
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.cold_storage_bytes > 0; });
+  EXPECT_GT(GetMetrics().tiered_stats.total_offloading_stashes, 0u);
+}
+
+// With tiered_offload_cooling=false and no free memory, cooling a proven-cold value would force an
+// eviction, so it goes straight to disk and the cooling layer stays empty.
+TEST_F(TieredStorageTest, BackgroundOffloadingSkipsCoolingUnderPressure) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  SetFlag(&FLAGS_tiered_offload_cooling, false);
+  SetFlag(&FLAGS_tiered_upload_threshold, 1.0f);  // no headroom -> cooling always evicts
+
+  PrimeHotValuesAndEnableOffloading(200);
+  // Nothing is cooled, so offloading drains every value straight to disk.
+  ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 200; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.tiered_stats.total_offloading_stashes, 200u);
+  EXPECT_EQ(metrics.tiered_stats.cold_storage_bytes, 0u);
+}
+
+// Contrast with the above under identical memory pressure: with tiered_offload_cooling=true
+// (default), background-offloaded values are still cooled like client writes.
+TEST_F(TieredStorageTest, BackgroundOffloadingKeepsCoolingUnderPressure) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  SetFlag(&FLAGS_tiered_offload_cooling, true);
+  SetFlag(&FLAGS_tiered_upload_threshold, 1.0f);  // same pressure as the test above
+
+  PrimeHotValuesAndEnableOffloading(200);
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.cold_storage_bytes > 0; });
+}
+
+// Regardless of tiered_offload_cooling, a client write under memory pressure is cooled (kept in
+// memory) so it can serve read-after-write, growing the cooling layer.
+TEST_F(TieredStorageTest, ClientWriteIsCooled) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  SetFlag(&FLAGS_tiered_offload_cooling, false);
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);  // force eager stash on write
+  UpdateFromFlags();
+
+  max_memory_limit = 1;  // any write is "over budget" -> eager stash
+  Run({"SET", "key", BuildString(3000)});
+  ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 1; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.tiered_stats.total_offloading_stashes, 0u);  // not via background scan
+  EXPECT_GT(metrics.tiered_stats.cold_storage_bytes, 0u);        // kept in cooling layer
 }
 
 // Test FLUSHALL while reading entries

--- a/src/server/tiering/common.h
+++ b/src/server/tiering/common.h
@@ -4,12 +4,19 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <optional>
 #include <variant>
 
 namespace dfly::tiering {
+
+// Who issued the stash
+enum class StashSource : uint8_t {
+  kClient,      // Client write
+  kOffloading,  // Background offloading loop
+};
 
 inline namespace literals {
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -95,14 +95,14 @@ void OpManager::DeleteOffloaded(DiskSegment segment) {
 }
 
 void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
-                      util::fb2::RegisteredSlice buf, uint8_t flags) {
+                      util::fb2::RegisteredSlice buf, StashSource source) {
   auto id = ToOwned(id_ref);
   unsigned version = ++pending_stash_counter_;
   pending_stash_ver_[id] = version;
 
-  auto io_cb = [this, version, id = std::move(id), segment, flags](std::error_code ec) {
+  auto io_cb = [this, version, id = std::move(id), segment, source](std::error_code ec) {
     auto segment_res = ec ? nonstd::make_unexpected(ec) : io::Result<DiskSegment>(segment);
-    ProcessStashed(id, version, segment_res, flags);
+    ProcessStashed(id, version, segment_res, source);
   };
 
   // May block due to blocking call to Grow.
@@ -111,13 +111,13 @@ void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
 
 std::error_code OpManager::PrepareAndStash(PendingId id, size_t length,
                                            const std::function<size_t(io::MutableBytes)>& writer,
-                                           uint8_t flags) {
+                                           StashSource source) {
   auto buf = PrepareStash(length);
   if (!buf.has_value())
     return buf.error();
 
   size_t written = writer(buf->second.bytes);
-  Stash(id, {buf->first, written}, buf->second, flags);
+  Stash(id, {buf->first, written}, buf->second, source);
   return {};
 }
 
@@ -136,11 +136,11 @@ OpManager::ReadOp& OpManager::PrepareRead(DiskSegment aligned_segment) {
 }
 
 void OpManager::ProcessStashed(const OwnedEntryId& id, unsigned version,
-                               const io::Result<DiskSegment>& segment, uint8_t flags) {
+                               const io::Result<DiskSegment>& segment, StashSource source) {
   if (auto it = pending_stash_ver_.find(id);
       it != pending_stash_ver_.end() && it->second == version) {
     pending_stash_ver_.erase(it);
-    NotifyStashed(id, segment, flags);
+    NotifyStashed(id, segment, source);
   } else if (segment) {
     // Throw away the value because it's no longer up-to-date even if no error occured
     VLOG(1) << "Releasing segment " << *segment << ", id: " << ToString(id);

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -95,14 +95,14 @@ void OpManager::DeleteOffloaded(DiskSegment segment) {
 }
 
 void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
-                      util::fb2::RegisteredSlice buf) {
+                      util::fb2::RegisteredSlice buf, uint8_t flags) {
   auto id = ToOwned(id_ref);
   unsigned version = ++pending_stash_counter_;
   pending_stash_ver_[id] = version;
 
-  auto io_cb = [this, version, id = std::move(id), segment](std::error_code ec) {
-    ProcessStashed(id, version,
-                   ec ? nonstd::make_unexpected(ec) : io::Result<DiskSegment>(segment));
+  auto io_cb = [this, version, id = std::move(id), segment, flags](std::error_code ec) {
+    auto segment_res = ec ? nonstd::make_unexpected(ec) : io::Result<DiskSegment>(segment);
+    ProcessStashed(id, version, segment_res, flags);
   };
 
   // May block due to blocking call to Grow.
@@ -110,13 +110,14 @@ void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
 }
 
 std::error_code OpManager::PrepareAndStash(PendingId id, size_t length,
-                                           const std::function<size_t(io::MutableBytes)>& writer) {
+                                           const std::function<size_t(io::MutableBytes)>& writer,
+                                           uint8_t flags) {
   auto buf = PrepareStash(length);
   if (!buf.has_value())
     return buf.error();
 
   size_t written = writer(buf->second.bytes);
-  Stash(id, {buf->first, written}, buf->second);
+  Stash(id, {buf->first, written}, buf->second, flags);
   return {};
 }
 
@@ -135,11 +136,11 @@ OpManager::ReadOp& OpManager::PrepareRead(DiskSegment aligned_segment) {
 }
 
 void OpManager::ProcessStashed(const OwnedEntryId& id, unsigned version,
-                               const io::Result<DiskSegment>& segment) {
+                               const io::Result<DiskSegment>& segment, uint8_t flags) {
   if (auto it = pending_stash_ver_.find(id);
       it != pending_stash_ver_.end() && it->second == version) {
     pending_stash_ver_.erase(it);
-    NotifyStashed(id, segment);
+    NotifyStashed(id, segment, flags);
   } else if (segment) {
     // Throw away the value because it's no longer up-to-date even if no error occured
     VLOG(1) << "Releasing segment " << *segment << ", id: " << ToString(id);

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -67,13 +67,15 @@ class OpManager {
     return storage_.PrepareStash(length);
   }
 
-  // Stash value to be offloaded. It is opaque to OpManager.
-  void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::RegisteredSlice buf);
+  // Stash value to be offloaded. It is opaque to OpManager. `flags` is an opaque byte passed
+  // back to NotifyStashed on completion (used by higher layers to carry stash metadata).
+  void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::RegisteredSlice buf,
+             uint8_t flags = 0);
 
   // PrepareStash + Stash via function
   std::error_code PrepareAndStash(
       PendingId id, size_t length,
-      const std::function<size_t /*written*/ (io::MutableBytes)>& writer);
+      const std::function<size_t /*written*/ (io::MutableBytes)>& writer, uint8_t flags = 0);
 
   Stats GetStats() const;
 
@@ -81,8 +83,9 @@ class OpManager {
   using OwnedEntryId = std::variant<uintptr_t, DbKeyId, ListNodeId>;
 
   // Notify that a stash succeeded and the entry was stored at the provided segment or failed with
-  // given error
-  virtual void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment) = 0;
+  // given error. `flags` is the opaque byte passed to Stash/PrepareAndStash.
+  virtual void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment,
+                             uint8_t flags) = 0;
 
   // Notify that an entry was successfully fetched. Includes whether entry was modified.
   // Returns true if value needs to be deleted from the storage.
@@ -136,7 +139,7 @@ class OpManager {
 
   // Called once Stash finished
   void ProcessStashed(const OwnedEntryId& id, unsigned version,
-                      const io::Result<DiskSegment>& segment);
+                      const io::Result<DiskSegment>& segment, uint8_t flags);
 
  private:
   static OwnedEntryId ToOwned(PendingId id);

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -67,15 +67,16 @@ class OpManager {
     return storage_.PrepareStash(length);
   }
 
-  // Stash value to be offloaded. It is opaque to OpManager. `flags` is an opaque byte passed
-  // back to NotifyStashed on completion (used by higher layers to carry stash metadata).
+  // Stash value to be offloaded. It is opaque to OpManager. `source` records who requested the
+  // stash and is passed back to NotifyStashed on completion (used by higher layers for policy).
   void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::RegisteredSlice buf,
-             uint8_t flags = 0);
+             StashSource source = StashSource::kClient);
 
   // PrepareStash + Stash via function
   std::error_code PrepareAndStash(
       PendingId id, size_t length,
-      const std::function<size_t /*written*/ (io::MutableBytes)>& writer, uint8_t flags = 0);
+      const std::function<size_t /*written*/ (io::MutableBytes)>& writer,
+      StashSource source = StashSource::kClient);
 
   Stats GetStats() const;
 
@@ -83,9 +84,9 @@ class OpManager {
   using OwnedEntryId = std::variant<uintptr_t, DbKeyId, ListNodeId>;
 
   // Notify that a stash succeeded and the entry was stored at the provided segment or failed with
-  // given error. `flags` is the opaque byte passed to Stash/PrepareAndStash.
+  // given error. `source` is the value passed to Stash/PrepareAndStash.
   virtual void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment,
-                             uint8_t flags) = 0;
+                             StashSource source) = 0;
 
   // Notify that an entry was successfully fetched. Includes whether entry was modified.
   // Returns true if value needs to be deleted from the storage.
@@ -139,7 +140,7 @@ class OpManager {
 
   // Called once Stash finished
   void ProcessStashed(const OwnedEntryId& id, unsigned version,
-                      const io::Result<DiskSegment>& segment, uint8_t flags);
+                      const io::Result<DiskSegment>& segment, StashSource source);
 
  private:
   static OwnedEntryId ToOwned(PendingId id);

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -66,7 +66,7 @@ struct OpManagerTest : PoolTestBase, OpManager {
   }
 
   void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment,
-                     uint8_t flags) override {
+                     StashSource source) override {
     VLOG(1) << std::get<0>(id) << " stashed";
     ASSERT_TRUE(segment);
     auto [it, inserted] = stashed_.emplace(id, *segment);

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -65,7 +65,8 @@ struct OpManagerTest : PoolTestBase, OpManager {
     return future;
   }
 
-  void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment) override {
+  void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment,
+                     uint8_t flags) override {
     VLOG(1) << std::get<0>(id) << " stashed";
     ASSERT_TRUE(segment);
     auto [it, inserted] = stashed_.emplace(id, *segment);

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -27,7 +27,7 @@ size_t StashedValueSize(string_view value) {
 }  // namespace
 
 std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_view key,
-                                                     std::string_view value, uint8_t flags) {
+                                                     std::string_view value, StashSource source) {
   DCHECK_LT(value.size(), 2_KB);
 
   size_t value_bytes = StashedValueSize(value);
@@ -38,7 +38,10 @@ std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_v
   }
 
   current_bin_.bytes_ += value_bytes;
-  current_bin_.flags |= flags;
+
+  if (source == StashSource::kClient)  // A client write flips the whole bin
+    current_bin_.source = StashSource::kClient;
+
   auto [it, inserted] = current_bin_.entries_.emplace(std::make_pair(dbid, key), string(value));
   CHECK(inserted);
 

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -27,7 +27,7 @@ size_t StashedValueSize(string_view value) {
 }  // namespace
 
 std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_view key,
-                                                     std::string_view value) {
+                                                     std::string_view value, uint8_t flags) {
   DCHECK_LT(value.size(), 2_KB);
 
   size_t value_bytes = StashedValueSize(value);
@@ -38,6 +38,7 @@ std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_v
   }
 
   current_bin_.bytes_ += value_bytes;
+  current_bin_.flags |= flags;
   auto [it, inserted] = current_bin_.entries_.emplace(std::make_pair(dbid, key), string(value));
   CHECK(inserted);
 

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -41,14 +41,13 @@ class SmallBins {
   struct FilledBin {
     friend class SmallBins;
     BinId id;
-    uint8_t flags = 0;
+    StashSource source = StashSource::kOffloading;
 
    private:
     explicit FilledBin(BinId id) : id{id} {
     }
 
     unsigned bytes_ = 0;
-    uint8_t flags_ = 0;
     tiering::EntryMap<std::string> entries_;
   };
 
@@ -63,10 +62,10 @@ class SmallBins {
     return current_bin_.entries_.count(std::make_pair(dbid, key)) > 0;
   }
 
-  // Enqueue key/value pair for stash. Returns page to be stashed if it filled up. Per-value flags
-  // are collapsed with bitwise or into a per-bin flag
+  // Enqueue key/value pair for stash. Returns page to be stashed if it filled up. A bin is
+  // marked as a client stash if any of its entries came from a client (see FilledBin::source).
   std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value,
-                                 uint8_t flags = 0);
+                                 StashSource source = StashSource::kClient);
 
   // Report that a stash succeeeded. Returns list of stored keys with calculated value locations.
   KeySegmentList ReportStashed(BinId id, DiskSegment segment);

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -41,12 +41,14 @@ class SmallBins {
   struct FilledBin {
     friend class SmallBins;
     BinId id;
+    uint8_t flags = 0;
 
    private:
     explicit FilledBin(BinId id) : id{id} {
     }
 
     unsigned bytes_ = 0;
+    uint8_t flags_ = 0;
     tiering::EntryMap<std::string> entries_;
   };
 
@@ -61,8 +63,10 @@ class SmallBins {
     return current_bin_.entries_.count(std::make_pair(dbid, key)) > 0;
   }
 
-  // Enqueue key/value pair for stash. Returns page to be stashed if it filled up.
-  std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value);
+  // Enqueue key/value pair for stash. Returns page to be stashed if it filled up. Per-value flags
+  // are collapsed with bitwise or into a per-bin flag
+  std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value,
+                                 uint8_t flags = 0);
 
   // Report that a stash succeeeded. Returns list of stored keys with calculated value locations.
   KeySegmentList ReportStashed(BinId id, DiskSegment segment);

--- a/src/server/tiering/small_bins_test.cc
+++ b/src/server/tiering/small_bins_test.cc
@@ -125,4 +125,20 @@ TEST_F(SmallBinsTest, UpdateStatsAfterDelete) {
   EXPECT_EQ(0u, bins_.GetStats().current_bin_bytes);
 }
 
+TEST_F(SmallBinsTest, StashSourceClientDominates) {
+  // A bin is marked as a client stash if any of its entries came from a client; a bin made up
+  // purely of background-offloaded entries stays kOffloading.
+  std::optional<SmallBins::FilledBin> offloading_bin, mixed_bin;
+  for (unsigned i = 0; !offloading_bin; i++)
+    offloading_bin = bins_.Stash(0, absl::StrCat("o", i), "v", StashSource::kOffloading);
+  EXPECT_EQ(offloading_bin->source, StashSource::kOffloading);
+
+  // Feed mostly offloading entries but a single client one: the whole bin becomes a client stash.
+  for (unsigned i = 0; !mixed_bin; i++) {
+    auto source = (i == 1) ? StashSource::kClient : StashSource::kOffloading;
+    mixed_bin = bins_.Stash(0, absl::StrCat("m", i), "v", source);
+  }
+  EXPECT_EQ(mixed_bin->source, StashSource::kClient);
+}
+
 }  // namespace dfly::tiering


### PR DESCRIPTION
Currently, we cool down each offloaded value, including cases where it was offloaded by background offloading. If it was offloaded by background offloading, it is already considered to be cool and better stored disk only - so we should avoid cooling it at all and polluting the cold queue with it

