### PR TITLE
fix(takeover): guard takeover state

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3421,11 +3421,13 @@ void ServerFamily::ReplTakeOver(facade::CmdArgParser parser, CommandContext* cmd
     return cmd_cntx->SendError("timeout is negative");
   }
 
+  // The LockGuard must precede the master check to ensure atomicity for the subsequent repl_ptr
+  // check
+  util::fb2::LockGuard lk(replicaof_mu_);
+
   // We return OK, to support idempotency semantics.
   if (IsMaster())
     return builder->SendOk();
-
-  util::fb2::LockGuard lk(replicaof_mu_);
 
   auto repl_ptr = replica_;
   CHECK(repl_ptr);


### PR DESCRIPTION
## Description

There is a bug in dragonfly where repltakeover command sent by the dragonfly-operator can timeout due to its low `read-timeout` setting and can perform multiple retries. If the master is still running the takeover, which we've noticed in production takes ~40 seconds sometimes, the subsequent takeover requests _bypass_ the `IsMaster` check and wait on the lock to be taken. The `repl_ptr` is now a nullptr and the `CHECK(repl_ptr);` causes a crash in replica that was just promoted to be a master. 

Fix by guarding the `IsMaster` check with a lock, so that the replica that gets promoted doesn't crash.

Logs

```
---- master log ---------
2026-06-10T14:54:29.898028518Z INFO Takeover initiated, locking down the database.
-------------------------

---- replica log ---------
2026-06-10T15:03:41.998687069Z INFO Takeover successful, promoting this instance to master.
-------------------------
```

```
Check failed: repl_ptr 
*** Check failure stack trace: ***
    @          0x137f56a  google::LogMessage::SendToLog()
    @          0x137720f  google::LogMessage::Flush()
    @          0x1377ed9  google::LogMessageFatal::~LogMessageFatal()
    @           0x4e554f  dfly::ServerFamily::ReplTakeOver()
    @           0x59a7e1  dfly::Service::InvokeCmd()
    @           0x59c0d9  dfly::Service::DispatchCommand()
    @           0xb06089  _ZN4absl12lts_2025051219functional_internal12InvokeObjectIZN6facade10Connection10ParseRedisEjEUlvE_vJEEET0_NS1_7VoidPtrEDpNS1_8ForwardTIT1_E4typeE
    @           0xb13626  facade::Connection::DispatchSingle()
    @           0xb13cac  facade::Connection::ParseRedis()
    @           0xb14455  facade::Connection::IoLoop()
    @           0xb14acd  facade::Connection::ConnectionFlow()
    @           0xb16270  facade::Connection::HandleRequests()
    @          0x104e0e2  util::ListenerInterface::RunSingleConnection()
    @          0x104e741  _ZN5boost7context6detail11fiber_entryINS1_12fiber_recordINS0_5fiberEN4util3fb219FixedStackAllocatorEZNS6_6detail15WorkerFiberImplIZZNS5_17ListenerInterface13RunAcceptLoopEvENKUlvE_clEvEUlvE_JEEC4IS7_EESt17basic_string_viewIcSt11char_traitsIcEENS6_13FiberPriorityERKNS0_12preallocatedEOT_OSC_EUlOS4_E_EEEEvNS1_10transfer_tE
    @          0x109765f  make_fcontext
*** SIGABRT received at time=1783014880 on cpu 2 ***
PC: @     0x7b04acc1f9fc  (unknown)  pthread_kill
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
