### PR TITLE
feat(server): Cascaded psync

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -40,6 +40,7 @@ using namespace std;
 ABSL_DECLARE_FLAG(bool, info_replication_valkey_compatible);
 ABSL_DECLARE_FLAG(uint32_t, replication_timeout);
 ABSL_DECLARE_FLAG(uint32_t, shard_repl_backlog_len);
+ABSL_DECLARE_FLAG(bool, experimental_cascaded_partial_sync);
 
 namespace dfly {
 
@@ -348,6 +349,27 @@ void DflyCmd::Flow(CmdArgParser parser, CommandContext* cmd_cntx) {
 
       // The LSN vector of the same master must be the same size on all replicas.
       if (lsns.size() != my_last_master->last_journal_LSNs.size()) {
+        return cmd_cntx->SendError(facade::kSyntaxErr);
+      }
+
+      DCHECK_LT(flow_id, lsns.size());
+      if (flow_id >= lsns.size()) {
+        LOG(ERROR) << "Invalid flow_id: " << flow_id << " exceeds LSN vector size: " << lsns.size()
+                   << ". Disabling partial sync.";
+        return;  // Fall back to full sync without an error reply.
+      }
+      flow_lsn = lsns[flow_id];
+    } else if (replica_last_master && replica_last_master->id == sf_->GetLineageId() &&
+               absl::GetFlag(FLAGS_experimental_cascaded_partial_sync)) {
+      // Cascaded replication: the connecting replica shares our lineage root, and every node in
+      // the chain keeps its journal in that root's LSN space. So its LSN vector is expressed in
+      // our own LSN space and we can partial-sync it straight from our replication buffer -
+      // whether we are the lineage root itself or an intermediate replica in the chain.
+      ++ServerState::tlocal()->stats.psync_requests_total;
+      const std::vector<LSN>& lsns = replica_last_master->last_journal_LSNs;
+
+      // The LSN vector must carry one entry per shard.
+      if (lsns.size() != shard_set->size()) {
         return cmd_cntx->SendError(facade::kSyntaxErr);
       }
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -288,19 +288,21 @@ void DflyCmd::Flow(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view sync_id_str = parser.Next<string_view>();
   string_view flow_id_str = parser.Next<string_view>();
 
-  std::optional<LSN> seqid;
+  std::optional<LSN> flow_lsn;
   std::optional<Replica::LastMasterSyncData> replica_last_master;
+
   if (parser.HasAtLeast(2)) {
     replica_last_master = {parser.Next<string>(), parser.Next(ParseLsnVec)};
   } else if (parser.HasNext()) {
-    seqid = parser.Next<LSN>();
+    flow_lsn = parser.Next<LSN>();
   }
+
   if (parser.TakeError()) {
     return cmd_cntx->SendError(facade::kInvalidIntErr);
   }
 
   VLOG(1) << "Got DFLY FLOW master_id: " << master_id << " sync_id: " << sync_id_str
-          << " flow: " << flow_id_str << " seq: " << seqid.value_or(-1);
+          << " flow: " << flow_id_str << " seq: " << flow_lsn.value_or(-1);
 
   if (master_id != sf_->master_replid()) {
     return cmd_cntx->SendError(kBadMasterId);
@@ -339,18 +341,22 @@ void DflyCmd::Flow(CmdArgParser parser, CommandContext* cmd_cntx) {
 
     std::optional<Replica::LastMasterSyncData> my_last_master = sf_->GetLastMasterData();
 
-    // The LSN this flow could resume from: either the per-flow seqid sent on a same-master
-    // reconnect, or this flow's entry in the LSN vector the replica saved from the master both
-    // nodes shared before a failover. Both feed the same partial-sync check below.
-    std::optional<LSN> flow_lsn = seqid;
-    if (replica_last_master && my_last_master && my_last_master->id == replica_last_master->id) {
+    // Skip full sync if we stem from the same master and this node was promoted (my_last_master)
+    const bool failover_match =
+        my_last_master && replica_last_master && replica_last_master->id == my_last_master->id;
+
+    // Skip full sync if we have the same parent in a cascaded setup
+    const bool cascaded_match = replica_last_master &&
+                                replica_last_master->id == sf_->GetLineageId() &&
+                                absl::GetFlag(FLAGS_experimental_cascaded_partial_sync);
+
+    // Case for partial sync
+    if (failover_match || cascaded_match) {
       ++ServerState::tlocal()->stats.psync_requests_total;
       const std::vector<LSN>& lsns = replica_last_master->last_journal_LSNs;
 
-      // The LSN vector of the same master must be the same size on all replicas.
-      if (lsns.size() != my_last_master->last_journal_LSNs.size()) {
+      if (lsns.size() != shard_set->size())  // Replica sends LSNs only on equal shard size
         return cmd_cntx->SendError(facade::kSyntaxErr);
-      }
 
       DCHECK_LT(flow_id, lsns.size());
       if (flow_id >= lsns.size()) {
@@ -358,37 +364,12 @@ void DflyCmd::Flow(CmdArgParser parser, CommandContext* cmd_cntx) {
                    << ". Disabling partial sync.";
         return;  // Fall back to full sync without an error reply.
       }
-      flow_lsn = lsns[flow_id];
-    } else if (replica_last_master && replica_last_master->id == sf_->GetLineageId() &&
-               absl::GetFlag(FLAGS_experimental_cascaded_partial_sync)) {
-      // Cascaded replication: the connecting replica shares our lineage root, and every node in
-      // the chain keeps its journal in that root's LSN space. So its LSN vector is expressed in
-      // our own LSN space and we can partial-sync it straight from our replication buffer -
-      // whether we are the lineage root itself or an intermediate replica in the chain.
-      ++ServerState::tlocal()->stats.psync_requests_total;
-      const std::vector<LSN>& lsns = replica_last_master->last_journal_LSNs;
-
-      // The LSN vector must carry one entry per shard.
-      if (lsns.size() != shard_set->size()) {
-        return cmd_cntx->SendError(facade::kSyntaxErr);
-      }
-
-      DCHECK_LT(flow_id, lsns.size());
-      if (flow_id >= lsns.size()) {
-        LOG(ERROR) << "Invalid flow_id: " << flow_id << " exceeds LSN vector size: " << lsns.size()
-                   << ". Disabling partial sync.";
-        return;  // Fall back to full sync without an error reply.
-      }
-      flow_lsn = lsns[flow_id];
+      flow_lsn = lsns[flow_id];  // this is a valid lsn - we can follow up with the buffer check
     }
 
-    std::optional<LSN> lsn_to_start_partial;
+    // Switch sync type to partial
     if (flow_lsn && IsLSNInPartialSyncBuffer(*flow_lsn)) {
-      lsn_to_start_partial = *flow_lsn;
-    }
-
-    if (lsn_to_start_partial) {
-      flow.start_partial_sync_at = *lsn_to_start_partial;
+      flow.start_partial_sync_at = *flow_lsn;
       sync_type = "PARTIAL";
       VLOG(1) << "Partial sync requested from LSN=" << flow.start_partial_sync_at.value()
               << " and is available. (current_lsn=" << journal::GetLsn() << ")";

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -275,11 +275,12 @@ class DflyCmd {
   // Return connection thread index or migrate to another thread.
   void Thread(facade::CmdArgParser parser, CommandContext* cmd_cntx);
 
-  // FLOW <masterid> <syncid> <flowid> [<seqid>]
-  // Register connection as flow for sync session.
-  // If seqid is given, it means the client wants to try partial sync.
-  // If it is possible, return Ok and prepare for a partial sync, else
-  // return error and ask the replica to execute FLOW again.
+  // FLOW <masterid> <syncid> <flowid> [<seqid> OR <last_master_id> <lsn-vec>]
+  // Register connection as flow for sync session and determine sync type (possibly partial).
+  // For <seqid> - this is the last LSN processed when replication broke with the same node
+  // For <last_master_id> <lsn-vec> - replicas last replication info, determine if partial sync
+  // is possible (node promotion (master-replica swap), cascaded replication omitting a node).
+  // Replies with sync type (partial/full) and eof token
   void Flow(facade::CmdArgParser parser, CommandContext* cmd_cntx);
 
   // SYNC <syncid>

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -63,6 +63,7 @@ ABSL_FLAG(bool, break_replication_on_master_restart, false,
           "flushing the replica's data.");
 ABSL_FLAG(std::string, replica_announce_ip, "",
           "IP address that Dragonfly announces to replication master");
+ABSL_FLAG(bool, experimental_cascaded_partial_sync, false, "Experimental cascaded psync");
 ABSL_DECLARE_FLAG(int32_t, port);
 ABSL_DECLARE_FLAG(uint16_t, announce_port);
 ABSL_FLAG(
@@ -187,7 +188,10 @@ std::optional<Replica::LastMasterSyncData> Replica::Stop() {
   }
 
   if (last_journal_LSNs_.has_value()) {
-    return LastMasterSyncData{master_context_.master_repl_id, last_journal_LSNs_.value()};
+    std::string lineage_id = absl::GetFlag(FLAGS_experimental_cascaded_partial_sync)
+                                 ? GetLineageId()
+                                 : master_context_.master_repl_id;
+    return LastMasterSyncData{lineage_id, last_journal_LSNs_.value()};
   }
   return nullopt;
 }
@@ -412,10 +416,20 @@ std::error_code Replica::HandleCapaDflyResp() {
     PC_RETURN_ON_BAD_RESPONSE(LastResponseArgs()[3].type == RespExpr::INT64);
     master_context_.version = DflyVersion(get<int64_t>(LastResponseArgs()[3].u));
   }
+
+  // If our master is itself a replica (cascaded), parse lineage id (grandparent id)
+  if (LastResponseArgs().size() >= 5) {
+    PC_RETURN_ON_BAD_RESPONSE(LastResponseArgs()[4].type == RespExpr::STRING);
+    master_context_.lineage_id = ToSV(LastResponseArgs()[4].GetBuf());
+  } else {
+    master_context_.lineage_id = master_context_.master_repl_id;
+  }
+
   VLOG(1) << "Master id: " << master_context_.master_repl_id
           << ", sync id: " << master_context_.dfly_session_id
           << ", num journals: " << param_num_flows
-          << ", version: " << unsigned(master_context_.version);
+          << ", version: " << unsigned(master_context_.version)
+          << ", lineage: " << master_context_.lineage_id;
 
   return error_code{};
 }
@@ -888,6 +902,13 @@ error_code Replica::ConsumeDflyStream() {
   RETURN_ON_ERR(exec_st_.SwitchErrorHandler(std::move(err_handler)));
 
   LOG(INFO) << "Transitioned into stable sync";
+
+  // Continue the master's LSN numbering so cascaded sub-replicas share the lineage root's LSN
+  // space and can negotiate partial sync when reconnecting up the chain.
+  if (absl::GetFlag(FLAGS_experimental_cascaded_partial_sync)) {
+    StartJournalAtOwnLSN();
+  }
+
   // Transition flows into stable sync.
   {
     auto shard_cb = [&](unsigned index, auto*) {
@@ -1492,6 +1513,16 @@ size_t Replica::GetRecCountExecutedPerShard(const std::vector<unsigned>& indexes
   }
   // Journal always starts at pos 1
   return std::max<size_t>(1UL, total_shard_lsn);
+}
+
+void Replica::StartJournalAtOwnLSN() {
+  shard_set->RunBriefInParallel([this](EngineShard* shard) {
+    size_t index = shard->shard_id();
+    auto flow_map = GetFlowMapAtIndex(index);
+    size_t rec_executed = GetRecCountExecutedPerShard(flow_map);
+    LOG(INFO) << "Shard " << index << " starts journal at: " << rec_executed;
+    journal::StartInThreadAtLsn(rec_executed);
+  });
 }
 
 uint32_t DflyShardReplica::FlowId() const {

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -36,6 +36,7 @@ struct MasterContext {
   std::string dfly_session_id;  // Sync session id for dfly sync.
   unsigned num_flows = 0;
   DflyVersion version = DflyVersion::VER1;
+  std::string lineage_id;  // lineage id of master
 };
 
 // This class manages replication from both Dragonfly and Redis masters.
@@ -124,6 +125,13 @@ class Replica : ProtocolClient {
     return !master_context_.dfly_session_id.empty();
   }
 
+  // The replication id of the lineage root master. Equals the direct master's id, unless the
+  // direct master advertised an ancestor id (cascaded replication), in which case it is the
+  // ancestor's id. Used to negotiate partial sync when reconnecting up the chain.
+  std::string GetLineageId() const {
+    return master_context_.lineage_id;
+  }
+
   std::vector<uint64_t> GetReplicaOffset() const;
   std::string GetSyncId() const;
 
@@ -146,6 +154,11 @@ class Replica : ProtocolClient {
   // Investigation-only (DEBUG REPLDIAG): bytes currently sitting unread in the
   // master socket's kernel receive buffer, or -1 if unavailable. Remove once closed.
   int GetMasterSocketUnreadBytes();
+
+  // Start the journal in every shard thread at this replica's per-shard executed LSN, so the
+  // journal continues the master's LSN numbering. Enables partial sync from the same source master
+  // (failover) and cascaded partial sync (sub-replicas share the lineage root's LSN space).
+  void StartJournalAtOwnLSN();
 
  private:
   ExecutionState exec_st_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -166,6 +166,7 @@ ABSL_FLAG(bool, replicaof_no_one_start_journal, true,
 ABSL_DECLARE_FLAG(int32_t, port);
 ABSL_DECLARE_FLAG(bool, cache_mode);
 ABSL_DECLARE_FLAG(int32_t, hz);
+ABSL_DECLARE_FLAG(bool, experimental_cascaded_partial_sync);
 ABSL_DECLARE_FLAG(bool, tls);
 ABSL_DECLARE_FLAG(string, tls_ca_cert_file);
 ABSL_DECLARE_FLAG(string, tls_ca_cert_dir);
@@ -3335,16 +3336,6 @@ void ServerFamily::Replicate(string_view host, string_view port) {
   ReplicaOfInternal(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
 }
 
-void ServerFamily::StartJournalInShardThreads(Replica* repl_ptr) {
-  shard_set->RunBriefInParallel([this, repl_ptr](auto* shard) {
-    size_t index = shard->shard_id();
-    auto flow_map = repl_ptr->GetFlowMapAtIndex(index);
-    size_t rec_executed = repl_ptr->GetRecCountExecutedPerShard(flow_map);
-    LOG(INFO) << "Shard " << index << " starts journal at: " << rec_executed;
-    journal::StartInThreadAtLsn(rec_executed);
-  });
-}
-
 void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
   util::fb2::LockGuard lk(replicaof_mu_);
 
@@ -3354,7 +3345,7 @@ void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
     auto repl_ptr = replica_;
     if (absl::GetFlag(FLAGS_replicaof_no_one_start_journal)) {
       // Start journal and keep offsets.
-      StartJournalInShardThreads(repl_ptr.get());
+      repl_ptr->StartJournalAtOwnLSN();
     }
     // flip flag before clearing replica_
     SetMasterFlagOnAllThreads(true);
@@ -3474,7 +3465,7 @@ void ServerFamily::ReplTakeOver(facade::CmdArgParser parser, CommandContext* cmd
   CHECK(repl_ptr);
 
   // Start journal to allow partial sync from same source master
-  StartJournalInShardThreads(repl_ptr.get());
+  repl_ptr->StartJournalAtOwnLSN();
 
   auto info = replica_->GetSummary();
   if (!info.full_sync_done) {
@@ -3500,10 +3491,17 @@ void ServerFamily::ReplTakeOver(facade::CmdArgParser parser, CommandContext* cmd
   return builder->SendOk();
 }
 
+std::string ServerFamily::GetLineageId() const {
+  util::fb2::LockGuard lk(replicaof_mu_);
+  return replica_ ? replica_->GetLineageId() : master_replid_;
+}
+
 void ServerFamily::ReplConf(CmdArgParser parser, CommandContext* cmd_cntx) {
   facade::ParsedArgs args = parser.UnparsedArgs();
   auto* builder = cmd_cntx->rb();
-  {
+
+  // Replicating a replica (cascaded replication) is only supported behind the experimental flag.
+  if (!absl::GetFlag(FLAGS_experimental_cascaded_partial_sync)) {
     util::fb2::LockGuard lk(replicaof_mu_);
     if (!IsMaster()) {
       return cmd_cntx->SendError("Replicating a replica is unsupported");
@@ -3534,13 +3532,17 @@ void ServerFamily::ReplConf(CmdArgParser parser, CommandContext* cmd_cntx) {
 
         cntx->replica_conn = true;
 
-        // The response for 'capa dragonfly' is: <masterid> <syncid> <numthreads> <version>
+        // The response for 'capa dragonfly' is:
+        //   <masterid> <syncid> <numthreads> <version> <lineage_id>
+        std::string lineage_id = GetLineageId();
+
         auto* rb = static_cast<RedisReplyBuilder*>(builder);
-        rb->StartArray(4);
+        rb->StartArray(5);
         rb->SendSimpleString(master_replid_);
         rb->SendSimpleString(sync_id);
         rb->SendLong(flow_count);
         rb->SendLong(unsigned(DflyVersion::CURRENT_VER));
+        rb->SendSimpleString(lineage_id);
         return;
       }
     } else if (cmd == "LISTENING-PORT") {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -210,6 +210,10 @@ class ServerFamily {
     return master_replid_;
   }
 
+  // The lineage root replication id of this node: its own replid if it is a true master, or the
+  // ancestor id advertised by its master when it is itself a replica (cascaded replication).
+  std::string GetLineageId() const ABSL_LOCKS_EXCLUDED(replicaof_mu_);
+
   DflyCmd* GetDflyCmd() const {
     return dfly_cmd_.get();
   }
@@ -305,8 +309,6 @@ class ServerFamily {
 
   void ReplicaOfInternal(facade::ParsedArgs args, CommandContext* cmnd_cntx,
                          ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
-
-  void StartJournalInShardThreads(Replica* repl_ptr);
 
   void ReplicaOfNoOne(SinkReplyBuilder* builder) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -966,7 +966,8 @@ async def test_double_take_over(df_factory, df_seeder_factory):
 
 
 async def test_replica_of_replica(df_factory):
-    # Can't connect a replica to a replica, but OK to connect 2 replicas to the same master
+    # Can't connect a replica to a replica, but OK to connect 2 replicas to the same master.
+    # Cascaded replication is only allowed behind --experimental_cascaded_partial_sync (off here).
     master = df_factory.create(proactor_threads=2)
     replica = df_factory.create(proactor_threads=2)
     replica2 = df_factory.create(proactor_threads=2)
@@ -1106,6 +1107,115 @@ async def test_partial_replication_on_same_source_master_with_replica_lsn_inc(df
     # Check logs for partial replication
     lines = server3.find_in_logs(f"Started partial sync with localhost:{server2.port}")
     assert len(lines) == 1
+
+
+@pytest.mark.parametrize("reconnect_to", [0, 1])
+async def test_cascaded_partial_sync(df_factory, reconnect_to):
+    """
+    Cascaded replication (master -> r1 -> ... -> rn): the last replica reconnects to node
+    `reconnect_to` in the chain and should partial sync instead of full sync. reconnect_to=0 is
+    the lineage root master; any other index is an intermediate node, which works too because
+    every node in the chain shares the lineage root's LSN space.
+    """
+    flag = {"proactor_threads": 4, "experimental_cascaded_partial_sync": None}
+    instances = [df_factory.create(**flag) for i in range(4)]
+    df_factory.start_all(instances)
+
+    clients = [i.client() for i in instances]
+
+    # Fill master with test data
+    seeder = DebugPopulateSeeder(key_target=50)
+    c_master = clients[0]
+    await seeder.run(c_master)
+
+    # Chain replication
+    for i in range(1, len(instances)):
+        await clients[i].execute_command(f"REPLICAOF localhost {instances[i-1].port}")
+        # Wait for this link to reach stable sync before chaining the next replica, otherwise the
+        # next replica may connect while this one is still LOADING and abort its handshake.
+        await wait_for_replicas_state(clients[i])
+
+    # Generate journal traffic that lands in the partial-sync buffer.
+    # NOTE: append (not set) because SET is omit-optimized which disables partial sync.
+    for i in range(100):
+        await c_master.append(f"k{i}", "val")
+
+    for i in range(1, len(instances)):
+        await check_all_replicas_finished([clients[i]], clients[i - 1])
+
+    # The last instance reconnects to the target node
+    target = instances[reconnect_to]
+    await clients[-1].execute_command(f"REPLICAOF localhost {target.port}")
+    await check_all_replicas_finished([clients[-1]], clients[reconnect_to])
+
+    # Further writes originating at the master should keep flowing down to the last replica.
+    for i in range(100, 150):
+        await c_master.append(f"k{i}", "val")
+    if reconnect_to != 0:
+        await check_all_replicas_finished([clients[reconnect_to]], c_master)
+    await check_all_replicas_finished([clients[-1]], clients[reconnect_to])
+
+    # Validate data consistency.
+    master_hash, last_hash = await asyncio.gather(
+        *(SeederV2.capture(c) for c in (c_master, clients[-1]))
+    )
+    assert master_hash == last_hash
+
+    info = await clients[-1].info("replication")
+    assert info["psync_successes"] == 1
+
+    instances[-1].stop()
+    lines = instances[-1].find_in_logs(f"Started partial sync with localhost:{target.port}")
+    assert len(lines) == 1
+    lines = instances[-1].find_in_logs(f"Started full sync with localhost:{target.port}")
+    assert len(lines) == 0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Master rotation not implemented yet",
+)
+async def test_cascaded_partial_sync_split_brain(df_factory):
+    """Split-brain safety: master -> r1 -> r2, then r1 is promoted to standalone and
+    BOTH master and r1 take independent writes to the same key. r2 (following r1) then reconnects
+    directly to master.
+    """
+    flag = {"proactor_threads": 4, "experimental_cascaded_partial_sync": None}
+    master, r1, r2 = (df_factory.create(**flag) for _ in range(3))
+    df_factory.start_all([master, r1, r2])
+
+    c_master, c_r1, c_r2 = master.client(), r1.client(), r2.client()
+
+    # Base data + a shared key that both branches will later diverge on.
+    # NOTE: append (not set) because SET is omit-optimized which disables partial sync.
+    for i in range(50):
+        await c_master.append(f"k{i}", "val")
+    await c_master.append("diverge", "base")
+
+    # Build chain master -> r1 -> r2.
+    await c_r1.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_for_replicas_state(c_r1)
+    await c_r2.execute_command(f"REPLICAOF localhost {r1.port}")
+    await wait_for_replicas_state(c_r2)
+    await check_all_replicas_finished([c_r1], c_master)
+    await check_all_replicas_finished([c_r2], c_r1)
+
+    # r1 splits from master and both sides write divergent values to the same key in the shared
+    # LSN space.
+    await c_r1.execute_command("REPLICAOF NO ONE")
+    await c_master.append("diverge", "_MASTER")
+    await c_r1.append("diverge", "_R1")
+    await check_all_replicas_finished([c_r2], c_r1)
+
+    assert (await c_master.get("diverge")) == "base_MASTER"
+    assert (await c_r2.get("diverge")) == "base_R1"
+
+    # r2 reconnects directly to master. It must converge to master's authoritative value.
+    await c_r2.execute_command(f"REPLICAOF localhost {master.port}")
+    await check_all_replicas_finished([c_r2], c_master)
+
+    master_val, r2_val = await asyncio.gather(c_master.get("diverge"), c_r2.get("diverge"))
+    assert r2_val == master_val, f"split-brain divergence: master={master_val!r} r2={r2_val!r}"
 
 
 @pytest.mark.parametrize("proactors", [1, 4, 6])


### PR DESCRIPTION
Phase one of cascaded PSYNC support: pass down "lineage" id to replicas so they recognize "grand" masters

Changes here:
1. Adds cascaded psync flag
2. When set, replica uses same LSN numbering as master
3. `CAPA DRAGONFLY` now passes down master "lineage" id
4. replication now detects own descendant and allows PSYNC
5. Adds two tests for this behaviour

The caveat is that this approach does not work if in M -> R1 -> R2 -> R3 for example R1 becomes standalone and executes a few more commands and we then try to connect R3 to M (it will think it has all the data). Basically when the state of two instances diverges that think of themselves as the master. For this case we need to introduce speical lsn "breaks" in a follow up PR