### PR TITLE
chore: monitor redis_replication_test

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -696,7 +696,7 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "STACKTRACE",
         "    Prints the stacktraces of all current fibers to the logs.",
         "REPLDIAG",
-        "    Investigation-only for #6940: like STACKTRACE, plus (if this instance is a redis-"
+        "    Investigation-only: like STACKTRACE, plus (if this instance is a redis-"
         "    stream replica) the unread byte count in the master socket's kernel recv buffer.",
         "SHARDS",
         "    Prints memory usage and key stats per shard, as well as min/max indicators.",
@@ -1377,7 +1377,7 @@ void DebugCmd::Stacktrace(CommandContext* cmd_cntx) {
   rb->SendOk();
 }
 
-// Investigation-only for #6940: dumps everything Stacktrace() does, plus (on a redis-stream
+// Investigation-only: dumps everything Stacktrace() does, plus (on a redis-stream
 // replica) the current unread byte count on the master socket, to tell apart "data is sitting
 // unread" (missed wakeup) from "genuinely nothing to read yet" at the moment of a stall. Remove
 // once the stalled-replica bug is closed.

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -695,6 +695,9 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "    Prints histogram of object sizes.",
         "STACKTRACE",
         "    Prints the stacktraces of all current fibers to the logs.",
+        "REPLDIAG",
+        "    Investigation-only for #6940: like STACKTRACE, plus (if this instance is a redis-"
+        "    stream replica) the unread byte count in the master socket's kernel recv buffer.",
         "SHARDS",
         "    Prints memory usage and key stats per shard, as well as min/max indicators.",
         "TOPK ON [min_freq] | OFF [max_keys]",
