### PR TITLE
fix(zset): clamp NaN once after full aggregation in ZUNIONSTORE

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -748,8 +748,7 @@ ScoredMap ScoreMapFromSet(const PrimeValue& pv, double weight, const DbContext& 
 double Aggregate(double v1, double v2, AggType atype) {
   switch (atype) {
     case AggType::SUM:
-      v1 += v2;
-      return isnan(v1) ? 0 : v1;
+      return v1 + v2;
     case AggType::MAX:
       return max(v1, v2);
     case AggType::MIN:
@@ -1599,6 +1598,16 @@ void ZBooleanOperation(CmdArgParser parser, string_view cmd, bool is_union, bool
 
     if (result.empty() && !is_union)  // intersection only shrinks
       break;
+  }
+
+  // NaN can appear here from inf + -inf cancelling out during SUM aggregation.
+  // Clamp it to 0 (matches Redis) only once, after all merges are done.
+  if (op_args->agg_type == AggType::SUM) {
+    for (auto& [member, score] : result) {
+      if (std::isnan(score)) {
+        score = 0;
+      }
+    }
   }
 
   // Copy to vector for sorting

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -753,6 +753,42 @@ TEST_F(ZSetFamilyTest, ZUnionStoreOpts) {
   EXPECT_THAT(resp, DoubleArg(0));
 }
 
+// Regression test: inf + -inf during SUM aggregation must clamp to 0, even when
+// an early clamp inside a single shard's merge would otherwise get overwritten
+// by a later merge and produce inf instead. See Aggregate()/ZBooleanOperation()..
+TEST_F(ZSetFamilyTest, ZUnionStoreSumNanCancelsToZero) {
+  // Case 1: all sources on the SAME shard — the corrupting merge sequence happens
+  // entirely inside UnionShardKeysWithScore's local merge loop.
+  const char kKeySameShardA[] = "x";
+  const char kKeySameShardB[] = "m";
+  ASSERT_EQ(Shard(kKeySameShardA, shard_set->size()), Shard(kKeySameShardB, shard_set->size()))
+      << "test requires these two keys on the same shard";
+
+  Run({"ZADD", kKeySameShardA, "inf", "e1"});
+  Run({"ZADD", kKeySameShardB, "-inf", "e1"});
+  Run({"ZUNIONSTORE", "dest_same_shard", "3", kKeySameShardA, kKeySameShardB, kKeySameShardA});
+  auto resp = Run({"ZSCORE", "dest_same_shard", "e1"});
+  EXPECT_THAT(resp, DoubleArg(0)) << "same-shard union: inf + -inf + inf must clamp to 0";
+
+  // Case 2: two sources on one shard (producing a premature within-shard clamp),
+  // a third source on a different shard.
+  const char kKeyPairShardA[] = "b";
+  const char kKeyPairShardB[] = "d";
+  const char kKeyOtherShard[] = "a";
+  ASSERT_EQ(Shard(kKeyPairShardA, shard_set->size()), Shard(kKeyPairShardB, shard_set->size()))
+      << "kKeyPairShardA/B must be on the same shard";
+  ASSERT_NE(Shard(kKeyPairShardA, shard_set->size()), Shard(kKeyOtherShard, shard_set->size()))
+      << "kKeyOtherShard must be on a different shard";
+
+  Run({"ZADD", kKeyPairShardA, "inf", "e1"});
+  Run({"ZADD", kKeyPairShardB, "-inf", "e1"});
+  Run({"ZADD", kKeyOtherShard, "inf", "e1"});
+  Run({"ZUNIONSTORE", "dest_diff_shard", "3", kKeyPairShardA, kKeyPairShardB, kKeyOtherShard});
+  resp = Run({"ZSCORE", "dest_diff_shard", "e1"});
+  EXPECT_THAT(resp, DoubleArg(0))
+      << "cross-shard union: within-shard clamp must not corrupt cross-shard merge";
+}
+
 TEST_F(ZSetFamilyTest, ZInterStore) {
   EXPECT_EQ(2, CheckedInt({"zadd", "z1", "1", "a", "2", "b"}));
   EXPECT_EQ(2, CheckedInt({"zadd", "z2", "3", "c", "2", "b"}));


### PR DESCRIPTION
`ZUNIONSTORE` with `SUM` aggregate could return `inf` instead of `0` when a member's score across 3+ sources included
both `inf` and `-inf` that should cancel out (e.g. `inf + -inf + inf`).

`Aggregate()` clamped `NaN` to `0` on every pairwise merge instead of once at the end. The first merge (`inf + -inf = NaN`)
got clamped to `0` immediately, erasing the fact a cancellation happened. A later merge then saw a clean `0 + inf` and
returned `inf` instead of `0`.

**Fix:** removed the per-merge clamp from `Aggregate()`. Added a single clamp in `ZBooleanOperation`, applied once after
all shard-local and cross-shard merges are done.

Added `ZUnionStoreSumNanCancelsToZero` covering both cases (all sources on one shard, and sources split across shards),
each verified to fail on the old code and pass on the fix.