### PR TITLE
fix(acl): support arguments in DRYRUN

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -594,6 +594,7 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
     rb->SendError(error);
     return;
   }
+  const facade::ParsedArgs simulated_args = parser.UnparsedArgs();
 
   const auto& user = registry.find(username)->second;
   // Stub, used to mimic connection context for a user.
@@ -602,8 +603,12 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
   // "mock" without an actual connection we can't know which db is active so we skip this check
   // for DryRun.
   stub.acl_db_idx = {};
-  stub.keys = {{}, true};
-  const auto [is_allowed, reason] = IsUserAllowedToInvokeCommandGeneric(stub, *cid, {});
+  stub.keys = user.Keys();
+  // The regular command path validates arity before checking ACLs. DRYRUN historically accepts a
+  // command without its arguments, so skip key-pattern validation for an incomplete simulation.
+  if (cid->Validate(simulated_args))
+    stub.keys = {{}, true};
+  const auto [is_allowed, reason] = IsUserAllowedToInvokeCommandGeneric(stub, *cid, simulated_args);
   if (is_allowed) {
     rb->SendOk();
     return;
@@ -1266,7 +1271,7 @@ void AclFamily::Register(dfly::CommandRegistry* registry) {
   *registry << CI{"ACL USERS", kAclMask, 1, 0, 0, acl::kUsers}.HFUNC(Users);
   *registry << CI{"ACL CAT", kAclMask, -1, 0, 0, acl::kCat}.HFUNC(Cat);
   *registry << CI{"ACL GETUSER", kAclMask, 2, 0, 0, acl::kGetUser}.HFUNC(GetUser);
-  *registry << CI{"ACL DRYRUN", kAclMask, 3, 0, 0, acl::kDryRun}.HFUNC(DryRun);
+  *registry << CI{"ACL DRYRUN", kAclMask, -3, 0, 0, acl::kDryRun}.HFUNC(DryRun);
   *registry << CI{"ACL GENPASS", CO::NOSCRIPT | CO::LOADING, -1, 0, 0, acl::kGenPass}.HFUNC(
       GenPass);
   *registry << CI{"ACL HELP", kAclMask, 0, 0, 0, acl::kHelp}.HFUNC(Help);

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -364,8 +364,8 @@ TEST_F(AclFamilyTest, TestDryRun) {
   resp = Run({"ACL", "DRYRUN", "default"});
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
 
-  resp = Run({"ACL", "DRYRUN", "default", "get", "more"});
-  EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
+  resp = Run({"ACL", "DRYRUN", "default", "SET", "key", "value"});
+  EXPECT_THAT(resp, "OK");
 
   resp = Run({"ACL", "DRYRUN", "kostas", "more"});
   EXPECT_THAT(resp, ErrArg("ERR User 'kostas' not found"));
@@ -384,6 +384,15 @@ TEST_F(AclFamilyTest, TestDryRun) {
 
   resp = Run({"ACL", "DRYRUN", "kostas", "SET"});
   EXPECT_THAT(resp, "This user has no permissions to run the 'SET' command");
+
+  resp = Run({"ACL", "SETUSER", "key-reader", "+GET", "~allowed:*"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "DRYRUN", "key-reader", "GET", "allowed:key"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "DRYRUN", "key-reader", "GET", "blocked:key"});
+  EXPECT_THAT(resp, "This user has no permissions to run the 'GET' command");
 }
 
 TEST_F(AclFamilyTest, AclGenPassTooManyArguments) {


### PR DESCRIPTION
Fixes #5437

## Summary

Allow `ACL DRYRUN` to accept simulated command arguments and check the target user's key patterns.

## Root cause

`DRYRUN` discarded simulated arguments and used unrestricted key permissions, so it could not apply key ACL rules.

## Changes

- Make `ACL DRYRUN` accept a variadic simulated command tail.
- Pass valid simulated arguments to the ACL validator with the target user's key permissions.
- Preserve the existing command-only behavior for incomplete simulated commands.
- Add allow/deny coverage for key-pattern ACL rules.

## Validation

- `ninja -C build-dbg acl_family_test`
- `build-dbg/acl_family_test`
- `pre-commit run --files src/server/acl/acl_family.cc src/server/acl/acl_family_test.cc`
