### PR TITLE
Support optional path in JSON.STRAPPEND

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -2025,10 +2025,15 @@ void CmdClear(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdStrAppend(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  string_view path = parser.Next();
+  string_view path;
+  if (parser.HasAtLeast(2))
+    path = parser.Next();
   string_view value = parser.Next();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  if (!parser.Finalize())
+    return builder->SendError(parser.TakeError().MakeReply());
+
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
   // We try parsing the value into json string object first.
@@ -2233,7 +2238,7 @@ void RegisterJsonFamily(CommandRegistry* registry) {
   *registry << CI{"JSON.FORGET", CO::JOURNALED, -2, 1, 1, acl::JSON}.HFUNC(
       Del);  // An alias of JSON.DEL.
   *registry << CI{"JSON.OBJKEYS", CO::READONLY | CO::FAST, -2, 1, 1, acl::JSON}.HFUNC(ObjKeys);
-  *registry << CI{"JSON.STRAPPEND", CO::JOURNALED | CO::DENYOOM | CO::FAST, 4, 1, 1, acl::JSON}
+  *registry << CI{"JSON.STRAPPEND", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::JSON}
                    .HFUNC(StrAppend);
   *registry << CI{"JSON.CLEAR", CO::JOURNALED | CO::FAST, -2, 1, 1, acl::JSON}.HFUNC(Clear);
   *registry << CI{"JSON.ARRPOP", CO::JOURNALED | CO::FAST, -2, 1, 1, acl::JSON}.HFUNC(ArrPop);

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1515,6 +1515,20 @@ TEST_F(JsonFamilyTest, ObjKeysLegacy) {
   EXPECT_THAT(resp.GetVec(), IsEmpty());
 }
 
+TEST_F(JsonFamilyTest, StrAppendDefaultPath) {
+  auto resp = Run({"JSON.SET", "json", ".", R"("foo")"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.STRAPPEND", "json", R"("bar")"});
+  EXPECT_THAT(resp, IntArg(6));
+
+  resp = Run({"JSON.STRAPPEND", "json", ".", R"("baz")", "extra"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"JSON.GET", "json"});
+  EXPECT_THAT(resp, R"("foobar")");
+}
+
 TEST_F(JsonFamilyTest, StrAppend) {
   string json = R"(
     {"a":{"a":"a"}, "b":{"a":"a", "b":1}, "c":{"a":"a", "b":"bb"}, "d":{"a":1, "b":"b", "c":3}}


### PR DESCRIPTION
## Summary

- Allow `JSON.STRAPPEND` to omit the path and use the legacy root by default.
- Reject trailing arguments before mutation and add regression coverage.

This aligns Dragonfly with the RedisJSON command syntax, where the path is optional and defaults
to `.`.

## Test Plan

- `./build-dbg/json_family_test`
- `ninja -C build-dbg dragonfly`
- `pre-commit run --files src/server/json_family.cc src/server/json_family_test.cc`
- `git diff --check upstream/main...HEAD`

Fixes #5479
