### PR TITLE
[WIP/DNM] server: Clear now_chunked_ items on home shards

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2582,6 +2582,7 @@ void RdbLoader::DiscardChunkedValuesOnFinish() {
     if (values.empty())
       continue;
 
+    LOG(ERROR) << "unexpected " << values.size() << " values found in chunk map on RDB load finish";
     bc->Add(1);
     shard_set->Add(sid, [values = std::move(values), bc]() mutable {
       values.clear();
@@ -3013,6 +3014,15 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
   PrimeValue* pv_ptr = &pv;
   DbIndex db_ind = db_cntx.db_index;
 
+  bool failed_should_cleanup = false;
+  ChunkedKey key{db_ind, item->key};
+  absl::Cleanup maybe_remove_chunk_entry = [&] {
+    if (!failed_should_cleanup)
+      return;
+    std::unique_lock l{now_chunked_mu_};
+    now_chunked_.erase(key);
+  };
+
   auto error_msg = [](const auto* item, auto db_ind) {
     return absl::StrCat("Found empty key: ", item->key, " in DB ", db_ind, " rdb_type ",
                         item->val.rdb_type);
@@ -3039,6 +3049,7 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
   }
 
   if (auto ec = FromOpaque(item->val, config_copy, pv_ptr); ec) {
+    failed_should_cleanup = item->load_config.chunked;
     if (ec.value() == errc::value_expired) {
       // hmap and sset values can expire and we ok with it,
       // so we don't set ec_ in this case

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2566,6 +2566,32 @@ error_code RdbLoader::Load(io::Source* src) {
   return kOk;
 }
 
+void RdbLoader::DiscardChunkedValuesOnFinish() {
+  using Values = std::vector<std::unique_ptr<PrimeValue>>;
+  std::vector<Values> by_shard(shard_set->size());
+  {
+    std::unique_lock l{now_chunked_mu_};
+    for (auto& [key, pv] : now_chunked_)
+      by_shard[Shard(key.second, shard_set->size())].push_back(std::move(pv));
+    now_chunked_.clear();
+  }
+
+  BlockingCounter bc{0};
+  for (ShardId sid = 0; sid < by_shard.size(); ++sid) {
+    auto& values = by_shard[sid];
+    if (values.empty())
+      continue;
+
+    bc->Add(1);
+    shard_set->Add(sid, [values = std::move(values), bc]() mutable {
+      values.clear();
+      bc->Dec();
+    });
+  }
+
+  bc->Wait();
+}
+
 void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
   BlockingCounter bc(shard_set->size());
   for (unsigned i = 0; i < shard_set->size(); ++i) {
@@ -2581,7 +2607,7 @@ void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
     GetCurrentDbSlice().DecrLoadInProgress();
   }
 
-  now_chunked_.clear();
+  DiscardChunkedValuesOnFinish();
 
   absl::Duration dur = absl::Now() - start_time;
   load_time_ = double(absl::ToInt64Milliseconds(dur)) / 1000;

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -412,6 +412,7 @@ class RdbLoader : protected RdbLoaderBase {
 
   std::error_code VerifyChecksum();
 
+  void DiscardChunkedValuesOnFinish();
   void FinishLoad(absl::Time start_time, size_t* keys_loaded);
 
   void FlushShardAsync(ShardId sid);

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -2060,4 +2060,30 @@ TEST_F(RdbTest, SnapshotEgressThrottle) {
   EXPECT_GT(t_lim, t_base * 3);
 }
 
+TEST_F(RdbTest, EofWithRemoteShardChunksPending) {
+  ASSERT_GT(shard_set->size(), 1);
+  std::string key;
+  ShardId sid = 0;
+  for (auto i = 0; i < 1000; ++i) {
+    key = absl::StrCat("uc-", i);
+    sid = Shard(key, shard_set->size());
+    if (sid > 0)
+      break;
+  }
+  ASSERT_GT(sid, 0);
+
+  std::string chunk;
+  chunk.push_back(RDB_TYPE_HASH);
+  AppendString(&chunk, key);
+
+  AppendLen(&chunk, 2);  // promise 2 and create 1 field
+  AddKV(&chunk, "field", "v1");
+
+  const std::string body = MakeTaggedChunk(1, chunk);
+  const auto ec = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body)); });
+
+  ASSERT_FALSE(ec) << ec.message();
+  EXPECT_EQ(Run({"EXISTS", key}), 0);
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Previously the items in now_chunked_ were destroyed on shard other than the home shard potentially, this is okay in mimalloc itself but we have checks on top to assert that the shard matches.

On finishing load we now submit the task to home shards to clear the items.

Root cause identified and fix by by https://github.com/avy2 ref https://github.com/dragonflydb/dragonfly/pull/7780

The entry is first removed during `RdbLoader::CreateObjectOnShard` if it has expired. The cleanup at finish load treats pending entries as error log but still cleans them up.