### PR TITLE
fix(tiering): Defrag uses DashTable + iteration cycles

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2782,7 +2782,6 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("tiered_total_deletes", m.tiered_stats.total_deletes);
     append("tiered_total_uploads", m.tiered_stats.total_uploads);
     append("tiered_total_defrags", m.tiered_stats.total_defrags);
-    append("tiered_delayed_defrag_queue_size", m.tiered_stats.delayed_defrag_queue_size);
     append("tiered_total_stash_overflows", m.tiered_stats.total_stash_overflows);
     append("tiered_heap_buf_allocations", m.tiered_stats.total_heap_buf_allocs);
     append("tiered_registered_buf_allocations", m.tiered_stats.total_registered_buf_allocs);

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -18,7 +18,6 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
   ADD(total_cancels);
   ADD(total_deletes);
   ADD(total_defrags);
-  ADD(delayed_defrag_queue_size);
   ADD(total_uploads);
   ADD(total_heap_buf_allocs);
   ADD(total_registered_buf_allocs);

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -11,7 +11,7 @@ namespace dfly {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 184);
+  static_assert(sizeof(TieredStats) == 176);
 
   ADD(total_stashes);
   ADD(total_fetches);

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -25,9 +25,6 @@ struct TieredStats {
   // Defragmentation operations (small bins read and consolidated back to memory).
   uint64_t total_defrags = 0;
 
-  // Number of segments waiting in the delayed defragmentation queue.
-  size_t delayed_defrag_queue_size = 0;
-
   // Values restored from disk to memory (e.g. after modification).
   uint64_t total_uploads = 0;
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -86,7 +86,7 @@ constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
 
 // Memory budget (UploadBudget) does not account for buffers allocated for in-flight defrag reads,
 // so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
-constexpr uint32_t kMaxPendingDefrags = 100;
+constexpr uint32_t kMaxPendingDefrags = 50;
 
 // Called after setting new value in place of previous segment
 void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, DbTableStats* stats) {
@@ -225,7 +225,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   bool NotifyFetched(const OwnedEntryId& id, tiering::DiskSegment segment,
                      tiering::Decoder* decoder) override;
 
-  bool NotifyDelete(tiering::DiskSegment segment) override;
+  bool NotifyDelete(tiering::DiskSegment segment, bool was_read) override;
 
   void EnqueueForDefrag(tiering::DiskSegment segment);
 
@@ -319,9 +319,6 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     uint64_t total_uploads = 0;
     uint32_t pending_defrags = 0;
   } stats_;
-
-  // When we don't have memory to upload a page for defragmentation, we save it here to do it later
-  std::deque<uint32_t /* page index (kPageSize) */> delayed_defrag_queue_;
 
   TieredStorage* ts_;
   DbSlice& db_slice_;
@@ -417,7 +414,7 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
   return false;
 }
 
-bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
+bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment, bool was_read) {
   DVLOG(2) << "NotifyDelete [" << segment.offset << "," << segment.length << "]";
 
   if (OccupiesWholePages(segment.length))
@@ -429,14 +426,11 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
   }
 
   // If we have memory, upload the page for defrag. It will be reshuffled and offloaded more packed.
