### PR TITLE
feat(search): support per-term  inside field groups

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -451,6 +451,7 @@ field_unary_expr:
   | NOT_OP field_unary_expr     { $$ = AstNegateNode(std::move($2));   }
   | TILDE field_unary_expr      { $$ = AstOptionalNode(std::move($2)); }
   | term_atom                   { $$ = std::move($1);                  }
+  | term_atom text_attrs_clause { $$ = AstAttributeNode(std::move($1), $2.weight.value_or(1.0)); }
 
 tag_list:
   tag_list_element                       { $$ = AstTagsNode(std::move($1));                }

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -459,6 +459,35 @@ TEST_F(SearchParserTest, WeightAttributes) {
   EXPECT_NE(0, Parse("*=>{$weight:2}"));
 }
 
+TEST_F(SearchParserTest, PerTermWeightInFieldGroup) {
+  QueryParams params;
+  params["w"] = "5.0";
+  SetParams(&params);
+
+  // Per-term weight inside a field group (as emitted by clients that weight individual words).
+  EXPECT_EQ(0, Parse("@description:(machine=>{$weight:2.0} | learning)"));
+  EXPECT_EQ(0, Parse("@description:(machine=>{$weight:2.0})"));
+  EXPECT_EQ(0, Parse("@description:(machine=>{$weight:2.0} networks)"));
+  EXPECT_EQ(0, Parse("@f:(a=>{$weight:2} | b=>{$weight:3} | c)"));
+  EXPECT_EQ(0, Parse("@f:(a=>{$weight:$w})"));
+  EXPECT_NE(0, Parse("@f:(*=>{$weight:2})"));
+
+  // The weighted term stays scoped to the field: Field{ Or[ Attribute{Term}, Term ] }.
+  EXPECT_EQ(0, Parse("@description:(machine=>{$weight:2.0} | learning)"));
+  auto ast = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstFieldNode>(ast.Variant()));
+  const auto& field = std::get<AstFieldNode>(ast.Variant());
+  EXPECT_EQ(field.field, "description");
+  ASSERT_TRUE(std::holds_alternative<AstLogicalNode>(field.node->Variant()));
+  const auto& logical = std::get<AstLogicalNode>(field.node->Variant());
+  EXPECT_EQ(logical.op, AstLogicalNode::OR);
+  ASSERT_EQ(logical.nodes.size(), 2u);
+  ASSERT_TRUE(std::holds_alternative<AstAttributeNode>(logical.nodes[0].Variant()));
+  const auto& weighted = std::get<AstAttributeNode>(logical.nodes[0].Variant());
+  EXPECT_EQ(weighted.weight, 2.0);
+  EXPECT_TRUE(std::holds_alternative<AstTermNode>(weighted.node->Variant()));
+}
+
 TEST_F(SearchParserTest, VectorRangeParse) {
   QueryParams params;
   params["radius"] = "1";

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -408,6 +408,20 @@ TEST_F(SearchTest, MatchField) {
   EXPECT_TRUE(Check()) << GetError();
 }
 
+TEST_F(SearchTest, MatchFieldPerTermWeight) {
+  PrepareSchema({{"f1", SchemaField::TEXT}, {"f2", SchemaField::TEXT}});
+
+  // A per-term weight inside a field group keeps the term scoped to that field.
+  PrepareQuery("@f1:(machine=>{$weight:2.0} | learning)");
+
+  ExpectAll(Map{{"f1", "machine models"}, {"f2", "x"}}, Map{{"f1", "deep learning"}, {"f2", "x"}},
+            Map{{"f1", "machine learning"}, {"f2", "x"}});
+  ExpectNone(Map{{"f1", "unrelated"}, {"f2", "machine learning"}},  // only in f2
+             Map{{"f1", "nothing here"}, {"f2", "x"}});
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
 TEST_F(SearchTest, MatchRange) {
   PrepareSchema({{"f1", SchemaField::NUMERIC}, {"f2", SchemaField::NUMERIC}});
   PrepareQuery("@f1:[1 10] @f2:[50 100]");

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7720,6 +7720,35 @@ TEST_F(SearchFamilyTest, SearchWithScoresBasic) {
   EXPECT_GT(scores["d:1"], scores["d:2"]) << "Doc with higher TF should score higher";
 }
 
+// A per-term weight inside a field group must parse, stay scoped to the field, and boost the
+// score of docs matching the weighted term (the shape emitted when weighting individual words).
+TEST_F(SearchFamilyTest, SearchPerTermWeightInFieldGroup) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT",
+                 "body", "TEXT"}),
+            "OK");
+  Run({"hset", "d:1", "title", "machine", "body", "z"});
+  Run({"hset", "d:2", "title", "learning", "body", "z"});
+  Run({"hset", "d:3", "title", "unrelated", "body", "machine learning"});
+
+  auto collect = [&](std::string_view query) {
+    auto resp = Run({"ft.search", "i1", query, "NOCONTENT", "WITHSCORES", "DIALECT", "2"});
+    std::map<std::string, double> scores;
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      scores[vals[i].GetString()] = std::stod(vals[i + 1].GetString());
+    return scores;
+  };
+
+  auto scores = collect("@title:(machine=>{$weight:3.0} | learning)");
+  // d:1 and d:2 match via title; d:3 has the words only in body -> field scoping excludes it.
+  ASSERT_EQ(scores.size(), 2u);
+  EXPECT_FALSE(scores.contains("d:3"));
+  ASSERT_TRUE(scores.contains("d:1") && scores.contains("d:2"));
+  // Weighting "machine" 3x boosts the otherwise-symmetric d:1 above d:2. Use at() so a missing
+  // key fails loudly instead of operator[] inserting a default score.
+  EXPECT_GT(scores.at("d:1"), scores.at("d:2"));
+}
+
 // Verify ADDSCORES injects __score for simple (non-KNN) FT.AGGREGATE
 TEST_F(SearchFamilyTest, AggregateAddScoresSimple) {
   EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),


### PR DESCRIPTION
Accept per-term weight attributes `=>{$weight:N}` on terms *inside* a field group `@field:(...)`, not only on a whole top-level term or group. This is the query shape emitted by client libraries that weight individual words (e.g. redisvl `TextQuery` /
`HybridQuery` with `text_weights`), which previously failed with `Query syntax error`.

Before: `@description:(machine=>{$weight:2.0} | learning)` -> `ERR Query syntax error`
After:  parses, stays scoped to the field, and the weight boosts the term's score.
