### PR TITLE
fix(migration): race between Finish and SyncFb

### DIFF
--- a/src/server/cluster/coordinator.cc
+++ b/src/server/cluster/coordinator.cc
@@ -74,7 +74,7 @@ class Coordinator::CrossShardClient : public ProtocolClient {
     auto timeout = absl::GetFlag(FLAGS_cluster_coordinator_connect_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
       LOG(WARNING) << "Couldn't connect to " << server().Description() << ": " << ec.message()
-                   << ", socket state: " << GetSocketInfo(Sock()->native_handle());
+                   << ", socket state: " << SockInfo();
       exec_st_.ReportError(GenericError(ec, "Couldn't connect to source."));
       return false;
     }
@@ -115,7 +115,7 @@ class Coordinator::CrossShardClient : public ProtocolClient {
         if (auto ec = ProtocolClient::SendCommand(send_queue_.front()->GetCommand()); ec) {
           exec_st_.ReportError(GenericError(
               ec, absl::StrCat("Coordinator could not send command to : ", server().Description(),
-                               "socket state: ", GetSocketInfo(Sock()->native_handle()))));
+                               "socket state: ", SockInfo())));
           // TODO reinit connection.
           break;
         }
@@ -136,8 +136,7 @@ class Coordinator::CrossShardClient : public ProtocolClient {
         auto resp = TakeRespReply(timeout);
         if (!resp) {
           LOG(WARNING) << "Error reading response from " << server().Description() << ": "
-                       << resp.error()
-                       << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                       << resp.error() << ", socket state: " + SockInfo();
 
           // TODO make all requests fail in this case.
           // TODO reinit connection.

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -36,9 +36,12 @@ namespace dfly::cluster {
 class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
  public:
   SliceSlotMigration(DbSlice* slice, ServerContext server_context, SlotSet slots,
-                     OutgoingMigration* om)
-      : ProtocolClient(server_context), streamer_(slice, std::move(slots), &exec_st_) {
-    exec_st_.SwitchErrorHandler([om](auto ge) { om->Finish(std::move(ge)); });
+                     OutgoingMigration* om, uint64_t attempt_gen)
+      : ProtocolClient(server_context),
+        streamer_(slice, std::move(slots), &exec_st_),
+        attempt_gen_(attempt_gen) {
+    exec_st_.SwitchErrorHandler(
+        [om, attempt_gen](auto ge) { om->Finish(std::move(ge), attempt_gen); });
   }
 
   ~SliceSlotMigration() {
@@ -59,8 +62,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
     auto timeout = absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
       LOG(WARNING) << "Couldn't connect to source node_id " << node_id << " shard_id " << shard_id
-                   << ": " << ec.message()
-                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                   << ": " << ec.message() << ", socket state: " + SockInfo();
       exec_st_.ReportError(GenericError(ec, "Couldn't connect to source."));
       return;
     }
@@ -106,11 +108,16 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
     return exec_st_.GetError();
   }
 
+  uint64_t AttemptGen() const {
+    return attempt_gen_;
+  }
+
   using ProtocolClient::CloseSocket;
 
  private:
   ExecutionState exec_st_;
   RestoreStreamer streamer_;
+  const uint64_t attempt_gen_;
 };
 
 OutgoingMigration::OutgoingMigration(MigrationInfo info, ClusterFamily* cf, ServerFamily* sf)
@@ -153,7 +160,19 @@ void OutgoingMigration::OnAllShards(std::function<void(UniqueSliceSlotMigration&
       [this, &func](auto* shard) { func(slot_migrations_[shard->shard_id()]); });
 }
 
-void OutgoingMigration::Finish(const GenericError& error) {
+void OutgoingMigration::Finish(const GenericError& error, std::optional<uint64_t> attempt_gen) {
+  // A Finish() spawned by a flow's error handler acts only on the attempt whose flow spawned it.
+  // If SyncFb has already started a newer attempt this call is stale: its flows are gone and the
+  // current attempt must not be touched. This early check is advisory (it keeps a stale handler
+  // from reporting an outdated error and shutting down the control socket); the authoritative
+  // checks are the locked generation re-check below (protects state_) and the per-shard
+  // generation check in the cancel lambda (protects the flows).
+  const uint64_t current_gen = attempt_gen_.load(std::memory_order_relaxed);
+  const uint64_t target_gen = attempt_gen.value_or(current_gen);
+  if (target_gen != current_gen) {
+    return;
+  }
+
   auto next_state = MigrationState::C_FINISHED;
   if (error) {
     // If OOM error move to FATAL, non-recoverable  state
@@ -176,15 +195,23 @@ void OutgoingMigration::Finish(const GenericError& error) {
 
   {
     util::fb2::LockGuard lk(state_mu_);
+    // Authoritative staleness check: SyncFb bumps attempt_gen_ under state_mu_, so passing this
+    // check guarantees target_gen is still the current attempt for as long as we hold the lock -
+    // a stale Finish() can never overwrite state_ of a newer attempt.
+    if (target_gen != attempt_gen_.load(std::memory_order_relaxed)) {
+      // Leave the newer attempt's control socket alone.
+      std::move(on_exit).Cancel();
+      return;
+    }
     switch (state_) {
       case MigrationState::C_FATAL:
       case MigrationState::C_FINISHED:
         return;  // Already finished, nothing else to do
 
+      // C_CONNECTING no longer implies "no flows exist": a retry may be connecting while the
+      // previous attempt's flows are still registered. Cancelling is always safe because the
+      // lambda below only touches flows of target_gen.
       case MigrationState::C_CONNECTING:
-        should_cancel_flows = false;
-        break;
-
       case MigrationState::C_SYNC:
       case MigrationState::C_ERROR:
         should_cancel_flows = true;
@@ -199,9 +226,12 @@ void OutgoingMigration::Finish(const GenericError& error) {
   }
 
   if (should_cancel_flows) {
-    OnAllShards([](auto& migration) {
-      CHECK(migration != nullptr);
-      migration->Cancel();
+    OnAllShards([target_gen](auto& migration) {
+      // Check-and-cancel runs inside the shard task, atomically with respect to the retry loop's
+      // replace task on the same shard, so Finish() can never cancel another attempt's flow.
+      if (migration && migration->AttemptGen() == target_gen) {
+        migration->Cancel();
+      }
     });
     exec_st_.JoinErrorHandler();
   }
@@ -232,8 +262,7 @@ void OutgoingMigration::SyncFb() {
     auto timeout = absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
       LOG(WARNING) << "Can't connect to target node " << server().Description()
-                   << " for migration: " << ec.message()
-                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                   << " for migration: " << ec.message() << ", socket state: " + SockInfo();
       exec_st_.ReportError(GenericError(ec, "Couldn't connect to source."));
       continue;
     }
@@ -247,8 +276,7 @@ void OutgoingMigration::SyncFb() {
 
     if (auto ec = SendCommandAndReadResponse(cmd); ec) {
       LOG(WARNING) << "Could not send INIT command to " << server().Description()
-                   << " for migration: " << ec.message()
-                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                   << " for migration: " << ec.message() << ", socket state: " + SockInfo();
       exec_st_.ReportError(GenericError(ec, "Could not send INIT command."));
       continue;
     }
@@ -277,11 +305,27 @@ void OutgoingMigration::SyncFb() {
       continue;
     }
 
-    OnAllShards([this](auto& migration) {
+    // Bump the attempt generation before creating this attempt's flows: from this point on,
+    // Finish() calls spawned by the previous attempt's flows are stale and act as no-ops. The
+    // bump is done under state_mu_ so it is ordered with Finish()'s locked generation re-check:
+    // a Finish() that writes state_ provably acts on the attempt that was current at that
+    // instant.
+    uint64_t attempt_gen;
+    {
+      util::fb2::LockGuard lk(state_mu_);
+      attempt_gen = attempt_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
+    }
+    OnAllShards([this, attempt_gen](auto& migration) {
+      // A flow from the previous attempt may still be registered if its Finish() raced with this
+      // retry loop. Cancel it here, sequenced before its destruction on the same shard task, so
+      // we never destroy a streamer that is still registered.
+      if (migration) {
+        migration->Cancel();
+      }
       DbSlice& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
       journal::StartInThread();
-      migration = std::make_unique<SliceSlotMigration>(&db_slice, server(),
-                                                       migration_info_.slot_ranges, this);
+      migration = std::make_unique<SliceSlotMigration>(
+          &db_slice, server(), migration_info_.slot_ranges, this, attempt_gen);
     });
 
     if (!ChangeState(MigrationState::C_SYNC)) {
@@ -342,7 +386,7 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
       LOG(WARNING) << "Couldn't connect to " << cf_->MyID() << " : " << migration_info_.node_info.id
                    << " attempt " << attempt << ": " << ec.message()
-                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                   << ", socket state: " + SockInfo();
       return false;
     }
   }
@@ -380,7 +424,7 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
 
   if (auto err = SendCommand(cmd); err) {
     LOG(WARNING) << "Error during sending DFLYMIGRATE ACK to " << server().Description() << ": "
-                 << err.message() << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                 << err.message() << ", socket state: " + SockInfo();
     return false;
   }
 
@@ -397,8 +441,7 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
 
     if (auto resp = ReadRespReply(ack_timeout_ms - passed_ms); !resp) {
       LOG(WARNING) << "Error reading response to ACK command from " << server().Description()
-                   << ": " << resp.error()
-                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                   << ": " << resp.error() << ", socket state: " + SockInfo();
       return false;
     }
 

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -6,8 +6,6 @@
 
 #include <absl/flags/flag.h>
 
-#include <atomic>
-
 #include "absl/cleanup/cleanup.h"
 #include "base/logging.h"
 #include "cluster_family.h"
@@ -36,12 +34,13 @@ namespace dfly::cluster {
 class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
  public:
   SliceSlotMigration(DbSlice* slice, ServerContext server_context, SlotSet slots,
-                     OutgoingMigration* om, uint64_t attempt_gen)
-      : ProtocolClient(server_context),
-        streamer_(slice, std::move(slots), &exec_st_),
-        attempt_gen_(attempt_gen) {
-    exec_st_.SwitchErrorHandler(
-        [om, attempt_gen](auto ge) { om->Finish(std::move(ge), attempt_gen); });
+                     OutgoingMigration* om)
+      : ProtocolClient(server_context), streamer_(slice, std::move(slots), &exec_st_) {
+    // Flows only report errors; teardown is owned by the migration-level handler
+    // (OutgoingMigration::OnAttemptError), which ResetError() joins at every attempt boundary.
+    // A forwarder that fires late (after the boundary) injects an error into the new attempt
+    // and costs one spurious retry - it cannot touch flows or migration state.
+    exec_st_.SwitchErrorHandler([om](auto ge) { om->exec_st_.ReportError(std::move(ge)); });
   }
 
   ~SliceSlotMigration() {
@@ -108,16 +107,11 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
     return exec_st_.GetError();
   }
 
-  uint64_t AttemptGen() const {
-    return attempt_gen_;
-  }
-
   using ProtocolClient::CloseSocket;
 
  private:
   ExecutionState exec_st_;
   RestoreStreamer streamer_;
-  const uint64_t attempt_gen_;
 };
 
 OutgoingMigration::OutgoingMigration(MigrationInfo info, ClusterFamily* cf, ServerFamily* sf)
@@ -160,87 +154,75 @@ void OutgoingMigration::OnAllShards(std::function<void(UniqueSliceSlotMigration&
       [this, &func](auto* shard) { func(slot_migrations_[shard->shard_id()]); });
 }
 
-void OutgoingMigration::Finish(const GenericError& error, std::optional<uint64_t> attempt_gen) {
-  // A Finish() spawned by a flow's error handler acts only on the attempt whose flow spawned it.
-  // If SyncFb has already started a newer attempt this call is stale: its flows are gone and the
-  // current attempt must not be touched. This early check is advisory (it keeps a stale handler
-  // from reporting an outdated error and shutting down the control socket); the authoritative
-  // checks are the locked generation re-check below (protects state_) and the per-shard
-  // generation check in the cancel lambda (protects the flows). Staleness only exists for calls
-  // carrying an explicit generation: nullopt means "the current attempt, whatever it is now" and
-  // is never stale.
-  if (attempt_gen && *attempt_gen != attempt_gen_.load(std::memory_order_relaxed)) {
-    return;
-  }
+void OutgoingMigration::Finish(const GenericError& error) {
+  // Only terminal transitions happen here: C_FINISHED, or C_FATAL for an OOM reported by the
+  // incoming node. Retryable errors never reach Finish() - they are reported on exec_st_ and
+  // handled by OnAttemptError().
+  const auto next_state =
+      error == errc::not_enough_memory ? MigrationState::C_FATAL : MigrationState::C_FINISHED;
 
-  auto next_state = MigrationState::C_FINISHED;
   if (error) {
-    // If OOM error move to FATAL, non-recoverable  state
-    if (error == errc::not_enough_memory) {
-      next_state = MigrationState::C_FATAL;
-    } else {
-      next_state = MigrationState::C_ERROR;
-      exec_st_.ReportError(error);
-    }
     LOG(WARNING) << "Finish outgoing migration for " << cf_->MyID() << ": "
                  << migration_info_.node_info.id << " with error: " << error.Format();
-
   } else {
     LOG(INFO) << "Finish outgoing migration for " << cf_->MyID() << ": "
               << migration_info_.node_info.id;
   }
 
-  bool should_cancel_flows = false;
-  uint64_t effective_gen = 0;
-  absl::Cleanup on_exit([this]() { ShutdownSocket(); });
-
   {
     util::fb2::LockGuard lk(state_mu_);
-    const uint64_t locked_gen = attempt_gen_.load(std::memory_order_relaxed);
-    // Authoritative staleness check: SyncFb bumps attempt_gen_ under state_mu_, so passing this
-    // check guarantees the explicit generation is still the current attempt for as long as we
-    // hold the lock - a stale Finish() can never overwrite state_ of a newer attempt. A nullopt
-    // caller resolves its target here, under the lock, and is never dropped: treating it as
-    // stale would turn an external cancel racing a retry bump into a no-op, leaving SyncFb
-    // looping forever and hanging teardown in ~OutgoingMigration.
-    if (attempt_gen && *attempt_gen != locked_gen) {
-      // Leave the newer attempt's control socket alone.
-      std::move(on_exit).Cancel();
-      return;
-    }
-    effective_gen = attempt_gen.value_or(locked_gen);
-    switch (state_) {
-      case MigrationState::C_FATAL:
-      case MigrationState::C_FINISHED:
-        return;  // Already finished, nothing else to do
-
-      // C_CONNECTING no longer implies "no flows exist": a retry may be connecting while the
-      // previous attempt's flows are still registered. Cancelling is always safe because the
-      // lambda below only touches flows of effective_gen.
-      case MigrationState::C_CONNECTING:
-      case MigrationState::C_SYNC:
-      case MigrationState::C_ERROR:
-        should_cancel_flows = true;
-        break;
+    if (state_ == MigrationState::C_FINISHED || state_ == MigrationState::C_FATAL) {
+      return;  // Already finished, nothing else to do
     }
     state_ = next_state;
   }
 
   if (next_state == MigrationState::C_FATAL) {
-    // Fatal state stop any further processing of migration so we need to update error here
+    // Fatal state stops any further processing of migration so we need to update error here
     SetLastError(error);
   }
 
-  if (should_cancel_flows) {
-    OnAllShards([effective_gen](auto& migration) {
-      // Check-and-cancel runs inside the shard task, atomically with respect to the retry loop's
-      // replace task on the same shard, so Finish() can never cancel another attempt's flow.
-      if (migration && migration->AttemptGen() == effective_gen) {
-        migration->Cancel();
-      }
-    });
-    exec_st_.JoinErrorHandler();
+  // Tear down whatever flows exist. This may run concurrently with SyncFb building an attempt
+  // and brush flows that are still setting up - that is intended: the whole migration is
+  // terminating, the state write above latches ChangeState() so SyncFb cannot start another
+  // attempt, and a flow cancelled during setup fails cleanly (ConnectAndAuth() reports a real
+  // error on a cancelled context). Flows created after this cancel die unstarted: SyncFb's next
+  // ChangeState() fails before PrepareFlow()/PrepareSync(), so nothing connects or registers,
+  // and ~OutgoingMigration reaps the objects.
+  OnAllShards([](auto& migration) {
+    if (migration) {
+      migration->Cancel();
+    }
+  });
+
+  ShutdownSocket();
+}
+
+void OutgoingMigration::OnAttemptError(const GenericError& error) {
+  LOG(WARNING) << "Outgoing migration attempt error for " << cf_->MyID() << ": "
+               << migration_info_.node_info.id << ": " << error.Format();
+
+  {
+    // Check-and-write in one critical section: never downgrade a terminal state. If Finish()
+    // won the race, the migration is over and there is nothing to tear down that Finish()'s own
+    // cancel does not already cover.
+    util::fb2::LockGuard lk(state_mu_);
+    if (state_ == MigrationState::C_FINISHED || state_ == MigrationState::C_FATAL) {
+      return;
+    }
+    state_ = MigrationState::C_ERROR;
   }
+
+  // Cancel this attempt's flows and shut down the control socket so SyncFb's blocking IO
+  // returns and the retry loop can run. The slots are guaranteed to hold this attempt's flows:
+  // ResetError() joins this handler before the next attempt replaces them.
+  OnAllShards([](auto& migration) {
+    if (migration) {
+      migration->Cancel();
+    }
+  });
+
+  ShutdownSocket();
 }
 
 MigrationState OutgoingMigration::GetState() const {
@@ -252,6 +234,11 @@ void OutgoingMigration::SyncFb() {
   VLOG(1) << "Starting outgoing migration fiber for migration " << migration_info_.ToString();
 
   const absl::Time start_time = absl::Now();
+
+  // Arm the attempt teardown handler. From here on, any error reported on exec_st_ - whether
+  // forwarded by a flow or reported by this fiber's own IO failures - runs OnAttemptError()
+  // exactly once per attempt; ResetError() joins it and re-arms at every attempt boundary.
+  exec_st_.Reset([this](const GenericError& ge) { OnAttemptError(ge); });
 
   // we retry starting migration until "cancel" is happened
   while (GetState() != MigrationState::C_FINISHED) {
@@ -311,27 +298,18 @@ void OutgoingMigration::SyncFb() {
       continue;
     }
 
-    // Bump the attempt generation before creating this attempt's flows: from this point on,
-    // Finish() calls spawned by the previous attempt's flows are stale and act as no-ops. The
-    // bump is done under state_mu_ so it is ordered with Finish()'s locked generation re-check:
-    // a Finish() that writes state_ provably acts on the attempt that was current at that
-    // instant.
-    uint64_t attempt_gen;
-    {
-      util::fb2::LockGuard lk(state_mu_);
-      attempt_gen = attempt_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
-    }
-    OnAllShards([this, attempt_gen](auto& migration) {
-      // A flow from the previous attempt may still be registered if its Finish() raced with this
-      // retry loop. Cancel it here, sequenced before its destruction on the same shard task, so
-      // we never destroy a streamer that is still registered.
+    OnAllShards([this](auto& migration) {
+      // A flow may still be registered if its teardown raced this retry loop (e.g. Finish()
+      // terminating the migration concurrently). Cancel it here, sequenced before its
+      // destruction on the same shard task, so we never destroy a streamer that is still
+      // registered.
       if (migration) {
         migration->Cancel();
       }
       DbSlice& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
       journal::StartInThread();
-      migration = std::make_unique<SliceSlotMigration>(
-          &db_slice, server(), migration_info_.slot_ranges, this, attempt_gen);
+      migration = std::make_unique<SliceSlotMigration>(&db_slice, server(),
+                                                       migration_info_.slot_ranges, this);
     });
 
     if (!ChangeState(MigrationState::C_SYNC)) {

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -166,10 +166,10 @@ void OutgoingMigration::Finish(const GenericError& error, std::optional<uint64_t
   // current attempt must not be touched. This early check is advisory (it keeps a stale handler
   // from reporting an outdated error and shutting down the control socket); the authoritative
   // checks are the locked generation re-check below (protects state_) and the per-shard
-  // generation check in the cancel lambda (protects the flows).
-  const uint64_t current_gen = attempt_gen_.load(std::memory_order_relaxed);
-  const uint64_t target_gen = attempt_gen.value_or(current_gen);
-  if (target_gen != current_gen) {
+  // generation check in the cancel lambda (protects the flows). Staleness only exists for calls
+  // carrying an explicit generation: nullopt means "the current attempt, whatever it is now" and
+  // is never stale.
+  if (attempt_gen && *attempt_gen != attempt_gen_.load(std::memory_order_relaxed)) {
     return;
   }
 
@@ -191,18 +191,24 @@ void OutgoingMigration::Finish(const GenericError& error, std::optional<uint64_t
   }
 
   bool should_cancel_flows = false;
+  uint64_t effective_gen = 0;
   absl::Cleanup on_exit([this]() { ShutdownSocket(); });
 
   {
     util::fb2::LockGuard lk(state_mu_);
+    const uint64_t locked_gen = attempt_gen_.load(std::memory_order_relaxed);
     // Authoritative staleness check: SyncFb bumps attempt_gen_ under state_mu_, so passing this
-    // check guarantees target_gen is still the current attempt for as long as we hold the lock -
-    // a stale Finish() can never overwrite state_ of a newer attempt.
-    if (target_gen != attempt_gen_.load(std::memory_order_relaxed)) {
+    // check guarantees the explicit generation is still the current attempt for as long as we
+    // hold the lock - a stale Finish() can never overwrite state_ of a newer attempt. A nullopt
+    // caller resolves its target here, under the lock, and is never dropped: treating it as
+    // stale would turn an external cancel racing a retry bump into a no-op, leaving SyncFb
+    // looping forever and hanging teardown in ~OutgoingMigration.
+    if (attempt_gen && *attempt_gen != locked_gen) {
       // Leave the newer attempt's control socket alone.
       std::move(on_exit).Cancel();
       return;
     }
+    effective_gen = attempt_gen.value_or(locked_gen);
     switch (state_) {
       case MigrationState::C_FATAL:
       case MigrationState::C_FINISHED:
@@ -210,7 +216,7 @@ void OutgoingMigration::Finish(const GenericError& error, std::optional<uint64_t
 
       // C_CONNECTING no longer implies "no flows exist": a retry may be connecting while the
       // previous attempt's flows are still registered. Cancelling is always safe because the
-      // lambda below only touches flows of target_gen.
+      // lambda below only touches flows of effective_gen.
       case MigrationState::C_CONNECTING:
       case MigrationState::C_SYNC:
       case MigrationState::C_ERROR:
@@ -226,10 +232,10 @@ void OutgoingMigration::Finish(const GenericError& error, std::optional<uint64_t
   }
 
   if (should_cancel_flows) {
-    OnAllShards([target_gen](auto& migration) {
+    OnAllShards([effective_gen](auto& migration) {
       // Check-and-cancel runs inside the shard task, atomically with respect to the retry loop's
       // replace task on the same shard, so Finish() can never cancel another attempt's flow.
-      if (migration && migration->AttemptGen() == target_gen) {
+      if (migration && migration->AttemptGen() == effective_gen) {
         migration->Cancel();
       }
     });

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <atomic>
-#include <optional>
 
 #include "server/cluster/cluster_defs.h"
 #include "server/execution_state.h"
@@ -28,17 +27,11 @@ class OutgoingMigration : private ProtocolClient {
   // start migration process, sends INIT command to the target node
   void Start();
 
-  // if is_error = false mark migration as FINISHED and cancel migration if it's not finished yet
-  // can be called from any thread, but only after Start()
-  // if is_error = true and migration is in progress it will be restarted otherwise nothing happens
-  // attempt_gen ties an error-handler Finish() to the sync attempt whose flow spawned it; a call
-  // with a stale generation (a newer attempt already exists) is a no-op. Callers acting on the
-  // current attempt (success path, OOM, external cancel) pass std::nullopt, which resolves to
-  // the current generation under state_mu_ and is never treated as stale - a nullopt call must
-  // always mean "the current attempt, whatever it is now", or it reintroduces cross-attempt
-  // cancellation.
-  void Finish(const GenericError& error = {}, std::optional<uint64_t> attempt_gen = std::nullopt)
-      ABSL_LOCKS_EXCLUDED(state_mu_);
+  // Terminal transition: marks the migration FINISHED (or FATAL for an OOM error) and tears down
+  // the current flows. Used by the success path, incoming-OOM handling and external cancellation
+  // (config update). Can be called from any thread, but only after Start(). Error-driven teardown
+  // with retry is not done here - it is owned by OnAttemptError(), the exec_st_ error handler.
+  void Finish(const GenericError& error = {}) ABSL_LOCKS_EXCLUDED(state_mu_);
 
   MigrationState GetState() const ABSL_LOCKS_EXCLUDED(state_mu_);
 
@@ -61,7 +54,10 @@ class OutgoingMigration : private ProtocolClient {
   void ResetError() {
     if (exec_st_.IsError()) {
       SetLastError(exec_st_.GetError());
-      exec_st_.Reset(nullptr);
+      // Attempt boundary barrier: Reset() joins the in-flight OnAttemptError() handler before
+      // returning, so no teardown from the previous attempt is still running when SyncFb builds
+      // the next one, and re-arms the handler for the new attempt.
+      exec_st_.Reset([this](const GenericError& ge) { OnAttemptError(ge); });
     }
   }
 
@@ -96,6 +92,12 @@ class OutgoingMigration : private ProtocolClient {
   // return true if migration is finalized even with C_ERROR state
   bool FinalizeMigration(long attempt);
 
+  // Error handler of exec_st_: tears down the failed attempt's flows and moves the state to
+  // C_ERROR so SyncFb retries. Runs as the handler fiber - at most one is in flight, and
+  // ResetError() joins it at the attempt boundary, so it can never overlap the construction of
+  // the next attempt.
+  void OnAttemptError(const GenericError& error) ABSL_LOCKS_EXCLUDED(state_mu_);
+
   bool ChangeState(MigrationState new_state) ABSL_LOCKS_EXCLUDED(state_mu_);
 
   void OnAllShards(std::function<void(UniqueSliceSlotMigration&)>);
@@ -114,16 +116,6 @@ class OutgoingMigration : private ProtocolClient {
 
   mutable util::fb2::Mutex state_mu_;
   MigrationState state_ ABSL_GUARDED_BY(state_mu_) = MigrationState::C_CONNECTING;
-
-  // Incremented by SyncFb before creating each attempt's flows. Written only by SyncFb; read by
-  // Finish() to drop stale error-handler calls that belong to a previous attempt's flows.
-  //
-  // Uses both an atomic and state_mu_, each for a different job: the increment and Finish()'s
-  // authoritative re-check run under state_mu_ because the invariant spans two variables (a
-  // Finish() that passes the check must write state_ before the next bump), which no memory
-  // order on a single atomic can express. The type stays atomic only for Finish()'s advisory
-  // pre-lock check - a plain read there would be a data race.
-  std::atomic<uint64_t> attempt_gen_{0};
 
   boost::intrusive_ptr<Transaction> tx_;
 

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -33,7 +33,10 @@ class OutgoingMigration : private ProtocolClient {
   // if is_error = true and migration is in progress it will be restarted otherwise nothing happens
   // attempt_gen ties an error-handler Finish() to the sync attempt whose flow spawned it; a call
   // with a stale generation (a newer attempt already exists) is a no-op. Callers acting on the
-  // current attempt (success path, OOM, external cancel) pass std::nullopt.
+  // current attempt (success path, OOM, external cancel) pass std::nullopt, which resolves to
+  // the current generation under state_mu_ and is never treated as stale - a nullopt call must
+  // always mean "the current attempt, whatever it is now", or it reintroduces cross-attempt
+  // cancellation.
   void Finish(const GenericError& error = {}, std::optional<uint64_t> attempt_gen = std::nullopt)
       ABSL_LOCKS_EXCLUDED(state_mu_);
 

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -3,6 +3,9 @@
 //
 #pragma once
 
+#include <atomic>
+#include <optional>
+
 #include "server/cluster/cluster_defs.h"
 #include "server/execution_state.h"
 #include "server/protocol_client.h"
@@ -28,7 +31,11 @@ class OutgoingMigration : private ProtocolClient {
   // if is_error = false mark migration as FINISHED and cancel migration if it's not finished yet
   // can be called from any thread, but only after Start()
   // if is_error = true and migration is in progress it will be restarted otherwise nothing happens
-  void Finish(const GenericError& error = {}) ABSL_LOCKS_EXCLUDED(state_mu_);
+  // attempt_gen ties an error-handler Finish() to the sync attempt whose flow spawned it; a call
+  // with a stale generation (a newer attempt already exists) is a no-op. Callers acting on the
+  // current attempt (success path, OOM, external cancel) pass std::nullopt.
+  void Finish(const GenericError& error = {}, std::optional<uint64_t> attempt_gen = std::nullopt)
+      ABSL_LOCKS_EXCLUDED(state_mu_);
 
   MigrationState GetState() const ABSL_LOCKS_EXCLUDED(state_mu_);
 
@@ -104,6 +111,16 @@ class OutgoingMigration : private ProtocolClient {
 
   mutable util::fb2::Mutex state_mu_;
   MigrationState state_ ABSL_GUARDED_BY(state_mu_) = MigrationState::C_CONNECTING;
+
+  // Incremented by SyncFb before creating each attempt's flows. Written only by SyncFb; read by
+  // Finish() to drop stale error-handler calls that belong to a previous attempt's flows.
+  //
+  // Uses both an atomic and state_mu_, each for a different job: the increment and Finish()'s
+  // authoritative re-check run under state_mu_ because the invariant spans two variables (a
+  // Finish() that passes the check must write state_ before the next bump), which no memory
+  // order on a single atomic can express. The type stays atomic only for Finish()'s advisory
+  // pre-lock check - a plain read there would be a data race.
+  std::atomic<uint64_t> attempt_gen_{0};
 
   boost::intrusive_ptr<Transaction> tx_;
 

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -183,7 +183,12 @@ error_code ProtocolClient::ConnectAndAuth(std::chrono::milliseconds connect_time
         sock_.reset(mythread->CreateSocket());
       }
     } else {
-      return cntx->GetError();
+      // The stored error may convert to a zero error_code: Cancel() records no error at all, and
+      // an error reported as a plain string has no code either. This branch is a failure (no
+      // socket was created), so it must never return a zero code - callers interpret that as
+      // "socket connected" and would proceed to use a null or stale sock_.
+      std::error_code ec = cntx->GetError();
+      return ec ? ec : make_error_code(errc::operation_canceled);
     }
   }
 
@@ -252,9 +257,14 @@ void ProtocolClient::ShutdownSocket() {
   return ShutdownSocketImpl(false);
 }
 
+std::string ProtocolClient::SockInfo() const {
+  auto* sock = Sock();
+  return GetSocketInfo(sock ? sock->native_handle() : -1);
+}
+
 void ProtocolClient::DefaultErrorHandler(const GenericError& err) {
   LOG(WARNING) << "Socket error: " << err.Format() << " in " << server_context_.Description()
-               << ", socket info: " << GetSocketInfo(sock_ ? sock_->native_handle() : -1);
+               << ", socket info: " << SockInfo();
   ShutdownSocket();
 }
 

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -138,6 +138,10 @@ class ProtocolClient {
     return sock_.get();
   }
 
+  // Socket diagnostics string for error logs. Evaluates the socket exactly once and tolerates a
+  // socket that was never created (e.g. ConnectAndAuth() refusing on a dead context).
+  std::string SockInfo() const;
+
  private:
   std::error_code Recv(util::FiberSocketBase* input, base::IoBuf* dest);
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -272,7 +272,7 @@ void Replica::MainReplicationFb(std::optional<LastMasterSyncData> last_master_sy
       if (ec) {
         LOG(WARNING) << "Error greeting " << server().Description()
                      << " (phase: " << GetCurrentPhase() << "): " << ec << " " << ec.message()
-                     << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                     << ", socket state: " + SockInfo();
         state_mask_ &= R_ENABLED;
         continue;
       }
@@ -290,7 +290,7 @@ void Replica::MainReplicationFb(std::optional<LastMasterSyncData> last_master_sy
       if (ec) {
         LOG(WARNING) << "Error syncing with " << server().Description()
                      << " (phase: " << GetCurrentPhase() << "): " << ec << " " << ec.message()
-                     << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                     << ", socket state: " + SockInfo();
         state_mask_ &= R_ENABLED;  // reset all flags besides R_ENABLED
         continue;
       }
@@ -310,7 +310,7 @@ void Replica::MainReplicationFb(std::optional<LastMasterSyncData> last_master_sy
     if (state_mask_ & R_ENABLED) {  // replication was not stopped.
       LOG(WARNING) << "Error stable sync with " << server().Description()
                    << " (phase: " << GetCurrentPhase() << "): " << ec << " " << ec.message()
-                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+                   << ", socket state: " + SockInfo();
     }
   }
 
@@ -768,8 +768,7 @@ error_code Replica::ConsumeRedisStream() {
     if (!response.has_value()) {
       LOG_REPL_ERROR("Error in Redis Stream at phase "
                      << GetCurrentPhase() << " with " << server().Description()
-                     << ", error: " << response.error()
-                     << ", socket state: " + GetSocketInfo(Sock()->native_handle()));
+                     << ", error: " << response.error() << ", socket state: " + SockInfo());
       exec_st_.ReportError(response.error());
       acks_fb_.JoinIfNeeded();
       return response.error();
@@ -877,8 +876,8 @@ error_code Replica::ConsumeDflyStream() {
     lock_guard lk{flows_op_mu_};
 
     LOG_REPL_ERROR("Replication error in phase "
-                   << GetCurrentPhase() << " with " << server().Description() << ", error: "
-                   << ge.Format() << ", socket state: " + GetSocketInfo(Sock()->native_handle()));
+                   << GetCurrentPhase() << " with " << server().Description()
+                   << ", error: " << ge.Format() << ", socket state: " + SockInfo());
 
     DefaultErrorHandler(ge);
     for (auto& flow : shard_flows_) {


### PR DESCRIPTION
Finish cancels the context (when error is set) and then grabs the `state_mu_` and polls the `state_`.  SyncFb (running on a different os thread) observes the cancelled context and spins at the top of its loop. At that point there is a race: either `Finish` grabs the state_mu_ first and we are clean (unregister the migration and go back to connecting) OR we `ChangeState(MigrationState::C_CONNECTING)` executes first `after` Finish cancels it but `before` it grabs the lock. Then once Finish wakes up and locks, it observes that the state is CONNECTING and `skips the cleanup` and we trigger the DCHECK shown in the issue. (`Bug 1`). It's a `tough` one because the `timing` is very `slim`.

The fix for that is to add a check in SyncFb and cancel the migration if it grabs the mutex first. 

However fixing bug 1 above adds another bug: the poll on `state_` is `stale` so we might end up in `C_SYNC` and we end up `cancelling the wrong flows` 😮‍💨 🤦  (`Bug 2`).

The solution is to allow the top down error handler (Outgoing Migration handle the error) while SyncFb polls it and Resets it (effectively joining on the error handler and linearizing the loop).  SliceSlotMigration now just reports the error on the OutgoingMigration error handler.

Then the third one (`bug 3`) in `ConnectAndAuth()`. We cancel the context, the canceled state is visible but the cancelation carries no error value and every function whose output is an error code it silently converts `cancelled` to no `error` violating its invariants. Returning `cntx->GetError()` on a cancelled context returns `no error`. This is what I warned a year and a half ago here: https://github.com/dragonflydb/dragonfly/pull/4549#discussion_r1955971760


resolves https://github.com/dragonflydb/dragonfly/issues/7739