@@ -781,6 +784,10 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
   if (subcmd == "STACKTRACE") {
     return Stacktrace(cmd_cntx);
+  }
+
+  if (subcmd == "REPLDIAG") {
+    return ReplDiag(cmd_cntx);
   }
 
   if (subcmd == "SHARDS") {
@@ -1354,6 +1361,35 @@ void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
 
 void DebugCmd::Stacktrace(CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  fb2::Mutex m;
+  shard_set->pool()->AwaitFiberOnAll([&m](unsigned index, ProactorBase* base) {
+    EngineShard* es = EngineShard::tlocal();
+    string txq;
+    if (es) {
+      EngineShard::TxQueueInfo txq_info = es->AnalyzeTxQueue();
+      txq = txq_info.Format();
+    }
+    std::unique_lock lk(m);
+    LOG_IF(INFO, !txq.empty()) << "Shard" << index << ": " << txq;
+    fb2::detail::FiberInterface::PrintAllFiberStackTraces();
+  });
+  base::FlushLogs();
+  rb->SendOk();
+}
+
+// Investigation-only for #6940: dumps everything Stacktrace() does, plus (on a redis-stream
+// replica) the current unread byte count on the master socket, to tell apart "data is sitting
+// unread" (missed wakeup) from "genuinely nothing to read yet" at the moment of a stall. Remove
+// once the stalled-replica bug is closed.
+void DebugCmd::ReplDiag(CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  if (auto unread = sf_.GetReplicaMasterSocketUnreadBytes(); unread) {
+    LOG(WARNING) << "DEBUG REPLDIAG: master_socket_unread_bytes=" << *unread;
+  } else {
+    LOG(WARNING) << "DEBUG REPLDIAG: not a redis-stream replica (no master socket)";
+  }
+
   fb2::Mutex m;
   shard_set->pool()->AwaitFiberOnAll([&m](unsigned index, ProactorBase* base) {
     EngineShard* es = EngineShard::tlocal();

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -54,6 +54,8 @@ class DebugCmd {
   void TxAnalysis(CommandContext* cmd_cntx);
   void ObjHist(CommandContext* cmd_cntx);
   void Stacktrace(CommandContext* cmd_cntx);
+  // Investigation-only for #6940. Remove once closed.
+  void ReplDiag(CommandContext* cmd_cntx);
   void Shards(CommandContext* cmd_cntx);
   void LogTraffic(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void RecvSize(std::string_view param, CommandContext* cmd_cntx);

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -54,7 +54,7 @@ class DebugCmd {
   void TxAnalysis(CommandContext* cmd_cntx);
   void ObjHist(CommandContext* cmd_cntx);
   void Stacktrace(CommandContext* cmd_cntx);
-  // Investigation-only for #6940. Remove once closed.
+  // Investigation-only. Remove once closed.
   void ReplDiag(CommandContext* cmd_cntx);
   void Shards(CommandContext* cmd_cntx);
   void LogTraffic(facade::CmdArgParser parser, CommandContext* cmd_cntx);

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -14,6 +14,7 @@ extern "C" {
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/strip.h>
+#include <sys/ioctl.h>
 
 #include <boost/asio/ip/tcp.hpp>
 #include <string>
@@ -260,6 +261,16 @@ void ProtocolClient::ShutdownSocket() {
 std::string ProtocolClient::SockInfo() const {
   auto* sock = Sock();
   return GetSocketInfo(sock ? sock->native_handle() : -1);
+}
+
+int ProtocolClient::GetSocketUnreadBytes() {
+  unique_lock lk(sock_mu_);
+  if (!sock_)
+    return -1;
+  int unread = 0;
+  if (ioctl(sock_->native_handle(), FIONREAD, &unread) != 0)
+    return -1;
+  return unread;
 }
 
 void ProtocolClient::DefaultErrorHandler(const GenericError& err) {

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -142,6 +142,11 @@ class ProtocolClient {
   // socket that was never created (e.g. ConnectAndAuth() refusing on a dead context).
   std::string SockInfo() const;
 
+  // Bytes currently sitting unread in the socket's kernel receive buffer, or -1 if unavailable
+  // (no socket yet, or the ioctl failed). Locks sock_mu_ so it can't race with ConnectAndAuth()/
+  // ShutdownSocketImpl() replacing or destroying sock_ concurrently.
+  int GetSocketUnreadBytes();
+
  private:
   std::error_code Recv(util::FiberSocketBase* input, base::IoBuf* dest);
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -3,6 +3,8 @@
 //
 #include "server/replica.h"
 
+#include <sys/ioctl.h>
+
 #include <chrono>
 
 #include "absl/strings/match.h"
@@ -1416,6 +1418,16 @@ std::vector<uint64_t> Replica::GetReplicaOffset() const {
 
 std::string Replica::GetSyncId() const {
   return master_context_.dfly_session_id;
+}
+
+int Replica::GetMasterSocketUnreadBytes() const {
+  auto* s = Sock();
+  if (s == nullptr)
+    return -1;
+  int unread = 0;
+  if (ioctl(s->native_handle(), FIONREAD, &unread) != 0)
+    return -1;
+  return unread;
 }
 
 string Replica::GetClientInfo() const {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -3,8 +3,6 @@
 //
 #include "server/replica.h"
 
-#include <sys/ioctl.h>
-
 #include <chrono>
 
 #include "absl/strings/match.h"
@@ -1420,14 +1418,8 @@ std::string Replica::GetSyncId() const {
   return master_context_.dfly_session_id;
 }
 
-int Replica::GetMasterSocketUnreadBytes() const {
-  auto* s = Sock();
-  if (s == nullptr)
-    return -1;
-  int unread = 0;
-  if (ioctl(s->native_handle(), FIONREAD, &unread) != 0)
-    return -1;
-  return unread;
+int Replica::GetMasterSocketUnreadBytes() {
+  return GetSocketUnreadBytes();
 }
 
 string Replica::GetClientInfo() const {

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -143,6 +143,10 @@ class Replica : ProtocolClient {
 
   size_t GetRecCountExecutedPerShard(const std::vector<unsigned>& indexes) const;
 
+  // Investigation-only for #6940 (DEBUG REPLDIAG): bytes currently sitting unread in the
+  // master socket's kernel receive buffer, or -1 if unavailable. Remove once closed.
+  int GetMasterSocketUnreadBytes() const;
+
  private:
   ExecutionState exec_st_;
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -143,9 +143,9 @@ class Replica : ProtocolClient {
 
   size_t GetRecCountExecutedPerShard(const std::vector<unsigned>& indexes) const;
 
-  // Investigation-only for #6940 (DEBUG REPLDIAG): bytes currently sitting unread in the
+  // Investigation-only (DEBUG REPLDIAG): bytes currently sitting unread in the
   // master socket's kernel receive buffer, or -1 if unavailable. Remove once closed.
-  int GetMasterSocketUnreadBytes() const;
+  int GetMasterSocketUnreadBytes();
 
  private:
   ExecutionState exec_st_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1627,6 +1627,17 @@ std::optional<ReplicaOffsetInfo> ServerFamily::GetReplicaOffsetInfo() {
   return nullopt;
 }
 
+std::optional<int> ServerFamily::GetReplicaMasterSocketUnreadBytes() {
+  util::fb2::LockGuard lk(replicaof_mu_);
+
+  if (!IsMaster()) {
+    auto repl_ptr = replica_;
+    CHECK(repl_ptr);
+    return repl_ptr->GetMasterSocketUnreadBytes();
+  }
+  return nullopt;
+}
+
 vector<facade::Listener*> ServerFamily::GetNonPriviligedListeners() const {
   std::vector<facade::Listener*> listeners;
   listeners.reserve(listeners.size());

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -203,7 +203,7 @@ class ServerFamily {
   void PauseReplication(bool pause) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   std::optional<ReplicaOffsetInfo> GetReplicaOffsetInfo() ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
-  // Investigation-only for #6940 (DEBUG REPLDIAG). Remove once closed.
+  // Investigation-only (DEBUG REPLDIAG). Remove once closed.
   std::optional<int> GetReplicaMasterSocketUnreadBytes() ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
   const std::string& master_replid() const {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -203,6 +203,9 @@ class ServerFamily {
   void PauseReplication(bool pause) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   std::optional<ReplicaOffsetInfo> GetReplicaOffsetInfo() ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
+  // Investigation-only for #6940 (DEBUG REPLDIAG). Remove once closed.
+  std::optional<int> GetReplicaMasterSocketUnreadBytes() ABSL_LOCKS_EXCLUDED(replicaof_mu_);
+
   const std::string& master_replid() const {
     return master_replid_;
   }

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -15,6 +15,17 @@ async def _bounded(awaitable, timeout=5):
     return await asyncio.wait_for(awaitable, timeout=timeout)
 
 
+# Investigation-only for #6940. Remove once closed.
+async def _dump_repl_diag(diag_clients, note):
+    if not diag_clients:
+        return
+    logging.warning(f"DEBUG REPLDIAG: {note}")
+    await asyncio.gather(
+        *(_bounded(c.execute_command("DEBUG", "REPLDIAG")) for c in diag_clients),
+        return_exceptions=True,
+    )
+
+
 async def _log_progress(c_master, c_replicas, interval=10):
     # Periodic progress so a long-running test phase (seeder.run, REPLICAOF, check_data)
     # is not silent. Caller cancels the task at teardown.
@@ -32,13 +43,21 @@ async def _log_progress(c_master, c_replicas, interval=10):
 
 # Checks that master redis and dragonfly replica are synced by writing a random key to master
 # and waiting for it to exist in replica. Foreach db in 0..dbcount-1.
-async def await_synced(c_master: aioredis.Redis, c_replica: aioredis.Redis, dbcount=1, timeout=30):
+async def await_synced(
+    c_master: aioredis.Redis, c_replica: aioredis.Redis, dbcount=1, timeout=30, diag_clients=None
+):
     rnd_str = "".join(random.choices(string.ascii_letters, k=10))
     key = "sync_key/" + rnd_str
     for db in range(dbcount):
         await c_master.set(key, "dummy")
         logging.info(f"await_synced: set {key} on MASTER db={db}, polling REPLICA up to {timeout}s")
         remaining = timeout
+        # Investigation-only for #6940: track the replica's own progress rate so we can tell a
+        # genuinely stalled/slow replica apart from one that's simply still early in a normal
+        # sync. Only fire the (expensive, verbose) diag dump once we see it isn't catching up.
+        prev_replica_dbsize = None
+        stall_ticks = 0
+        diag_fired = False
         while remaining > 0:
             # Run concurrently so a tick is bounded by the slowest single call (5s), not their sum.
             # return_exceptions=True so a stalled call surfaces in its slot without aborting the rest.
@@ -58,9 +77,29 @@ async def await_synced(c_master: aioredis.Redis, c_replica: aioredis.Redis, dbco
                 f"dbsize master={master_dbsize} replica={replica_dbsize} "
                 f"master_info={master_info} replica_info={replica_info}"
             )
+            # "Slow" = replica made little or no progress this tick (not behind by definition:
+            # it could legitimately still be receiving its first batch). Combined with "running
+            # out of budget" below, this distinguishes a real stall from an early/normal sync.
+            made_progress = (
+                isinstance(replica_dbsize, int)
+                and isinstance(prev_replica_dbsize, int)
+                and replica_dbsize > prev_replica_dbsize
+            )
+            stall_ticks = 0 if made_progress else stall_ticks + 1
+            if isinstance(replica_dbsize, int):
+                prev_replica_dbsize = replica_dbsize
+            # About to fail: little/no progress recently, and little time left to recover.
+            if not diag_fired and stall_ticks >= 3 and remaining <= 10:
+                diag_fired = True
+                await _dump_repl_diag(
+                    diag_clients,
+                    f"db={db} rate looks stalled ({stall_ticks} flat ticks), "
+                    f"{remaining}s left before timeout",
+                )
             await asyncio.sleep(1)
             remaining -= 1
         else:
+            await _dump_repl_diag(diag_clients, f"db={db} TIMEOUT after {timeout}s")
             logging.error(
                 f"await_synced TIMEOUT db={db} key={key} after {timeout}s "
                 f"dbsize master={master_dbsize} replica={replica_dbsize} "
@@ -72,7 +111,11 @@ async def await_synced(c_master: aioredis.Redis, c_replica: aioredis.Redis, dbco
 async def await_synced_all(c_master, c_replicas, timeout=30, dbcount=1):
     for i, c_replica in enumerate(c_replicas):
         logging.info(f"await_synced_all: checking replica {i + 1}/{len(c_replicas)}")
-        await await_synced(c_master, c_replica, dbcount=dbcount, timeout=timeout)
+        # diag_clients=c_replicas (not just c_replica): a stall dump is only useful compared
+        # against its siblings at the same instant, see #6940 investigation notes.
+        await await_synced(
+            c_master, c_replica, dbcount=dbcount, timeout=timeout, diag_clients=c_replicas
+        )
 
 
 async def check_data(seeder, replicas, c_replicas):

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -15,15 +15,18 @@ async def _bounded(awaitable, timeout=5):
     return await asyncio.wait_for(awaitable, timeout=timeout)
 
 
-# Investigation-only for #6940. Remove once closed.
+# Investigation-only. Remove once closed.
 async def _dump_repl_diag(diag_clients, note):
     if not diag_clients:
         return
     logging.warning(f"DEBUG REPLDIAG: {note}")
-    await asyncio.gather(
+    results = await asyncio.gather(
         *(_bounded(c.execute_command("DEBUG", "REPLDIAG")) for c in diag_clients),
         return_exceptions=True,
     )
+    for i, result in enumerate(results):
+        if isinstance(result, BaseException):
+            logging.warning(f"DEBUG REPLDIAG: client[{i}] failed: {result!r}")
 
 
 async def _log_progress(c_master, c_replicas, interval=10):
@@ -52,7 +55,7 @@ async def await_synced(
         await c_master.set(key, "dummy")
         logging.info(f"await_synced: set {key} on MASTER db={db}, polling REPLICA up to {timeout}s")
         remaining = timeout
-        # Investigation-only for #6940: track the replica's own progress rate so we can tell a
+        # Investigation-only: track the replica's own progress rate so we can tell a
         # genuinely stalled/slow replica apart from one that's simply still early in a normal
         # sync. Only fire the (expensive, verbose) diag dump once we see it isn't catching up.
         prev_replica_dbsize = None
@@ -112,7 +115,7 @@ async def await_synced_all(c_master, c_replicas, timeout=30, dbcount=1):
     for i, c_replica in enumerate(c_replicas):
         logging.info(f"await_synced_all: checking replica {i + 1}/{len(c_replicas)}")
         # diag_clients=c_replicas (not just c_replica): a stall dump is only useful compared
-        # against its siblings at the same instant, see #6940 investigation notes.
+        # against its siblings at the same instant.
         await await_synced(
             c_master, c_replica, dbcount=dbcount, timeout=timeout, diag_clients=c_replicas
         )


### PR DESCRIPTION
When the rate of the replica drops monitor the exact state of dragonfly via traces.