### PR TITLE
Fix mutable cluster announce flags

### DIFF
--- a/src/server/cluster/cluster_defs.cc
+++ b/src/server/cluster/cluster_defs.cc
@@ -64,6 +64,20 @@ ClusterShardInfos::ClusterShardInfos(std::vector<ClusterShardInfo> infos)
   rng::sort(infos_, std::less<>{});
 }
 
+ClusterExtendedNodeInfo* ClusterShardInfos::Find(std::string_view id) noexcept {
+  for (auto& shard : infos_) {
+    if (shard.master.id == id) {
+      return &shard.master;
+    }
+    for (auto& replica : shard.replicas) {
+      if (replica.id == id) {
+        return &replica;
+      }
+    }
+  }
+  return nullptr;
+}
+
 facade::ErrorReply SlotOwnershipError(SlotId slot_id) {
   const auto cluster_config = ClusterConfig::Current();
   if (!cluster_config)

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -174,19 +174,7 @@ class ClusterShardInfos {
     return infos_.empty();
   }
 
-  ClusterExtendedNodeInfo* Find(std::string_view id) noexcept {
-    for (auto& shard : infos_) {
-      if (shard.master.id == id) {
-        return &shard.master;
-      }
-      for (auto& replica : shard.replicas) {
-        if (replica.id == id) {
-          return &replica;
-        }
-      }
-    }
-    return nullptr;
-  }
+  ClusterExtendedNodeInfo* Find(std::string_view id) noexcept;
 
   bool operator==(const ClusterShardInfos& r) const noexcept {
     return infos_ == r.infos_;

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -174,6 +174,20 @@ class ClusterShardInfos {
     return infos_.empty();
   }
 
+  ClusterExtendedNodeInfo* Find(std::string_view id) noexcept {
+    for (auto& shard : infos_) {
+      if (shard.master.id == id) {
+        return &shard.master;
+      }
+      for (auto& replica : shard.replicas) {
+        if (replica.id == id) {
+          return &replica;
+        }
+      }
+    }
+    return nullptr;
+  }
+
   bool operator==(const ClusterShardInfos& r) const noexcept {
     return infos_ == r.infos_;
   }

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -72,13 +72,42 @@ constexpr char kIdNotFound[] = "syncid not found";
 constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
 
+ClusterNodeInfo GetLocalBindNodeInfo(const ServerFamily* server_family) {
+  for (auto* listener : server_family->GetListeners()) {
+    if (listener->IsMainInterface()) {
+      auto endpoint = listener->socket()->LocalEndpoint();
+      return {.id = {}, .ip = endpoint.address().to_string(), .port = endpoint.port()};
+    }
+  }
+
+  return {.id = {}, .ip = "127.0.0.1", .port = static_cast<uint16_t>(absl::GetFlag(FLAGS_port))};
+}
+
+void ApplyAnnounceFlags(string_view my_id, const ClusterNodeInfo& local_node,
+                        ClusterShardInfos* shard_infos, bool use_local_bind_fallback) {
+  auto* node = shard_infos->Find(my_id);
+  if (node == nullptr) {
+    return;
+  }
+
+  std::string announce_ip = absl::GetFlag(FLAGS_cluster_announce_ip);
+  uint16_t announce_port = absl::GetFlag(FLAGS_announce_port);
+
+  if (!use_local_bind_fallback && announce_ip.empty() && announce_port == 0) {
+    return;
+  }
+
+  if (announce_ip.empty()) {
+    announce_ip = local_node.ip;
+  }
+  node->ip = std::move(announce_ip);
+  node->port = announce_port == 0 ? local_node.port : announce_port;
+}
+
 }  // namespace
 
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
   CHECK_NOTNULL(server_family_);
-
-  config_registry.RegisterMutable("cluster_announce_ip");
-  config_registry.RegisterMutable("announce_port");
 
   InitializeCluster();
 
@@ -89,6 +118,29 @@ ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(serve
     LOG(ERROR) << "Setting --cluster_node_id in emulated mode is unsupported";
     exit(1);
   }
+
+  auto announce_cb = [this](const absl::CommandLineFlag&) {
+    if (IsClusterEmulated()) {
+      return true;
+    }
+
+    util::fb2::LockGuard lk(set_config_mu);
+    auto current = ClusterConfig::Current();
+    if (!current) {
+      return true;
+    }
+
+    auto new_config = current->CloneWithChanges({}, {});
+    ApplyAnnounceFlags(id_, GetLocalBindNodeInfo(server_family_), &new_config->GetMutableConfig(),
+                       true);
+
+    server_family_->service().proactor_pool().AwaitFiberOnAll(
+        [&new_config](util::ProactorBase*) { ClusterConfig::SetCurrent(new_config); });
+    return true;
+  };
+
+  config_registry.RegisterMutable("cluster_announce_ip", announce_cb);
+  config_registry.RegisterMutable("announce_port", announce_cb);
 }
 
 void ClusterFamily::Shutdown() {
@@ -593,8 +645,9 @@ void ClusterFamily::DflyClusterConfig(CmdArgParser parser, CommandContext* cmd_c
         }
       }
     }
