### PR TITLE
fix(stream): honor COUNT when a blocked XREAD/XREADGROUP is woken

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3068,6 +3068,10 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
   auto range_cb = [&](Transaction* t, EngineShard* shard) {
     if (auto wake_key = t->GetWakeKey(shard->shard_id()); wake_key) {
       RangeOpts range_opts;
+      // Ensure the woken read honors COUNT like the non-blocking path
+      // (OpRead) does: without it, a consumer woken by a transaction that
+      // added multiple entries receives all of them in one reply.
+      range_opts.count = opts->count;
       range_opts.end = ParsedStreamId{.val = streamID{
                                           .ms = UINT64_MAX,
                                           .seq = UINT64_MAX,

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -448,7 +448,10 @@ TEST_F(StreamFamilyTest, XReadGroupBlockHonorsCount) {
     resp0 = Run({"xreadgroup", "group", "group", "alice", "count", "1", "block", "0", "streams",
                  "foo", ">"});
   });
-  ThisFiber::SleepFor(50us);
+  // Wait until the reader is parked in the blocking path (WaitOnWatch flips
+  // the connection's `blocked` flag) so the transaction below exercises the
+  // wake-up read, not the immediate one. fb0 runs on proactor 0 -> "IO0".
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
 
   // Wake it with a transaction adding multiple entries at once. The woken
   // read must honor COUNT like the non-blocking path does, instead of

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -439,6 +439,39 @@ TEST_F(StreamFamilyTest, XReadGroupBlockDelconsumer) {
   EXPECT_THAT(resp_del_consumer, IntArg(0));
 }
 
+TEST_F(StreamFamilyTest, XReadGroupBlockHonorsCount) {
+  Run({"xgroup", "create", "foo", "group", "0", "MKSTREAM"});
+
+  // Block a consumer with COUNT 1.
+  RespExpr resp0;
+  auto fb0 = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp0 = Run({"xreadgroup", "group", "group", "alice", "count", "1", "block", "0", "streams",
+                 "foo", ">"});
+  });
+  ThisFiber::SleepFor(50us);
+
+  // Wake it with a transaction adding multiple entries at once. The woken
+  // read must honor COUNT like the non-blocking path does, instead of
+  // delivering the transaction's whole burst to one consumer.
+  auto fb1 = pp_->at(1)->LaunchFiber([&] {
+    Run({"multi"});
+    Run({"xadd", "foo", "1-1", "k1", "v1"});
+    Run({"xadd", "foo", "1-2", "k2", "v2"});
+    Run({"xadd", "foo", "1-3", "k3", "v3"});
+    auto resp = Run({"exec"});
+    ASSERT_THAT(resp, ArrLen(3));
+  });
+
+  fb0.Join();
+  fb1.Join();
+
+  EXPECT_THAT(resp0.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+
+  // The entries beyond COUNT stay undelivered, available to other consumers.
+  auto resp = Run({"xreadgroup", "group", "group", "bob", "count", "10", "streams", "foo", ">"});
+  EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(2)));
+}
+
 TEST_F(StreamFamilyTest, XReadInvalidArgs) {
   // Invalid COUNT value.
   auto resp = Run({"xread", "count", "invalid", "streams", "s1", "s2", "0", "0"});

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -678,6 +678,14 @@ string BaseFamilyTest::GetId() const {
   return absl::StrCat("IO", id);
 }
 
+bool BaseFamilyTest::IsConnBlocked(string_view conn_id) {
+  unique_lock lk(mu_);
+  auto it = connections_.find(conn_id);
+  // The connection may not exist yet: it is created lazily by the first Run
+  // on its thread, which is exactly the window callers are waiting out.
+  return it != connections_.end() && it->second->cmd_cntx()->blocked;
+}
+
 size_t BaseFamilyTest::NumSubscriptions(string_view conn_id) const {
   auto it = connections_.find(conn_id);
   CHECK(it != connections_.end());

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -163,6 +163,12 @@ class BaseFamilyTest : public ::testing::Test {
                           std::chrono::milliseconds timeout_ms = std::chrono::milliseconds(100));
 
   std::string GetId() const;
+
+  // Whether connection `conn_id` is currently parked in a blocking command
+  // (e.g. BLPOP / XREAD ... BLOCK). Combine with WaitUntilCondition to
+  // deterministically order a wake-up write after the block is entered.
+  bool IsConnBlocked(std::string_view conn_id);
+
   size_t SubscriberMessagesLen(std::string_view conn_id) const;
 
   size_t NumSubscriptions(std::string_view conn_id) const;


### PR DESCRIPTION
## Problem

A blocked `XREADGROUP ... COUNT 1 BLOCK ...` consumer that is woken by a MULTI/EXEC transaction containing multiple `XADD`s receives **all of the transaction's entries in one reply** — `COUNT` is ignored on the wake path. Redis 7 delivers exactly `COUNT` entries to each woken consumer for the same command sequence.

Reproduction against `dragonfly:v1.38.1` / `v1.39.0` (both affected):

```bash
redis-cli XGROUP CREATE q workers '$' MKSTREAM

# Park consumers (e.g. in 4 shells):
redis-cli XREADGROUP GROUP workers c1 COUNT 1 BLOCK 15000 STREAMS q '>'

# Burst entries in one transaction:
(echo MULTI; for i in $(seq 50); do echo "XADD q * f $i"; done; echo EXEC) | redis-cli
```

One parked consumer receives all 50 entries in a single reply (all 50 land in its PEL, per `XPENDING q workers`); the others receive nothing. On Redis 7 each parked consumer receives exactly 1 entry and 46 remain undelivered.

We hit this in production with a job queue built on streams + consumer groups: a batch of ~500 jobs enqueued in one MULTI/EXEC was delivered whole to a single worker's PEL, so one process ran the entire batch serially while the rest of the fleet saw an empty queue. (Entries delivered but unacknowledged are invisible to other consumers' `>` reads, so the work cannot be picked up elsewhere until idle-reclaim.)

## Root cause

`XReadBlock()`'s resume-after-wake callback builds its `RangeOpts` without setting `count`, which therefore stays at the struct default `kuint32max`. The non-blocking path (`OpRead()`) already sets `range_opts.count = opts.count`.

## Fix

Set `range_opts.count = opts->count` in the wake path, mirroring `OpRead()`. Behaviour without an explicit `COUNT` is unchanged (`ReadOpts::count` defaults to `kuint32max` as well).