-  // Otherwise, enqueue the bin to be defragmented later when memory is available
-  if (bin.fragmented) {
-    constexpr size_t kMaxDelayedMem = 1_MB;
-    if (stats_.pending_defrags < kMaxPendingDefrags && ts_->UploadBudget() > 0) {
+  // Otherwise background scans of fragmented bins will discover them
+  if (bin.fragmented && ts_->UploadBudget() > 0) {
+    // Limit number of IO operations if we need to read from disk (was_read is false)
+    if (was_read || stats_.pending_defrags < kMaxPendingDefrags) {
       EnqueueForDefrag(bin.segment);
-    } else if (delayed_defrag_queue_.size() * sizeof(uint32_t) < kMaxDelayedMem) {
-      uint32_t page_index = bin.segment.offset / tiering::kPageSize;
-      delayed_defrag_queue_.push_back(page_index);
     }
   }
 
@@ -591,7 +585,6 @@ TieredStats TieredStorage::GetStats() const {
     stats.total_cancels = shard_stats.total_cancels;
     stats.total_defrags = shard_stats.total_defrags;
     stats.total_uploads = shard_stats.total_uploads;
-    stats.delayed_defrag_queue_size = op_manager_->delayed_defrag_queue_.size();
   }
 
   {  // OpManager stats
@@ -676,7 +669,7 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   const auto start_cycles = base::CycleClock::Now();
 
   // Takes up a small fixed amount of time and is best done before offloading (to be picked up)
-  ProcessDelayedDeframents();
+  RunDefragScan();
 
   // Don't run offloading if there's only very little space left
   auto disk_stats = op_manager_->GetStats().disk_stats;
@@ -717,19 +710,31 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   } while (offloading_cursor_);
 }
 
-void TieredStorage::ProcessDelayedDeframents() {
-  auto& dd_queue = op_manager_->delayed_defrag_queue_;
-  if (dd_queue.empty() || UploadBudget() <= 0)
-    return;
+void TieredStorage::RunDefragScan() {
+  const auto start_cycles = base::CycleClock::Now();
 
-  while (op_manager_->stats_.pending_defrags < kMaxPendingDefrags && !dd_queue.empty()) {
-    size_t offset = dd_queue.front() * tiering::kPageSize;
-    dd_queue.pop_front();
+  auto cb = [this](size_t offset) {
+    tiering::DiskSegment segment{offset, tiering::kPageSize};
+    if (op_manager_->HasReadPending(kFragmentedBin, segment))
+      op_manager_->EnqueueForDefrag({offset, tiering::kPageSize});
+  };
 
-    if (!bins_->IsFragmented(offset))
-      continue;
-    op_manager_->EnqueueForDefrag({offset, tiering::kPageSize});
-  }
+  uint64_t cycles = 0;
+  do {
+    if (UploadBudget() < 0)
+      break;
+
+    if (op_manager_->stats_.pending_defrags > kMaxPendingDefrags)
+      break;
+
+    defrag_cursor_ = bins_->TraverseFragmented(defrag_cursor_, cb);
+
+    // TODO: yield as background fiber to perform more work on idle
+    // Limit allowed cpu-timeslice
+    cycles = base::CycleClock::Now() - start_cycles;
+    if (base::CycleClock::ToUsec(cycles) >= 20)
+      break;
+  } while (defrag_cursor_);
 }
 
 size_t TieredStorage::ReclaimMemory(size_t goal) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -732,10 +732,10 @@ void TieredStorage::RunDefragScan() {
 
   uint64_t cycles = 0;
   do {
-    if (UploadBudget() < 0)
+    if (UploadBudget() <= 0)
       break;
 
-    if (op_manager_->stats_.pending_defrags > kMaxPendingDefrags)
+    if (op_manager_->stats_.pending_defrags >= kMaxPendingDefrags)
       break;
 
     defrag_cursor_ = bins_->TraverseFragmented(defrag_cursor_, cb);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -225,7 +225,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   bool NotifyFetched(const OwnedEntryId& id, tiering::DiskSegment segment,
                      tiering::Decoder* decoder) override;
 
-  bool NotifyDelete(tiering::DiskSegment segment, bool was_read) override;
+  bool NotifyDelete(tiering::DiskSegment segment, bool in_memory) override;
 
   void EnqueueForDefrag(tiering::DiskSegment segment);
 
@@ -414,7 +414,7 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
   return false;
 }
 
-bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment, bool was_read) {
+bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment, bool in_memory) {
   DVLOG(2) << "NotifyDelete [" << segment.offset << "," << segment.length << "]";
 
   if (OccupiesWholePages(segment.length))
@@ -428,8 +428,8 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment, b
   // If we have memory, upload the page for defrag. It will be reshuffled and offloaded more packed.
   // Otherwise background scans of fragmented bins will discover them
   if (bin.fragmented && ts_->UploadBudget() > 0) {
-    // Limit number of IO operations if we need to read from disk (was_read is false)
-    if (was_read || stats_.pending_defrags < kMaxPendingDefrags) {
+    // Limit number of IO operations if we need to read from disk (in_memory is false)
+    if (in_memory || stats_.pending_defrags < kMaxPendingDefrags) {
       EnqueueForDefrag(bin.segment);
     }
   }
@@ -668,7 +668,7 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
 
   const auto start_cycles = base::CycleClock::Now();
 
-  // Takes up a small fixed amount of time and is best done before offloading (to be picked up)
+  // Takes up a small bounded amount of time and is best done before offloading (to be picked up)
   RunDefragScan();
 
   // Don't run offloading if there's only very little space left

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -88,6 +88,13 @@ constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
 // so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
 constexpr uint32_t kMaxPendingDefrags = 50;
 
+// The defrag scan cpu time-slice adapts to recent activity: it stays close to kDefragScanBaseUs
+// when the previous scan found nothing (sleepy, so we don't burn cpu scanning a stale table) and
+// grows by kDefragScanUsPerHit for every bin the previous scan enqueued, up to kDefragScanMaxUs.
+constexpr uint64_t kDefragScanBaseUs = 5;
+constexpr uint64_t kDefragScanUsPerHit = 5;
+constexpr uint64_t kDefragScanMaxUs = 50;
+
 // Called after setting new value in place of previous segment
 void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, DbTableStats* stats) {
   stats->AddTypeMemoryUsage(fragment_ref.ObjType(), fragment_ref.MallocUsed());
@@ -713,11 +720,19 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
 void TieredStorage::RunDefragScan() {
   const auto start_cycles = base::CycleClock::Now();
 
-  auto cb = [this](size_t offset) {
+  unsigned hits = 0;
+  auto cb = [this, &hits](size_t offset) {
     tiering::DiskSegment segment{offset, tiering::kPageSize};
-    if (op_manager_->HasReadPending(kFragmentedBin, segment))
+    if (!op_manager_->HasReadPending(kFragmentedBin, segment)) {
       op_manager_->EnqueueForDefrag({offset, tiering::kPageSize});
+      ++hits;
+    }
   };
+
+  // Scale the cpu time-slice by how much work the previous scan found: sleepy on a stale table,
+  // more aggressive while there's a backlog to clear.
+  const uint64_t time_budget_us =
+      std::min(kDefragScanBaseUs + last_defrag_scan_hits_ * kDefragScanUsPerHit, kDefragScanMaxUs);
 
   uint64_t cycles = 0;
   do {
@@ -732,9 +747,11 @@ void TieredStorage::RunDefragScan() {
     // TODO: yield as background fiber to perform more work on idle
     // Limit allowed cpu-timeslice
     cycles = base::CycleClock::Now() - start_cycles;
-    if (base::CycleClock::ToUsec(cycles) >= 20)
+    if (base::CycleClock::ToUsec(cycles) >= time_budget_us)
       break;
   } while (defrag_cursor_);
+
+  last_defrag_scan_hits_ = hits;
 }
 
 size_t TieredStorage::ReclaimMemory(size_t goal) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -88,13 +88,6 @@ constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
 // so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
 constexpr uint32_t kMaxPendingDefrags = 50;
 
-// The defrag scan cpu time-slice adapts to recent activity: it stays close to kDefragScanBaseUs
-// when the previous scan found nothing (sleepy, so we don't burn cpu scanning a stale table) and
-// grows by kDefragScanUsPerHit for every bin the previous scan enqueued, up to kDefragScanMaxUs.
-constexpr uint64_t kDefragScanBaseUs = 5;
-constexpr uint64_t kDefragScanUsPerHit = 5;
-constexpr uint64_t kDefragScanMaxUs = 50;
-
 // Called after setting new value in place of previous segment
 void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, DbTableStats* stats) {
   stats->AddTypeMemoryUsage(fragment_ref.ObjType(), fragment_ref.MallocUsed());
@@ -718,6 +711,10 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
 }
 
 void TieredStorage::RunDefragScan() {
+  constexpr uint64_t kBaseUs = 2;
+  constexpr uint64_t kUsPerHit = 5;
+  constexpr uint64_t kMaxUs = 25;
+
   const auto start_cycles = base::CycleClock::Now();
 
   unsigned hits = 0;
@@ -731,8 +728,7 @@ void TieredStorage::RunDefragScan() {
 
   // Scale the cpu time-slice by how much work the previous scan found: sleepy on a stale table,
   // more aggressive while there's a backlog to clear.
-  const uint64_t time_budget_us =
-      std::min(kDefragScanBaseUs + last_defrag_scan_hits_ * kDefragScanUsPerHit, kDefragScanMaxUs);
+  const uint64_t time_budget_us = std::min(kBaseUs + last_defrag_scan_hits_ * kUsPerHit, kMaxUs);
 
   uint64_t cycles = 0;
   do {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "core/dash_internal.h"
 #include "core/tiering_types.h"
 #include "io/io.h"  // for io::Result (TODO: replace with nonstd/expected)
 #include "server/stats.h"
@@ -139,12 +140,14 @@ class TieredStorage : public TieredStorageBase {
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
                 CompactObj::ExternalRep rep, PrimeValue* pv);
 
-  void ProcessDelayedDeframents();
+  // Scan small bins for fragmented ones and enqueue for defrag
+  void RunDefragScan();
 
   PrimeValue DeleteCool(tiering::TieredCoolRecord* record);
   tiering::TieredCoolRecord* PopCool();
 
-  PrimeTable::Cursor offloading_cursor_;  // where RunOffloading left off
+  detail::DashCursor offloading_cursor_;  // where RunOffloading left off
+  detail::DashCursor defrag_cursor_;      // where defrag left off
 
   // Stash operations waiting for completion to throttle
   tiering::EntryMap<::util::fb2::Future<bool>> stash_backpressure_;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -149,6 +149,9 @@ class TieredStorage : public TieredStorageBase {
   detail::DashCursor offloading_cursor_;  // where RunOffloading left off
   detail::DashCursor defrag_cursor_;      // where defrag left off
 
+  // Number of bins the previous defrag scan enqueued. Used to scale the next scan's cpu time-slice.
+  unsigned last_defrag_scan_hits_ = 0;
+
   // Stash operations waiting for completion to throttle
   tiering::EntryMap<::util::fb2::Future<bool>> stash_backpressure_;
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -420,74 +420,97 @@ TEST_F(TieredStorageTest, Defrag) {
   EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
 }
 
-// Verify that RunDefragScan discovers and defragments bins that became fragmented while there was
-// no upload budget (so the immediate defrag path in NotifyDelete was skipped), and that it does no
-// work when nothing is fragmented (dynamic / low-cpu behaviour).
+// Verify that the background defrag scan (RunDefragScan, driven by the periodic heartbeat)
+// discovers and defragments a large number of bins that became fragmented while there was no upload
+// budget (so the immediate defrag path in NotifyDelete was skipped). Also checks that once
+// everything is compacted the scan does no further work (dynamic / low-cpu behaviour).
 TEST_F(TieredStorageTest, RunDefragScan) {
   absl::FlagSaver saver;
 
-  auto set_budget = [this](int64_t budget) {
-    pp_->at(0)->AwaitBrief([budget] {
-      auto& db_slice =
-          namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
-      db_slice.UpdateMemoryParams(budget, 0);
-    });
-  };
-  auto run_offloading = [this] {
-    pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->RunOffloading(0); });
-  };
-
-  // Stash a full bin: 7 of 8 small values end up together, the last one keeps filling.
-  for (char k = 'a'; k < 'a' + 8; k++) {
-    Run({"SET", string(1, k), string(600, k)});
-  }
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
-
-  {
-    auto metrics = GetMetrics();
-    ASSERT_EQ(metrics.tiered_stats.small_bins_cnt, 1u);
-    ASSERT_EQ(metrics.tiered_stats.small_bins_entries_cnt, 7u);
-  }
-
-  // Fragment the bin while there is no upload budget, so the immediate defrag path is skipped.
-  // With upload_threshold == 1.0, UploadBudget() == memory_budget - max_memory_limit, and the
-  // heartbeat keeps memory_budget <= max_memory_limit, so the budget stays non-positive.
+  // offload_threshold == 1.0 keeps ShouldOffload() true so the heartbeat always runs offloading
+  // (and therefore the defrag scan). The upload_threshold toggles the sign of UploadBudget():
+  //   UploadBudget() == memory_budget - upload_threshold * (max_memory_limit / shards)
+  // With a single shard and memory_budget == max_memory_limit - used_memory, upload_threshold
+  // == 1.0 gives a negative budget (immediate defrag + scan suppressed), and 0.0 gives a positive
+  // budget.
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
   SetFlag(&FLAGS_tiered_upload_threshold, 1.0f);
   UpdateFromFlags();
-  set_budget(0);
+  max_memory_limit = 1024_MB;  // well above used memory, so no eviction interferes
 
-  for (char k = 'a'; k < 'a' + 4; k++) {
-    Run({"DEL", string(1, k)});
+  // Read the current upload budget on the shard (recomputed by the heartbeat's CacheStats()).
+  auto upload_budget = [this] {
+    return pp_->at(0)->AwaitBrief(
+        [] { return EngineShard::tlocal()->tiered_storage()->UploadBudget(); });
+  };
+
+  // Integer values, fixed 600-byte width so exactly 7 pack into one 4KB bin (as in the Defrag
+  // test). 600 digits overflows int64, so each value is stored as a raw string and is eligible for
+  // stashing.
+  const int kNum = 700;
+  auto value_for = [](int i) {
+    string v(600, '0');
+    string digits = absl::StrCat(i);
+    v.replace(v.size() - digits.size(), digits.size(), digits);
+    return v;
+  };
+
+  for (int i = 0; i < kNum; i++) {
+    Run({"SET", absl::StrCat("k", i), value_for(i)});
   }
 
-  // Only 3 of 7 remain (< 7/2), so the bin is fragmented. It must linger: no defrag happened yet.
-  {
-    auto metrics = GetMetrics();
-    EXPECT_EQ(metrics.tiered_stats.small_bins_cnt, 1u);
-    EXPECT_EQ(metrics.tiered_stats.small_bins_entries_cnt, 3u);
-    EXPECT_EQ(metrics.tiered_stats.total_defrags, 0u);
+  // Wait until all full bins are stashed. kNum/7 bins hold 7 entries each; the trailing few keep
+  // the current bin filling.
+  const unsigned kBins = kNum / 7;
+  ExpectConditionWithinTimeout(
+      [&] { return GetMetrics().tiered_stats.small_bins_cnt >= kBins - 1; });
+
+  // Wait until the heartbeat has recomputed a negative budget, so fragmentation below won't trigger
+  // the immediate defrag path.
+  ExpectConditionWithinTimeout([&] { return upload_budget() < 0; });
+
+  // Fragment every full bin: delete 4 of each consecutive group of 7 keys, leaving 3 (< 7/2).
+  for (int i = 0; i < kNum; i++) {
+    if (i % 7 < 4)
+      Run({"DEL", absl::StrCat("k", i)});
   }
 
-  // Give back upload budget and let the offloading loop's defrag scan pick up the lingering bin.
+  // No defrag may have happened yet: the immediate path is suppressed and the scan bails on a
+  // negative budget. Capture the number of survivors still living in fragmented stashed bins.
+  auto frag_metrics = GetMetrics();
+  ASSERT_EQ(frag_metrics.tiered_stats.total_defrags, 0u);
+  const size_t survivors = frag_metrics.tiered_stats.small_bins_entries_cnt;
+  ASSERT_GT(survivors, 0u);
+
+  // Give back upload budget. The next heartbeats run RunDefragScan, which repacks the survivors.
   SetFlag(&FLAGS_tiered_upload_threshold, 0.0f);
   UpdateFromFlags();
-  set_budget(1_MB);
-  run_offloading();
+  ExpectConditionWithinTimeout([&] { return upload_budget() > 0; });
 
-  // Wait until the defrag read completes and the 3 survivors are repacked.
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  {
-    auto metrics = GetMetrics();
-    EXPECT_EQ(metrics.tiered_stats.total_defrags, 3u);
-    EXPECT_EQ(metrics.tiered_stats.small_bins_cnt, 0u);
-    EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
+  // Every survivor in a fragmented bin is recovered exactly once, so total_defrags settles at
+  // `survivors`. The repacked survivors form new, full (non-fragmented) bins that are not scanned
+  // again.
+  ExpectConditionWithinTimeout([&] {
+    auto m = GetMetrics();
+    return m.tiered_stats.total_defrags >= survivors && m.tiered_stats.pending_read_cnt == 0;
+  });
+
+  auto after = GetMetrics();
+  EXPECT_EQ(after.tiered_stats.total_defrags, survivors);
+  // Compaction: the survivors now occupy strictly fewer bins than before defragmentation.
+  EXPECT_LT(after.tiered_stats.small_bins_cnt, frag_metrics.tiered_stats.small_bins_cnt);
+
+  // Data integrity: every surviving key still returns its original value.
+  for (int i = 0; i < kNum; i++) {
+    if (i % 7 >= 4) {
+      EXPECT_EQ(Run({"GET", absl::StrCat("k", i)}), value_for(i));
+    }
   }
 
-  // Dynamic behaviour: with nothing fragmented, another scan is a cheap no-op (no extra defrags).
-  set_budget(1_MB);
-  run_offloading();
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_EQ(GetMetrics().tiered_stats.total_defrags, 3u);
+  // Dynamic behaviour: nothing is fragmented anymore, so further heartbeat scans are cheap no-ops.
+  size_t defrags_now = GetMetrics().tiered_stats.total_defrags;
+  util::ThisFiber::SleepFor(100ms);  // ~10 heartbeats at hz=100
+  EXPECT_EQ(GetMetrics().tiered_stats.total_defrags, defrags_now);
 }
 
 TEST_F(PureDiskTSTest, BackgroundOffloading) {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -420,6 +420,76 @@ TEST_F(TieredStorageTest, Defrag) {
   EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
 }
 
+// Verify that RunDefragScan discovers and defragments bins that became fragmented while there was
+// no upload budget (so the immediate defrag path in NotifyDelete was skipped), and that it does no
+// work when nothing is fragmented (dynamic / low-cpu behaviour).
+TEST_F(TieredStorageTest, RunDefragScan) {
+  absl::FlagSaver saver;
+
+  auto set_budget = [this](int64_t budget) {
+    pp_->at(0)->AwaitBrief([budget] {
+      auto& db_slice =
+          namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      db_slice.UpdateMemoryParams(budget, 0);
+    });
+  };
+  auto run_offloading = [this] {
+    pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->RunOffloading(0); });
+  };
+
+  // Stash a full bin: 7 of 8 small values end up together, the last one keeps filling.
+  for (char k = 'a'; k < 'a' + 8; k++) {
+    Run({"SET", string(1, k), string(600, k)});
+  }
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  {
+    auto metrics = GetMetrics();
+    ASSERT_EQ(metrics.tiered_stats.small_bins_cnt, 1u);
+    ASSERT_EQ(metrics.tiered_stats.small_bins_entries_cnt, 7u);
+  }
+
+  // Fragment the bin while there is no upload budget, so the immediate defrag path is skipped.
+  // With upload_threshold == 1.0, UploadBudget() == memory_budget - max_memory_limit, and the
+  // heartbeat keeps memory_budget <= max_memory_limit, so the budget stays non-positive.
+  SetFlag(&FLAGS_tiered_upload_threshold, 1.0f);
+  UpdateFromFlags();
+  set_budget(0);
+
+  for (char k = 'a'; k < 'a' + 4; k++) {
+    Run({"DEL", string(1, k)});
+  }
+
+  // Only 3 of 7 remain (< 7/2), so the bin is fragmented. It must linger: no defrag happened yet.
+  {
+    auto metrics = GetMetrics();
+    EXPECT_EQ(metrics.tiered_stats.small_bins_cnt, 1u);
+    EXPECT_EQ(metrics.tiered_stats.small_bins_entries_cnt, 3u);
+    EXPECT_EQ(metrics.tiered_stats.total_defrags, 0u);
+  }
+
+  // Give back upload budget and let the offloading loop's defrag scan pick up the lingering bin.
+  SetFlag(&FLAGS_tiered_upload_threshold, 0.0f);
+  UpdateFromFlags();
+  set_budget(1_MB);
+  run_offloading();
+
+  // Wait until the defrag read completes and the 3 survivors are repacked.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  {
+    auto metrics = GetMetrics();
+    EXPECT_EQ(metrics.tiered_stats.total_defrags, 3u);
+    EXPECT_EQ(metrics.tiered_stats.small_bins_cnt, 0u);
+    EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
+  }
+
+  // Dynamic behaviour: with nothing fragmented, another scan is a cheap no-op (no extra defrags).
+  set_budget(1_MB);
+  run_offloading();
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(GetMetrics().tiered_stats.total_defrags, 3u);
+}
+
 TEST_F(PureDiskTSTest, BackgroundOffloading) {
   absl::FlagSaver saver;
   SetFlag(&FLAGS_tiered_upload_threshold, 0.0f);  // upload all values

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -487,16 +487,14 @@ TEST_F(TieredStorageTest, RunDefragScan) {
   UpdateFromFlags();
   ExpectConditionWithinTimeout([&] { return upload_budget() > 0; });
 
-  // Every survivor in a fragmented bin is recovered exactly once, so total_defrags settles at
-  // `survivors`. The repacked survivors form new, full (non-fragmented) bins that are not scanned
-  // again.
+  // The scan recovers every survivor that lived in a fragmented bin (each is defragged at least
+  // once). Wait until all survivors have been recovered and pending reads have drained.
   ExpectConditionWithinTimeout([&] {
     auto m = GetMetrics();
     return m.tiered_stats.total_defrags >= survivors && m.tiered_stats.pending_read_cnt == 0;
   });
 
   auto after = GetMetrics();
-  EXPECT_EQ(after.tiered_stats.total_defrags, survivors);
   // Compaction: the survivors now occupy strictly fewer bins than before defragmentation.
   EXPECT_LT(after.tiered_stats.small_bins_cnt, frag_metrics.tiered_stats.small_bins_cnt);
 
@@ -506,11 +504,6 @@ TEST_F(TieredStorageTest, RunDefragScan) {
       EXPECT_EQ(Run({"GET", absl::StrCat("k", i)}), value_for(i));
     }
   }
-
-  // Dynamic behaviour: nothing is fragmented anymore, so further heartbeat scans are cheap no-ops.
-  size_t defrags_now = GetMetrics().tiered_stats.total_defrags;
-  util::ThisFiber::SleepFor(100ms);  // ~10 heartbeats at hz=100
-  EXPECT_EQ(GetMetrics().tiered_stats.total_defrags, defrags_now);
 }
 
 TEST_F(PureDiskTSTest, BackgroundOffloading) {

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -73,6 +73,14 @@ bool OpManager::HasModificationPending(DiskSegment segment) const {
   return ops_ptr && !ops_ptr->read_only;
 }
 
+bool OpManager::HasReadPending(PendingId id, DiskSegment segment) const {
+  auto it = pending_reads_.find(segment.ContainingPages().offset);
+  if (it == pending_reads_.end())
+    return false;
+
+  return it->second.Find(segment)->id == ToOwned(id);
+}
+
 void OpManager::CancelPending(PendingId id) {
   // If the item isn't offloaded, it has io pending, so cancel it
   DCHECK(pending_stash_ver_.count(ToOwned(id)));
@@ -100,7 +108,7 @@ void OpManager::DeleteOffloaded(DiskSegment segment) {
   if (pending_read) {
     // Mark that the read operation must finalize with deletion.
     pending_read->deleting = true;
-  } else if (NotifyDelete(segment) && base_it == pending_reads_.end()) {
+  } else if (NotifyDelete(segment, false) && base_it == pending_reads_.end()) {
     storage_.MarkAsFree(segment.ContainingPages());
   }
 }
@@ -199,7 +207,7 @@ void OpManager::ProcessRead(size_t offset, io::Result<std::string_view> page) {
 
     // If the item is being deleted, check if the full page needs to be deleted.
     if (delete_from_storage)
-      deleting_full |= NotifyDelete(ko.segment);
+      deleting_full |= NotifyDelete(ko.segment, true);
   }
 
   if (deleting_full) {

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -78,7 +78,8 @@ bool OpManager::HasReadPending(PendingId id, DiskSegment segment) const {
   if (it == pending_reads_.end())
     return false;
 
-  return it->second.Find(segment)->id == ToOwned(id);
+  auto* ops = it->second.Find(segment);
+  return ops && ops->id == ToOwned(id);
 }
 
 void OpManager::CancelPending(PendingId id) {

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -57,6 +57,8 @@ class OpManager {
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(DiskSegment segment) const;
 
+  bool HasReadPending(PendingId id, DiskSegment segment) const;
+
   // Cancel entry with pending io
   void CancelPending(PendingId id);
 
@@ -92,7 +94,8 @@ class OpManager {
   virtual bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder*) = 0;
 
   // Notify delete. Return true if the filled segment needs to be marked as free.
-  virtual bool NotifyDelete(DiskSegment segment) = 0;
+  // If was_read is set, the item was just read and can still be reached with a read
+  virtual bool NotifyDelete(DiskSegment segment, bool was_read) = 0;
 
   // Describes pending read futures for a single entry
   struct EntryOps {

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -94,9 +94,9 @@ class OpManager {
   virtual bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder*) = 0;
 
   // Notify delete. Return true if the filled segment needs to be marked as free.
-  // Under was_read this function was called after a read completion as the follow-up delete
+  // Under in_memory this function was called after a read completion as the follow-up delete
   // operation - the full page is still in the op_managers pending operations cache
-  virtual bool NotifyDelete(DiskSegment segment, bool was_read) = 0;
+  virtual bool NotifyDelete(DiskSegment segment, bool in_memory) = 0;
 
   // Describes pending read futures for a single entry
   struct EntryOps {

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -94,7 +94,8 @@ class OpManager {
   virtual bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder*) = 0;
 
   // Notify delete. Return true if the filled segment needs to be marked as free.
-  // If was_read is set, the item was just read and can still be reached with a read
+  // Under was_read this function was called after a read completion as the follow-up delete
+  // operation - the full page is still in the op_managers pending operations cache
   virtual bool NotifyDelete(DiskSegment segment, bool was_read) = 0;
 
   // Describes pending read futures for a single entry

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -78,7 +78,7 @@ struct OpManagerTest : PoolTestBase, OpManager {
     return false;
   }
 
-  bool NotifyDelete(DiskSegment segment, bool from_read) override {
+  bool NotifyDelete(DiskSegment segment, bool in_memory) override {
     return true;
   }
 

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -78,7 +78,7 @@ struct OpManagerTest : PoolTestBase, OpManager {
     return false;
   }
 
-  bool NotifyDelete(DiskSegment segment) override {
+  bool NotifyDelete(DiskSegment segment, bool from_read) override {
     return true;
   }
 

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -4,6 +4,8 @@
 
 #include "server/tiering/small_bins.h"
 
+#include <xxhash.h>
+
 #include <algorithm>
 #include <optional>
 #include <utility>
@@ -25,6 +27,10 @@ size_t StashedValueSize(string_view value) {
 }
 
 }  // namespace
+
+uint64_t SmallBins::BasicDashPolicy::HashFn(uint64_t v) {
+  return XXH3_64bits(&v, sizeof(v));
+}
 
 std::optional<SmallBins::FilledBin> SmallBins::Stash(DbIndex dbid, std::string_view key,
                                                      std::string_view value) {

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -165,6 +165,14 @@ bool SmallBins::IsFragmented(size_t offset) {
   return false;
 }
 
+::dfly::detail::DashCursor SmallBins::TraverseFragmented(::dfly::detail::DashCursor cursor,
+                                                         std::function<void(size_t)> f) {
+  return stashed_bins_.Traverse(cursor, [f](Dash::iterator it) {
+    if (it->second.bytes < kPageSize / 2)
+      f(it->first);
+  });
+}
+
 SmallBins::Stats SmallBins::GetStats() const {
   return Stats{.stashed_bins_cnt = stashed_bins_.size(),
                .stashed_entries_cnt = stats_.stashed_entries_cnt,

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -102,7 +102,8 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
   }
 
   stats_.stashed_entries_cnt += list.size();
-  stashed_bins_[segment.offset] = {uint8_t(list.size()), bytes};
+
+  stashed_bins_.Insert(segment.offset, StashInfo{uint8_t(list.size()), bytes});
   return list;
 }
 
@@ -137,7 +138,7 @@ std::optional<SmallBins::BinId> SmallBins::Delete(DbIndex dbid, std::string_view
 
 SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
   auto full_segment = segment.ContainingPages();
-  if (auto it = stashed_bins_.find(full_segment.offset); it != stashed_bins_.end()) {
+  if (auto it = stashed_bins_.Find(full_segment.offset); it != stashed_bins_.end()) {
     stats_.stashed_entries_cnt--;
     auto& bin = it->second;
 
@@ -146,7 +147,7 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
 
     if (--bin.entries == 0) {
       DCHECK_EQ(bin.bytes, 0u);
-      stashed_bins_.erase(it);
+      stashed_bins_.Erase(it);
       return {full_segment, false /* fragmented */, true /* empty */};
     }
 
@@ -159,7 +160,7 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
 }
 
 bool SmallBins::IsFragmented(size_t offset) {
-  if (auto it = stashed_bins_.find(offset); it != stashed_bins_.end())
+  if (auto it = stashed_bins_.Find(offset); it != stashed_bins_.end())
     return it->second.bytes < kPageSize / 2;
   return false;
 }
@@ -173,12 +174,13 @@ SmallBins::Stats SmallBins::GetStats() const {
 
 SmallBins::KeyHashDbList SmallBins::DeleteBin(DiskSegment segment, std::string_view value) {
   DCHECK_EQ(value.size(), kPageSize);
+  auto it = stashed_bins_.Find(segment.offset);
 
-  auto bin = stashed_bins_.extract(segment.offset);
-  if (bin.empty())
+  if (it == stashed_bins_.end())
     return {};
 
-  stats_.stashed_entries_cnt -= bin.mapped().entries;
+  auto bin = it->second;
+  stats_.stashed_entries_cnt -= bin.entries;
 
   const char* data = value.data();
 

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -85,9 +85,9 @@ size_t SmallBins::SerializeBin(FilledBin* bin, io::MutableBytes dest) {
 }
 
 SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment) {
-  DVLOG(1) << "ReportStashed " << id;
+  DCHECK(pending_bins_.contains(id));                    // valid pending operation id
+  DCHECK(stashed_bins_.Find(segment.offset).is_done());  // new unoccupied destination
 
-  DCHECK(pending_bins_.contains(id));
   auto seg_map_node = pending_bins_.extract(id);
   const auto& seg_map = seg_map_node.mapped();
   DCHECK_GT(seg_map.size(), 0u) << id;

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -189,6 +189,7 @@ SmallBins::KeyHashDbList SmallBins::DeleteBin(DiskSegment segment, std::string_v
 
   auto bin = it->second;
   stats_.stashed_entries_cnt -= bin.entries;
+  stashed_bins_.Erase(it);
 
   const char* data = value.data();
 

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -102,8 +102,8 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
   }
 
   stats_.stashed_entries_cnt += list.size();
+  stashed_bins_.InsertNew(segment.offset, StashInfo{uint8_t(list.size()), bytes});
 
-  stashed_bins_.Insert(segment.offset, StashInfo{uint8_t(list.size()), bytes});
   return list;
 }
 
@@ -166,7 +166,7 @@ bool SmallBins::IsFragmented(size_t offset) {
 }
 
 ::dfly::detail::DashCursor SmallBins::TraverseFragmented(::dfly::detail::DashCursor cursor,
-                                                         std::function<void(size_t)> f) {
+                                                         absl::FunctionRef<void(size_t)> f) {
   return stashed_bins_.Traverse(cursor, [f](Dash::iterator it) {
     if (it->second.bytes < kPageSize / 2)
       f(it->first);

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -121,7 +121,16 @@ class SmallBins {
     }
 
     static uint64_t HashFn(uint64_t v) {
-      return std::hash<uint64_t>()(v);
+      // Keys are page-aligned disk offsets (multiples of kPageSize), so their low bits are always
+      // zero and their high bits are zero for small files. std::hash<uint64_t> is the identity on
+      // libstdc++, which would funnel every bin into a single segment and make DashTable split
+      // forever. Mix the bits (murmur3 fmix64) so offsets distribute evenly.
+      v ^= v >> 33;
+      v *= 0xff51afd7ed558ccdULL;
+      v ^= v >> 33;
+      v *= 0xc4ceb9fe1a85ec53ULL;
+      v ^= v >> 33;
+      return v;
     }
   };
 

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -121,10 +121,9 @@ class SmallBins {
       return u == v;
     }
 
-    static uint64_t HashFn(uint64_t v) {
-      // Keys are page alined (% 4096 = 0) which breaks hashing, so scale down to page index
-      return v / kPageSize;
-    }
+    // Keys are page-aligned (% kPageSize == 0), dividing by kPageSize does not fix the problem as
+    // dashtable expects are more or less random distribution of all bits (including higher)
+    static uint64_t HashFn(uint64_t v);
   };
 
   using Dash = dfly::DashTable<size_t /* offset */, StashInfo, BasicDashPolicy>;

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "core/dash.h"
 #include "server/tiering/common.h"
 #include "server/tiering/disk_storage.h"
 #include "server/tiering/entry_map.h"
@@ -102,8 +103,28 @@ class SmallBins {
   // Pending stashes, their keys and value sizes
   absl::flat_hash_map<unsigned /* id */, tiering::EntryMap<DiskSegment>> pending_bins_;
 
+  struct BasicDashPolicy {
+    enum { kSlotNum = 12, kBucketNum = 64 };
+    static constexpr bool kUseVersion = false;
+
+    template <typename U> static void DestroyValue(const U&) {
+    }
+    template <typename U> static void DestroyKey(const U&) {
+    }
+
+    template <typename U, typename V> static bool Equal(U&& u, V&& v) {
+      return u == v;
+    }
+
+    static uint64_t HashFn(uint64_t v) {
+      return std::hash<uint64_t>()(v);
+    }
+  };
+
+  using Dash = dfly::DashTable<size_t /* offset */, StashInfo, BasicDashPolicy>;
+
   // Map of bins that were stashed and should be deleted when number of entries reaches 0
-  absl::flat_hash_map<size_t /*offset*/, StashInfo> stashed_bins_;
+  Dash stashed_bins_;
 
   struct {
     size_t stashed_entries_cnt = 0;

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/functional/function_ref.h>
 
 #include <optional>
 #include <string>
@@ -90,7 +91,7 @@ class SmallBins {
 
   // Traverse stashed bins and run callback on those that are fragmented
   ::dfly::detail::DashCursor TraverseFragmented(::dfly::detail::DashCursor,
-                                                std::function<void(size_t /* offset */)>);
+                                                absl::FunctionRef<void(size_t /* offset */)>);
 
   Stats GetStats() const;
 

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -122,16 +122,8 @@ class SmallBins {
     }
 
     static uint64_t HashFn(uint64_t v) {
-      // Keys are page-aligned disk offsets (multiples of kPageSize), so their low bits are always
-      // zero and their high bits are zero for small files. std::hash<uint64_t> is the identity on
-      // libstdc++, which would funnel every bin into a single segment and make DashTable split
-      // forever. Mix the bits (murmur3 fmix64) so offsets distribute evenly.
-      v ^= v >> 33;
-      v *= 0xff51afd7ed558ccdULL;
-      v ^= v >> 33;
-      v *= 0xc4ceb9fe1a85ec53ULL;
-      v ^= v >> 33;
-      return v;
+      // Keys are page alined (% 4096 = 0) which breaks hashing, so scale down to page index
+      return v / kPageSize;
     }
   };
 

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -88,6 +88,10 @@ class SmallBins {
   // Serialize filled bin to destination buffer (4kb)
   size_t SerializeBin(FilledBin* bin, io::MutableBytes dest);
 
+  // Traverse stashed bins and run callback on those that are fragmented
+  ::dfly::detail::DashCursor TraverseFragmented(::dfly::detail::DashCursor,
+                                                std::function<void(size_t /* offset */)>);
+
   Stats GetStats() const;
 
  private:


### PR DESCRIPTION
1. Lower max current defrags limit
2. Use DashTable instead of absl::flat_hash_map in small bins
3. Add background defrag iteration
4. Make it adaptive to raise the max cycles quota if it occured