### PR TITLE
fix(server): emit db= once in CLIENT INFO

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -391,9 +391,6 @@ void ClientInfo(facade::ParsedArgs args, CommandContext* cmd_cntx) {
   }
   auto* conn = cmd_cntx->conn();
   string info = conn->GetClientInfo();
-
-  // redis-py (5expects these fields. We append dummy values to keep the output parsable.
-  absl::StrAppend(&info, " db=", cmd_cntx->server_conn_cntx()->db_index(), "\r\n");
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   return rb->SendBulkString(info);
 }

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -316,6 +316,17 @@ TEST_F(ServerFamilyTest, ClientListRejected) {
   }
 }
 
+TEST_F(ServerFamilyTest, ClientInfoSingleDbField) {
+  const string info = Run({"CLIENT", "INFO"}).GetString();
+  // Regression: "db=" used to be emitted twice (FormatClientInfo + a redundant append).
+  size_t count = 0;
+  for (size_t pos = info.find(" db="); pos != string::npos; pos = info.find(" db=", pos + 1))
+    ++count;
+  EXPECT_EQ(count, 1u) << info;
+  // CLIENT INFO returns a single line with no trailing newline (unlike CLIENT LIST).
+  EXPECT_FALSE(absl::EndsWith(info, "\r\n")) << info;
+}
+
 TEST_F(ServerFamilyTest, ClientTrackingOnAndOff) {
   // case 1. can't use the feature for resp2
   auto resp = Run({"CLIENT", "TRACKING", "ON"});


### PR DESCRIPTION
`CLIENT INFO` appended a second `db=<index>` (and a stray trailing `\r\n`) on top of the `db=` that `GetClientInfo()` already produces, so the reply carried the field twice and ended with an extra newline. Valkey returns a single line with `db=` once and no trailing newline.

Changes:
- Remove the redundant `db=`/`\r\n` append in the `CLIENT INFO` handler; `GetClientInfo()` already includes `db=` and the dummy counter fields.
- Add regression test `ServerFamilyTest.ClientInfoSingleDbField` asserting `db=` appears exactly once and the reply has no trailing CRLF.