-
     new_config = new_config->CloneWithChanges(enable_slots, disable_slots);
+    ApplyAnnounceFlags(id_, GetLocalBindNodeInfo(server_family_), &new_config->GetMutableConfig(),
+                       false);
 
     // Capture prev config before SetCurrent so StartNewSlotMigrations can diff correctly.
     auto prev_config = ClusterConfig::Current();

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -72,36 +72,26 @@ constexpr char kIdNotFound[] = "syncid not found";
 constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
 
-ClusterNodeInfo GetLocalBindNodeInfo(const ServerFamily* server_family) {
-  for (auto* listener : server_family->GetListeners()) {
-    if (listener->IsMainInterface()) {
-      auto endpoint = listener->socket()->LocalEndpoint();
-      return {.id = {}, .ip = endpoint.address().to_string(), .port = endpoint.port()};
-    }
-  }
-
-  return {.id = {}, .ip = "127.0.0.1", .port = static_cast<uint16_t>(absl::GetFlag(FLAGS_port))};
-}
-
-void ApplyAnnounceFlags(string_view my_id, const ClusterNodeInfo& local_node,
-                        ClusterShardInfos* shard_infos, bool use_local_bind_fallback) {
+bool ApplyAnnounceFlags(string_view my_id, ClusterShardInfos* shard_infos) {
   auto* node = shard_infos->Find(my_id);
   if (node == nullptr) {
-    return;
+    return false;
   }
 
   std::string announce_ip = absl::GetFlag(FLAGS_cluster_announce_ip);
   uint16_t announce_port = absl::GetFlag(FLAGS_announce_port);
 
-  if (!use_local_bind_fallback && announce_ip.empty() && announce_port == 0) {
-    return;
+  if (announce_ip.empty() && announce_port == 0) {
+    return false;
   }
 
-  if (announce_ip.empty()) {
-    announce_ip = local_node.ip;
+  if (!announce_ip.empty()) {
+    node->ip = std::move(announce_ip);
   }
-  node->ip = std::move(announce_ip);
-  node->port = announce_port == 0 ? local_node.port : announce_port;
+  if (announce_port != 0) {
+    node->port = announce_port;
+  }
+  return true;
 }
 
 }  // namespace
@@ -131,8 +121,9 @@ ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(serve
     }
 
     auto new_config = current->CloneWithChanges({}, {});
-    ApplyAnnounceFlags(id_, GetLocalBindNodeInfo(server_family_), &new_config->GetMutableConfig(),
-                       true);
+    if (!ApplyAnnounceFlags(id_, &new_config->GetMutableConfig())) {
+      return true;
+    }
 
     server_family_->service().proactor_pool().AwaitFiberOnAll(
         [&new_config](util::ProactorBase*) { ClusterConfig::SetCurrent(new_config); });
@@ -646,8 +637,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgParser parser, CommandContext* cmd_c
       }
     }
     new_config = new_config->CloneWithChanges(enable_slots, disable_slots);
-    ApplyAnnounceFlags(id_, GetLocalBindNodeInfo(server_family_), &new_config->GetMutableConfig(),
-                       false);
+    ApplyAnnounceFlags(id_, &new_config->GetMutableConfig());
 
     // Capture prev config before SetCurrent so StartNewSlotMigrations can diff correctly.
     auto prev_config = ClusterConfig::Current();

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -203,6 +203,71 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
 
   EXPECT_EQ(Run({"cluster", "nodes"}),
             "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\n");
