### PR TITLE
refactor(facade): rename ClearPipelinedMessages

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1327,12 +1327,12 @@ void Connection::ConnectionFlow() {
 
   phase_ = PRECLOSE;
 
-  ClearPipelinedMessages();
+  DrainConnectionQueues();
   DCHECK(!HasPendingMessages());
 
   service_->OnConnectionClose(cc_.get());
 
-  // We have already cleared the queues above (ClearPipelinedMessages), so local queue stats
+  // We have already cleared the queues above (DrainConnectionQueues), so local queue stats
   // (dispatch_q_bytes_, etc.) represent 0 usage. DecreaseConnStats will safely subtract 0 for those
   // stats, while correctly removing this connection from the global connection counts and buffer
   // capacity tracking.
@@ -1896,7 +1896,7 @@ void Connection::SquashPipeline() {
   skip_next_squashing_ = (squashed != pipeline_count);
 }
 
-void Connection::ClearPipelinedMessages() {
+void Connection::DrainConnectionQueues() {
   AsyncOperations async_op{reply_builder_.get(), this};
 
   // First, clear dispatch queue

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -443,8 +443,10 @@ class Connection : public util::Connection {
   // Squashes pipelined commands from the dispatch queue to spread load over all threads
   void SquashPipeline();
 
-  // Clear pipelined messages, dispatching only intrusive ones.
-  void ClearPipelinedMessages();
+  // Drain the control message queue (dispatch_q_) and the parsed command queue (parsed_head_) at
+  // close time, processing checkpoints and waiting on in-flight commands, then release deferred
+  // checkpoints.
+  void DrainConnectionQueues();
 
   // Dec()s every BlockingCounter held in deferred_checkpoints_, then clear the vector.
   // These belong to the checkpoint commands the V2 loop deferred in

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1428,7 +1428,7 @@ async def test_client_pause_v2_close_releases_deferred_checkpoint(df_server: Dfl
     """Regression: closing a client mid-flight must release its deferred CLIENT PAUSE checkpoint.
 
     A paused V2 connection with an in-flight async command defers its DispatchTracker
-    counter. If the client disconnects before the command lands, ClearPipelinedMessages
+    counter. If the client disconnects before the command lands, DrainConnectionQueues
     must release it so CLIENT PAUSE returns well before pause_wait_timeout.
     """
 


### PR DESCRIPTION
Rename Connection::ClearPipelinedMessages to DrainConnectionQueues. The old name named only the pipelined path, but at close time the function drains both the control message queue (dispatch_q_) and the parsed command queue (parsed_head_), waits on in-flight commands, and releases deferred checkpoints. Pure rename, no behavior change.
