### PR TITLE
test(search): cover non-float32 vector dtypes (reload, replication, e2e, FT.INFO)

### DIFF
--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7089,6 +7089,63 @@ TEST(BuildRestoreCommandTest, HnswVectorPreservesAllParams) {
   EXPECT_THAT(cmd, HasSubstr("EPSILON 0.07"));
 }
 
+// Builds the FT.CREATE restore command for a single vector field of the given algorithm, dtype and
+// storage — the shared setup for the data_type round-trip tests below.
+static std::string BuildVectorRestoreCommand(bool use_hnsw, dfly::search::VectorDataType dt,
+                                             dfly::DocIndex::DataType storage) {
+  using dfly::DocIndex;
+  using dfly::DocIndexInfo;
+  using dfly::search::IndicesOptions;
+  using dfly::search::SchemaField;
+  using dfly::search::VectorSimilarity;
+
+  SchemaField field;
+  field.type = SchemaField::VECTOR;
+  field.flags = 0;
+  field.short_name = "embedding";
+
+  SchemaField::VectorParams vparams;
+  vparams.use_hnsw = use_hnsw;
+  vparams.dim = 4;
+  vparams.sim = VectorSimilarity::COSINE;
+  vparams.data_type = dt;
+  vparams.capacity = 500;
+  vparams.hnsw_m = 32;
+  vparams.hnsw_ef_construction = 400;
+  vparams.hnsw_ef_runtime = 75;
+  vparams.hnsw_epsilon = 0.07;
+  field.special_params = vparams;
+
+  DocIndex base;
+  base.type = storage;
+  base.prefixes = {"doc:"};
+  base.options = IndicesOptions(absl::flat_hash_set<std::string>{});
+  base.schema.fields["embedding"] = std::move(field);
+
+  DocIndexInfo info;
+  info.base_index = std::move(base);
+  return info.BuildRestoreCommand();
+}
+
+// A FLAT index restores its non-float32 TYPE (and stays FLAT).
+TEST(BuildRestoreCommandTest, FlatVectorPreservesDataType) {
+  std::string cmd =
+      BuildVectorRestoreCommand(false, dfly::search::VectorDataType::INT8, dfly::DocIndex::HASH);
+  EXPECT_THAT(cmd, HasSubstr("FLAT"));
+  EXPECT_THAT(cmd, HasSubstr("TYPE INT8"));
+  EXPECT_THAT(cmd, HasSubstr("DIM 4"));
+  EXPECT_THAT(cmd, HasSubstr("DISTANCE_METRIC COSINE"));
+}
+
+// An HNSW index restores a non-float32 TYPE.
+TEST(BuildRestoreCommandTest, HnswVectorPreservesNonFloat32DataType) {
+  std::string cmd =
+      BuildVectorRestoreCommand(true, dfly::search::VectorDataType::FLOAT16, dfly::DocIndex::HASH);
+  EXPECT_THAT(cmd, HasSubstr("HNSW"));
+  EXPECT_THAT(cmd, HasSubstr("TYPE FLOAT16"));
+  EXPECT_THAT(cmd, HasSubstr("DIM 4"));
+}
+
 // FT.CREATE with a VECTOR FLAT field whose DIM is enormous (e.g. 99999999999)
 // used to cause std::bad_alloc inside FlatVectorIndex, leaving a broken
 // ShardDocIndex registered.  A subsequent FT.SEARCH would dereference the empty

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4506,6 +4506,31 @@ async def test_hnsw_failover_chain(
     await seeder.verify(c1, c2)
 
 
+@pytest.mark.parametrize("document_type", ["HASH", "JSON"])
+@pytest.mark.parametrize("data_type", ["INT8", "FLOAT16"])
+async def test_hnsw_search_replication_dtypes(
+    df_factory: DflyInstanceFactory, document_type: str, data_type: str
+):
+    """A non-float32 HNSW index replicates: the replica rebuilds it at the field's native
+    width and serves KNN identical to the master."""
+    master = df_factory.create(proactor_threads=2)
+    replica = df_factory.create(proactor_threads=2)
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    seeder = HnswSearchSeeder(
+        num_initial_docs=200, num_dims=8, document_type=document_type, data_type=data_type
+    )
+    await seeder.create_index(c_master)
+    await seeder.seed_initial_docs(c_master)
+
+    await start_replication(c_replica, master.port)
+    await check_all_replicas_finished([c_replica], c_master)
+    await seeder.verify(c_master, c_replica)
+
+
 async def test_rm_replication(df_factory: DflyInstanceFactory):
     """Test that RM command propagates deletions to replica and is rejected on replica."""
     master = df_factory.create(proactor_threads=2)

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -17,6 +17,7 @@ meta_memcache>=2.2.0
 prometheus_client>=0.17.0
 aiohttp>=3.10.2
 numpy
+ml_dtypes>=0.2.0
 pytest-json-report>=1.5.0
 psutil>=5.9.5
 boto3>=1.28.55

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -22,7 +22,7 @@ from redis.commands.search.query import Query
 
 from . import dfly_args
 from .instance import DflyInstanceFactory
-from .seeder import HnswSearchSeeder
+from .seeder import HnswSearchSeeder, np_dtype_for
 from .utility import (
     check_all_replicas_finished,
     skip_if_not_in_github,
@@ -433,8 +433,8 @@ async def test_big_json(async_client: aioredis.Redis):
     await i1.dropindex()
 
 
-async def knn_query(idx, query, vector):
-    params = {"vec": np.array(vector, dtype=np.float32).tobytes()}
+async def knn_query(idx, query, vector, np_dtype=np.float32):
+    params = {"vec": np.array(vector, dtype=np_dtype).tobytes()}
     result = await idx.search(query, params)
     return {doc["id"] for doc in result.docs}
 
@@ -490,6 +490,69 @@ async def test_knn(async_client: aioredis.Redis, index_type, algo_type):
 
     assert await knn_query(i2, "@even:{yes} => [KNN 3 @pos $vec]", [10.0] == {"k8", "k10", "k12"})
     await i2.dropindex()
+
+
+@dfly_args({"proactor_threads": 4})
+@pytest.mark.parametrize("index_type", [IndexType.HASH, IndexType.JSON])
+@pytest.mark.parametrize("algo_type", ["FLAT", "HNSW"])
+@pytest.mark.parametrize("data_type", ["INT8", "UINT8", "FLOAT16", "BFLOAT16", "FLOAT64"])
+async def test_knn_dtypes(async_client: aioredis.Redis, index_type, algo_type, data_type):
+    """End-to-end KNN via redis-py for every non-float32 dtype, over HASH+JSON and FLAT+HNSW.
+    Positions are small integers, exactly representable in all dtypes, so ordering is exact."""
+    np_dtype = np_dtype_for(data_type)
+    idx = async_client.ft(f"i-{index_type}-{algo_type}-{data_type}")
+
+    vector_field = VectorField(
+        "pos",
+        algorithm=algo_type,
+        attributes={"TYPE": data_type, "DIM": 1, "DISTANCE_METRIC": "L2"},
+    )
+    await idx.create_index(
+        fix_schema_naming(index_type, [TagField("even"), vector_field]),
+        definition=IndexDefinition(index_type=index_type),
+    )
+
+    n = 40  # keep within int8/uint8 range
+    pipe = async_client.pipeline()
+    for i in range(n):
+        even = "yes" if i % 2 == 0 else "no"
+        if index_type == IndexType.HASH:
+            pipe.hset(
+                f"k{i}",
+                mapping={"even": even, "pos": np.array([i], dtype=np_dtype).tobytes()},
+            )
+        else:
+            pipe.json().set(f"k{i}", "$", {"even": even, "pos": [i]})
+    await pipe.execute()
+
+    assert await knn_query(idx, "* => [KNN 3 @pos $vec]", [20], np_dtype) == {"k19", "k20", "k21"}
+    assert await knn_query(idx, "@even:{yes} => [KNN 3 @pos $vec]", [10], np_dtype) == {
+        "k8",
+        "k10",
+        "k12",
+    }
+    await idx.dropindex()
+
+
+@dfly_args({"proactor_threads": 4})
+@pytest.mark.parametrize("data_type", ["INT8", "UINT8", "FLOAT16", "BFLOAT16", "FLOAT64"])
+async def test_ftinfo_vector_data_type(async_client: aioredis.Redis, data_type):
+    """FT.INFO must round-trip the vector field's declared data_type (redisvl validates on it)."""
+    name = f"info-{data_type}"
+    idx = async_client.ft(name)
+    await idx.create_index(
+        [
+            VectorField(
+                "pos",
+                algorithm="HNSW",
+                attributes={"TYPE": data_type, "DIM": 4, "DISTANCE_METRIC": "L2"},
+            )
+        ],
+        definition=IndexDefinition(index_type=IndexType.HASH),
+    )
+    attr = _search_attribute(await async_client.execute_command("FT.INFO", name), "pos")
+    assert attr[attr.index("data_type") + 1] == data_type
+    await idx.dropindex()
 
 
 NUM_DIMS = 10
@@ -604,18 +667,15 @@ async def test_vector_empty_and_update(async_client: aioredis.Redis, index_type,
     await idx.dropindex()
 
 
-@pytest.mark.parametrize("document_type", ["HASH", "JSON"])
-@pytest.mark.parametrize("start_threads, reload_threads", [(4, 4), (4, 2), (2, 4)])
-async def test_hnsw_reload_different_threads(
-    df_factory: DflyInstanceFactory, document_type, start_threads, reload_threads
+async def _hnsw_save_reload_check(
+    df_factory: DflyInstanceFactory, seeder: HnswSearchSeeder, start_threads=4, reload_threads=4
 ):
-    """HNSW KNN must still work after SAVE + restart with a different thread count."""
-    dbfilename = f"hnsw_threads_{tmp_file_name()}"
+    """Seed an HNSW index, SAVE, restart, and assert every doc stays indexed after reload."""
+    dbfilename = f"hnsw_reload_{tmp_file_name()}"
     inst = df_factory.create(proactor_threads=start_threads, dbfilename=dbfilename)
     inst.start()
     client = inst.client()
 
-    seeder = HnswSearchSeeder(num_initial_docs=50, num_dims=8, document_type=document_type)
     await seeder.create_index(client)
     await seeder.seed_initial_docs(client)
 
@@ -643,6 +703,26 @@ async def test_hnsw_reload_different_threads(
         assert await seeder._search_knn_filtered(
             client2, query_vec, key, k=1
         ), f"doc {key} lost from index after reload"
+
+
+@pytest.mark.parametrize("document_type", ["HASH", "JSON"])
+@pytest.mark.parametrize("start_threads, reload_threads", [(4, 4), (4, 2), (2, 4)])
+async def test_hnsw_reload_different_threads(
+    df_factory: DflyInstanceFactory, document_type, start_threads, reload_threads
+):
+    """HNSW KNN must still work after SAVE + restart with a different thread count."""
+    seeder = HnswSearchSeeder(num_initial_docs=50, num_dims=8, document_type=document_type)
+    await _hnsw_save_reload_check(df_factory, seeder, start_threads, reload_threads)
+
+
+@pytest.mark.parametrize("document_type", ["HASH", "JSON"])
+@pytest.mark.parametrize("data_type", ["INT8", "UINT8", "FLOAT16", "BFLOAT16", "FLOAT64"])
+async def test_hnsw_reload_dtypes(df_factory: DflyInstanceFactory, document_type, data_type):
+    """A non-float32 HNSW index survives SAVE + reload with its native width intact."""
+    seeder = HnswSearchSeeder(
+        num_initial_docs=50, num_dims=8, document_type=document_type, data_type=data_type
+    )
+    await _hnsw_save_reload_check(df_factory, seeder)
 
 
 async def test_search_options_reload(df_factory: DflyInstanceFactory):

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -241,6 +241,24 @@ class Seeder(SeederBase):
         logging.debug(msg)
 
 
+def np_dtype_for(data_type: str):
+    """Maps a vector field TYPE token to the numpy dtype clients encode with."""
+    simple = {
+        "FLOAT32": np.float32,
+        "FLOAT64": np.float64,
+        "FLOAT16": np.float16,
+        "INT8": np.int8,
+        "UINT8": np.uint8,
+    }
+    if data_type in simple:
+        return simple[data_type]
+    if data_type == "BFLOAT16":
+        import ml_dtypes  # optional dependency, only needed for bfloat16
+
+        return ml_dtypes.bfloat16
+    raise ValueError(f"unsupported vector data_type: {data_type}")
+
+
 class HnswSearchSeeder:
 
     def __init__(
@@ -251,6 +269,7 @@ class HnswSearchSeeder:
         num_initial_docs=200,
         seed=42,
         document_type="HASH",
+        data_type="FLOAT32",
     ):
         if document_type not in ("HASH", "JSON"):
             raise ValueError(f"document_type must be HASH or JSON, got {document_type}")
@@ -260,12 +279,20 @@ class HnswSearchSeeder:
         self.num_initial_docs = num_initial_docs
         self.seed = seed
         self.document_type = document_type
+        self.data_type = data_type
+        self.np_dtype = np_dtype_for(data_type)
 
         self._doc_counter = 0
         self._stop_event = asyncio.Event()
 
     def _make_embedding(self):
-        return np.random.uniform(-10, 10, self.num_dims).astype(np.float32)
+        # Integer dtypes must carry whole numbers (JSON stores them as JSON numbers); keep the
+        # range well inside the type so quantization is lossless and KNN ordering is stable.
+        if np.issubdtype(self.np_dtype, np.integer):
+            info = np.iinfo(self.np_dtype)
+            lo, hi = max(info.min, -100), min(info.max, 100)
+            return np.random.randint(lo, hi + 1, self.num_dims).astype(self.np_dtype)
+        return np.random.uniform(-10, 10, self.num_dims).astype(self.np_dtype)
 
     def _field(self, name: str, *spec: str) -> list:
         # FT.CREATE field syntax: HASH uses the field name directly; JSON
@@ -285,7 +312,7 @@ class HnswSearchSeeder:
                 "HNSW",
                 "6",
                 "TYPE",
-                "FLOAT32",
+                self.data_type,
                 "DIM",
                 str(self.num_dims),
                 "DISTANCE_METRIC",


### PR DESCRIPTION
Adds coverage for the non-float32 vector dtypes shipped in #7839 / #7849. Pure tests - no production changes. Proves the dtype survives the paths C++ unit tests don't exercise: persistence, replication, and the redis-py wire round-trip.

Changes:
- HnswSearchSeeder: a `data_type` param drives both the embedding (numpy dtype) and the schema TYPE; the FLOAT32 default is unchanged, so existing seeder-based tests are unaffected.
- Reload: factor the SAVE+restart body into a shared helper; the thread-count test and a new per-dtype test (INT8/UINT8/FLOAT16/BFLOAT16/FLOAT64 x HASH/JSON) both use it.
- Replication: a focused non-float32 test reusing seeder.verify() (replica rebuilds at native width).
- E2E: knn_query gained an optional dtype; a parametrized test_knn_dtypes covers HASH/JSON × FLAT/HNSW.
- FT.INFO: assert the vector field's data_type round-trips for every dtype.
- C++: a shared helper + two BuildRestoreCommand tests (FLAT/INT8, HNSW/FLOAT16).

VECTOR_RANGE / FT.HYBRID for non-float32 are intentionally not duplicated in Python - same query blob path as KNN, already covered at the C++ level (HnswVectorRangeInt8, FtHybridInt8).