+
+  ConfigSingleNodeCluster(GetMyId());
+
+  EXPECT_EQ(RunPrivileged({"config", "set", "cluster_announce_ip", "updated-host"}), "OK");
+  EXPECT_EQ(RunPrivileged({"config", "set", "announce_port", "6380"}), "OK");
+
+  EXPECT_THAT(
+      Run({"cluster", "shards"}),
+      RespElementsAre(RespArray(ElementsAre("slots",                                            //
+                                            RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
+                                            "nodes",                                            //
+                                            RespArray(ElementsAre(                              //
+                                                RespArray(ElementsAre(                          //
+                                                    "id", GetMyId(),                            //
+                                                    "endpoint", "updated-host",                 //
+                                                    "ip", "updated-host",                       //
+                                                    "port", IntArg(6380),                       //
+                                                    "role", "master",                           //
+                                                    "replication-offset", IntArg(0),            //
+                                                    "health", "online"))))))));
+
+  EXPECT_THAT(Run({"cluster", "slots"}),
+              RespElementsAre(RespArray(ElementsAre(IntArg(0),              //
+                                                    IntArg(16'383),         //
+                                                    RespArray(ElementsAre(  //
+                                                        "updated-host",     //
+                                                        IntArg(6'380),      //
+                                                        GetMyId()))))));
+
+  EXPECT_EQ(Run({"cluster", "nodes"}),
+            GetMyId() + " updated-host:6380@6380 myself,master - 0 0 0 connected 0-16383\n");
+
+  ConfigSingleNodeCluster(GetMyId());
+  EXPECT_EQ(Run({"cluster", "nodes"}),
+            GetMyId() + " updated-host:6380@6380 myself,master - 0 0 0 connected 0-16383\n");
+
+  SetTestFlag("port", "6379");
+  EXPECT_EQ(RunPrivileged({"config", "set", "cluster_announce_ip", ""}), "OK");
+  EXPECT_EQ(RunPrivileged({"config", "set", "announce_port", "0"}), "OK");
+
+  EXPECT_THAT(
+      Run({"cluster", "shards"}),
+      RespElementsAre(RespArray(ElementsAre("slots",                                            //
+                                            RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
+                                            "nodes",                                            //
+                                            RespArray(ElementsAre(                              //
+                                                RespArray(ElementsAre(                          //
+                                                    "id", GetMyId(),                            //
+                                                    "endpoint", "127.0.0.1",                    //
+                                                    "ip", "127.0.0.1",                          //
+                                                    "port", IntArg(6379),                       //
+                                                    "role", "master",                           //
+                                                    "replication-offset", IntArg(0),            //
+                                                    "health", "online"))))))));
+
+  EXPECT_THAT(Run({"cluster", "slots"}),
+              RespElementsAre(RespArray(ElementsAre(IntArg(0),              //
+                                                    IntArg(16'383),         //
+                                                    RespArray(ElementsAre(  //
+                                                        "127.0.0.1",        //
+                                                        IntArg(6'379),      //
+                                                        GetMyId()))))));
+
+  EXPECT_EQ(Run({"cluster", "nodes"}),
+            GetMyId() + " 127.0.0.1:6379@6379 myself,master - 0 0 0 connected 0-16383\n");
 }
 
 TEST_F(ClusterFamilyTest, ClusterConfigFull) {

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -239,7 +239,6 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
   EXPECT_EQ(Run({"cluster", "nodes"}),
             GetMyId() + " updated-host:6380@6380 myself,master - 0 0 0 connected 0-16383\n");
 
-  SetTestFlag("port", "6379");
   EXPECT_EQ(RunPrivileged({"config", "set", "cluster_announce_ip", ""}), "OK");
   EXPECT_EQ(RunPrivileged({"config", "set", "announce_port", "0"}), "OK");
 
@@ -251,9 +250,9 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
                                             RespArray(ElementsAre(                              //
                                                 RespArray(ElementsAre(                          //
                                                     "id", GetMyId(),                            //
-                                                    "endpoint", "127.0.0.1",                    //
-                                                    "ip", "127.0.0.1",                          //
-                                                    "port", IntArg(6379),                       //
+                                                    "endpoint", "updated-host",                 //
+                                                    "ip", "updated-host",                       //
+                                                    "port", IntArg(6380),                       //
                                                     "role", "master",                           //
                                                     "replication-offset", IntArg(0),            //
                                                     "health", "online"))))))));
@@ -262,12 +261,12 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
               RespElementsAre(RespArray(ElementsAre(IntArg(0),              //
                                                     IntArg(16'383),         //
                                                     RespArray(ElementsAre(  //
-                                                        "127.0.0.1",        //
-                                                        IntArg(6'379),      //
+                                                        "updated-host",     //
+                                                        IntArg(6'380),      //
                                                         GetMyId()))))));
 
   EXPECT_EQ(Run({"cluster", "nodes"}),
-            GetMyId() + " 127.0.0.1:6379@6379 myself,master - 0 0 0 connected 0-16383\n");
+            GetMyId() + " updated-host:6380@6380 myself,master - 0 0 0 connected 0-16383\n");
 }
 
 TEST_F(ClusterFamilyTest, ClusterConfigFull) {


### PR DESCRIPTION
## Summary

Update the active cluster topology when `cluster_announce_ip` or `announce_port` changes through `CONFIG SET`. Preserve configured endpoints when flags are unset, and reapply active announce flags after subsequent `DFLYCLUSTER CONFIG` updates.

Fixes faulty #7860