### PR TITLE
fix(search): avoid use-after-free garbling long WITHSORTKEYS values

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1312,7 +1312,19 @@ void SearchReply(const SearchParams& params,
   Overloaded sortable_value_sender{
       [rb](monostate) { rb->SendNull(); },
       [rb](double d) { rb->SendBulkString(absl::StrCat("#", d)); },
-      [rb](const string& s) { rb->SendBulkString("$" + s); },
+      [rb](const string& s) {
+        // absl::StrCat("$", s) is a temporary: a bulk string longer than kMaxInlineSize is
+        // enqueued by reference and copied only when the enclosing ArrayScope ends — after the
+        // temporary is gone (use-after-free). Pause the scope for long values so the string is
+        // materialized while still alive; short ones are inlined immediately and need no pause.
+        string v = absl::StrCat("$", s);
+        if (v.size() > RedisReplyBuilder::kMaxInlineSize) {
+          RedisReplyBuilder::ScopePause pause{rb};
+          rb->SendBulkString(v);
+        } else {
+          rb->SendBulkString(v);
+        }
+      },
   };
 
   rb->SendLong(total_hits);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -5491,6 +5491,18 @@ TEST_F(SearchFamilyTest, WithSortKeysOption) {
                    IsMap("last_name", "jones", "first_name", "alice", "age", "35")));
 }
 
+TEST_F(SearchFamilyTest, WithSortKeysLongValue) {
+  // Regression: a WITHSORTKEYS string sortkey whose "$"-prefixed form exceeds kMaxInlineSize was
+  // garbled when read back — the "$" + s temporary was enqueued into the reply by reference past
+  // its lifetime (use-after-free). Derive the length from the constant so the test keeps exercising
+  // the non-inlined (WriteRef) path even if kMaxInlineSize changes.
+  EXPECT_EQ(Run({"ft.create", "idx", "SCHEMA", "txt", "TEXT", "SORTABLE"}), "OK");
+  const string long_val(RedisReplyBuilder::kMaxInlineSize + 8, 'a');
+  Run({"HSET", "doc1", "txt", long_val});
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "*", "SORTBY", "txt", "WITHSORTKEYS", "NOCONTENT"}),
+              IsArray(IntArg(1), "doc1", "$" + long_val));
+}
+
 // GEO index tests for FT.SEARCH with HASH and JSON documents
 
 TEST_F(SearchFamilyTest, GeoSearchHash) {


### PR DESCRIPTION
`FT.SEARCH … WITHSORTKEYS` with a string sort value whose `$`-prefixed form exceeds 32 bytes returned a garbled sortkey. The `"$" + s` temporary was enqueued into the reply by reference under the result `ArrayScope` and copied only when the scope ended - after the temporary was destroyed (use-after-free). Same class as the stream-id UAF (#7874).

Changes,
- Materialize the sortkey and force a copy (via `ScopePause`) for values > `kMaxInlineSize`.
- Add regression test `SearchFamilyTest.WithSortKeysLongValue`.