### PR TITLE
Make cluster announce flags mutable

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -77,6 +77,9 @@ constexpr string_view kClusterDisabled =
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
   CHECK_NOTNULL(server_family_);
 
+  config_registry.RegisterMutable("cluster_announce_ip");
+  config_registry.RegisterMutable("announce_port");
+
   InitializeCluster();
 
   id_ = absl::GetFlag(FLAGS_cluster_node_id);

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -966,6 +966,24 @@ TEST_F(ClusterFamilyEmulatedTest, ClusterShardInfos) {
                                                     "role", "master",                          //
                                                     "replication-offset", IntArg(0),           //
                                                     "health", "online"))))))));
+
+  EXPECT_EQ(RunPrivileged({"config", "set", "cluster_announce_ip", "updated-host"}), "OK");
+  EXPECT_EQ(RunPrivileged({"config", "set", "announce_port", "6380"}), "OK");
+
+  EXPECT_THAT(
+      Run({"cluster", "shards"}),
+      RespElementsAre(RespArray(ElementsAre("slots",                                           //
+                                            RespArray(ElementsAre(IntArg(0), IntArg(16383))),  //
+                                            "nodes",                                           //
+                                            RespArray(ElementsAre(                             //
+                                                RespArray(ElementsAre(                         //
+                                                    "id", GetMyId(),                           //
+                                                    "endpoint", "updated-host",                //
+                                                    "ip", "updated-host",                      //
+                                                    "port", IntArg(6380),                      //
+                                                    "role", "master",                          //
+                                                    "replication-offset", IntArg(0),           //
+                                                    "health", "online"))))))));
 }
 
 TEST_F(ClusterFamilyEmulatedTest, ClusterSlots) {

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -27,11 +27,18 @@ using namespace testing;
 
 class ClusterFamilyTest : public BaseFamilyTest {
  public:
-  ClusterFamilyTest() {
-    SetTestFlag("cluster_mode", "yes");
-  }
+  ClusterFamilyTest() = default;
 
  protected:
+  void SetUp() override {
+    SetTestFlag("cluster_mode", "yes");
+    BaseFamilyTest::SetUp();
+  }
+
+  void TearDown() override {
+    BaseFamilyTest::TearDown();
+  }
+
   static constexpr string_view kInvalidConfiguration = "Invalid cluster configuration";
 
   string GetMyId() {
@@ -935,10 +942,18 @@ TEST_F(ClusterFamilyTest, ClusterCrossSlot) {
 }
 
 class ClusterFamilyEmulatedTest : public ClusterFamilyTest {
- public:
-  ClusterFamilyEmulatedTest() {
+ protected:
+  void SetUp() override {
     SetTestFlag("cluster_mode", "emulated");
     SetTestFlag("cluster_announce_ip", "fake-host");
+    SetTestFlag("announce_port", "6379");
+    BaseFamilyTest::SetUp();
+  }
+
+  void TearDown() override {
+    BaseFamilyTest::TearDown();
+    SetTestFlag("cluster_announce_ip", "");
+    SetTestFlag("announce_port", "0");
   }
 };
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -30,13 +30,13 @@ class ClusterFamilyTest : public BaseFamilyTest {
   ClusterFamilyTest() = default;
 
  protected:
-  void SetUp() override {
+  virtual void ConfigureClusterFlags() {
     SetTestFlag("cluster_mode", "yes");
-    BaseFamilyTest::SetUp();
   }
 
-  void TearDown() override {
-    BaseFamilyTest::TearDown();
+  void SetUp() override {
+    ConfigureClusterFlags();
+    BaseFamilyTest::SetUp();
   }
 
   static constexpr string_view kInvalidConfiguration = "Invalid cluster configuration";
@@ -943,17 +943,10 @@ TEST_F(ClusterFamilyTest, ClusterCrossSlot) {
 
 class ClusterFamilyEmulatedTest : public ClusterFamilyTest {
  protected:
-  void SetUp() override {
+  void ConfigureClusterFlags() override {
     SetTestFlag("cluster_mode", "emulated");
     SetTestFlag("cluster_announce_ip", "fake-host");
     SetTestFlag("announce_port", "6379");
-    BaseFamilyTest::SetUp();
-  }
-
-  void TearDown() override {
-    BaseFamilyTest::TearDown();
-    SetTestFlag("cluster_announce_ip", "");
-    SetTestFlag("announce_port", "0");
   }
 };
 


### PR DESCRIPTION
## Summary

Allow `cluster_announce_ip` and `announce_port` to be updated via `CONFIG SET` in cluster emulation mode and cover the behavior in the emulated cluster shard test.

## Testing

- `pre-commit run --files src/server/cluster/cluster_family.cc src/server/cluster/cluster_family_test.cc`
- `./build-dbg/cluster_family_test --gtest_filter='ClusterFamilyEmulatedTest.ClusterShardInfos'`
