### PR TITLE
build: add memory tracking flag to release makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ HELIO_ENABLE_GIT_VERSION = ON
 HELIO_WITH_UNWIND ?= OFF
 RELEASE_DIR=build-release
 WITH_SIMSIMD ?= ON
+TRACK_MEMORY_ALLOCS ?= OFF
 
 # Release build use glog. Everything else (local dev, CI tests) use absl logging through the root CMakeLists.txt cache
 # default.
@@ -41,7 +42,8 @@ HELIO_FLAGS = -DHELIO_RELEASE_FLAGS="-g" \
               -DWITH_SIMSIMD=$(WITH_SIMSIMD) \
               -DWITH_UNWIND=$(HELIO_WITH_UNWIND) \
               -DMARCH_OPT="$(HELIO_MARCH_OPT)" \
-              -DLEGACY_GLOG=$(LEGACY_GLOG)
+              -DLEGACY_GLOG=$(LEGACY_GLOG) \
+			  -DDF_ENABLE_MEMORY_TRACKING=$(TRACK_MEMORY_ALLOCS)
 
 .PHONY: default
 


### PR DESCRIPTION
## Summary
- expose the memory tracking toggle in the release Makefile so it can be enabled from the build entrypoint

## Testing
- verified the Makefile still parses with make -n
