### PR TITLE
feat: add ASCII packing for OAH

### DIFF
--- a/src/core/detail/bitpacking.cc
+++ b/src/core/detail/bitpacking.cc
@@ -202,6 +202,31 @@ void ascii_pack2(const char* ascii, size_t len, uint8_t* bin) {
   }
 }
 
+size_t ascii_try_pack(const char* ascii, size_t len, uint8_t* bin) {
+  const uint8_t* src = reinterpret_cast<const uint8_t*>(ascii);
+  uint8_t* out = bin;
+  uint8_t hi = 0;  // OR of every byte; bit 7 set means some byte was >= 128 (not ascii)
+  size_t i = 0;
+
+  for (; i + 8 <= len; i += 8) {  // 8 bytes -> 7: byte j supplies bits [7*j, 7*j+6] of val
+    uint64_t val = 0;
+    for (unsigned j = 0; j < 8; ++j) {
+      hi |= src[i + j];
+      val |= static_cast<uint64_t>(src[i + j] & 0x7F) << (7 * j);
+    }
+    for (unsigned j = 0; j < 7; ++j)  // low 7 bytes, least-significant first (endian-neutral)
+      out[j] = static_cast<uint8_t>(val >> (8 * j));
+    out += 7;
+  }
+
+  for (; i < len; ++i) {  // tail (< 8 bytes) stays verbatim
+    hi |= src[i];
+    *out++ = src[i];
+  }
+
+  return (hi & 0x80) ? 0 : static_cast<size_t>(out - bin);
+}
+
 // The algo - do in parallel what ascii_pack does on two uint64_t integers
 void ascii_pack_simd(const char* ascii, size_t len, uint8_t* bin) {
 #if defined(__SSE3__) || defined(__aarch64__)

--- a/src/core/detail/bitpacking.h
+++ b/src/core/detail/bitpacking.h
@@ -34,6 +34,13 @@ void ascii_pack_byte(uint8_t* bin, size_t ascii_len, size_t idx, uint8_t ascii);
 void ascii_pack(const char* ascii, size_t len, uint8_t* bin);
 void ascii_pack2(const char* ascii, size_t len, uint8_t* bin);
 
+// Fused ASCII validation + pack. If every byte of [ascii, ascii+len) is 7-bit ASCII (high bit
+// clear), packs them into `bin` in the format ascii_unpack decodes (byte-identical to ascii_pack,
+// but endian-neutral and valid for any len) and returns the packed length binpacked_len(len);
+// returns 0 if any byte has its high bit set. `bin` is scratch: it needs binpacked_len(len) bytes
+// and is written even on failure.
+size_t ascii_try_pack(const char* ascii, size_t len, uint8_t* bin);
+
 // SIMD implementation 1 of ascii_pack.
 void ascii_pack_simd(const char* ascii, size_t len, uint8_t* bin);
 

--- a/src/core/oah_base.h
+++ b/src/core/oah_base.h
@@ -15,20 +15,19 @@
 namespace dfly {
 
 // A key reduced once to the bytes used for hashing and comparison: 7-bit ASCII-packed into buf_
-// when worth it (ascii, length 8..128), else a view of the original bytes. Uses the shared
-// detail::bitpacking codec. Non-copyable: content() may alias buf_.
+// when worth it (ascii, length 8..128) via the shared detail::ascii_try_pack codec, else a view
+// of the original bytes. Non-copyable: content() may alias buf_.
 class ASCIIStr {
  public:
   static constexpr uint32_t kMinLen = 8;    // shorter strings pack to the same size, so stay raw
   static constexpr uint32_t kMaxLen = 128;  // largest length we ascii-encode
 
-  explicit ASCIIStr(std::string_view s) : len_(static_cast<uint32_t>(s.size())) {
-    if (s.size() >= kMinLen && s.size() <= kMaxLen &&
-        detail::validate_ascii_fast(s.data(), s.size())) {
-      detail::ascii_pack_simd2(s.data(), s.size(), reinterpret_cast<uint8_t*>(buf_));
-      content_ = {buf_, detail::binpacked_len(s.size())};
-    } else {
-      content_ = s;
+  explicit ASCIIStr(std::string_view s) : content_(s), len_(static_cast<uint32_t>(s.size())) {
+    if (s.size() >= kMinLen && s.size() <= kMaxLen) {
+      const size_t packed =
+          detail::ascii_try_pack(s.data(), s.size(), reinterpret_cast<uint8_t*>(buf_));
+      if (packed)
+        content_ = std::string_view{buf_, packed};
     }
   }
 

--- a/src/core/oah_base.h
+++ b/src/core/oah_base.h
@@ -7,8 +7,49 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <string_view>
+
+#include "core/detail/bitpacking.h"
 
 namespace dfly {
+
+// A key reduced once to the bytes used for hashing and comparison: 7-bit ASCII-packed into buf_
+// when worth it (ascii, length 8..128), else a view of the original bytes. Uses the shared
+// detail::bitpacking codec. Non-copyable: content() may alias buf_.
+class ASCIIStr {
+ public:
+  static constexpr uint32_t kMinLen = 8;    // shorter strings pack to the same size, so stay raw
+  static constexpr uint32_t kMaxLen = 128;  // largest length we ascii-encode
+
+  explicit ASCIIStr(std::string_view s) : len_(static_cast<uint32_t>(s.size())) {
+    if (s.size() >= kMinLen && s.size() <= kMaxLen &&
+        detail::validate_ascii_fast(s.data(), s.size())) {
+      detail::ascii_pack_simd2(s.data(), s.size(), reinterpret_cast<uint8_t*>(buf_));
+      content_ = {buf_, detail::binpacked_len(s.size())};
+    } else {
+      content_ = s;
+    }
+  }
+
+  ASCIIStr(const ASCIIStr&) = delete;
+  ASCIIStr& operator=(const ASCIIStr&) = delete;
+
+  std::string_view content() const {
+    return content_;
+  }
+  uint32_t len() const {
+    return len_;
+  }
+  bool encoded() const {
+    return content_.size() != len_;  // packed keys are strictly shorter than their logical length
+  }
+
+ private:
+  std::string_view content_;
+  uint32_t len_;
+  char buf_[kMaxLen];
+};
 
 // Shared building blocks for the open-addressing hash containers (OAHEntry/OAHPair/OAHTable).
 namespace oah {
@@ -32,10 +73,9 @@ inline void PrefetchRead(const void* ptr) noexcept {
   __builtin_prefetch(ptr, 0, 1);
 }
 
-// Variable-width size field shared by OAHEntry and OAHPair.
-//
-// Control-byte layout:
-//   bit 7    : reserved ASCII/raw encoding flag (currently always 0)
+// Variable-width size field shared by OAHEntry and OAHPair. Control-byte layout (size::Read masks
+// bit 7 off, so the key codec below can layer its flag there without disturbing the size):
+//   bit 7    : kEncodingBit   - key-codec flag (ascii-packed key); 0 for a plain size
 //   bit 6    : kBigSizeBit    - size doesn't fit in 6 bits, extra bytes follow
 //   bit 5    : kThreeBytesBit - when kBigSizeBit is set: 3 extra bytes (otherwise 1)
 //   bits 0-5 : inline size (< 64B); or bits 0-4 hold the low 5 bits of a larger size
@@ -101,5 +141,125 @@ inline Decoded Read(const char* src) {
 }
 
 }  // namespace size
+
+// Key codec shared by OAHEntry/OAHPair. A stored key is a control/size header followed by content
+// bytes (ascii-packed or raw). Hashing and comparison run on the content bytes; only retrieval
+// (Decode) reconstructs the logical key. The header and content need not be contiguous (the map
+// keeps the value pointer between them), so read/compare/decode take the two pointers separately.
+namespace key {
+
+inline constexpr uint8_t kEncodedBit = size::kEncodingBit;  // control bit 7 marks an encoded key
+
+struct Header {
+  bool encoded;
+  uint32_t len;           // logical key length
+  uint32_t field_size;    // header (control/size) bytes
+  uint32_t content_size;  // stored content bytes (packed or raw)
+};
+
+// A deserialized key: its header plus a pointer to the stored content bytes (packed or raw).
+// OAHEntry/OAHPair produce this from a blob; the table compares (Matches) or decodes (Decode) it.
+struct Stored {
+  Header header;
+  const char* content;
+};
+
+// Writes the key header for a logical length `len` at `hdr`; returns its size. The length uses the
+// oah::size encoding (bit 7 clear); `encoded_bit` (kEncodedBit or 0) is then set on top to flag an
+// ascii-packed key, keeping the size format independent of the flag.
+inline uint32_t WriteHeader(uint8_t encoded_bit, uint32_t len, char* hdr) {
+  const uint32_t fs = size::FieldSize(len);
+  size::Write(len, fs, hdr);
+  *hdr = static_cast<char>(*hdr | encoded_bit);
+  return fs;
+}
+
+inline Header ReadHeader(const char* hdr) {
+  const bool encoded = static_cast<uint8_t>(*hdr) & kEncodedBit;
+  const size::Decoded d = size::Read(hdr);  // ignores bit 7, so the flag doesn't disturb the size
+  const uint32_t content_size =
+      encoded ? static_cast<uint32_t>(detail::binpacked_len(d.size)) : d.size;
+  return {encoded, d.size, d.field_size, content_size};
+}
+
+// Compares a stored key (header `h`, content `content`) against a query key (its stored content
+// bytes `key_content` and logical length `key_len`). The len check guards packed keys whose
+// distinct lengths collide to the same packed size (e.g. 15 and 16 chars both pack to 14 bytes).
+inline bool Matches(const Header& h, const char* content, std::string_view key_content,
+                    uint32_t key_len) {
+  const bool key_encoded = key_content.size() != key_len;
+  if (h.encoded != key_encoded || (h.encoded && h.len != key_len))
+    return false;
+  return h.content_size == key_content.size() &&
+         std::memcmp(content, key_content.data(), key_content.size()) == 0;
+}
+
+// A logical-key view that keeps decoded content inline. Raw keys remain a zero-copy view into their
+// entry; encoded keys are unpacked into the bounded inline buffer. Keeping this object alive keeps
+// an encoded key view valid across nested calls and fiber yields, without thread-local storage.
+class Decoded {
+ public:
+  explicit Decoded(const Stored& stored)
+      : content_(stored.content), len_(stored.header.len), encoded_(stored.header.encoded) {
+    assert(!encoded_ || (len_ >= ASCIIStr::kMinLen && len_ <= ASCIIStr::kMaxLen));
+    if (encoded_) {
+      detail::ascii_unpack(reinterpret_cast<const uint8_t*>(content_), len_, decoded_);
+      content_ = nullptr;
+    }
+  }
+
+  Decoded(const Decoded& other) noexcept
+      : content_(other.content_), len_(other.len_), encoded_(other.encoded_) {
+    if (encoded_)
+      std::memcpy(decoded_, other.decoded_, len_);
+  }
+
+  Decoded& operator=(const Decoded& other) noexcept {
+    if (this != &other) {
+      content_ = other.content_;
+      len_ = other.len_;
+      encoded_ = other.encoded_;
+      if (encoded_)
+        std::memcpy(decoded_, other.decoded_, len_);
+    }
+    return *this;
+  }
+
+  Decoded(Decoded&& other) noexcept : Decoded(other) {
+  }
+
+  Decoded& operator=(Decoded&& other) noexcept {
+    return operator=(other);
+  }
+
+  std::string_view view() const& {
+    return {data(), len_};
+  }
+  std::string_view view() const&& = delete;
+
+  const char* data() const& {
+    return encoded_ ? decoded_ : content_;
+  }
+  const char* data() const&& = delete;
+  size_t size() const {
+    return len_;
+  }
+  bool empty() const {
+    return len_ == 0;
+  }
+
+ private:
+  const char* content_;
+  uint32_t len_;
+  bool encoded_;
+  char decoded_[ASCIIStr::kMaxLen];
+};
+
+inline Decoded Decode(const Stored& stored) {
+  return Decoded{stored};
+}
+
+}  // namespace key
+
 }  // namespace oah
 }  // namespace dfly

--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -11,13 +11,12 @@ namespace dfly {
 
 using namespace oah;
 
-TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
-  const size_t key_size = key.size();
-  assert(key_size <= size::kMaxSize);
+TaggedPtr OAHEntry::Create(std::string_view key, uint32_t real_size, uint32_t expiry) {
+  const uint8_t encoded_bit = (key.size() != real_size) * key::kEncodedBit;
   const uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
-  const uint32_t key_size_field = size::FieldSize(key_size);
+  const uint32_t hdr_size = size::FieldSize(real_size);
 
-  auto* blob = (char*)zmalloc(expiry_size + key_size_field + key_size);
+  auto* blob = (char*)zmalloc(expiry_size + hdr_size + key.size());
   TaggedPtr tagged_ptr = reinterpret_cast<TaggedPtr>(blob);
   if (expiry_size) {
     tagged_ptr |= kExpiryBit;
@@ -25,10 +24,10 @@ TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
   }
 
   char* p = blob + expiry_size;
-  size::Write(key_size, key_size_field, p);
-  p += key_size_field;
-  DCHECK(key.data());  // args are never null, even when empty (see CmdArgParser::SafeSV)
-  std::memcpy(p, key.data(), key_size);
+  key::WriteHeader(encoded_bit, real_size, p);
+  // args are never null, even when empty (see CmdArgParser::SafeSV), so memcpy needs no size guard.
+  DCHECK(key.data());
+  std::memcpy(p + hdr_size, key.data(), key.size());
   return tagged_ptr;
 }
 
@@ -52,7 +51,10 @@ void OAHEntry::SetExtHash(uint64_t ext_hash) {
 
 void OAHEntry::Rebuild(uint32_t expiry) {
   const uint64_t saved_hash = GetHash();
-  TaggedPtr rebuilt = Create(Key(), expiry);
+  // Copy the stored key verbatim (already encoded): no decode/re-encode, keep the encoded flag.
+  const char* hdr = Raw() + GetExpirySize();
+  const key::Header h = key::ReadHeader(hdr);
+  TaggedPtr rebuilt = Create({hdr + h.field_size, h.content_size}, h.len, expiry);
   OAHEntry(rebuilt).SetExtHash(saved_hash);
   Destroy(Release());
   SetTaggedPtr(rebuilt);

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -34,7 +34,10 @@ class OAHEntry {
  public:
   using TaggedPtr = oah::TaggedPtr;
 
-  static TaggedPtr Create(std::string_view key, uint32_t expiry = UINT32_MAX);
+  // Builds an entry blob [expiry?, key_header, key] storing `key` (already-encoded content)
+  // verbatim. The header records `real_size`; whether the key is encoded is derived from
+  // key.size() != real_size.
+  static TaggedPtr Create(std::string_view key, uint32_t real_size, uint32_t expiry = UINT32_MAX);
   static void Destroy(TaggedPtr tagged_ptr);
 
   explicit OAHEntry(TaggedPtr& slot) : slot_(&slot) {
@@ -53,10 +56,26 @@ class OAHEntry {
     return zmalloc_usable_size(Raw());
   }
 
-  std::string_view Key() const {
-    const char* p = Raw() + GetExpirySize();
-    const oah::size::Decoded key = oah::size::Read(p);
-    return {p + key.field_size, key.size};
+  // Deserializes the stored key: its codec header plus a pointer to the stored content bytes. The
+  // table decodes/compares this (OAHEntry itself never ascii-encodes or decodes).
+  oah::key::Stored StoredKey() const {
+    const char* hdr = Raw() + GetExpirySize();
+    const oah::key::Header h = oah::key::ReadHeader(hdr);
+    return {h, hdr + h.field_size};
+  }
+
+  // Stored key content (ascii-packed or raw) used for hashing. Not the logical key.
+  std::string_view KeyContent() const {
+    const oah::key::Stored s = StoredKey();
+    return {s.content, s.header.content_size};
+  }
+
+  // Compares this entry's key against a query key (content bytes + logical length). Reads the
+  // header inline (not via StoredKey) to stay register-friendly on the hot path.
+  bool KeyMatches(std::string_view content, uint32_t len) const {
+    const char* hdr = Raw() + GetExpirySize();
+    const oah::key::Header h = oah::key::ReadHeader(hdr);
+    return oah::key::Matches(h, hdr + h.field_size, content, len);
   }
 
   bool HasExpiry() const {
@@ -94,7 +113,7 @@ class OAHEntry {
     return res;
   }
 
-  // Lets the iterator drill down (it->Key()).
+  // Lets the iterator drill down (it->KeyContent()).
   OAHEntry* operator->() {
     return this;
   }

--- a/src/core/oah_map.h
+++ b/src/core/oah_map.h
@@ -24,22 +24,28 @@ class OAHMap : public OAHTable<OAHPair> {
   // Returns true if added, false if an existing field was updated.
   bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX,
                    bool keepttl = false) {
-    TaggedPtr new_tp = MakePair(field, value, ComputeTtl(field, ttl_sec, keepttl));
-    return AddPairImpl(field, new_tp, /*replace=*/true, nullptr);
+    const ASCIIStr key(field);
+    TaggedPtr new_tp = MakePair(key.content(), key.len(), value,
+                                ComputeTtl(key.content(), key.len(), ttl_sec, keepttl));
+    return AddPairImpl(key.content(), key.len(), new_tp, /*replace=*/true, nullptr);
   }
 
   // Returns false (no update) if the field already exists.
   bool AddOrSkip(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX) {
-    return AddPairImpl(field, MakePair(field, value, ttl_sec), /*replace=*/false, nullptr);
+    const ASCIIStr key(field);
+    return AddPairImpl(key.content(), key.len(), MakePair(key.content(), key.len(), value, ttl_sec),
+                       /*replace=*/false, nullptr);
   }
 
   // Like AddOrUpdate but on update returns the previous entry (RAII-owned; freed on destruction);
   // empty if a new field was added.
   OwnedOAHPair AddOrExchange(std::string_view field, std::string_view value,
                              uint32_t ttl_sec = UINT32_MAX, bool keepttl = false) {
-    TaggedPtr new_tp = MakePair(field, value, ComputeTtl(field, ttl_sec, keepttl));
+    const ASCIIStr key(field);
+    TaggedPtr new_tp = MakePair(key.content(), key.len(), value,
+                                ComputeTtl(key.content(), key.len(), ttl_sec, keepttl));
     TaggedPtr old_tp = 0;
-    AddPairImpl(field, new_tp, /*replace=*/true, &old_tp);
+    AddPairImpl(key.content(), key.len(), new_tp, /*replace=*/true, &old_tp);
     return OwnedOAHPair(old_tp);
   }
 
@@ -52,7 +58,8 @@ class OAHMap : public OAHTable<OAHPair> {
   OwnedOAHPair Extract(std::string_view field) {
     if (entries_.empty())
       return {};
-    const uint64_t hash = Hash(field);
+    const ASCIIStr key(field);
+    const uint64_t hash = Hash(key.content());
     const uint32_t bid = BucketId(hash, capacity_log_);
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
     const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << oah::kExtHashShift);
@@ -61,7 +68,7 @@ class OAHMap : public OAHTable<OAHPair> {
     TaggedPtr* base = entries_.data();
     for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
       TaggedPtr* cell = &base[bid + std::countr_zero(cand_bits)];
-      if (OAHPair(*cell).Key() == field) {
+      if (OAHPair(*cell).KeyMatches(key.content(), key.len())) {
         matched = cell;
         break;
       }
@@ -69,7 +76,7 @@ class OAHMap : public OAHTable<OAHPair> {
     const uint32_t ext_bid = GetExtensionPoint(bid);
     bool in_vector = false;
     if (!matched && At(ext_bid).IsVector()) {
-      matched = ProbeExtensionVector(ext_bid, field, ext_hash);
+      matched = ProbeExtensionVector(ext_bid, key.content(), key.len(), ext_hash);
       in_vector = matched != nullptr;
     }
     if (!matched)
@@ -113,7 +120,8 @@ class OAHMap : public OAHTable<OAHPair> {
       double threshold = double(remaining) / (total - index);
       if (absl::Uniform(rng, 0.0, 1.0) <= threshold) {
         OAHPair e = *it;
-        keys.emplace_back(e.Key());
+        const oah::key::Decoded key = DecodeKey(e);
+        keys.emplace_back(key.view());
         if (with_value)
           vals.emplace_back(e.Value());
         --remaining;
@@ -122,32 +130,33 @@ class OAHMap : public OAHTable<OAHPair> {
   }
 
  private:
-  uint32_t ComputeTtl(std::string_view field, uint32_t ttl_sec, bool keepttl) {
-    if (keepttl) {
-      auto it = Find(field);
+  uint32_t ComputeTtl(std::string_view content, uint32_t len, uint32_t ttl_sec, bool keepttl) {
+    if (keepttl && !entries_.empty()) {
+      auto it = Find(content, len);
       if (it != end() && it.HasExpiry() && it.ExpiryTime() > time_now_)
         return it.ExpiryTime() - time_now_;
     }
     return ttl_sec;
   }
 
-  // Creates a pair blob for field/value with a relative ttl, flagging expiry use.
-  TaggedPtr MakePair(std::string_view field, std::string_view value, uint32_t ttl) {
+  // Creates a pair blob for key/value with a relative ttl, flagging expiry use.
+  TaggedPtr MakePair(std::string_view content, uint32_t len, std::string_view value, uint32_t ttl) {
     if (ttl != UINT32_MAX)
       expiration_used_ = true;
-    return OAHPair::Create(field, value, EntryTTL(ttl));
+    return OAHPair::Create(content, len, value, EntryTTL(ttl));
   }
 
   // Map insertion core. On a live duplicate: replace=false destroys new_tp; replace=true swaps it
   // in, returning the old TaggedPtr via *old_out (or destroying it when null). Returns true only on
   // a fresh insert.
-  bool AddPairImpl(std::string_view field, TaggedPtr new_tp, bool replace, TaggedPtr* old_out) {
+  bool AddPairImpl(std::string_view content, uint32_t len, TaggedPtr new_tp, bool replace,
+                   TaggedPtr* old_out) {
     if (size_ >= entries_.size()) [[unlikely]] {
       Reserve(BucketCount() * 2);
     }
     assert(Capacity() >= kDisplacementSize);
 
-    uint64_t hash = Hash(field);
+    uint64_t hash = Hash(content);
     auto bucket_id = BucketId(hash, capacity_log_);
     oah::PrefetchRead(entries_.data() + bucket_id);
 
@@ -165,13 +174,13 @@ class OAHMap : public OAHTable<OAHPair> {
     TaggedPtr* base = entries_.data();
     for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
       TaggedPtr* cell = &base[bucket_id + std::countr_zero(cand_bits)];
-      if (OAHPair(*cell).Key() == field) {
+      if (OAHPair(*cell).KeyMatches(content, len)) {
         matched = cell;
         break;
       }
     }
     if (!matched && At(ext_bid).IsVector())
-      matched = ProbeExtensionVector(ext_bid, field, ext_hash);
+      matched = ProbeExtensionVector(ext_bid, content, len, ext_hash);
 
     if (matched) {
       OAHPair dup(*matched);

--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -14,6 +14,7 @@
 
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "core/detail/bitpacking.h"
 #include "core/mi_memory_resource.h"
 #include "core/page_usage/page_usage_stats.h"
 
@@ -25,8 +26,20 @@ namespace dfly {
 
 using namespace std;
 
+// Encodes a logical key the way OAHMap does, then serializes it into a pair blob.
+static uint64_t CreatePair(string_view key, string_view value, uint32_t expiry = UINT32_MAX) {
+  const ASCIIStr ek(key);
+  return OAHPair::Create(ek.content(), ek.len(), value, expiry);
+}
+
+// Decodes a pair's logical key (production does this at the table level, via OAHMap::DecodeKey).
+static string KeyOf(OAHPair p) {
+  const oah::key::Decoded key = OAHMap::DecodeKey(p);
+  return string{key.view()};
+}
+
 // Mirrors string_map_test.cc for the OAHMap (OAHTable<OAHPair>) container. The StringMap SdsPair
-// iterator (it->first/it->second) maps to the OAHPair accessor (it->Key()/it->Value()), and
+// iterator (it->first/it->second) maps to the OAHPair accessor (KeyOf(*it)/it->Value()), and
 // AddOrExchange/Extract return an OwnedOAHPair (RAII, frees on destruction) instead of an SdsEntry.
 class OAHMapTest : public ::testing::Test {
  protected:
@@ -100,13 +113,13 @@ TEST_F(OAHMapTest, Basic) {
   EXPECT_EQ(it->Value(), "bar"sv);
 
   it = m_->begin();
-  EXPECT_EQ(it->Key(), "foo"sv);
+  EXPECT_EQ(KeyOf(*it), "foo"sv);
   EXPECT_EQ(it->Value(), "bar"sv);
   ++it;
   EXPECT_TRUE(it == m_->end());
 
   for (auto e : *m_) {
-    EXPECT_EQ(e.Key(), "foo"sv);
+    EXPECT_EQ(KeyOf(e), "foo"sv);
     EXPECT_EQ(e.Value(), "bar"sv);
   }
 
@@ -127,9 +140,9 @@ TEST_F(OAHMapTest, Basic) {
 TEST_F(OAHMapTest, EmptyKeyAndValue) {
   // Empty members arrive as non-null empty views (""sv), never a null std::string_view{} -- see
   // CmdArgParser::SafeSV. OAHPair::Create relies on that invariant (DCHECK on the data pointers).
-  uint64_t bits = OAHPair::Create(""sv, ""sv);
+  uint64_t bits = CreatePair(""sv, ""sv);
   OAHPair pair(bits);
-  EXPECT_TRUE(pair.Key().empty());
+  EXPECT_TRUE(KeyOf(pair).empty());
   EXPECT_TRUE(pair.Value().empty());
   OAHPair::Destroy(pair.Release());
 
@@ -139,7 +152,7 @@ TEST_F(OAHMapTest, EmptyKeyAndValue) {
   EXPECT_TRUE(value->empty());
   auto it = m_->Find("");
   ASSERT_NE(it, m_->end());
-  EXPECT_TRUE(it->Key().empty());
+  EXPECT_TRUE(KeyOf(*it).empty());
   EXPECT_TRUE(it->Value().empty());
   EXPECT_TRUE(m_->Erase(""));
   EXPECT_FALSE(m_->GetValue("").has_value());
@@ -152,29 +165,34 @@ TEST_F(OAHMapTest, OAHPairSizeEncoding) {
       const string value = sized_string(value_size, 'v');
       for (uint32_t expiry : {UINT32_MAX, 7u}) {
         const size_t used_before = zmalloc_used_memory_tl;
-        uint64_t bits = OAHPair::Create(key, value, expiry);
+        uint64_t bits = CreatePair(key, value, expiry);
         OAHPair pair(bits);
 
-        EXPECT_EQ(pair.Key(), key);
+        EXPECT_EQ(KeyOf(pair), key);
         EXPECT_EQ(pair.Value(), value);
-        EXPECT_EQ(pair.KeyValue(), make_pair(string_view(key), string_view(value)));
         EXPECT_EQ(pair.HasExpiry(), expiry != UINT32_MAX);
         EXPECT_EQ(pair.GetExpiry(), expiry);
         EXPECT_EQ(pair.AllocSize(), zmalloc_used_memory_tl - used_before);
 
-        // Decode the fields directly from the blob: [expiry?, key_size, value_size, value_ptr:8B].
-        const char* key_size_field = pair.Raw() + (expiry != UINT32_MAX) * sizeof(expiry);
-        const oah::size::Decoded decoded_key_size = oah::size::Read(key_size_field);
-        const char* value_size_field = key_size_field + decoded_key_size.field_size;
+        // Decode the fields directly from the blob:
+        //   [expiry?, key_header, value_size, value_ptr:8B, key_content]
+        const char* key_header = pair.Raw() + (expiry != UINT32_MAX) * sizeof(expiry);
+        const oah::key::Header kh = oah::key::ReadHeader(key_header);
+        EXPECT_EQ(kh.len, key_size);
+        EXPECT_EQ(kh.encoded, ASCIIStr(key).encoded());
+        const char* value_size_field = key_header + kh.field_size;
         const oah::size::Decoded decoded_value_size = oah::size::Read(value_size_field);
         const char* value_ptr_field = value_size_field + decoded_value_size.field_size;
-        EXPECT_EQ(decoded_key_size.size, key_size);
         EXPECT_EQ(decoded_value_size.size, value_size);
 
         char* stored_value = nullptr;
         std::memcpy(&stored_value, value_ptr_field, sizeof(stored_value));
         EXPECT_EQ(stored_value, pair.Value().data());
-        EXPECT_EQ(pair.Key().data(), value_ptr_field + sizeof(stored_value));
+
+        // Key content (ascii-packed or raw) is stored right after the value pointer.
+        const char* key_content = value_ptr_field + sizeof(stored_value);
+        EXPECT_EQ(pair.KeyContent().data(), key_content);
+        EXPECT_EQ(pair.KeyContent().size(), ASCIIStr(key).content().size());
 
         const uintptr_t raw = reinterpret_cast<uintptr_t>(pair.Raw());
         const uintptr_t raw_end = raw + zmalloc_usable_size(pair.Raw());
@@ -191,6 +209,50 @@ TEST_F(OAHMapTest, OAHPairSizeEncoding) {
       }
     }
   }
+}
+
+TEST_F(OAHMapTest, AsciiEncoding) {
+  string ascii_key(80, 'a');                // 80 ascii chars -> 70 packed bytes
+  string boundary(128, 'b');                // largest ascii-encodable field
+  string too_long(129, 'c');                // one over -> raw
+  string non_ascii(80, 'd');                //
+  non_ascii[40] = static_cast<char>(0xC3);  // a non-ascii byte -> raw
+  const string value = "some-value";
+
+  for (string* k : {&ascii_key, &boundary, &too_long, &non_ascii})
+    EXPECT_TRUE(m_->AddOrUpdate(*k, value)) << k->size();
+
+  // Encodable fields are packed; the others stay raw. The value is never encoded.
+  auto it = m_->Find(ascii_key);
+  ASSERT_NE(it, m_->end());
+  EXPECT_EQ(it->KeyContent().size(), detail::binpacked_len(80));
+  EXPECT_EQ(it->Value(), value);
+  EXPECT_EQ(m_->Find(boundary)->KeyContent().size(), detail::binpacked_len(128));
+  EXPECT_EQ(m_->Find(too_long)->KeyContent().size(), too_long.size());
+  EXPECT_EQ(m_->Find(non_ascii)->KeyContent().size(), non_ascii.size());
+
+  // Updating an existing encoded field works, and lookups respect the logical length.
+  EXPECT_FALSE(m_->AddOrUpdate(ascii_key, "v2"));
+  EXPECT_EQ(m_->Find(ascii_key)->Value(), "v2"sv);
+  EXPECT_FALSE(m_->Contains(string(79, 'a')));
+  EXPECT_FALSE(m_->Contains(string(81, 'a')));
+
+  // Iteration reconstructs the logical fields.
+  vector<string> keys;
+  for (auto e = m_->begin(); e != m_->end(); ++e)
+    keys.push_back(string{KeyOf(*e)});
+  EXPECT_EQ(keys.size(), 4u);
+  auto has = [&](const string& k) {
+    for (const string& x : keys)
+      if (x == k)
+        return true;
+    return false;
+  };
+  for (string* k : {&ascii_key, &boundary, &too_long, &non_ascii})
+    EXPECT_TRUE(has(*k)) << k->size();
+
+  for (string* k : {&ascii_key, &boundary, &too_long, &non_ascii})
+    EXPECT_TRUE(m_->Extract(*k)) << k->size();
 }
 
 TEST_F(OAHMapTest, OAHSizeFieldEncoding) {
@@ -255,7 +317,7 @@ TEST_F(OAHMapTest, ExternalValueOwnership) {
   {
     auto extracted = m_->Extract(key);
     ASSERT_TRUE(extracted);
-    EXPECT_EQ(extracted.pair().Key(), key);
+    EXPECT_EQ(KeyOf(extracted.pair()), key);
     EXPECT_EQ(extracted.pair().Value(), replacement);
     EXPECT_EQ(m_->ObjMallocUsed(), 0u);
     EXPECT_EQ(zmalloc_used_memory_tl, used_before_extract);
@@ -294,7 +356,7 @@ TEST_F(OAHMapTest, ExternalValueExpiryRebuild) {
   ASSERT_NE(it, m_->end());
   EXPECT_NE(it->Raw(), old_raw);
   EXPECT_EQ(it->Value().data(), old_value);
-  EXPECT_EQ(it->Key(), key);
+  EXPECT_EQ(KeyOf(*it), key);
   EXPECT_EQ(it->Value(), value);
   EXPECT_EQ(it->GetHash(), old_hash);
   EXPECT_EQ(it.ExpiryTime(), 7u);
@@ -316,7 +378,7 @@ TEST_F(OAHMapTest, ExternalValueExpiryRebuild) {
 TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   const string key = sized_string(8192, 'k');
   const string value = sized_string(8192, 'v');
-  uint64_t bits = OAHPair::Create(key, value, 11);
+  uint64_t bits = CreatePair(key, value, 11);
   OAHPair pair(bits);
   pair.SetExtHash(123);
 
@@ -331,7 +393,7 @@ TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   EXPECT_EQ(pair.Raw(), old_raw);
   EXPECT_NE(pair.Value().data(), old_value);
   EXPECT_EQ(delta, static_cast<ssize_t>(pair.AllocSize()) - static_cast<ssize_t>(old_alloc));
-  EXPECT_EQ(pair.Key(), key);
+  EXPECT_EQ(KeyOf(pair), key);
   EXPECT_EQ(pair.Value(), value);
   EXPECT_EQ(pair.GetExpiry(), 11u);
   EXPECT_EQ(pair.GetHash(), 123u);
@@ -347,7 +409,7 @@ TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   EXPECT_NE(pair.Raw(), old_raw);
   EXPECT_EQ(pair.Value().data(), old_value);
   EXPECT_EQ(delta, static_cast<ssize_t>(pair.AllocSize()) - static_cast<ssize_t>(old_alloc));
-  EXPECT_EQ(pair.Key(), key);
+  EXPECT_EQ(KeyOf(pair), key);
   EXPECT_EQ(pair.Value(), value);
   EXPECT_EQ(pair.GetExpiry(), 11u);
   EXPECT_EQ(pair.GetHash(), 123u);
@@ -362,7 +424,7 @@ TEST_F(OAHMapTest, ExternalValueSelectiveRealloc) {
   EXPECT_NE(pair.Raw(), old_raw);
   EXPECT_NE(pair.Value().data(), old_value);
   EXPECT_EQ(delta, static_cast<ssize_t>(pair.AllocSize()) - static_cast<ssize_t>(old_alloc));
-  EXPECT_EQ(pair.Key(), key);
+  EXPECT_EQ(KeyOf(pair), key);
   EXPECT_EQ(pair.Value(), value);
   EXPECT_EQ(pair.GetExpiry(), 11u);
   EXPECT_EQ(pair.GetHash(), 123u);
@@ -571,7 +633,7 @@ TEST_F(OAHMapTest, Extract) {
   {
     auto entry = m_->Extract("f1");
     ASSERT_TRUE(entry);
-    EXPECT_EQ(entry.pair().Key(), "f1"sv);
+    EXPECT_EQ(KeyOf(entry.pair()), "f1"sv);
     EXPECT_EQ(entry.pair().Value(), "v1"sv);
   }
   EXPECT_EQ(m_->UpperBoundSize(), 1u);
@@ -679,7 +741,7 @@ void BM_Clone(benchmark::State& state) {
   dst.Reserve(src.UpperBoundSize());
   while (state.KeepRunning()) {
     for (auto e : src)
-      dst.AddOrUpdate(e.Key(), e.Value());
+      dst.AddOrUpdate(KeyOf(e), e.Value());
     state.PauseTiming();
     dst.Clear();
     dst.Reserve(src.UpperBoundSize());
@@ -798,7 +860,7 @@ void BM_Scan(benchmark::State& state) {
     uint32_t cursor = 0;
     size_t seen = 0;
     do {
-      cursor = m.Scan(cursor, [&](auto key) {
+      cursor = m.Scan(cursor, [&](const auto& key) {
         benchmark::DoNotOptimize(key.size());
         ++seen;
       });

--- a/src/core/oah_pair.cc
+++ b/src/core/oah_pair.cc
@@ -11,16 +11,15 @@ namespace dfly {
 
 using namespace oah;
 
-TaggedPtr OAHPair::BuildBlob(std::string_view key, char* value_ptr, size_t value_size,
-                             uint32_t expiry) {
-  const size_t key_size = key.size();
-  assert(key_size <= size::kMaxSize);
+TaggedPtr OAHPair::BuildBlob(std::string_view key, uint32_t real_size, char* value_ptr,
+                             size_t value_size, uint32_t expiry) {
+  const uint8_t encoded_bit = (key.size() != real_size) * key::kEncodedBit;
   assert(value_size <= size::kMaxSize);
   const uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
-  const uint32_t key_size_field = size::FieldSize(key_size);
+  const uint32_t key_field = size::FieldSize(real_size);
   const uint32_t val_size_field = size::FieldSize(value_size);
 
-  const size_t blob_size = expiry_size + key_size_field + val_size_field + sizeof(char*) + key_size;
+  const size_t blob_size = expiry_size + key_field + val_size_field + sizeof(char*) + key.size();
   char* blob = (char*)zmalloc(blob_size);
   TaggedPtr tagged_ptr = reinterpret_cast<TaggedPtr>(blob);
   if (expiry_size) {
@@ -29,8 +28,8 @@ TaggedPtr OAHPair::BuildBlob(std::string_view key, char* value_ptr, size_t value
   }
 
   char* p = blob + expiry_size;
-  size::Write(key_size, key_size_field, p);
-  p += key_size_field;
+  key::WriteHeader(encoded_bit, real_size, p);
+  p += key_field;
   size::Write(value_size, val_size_field, p);
   p += val_size_field;
 
@@ -39,17 +38,18 @@ TaggedPtr OAHPair::BuildBlob(std::string_view key, char* value_ptr, size_t value
 
   // args are never null, even when empty (see CmdArgParser::SafeSV), so memcpy needs no size guard.
   DCHECK(key.data());
-  std::memcpy(p, key.data(), key_size);
+  std::memcpy(p, key.data(), key.size());
   return tagged_ptr;
 }
 
-TaggedPtr OAHPair::Create(std::string_view key, std::string_view value, uint32_t expiry) {
+TaggedPtr OAHPair::Create(std::string_view key, uint32_t real_size, std::string_view value,
+                          uint32_t expiry) {
   char* value_ptr = nullptr;
   if (!value.empty()) {
     value_ptr = (char*)zmalloc(value.size());
     std::memcpy(value_ptr, value.data(), value.size());
   }
-  return BuildBlob(key, value_ptr, value.size(), expiry);
+  return BuildBlob(key, real_size, value_ptr, value.size(), expiry);
 }
 
 void OAHPair::Destroy(TaggedPtr tagged_ptr) {
@@ -76,9 +76,12 @@ void OAHPair::SetExtHash(uint64_t ext_hash) {
 void OAHPair::Rebuild(uint32_t expiry) {
   const uint64_t saved_hash = GetHash();
   const Header header = ParseHeader();
-  // The rebuilt blob references the same value buffer, so only the old blob is freed.
-  TaggedPtr rebuilt =
-      BuildBlob({header.key, header.key_size}, ReadValuePtr(header), header.value_size, expiry);
+  char* value_ptr = ReadValuePtr(header);
+  // Copy the stored key verbatim (already encoded): no decode/re-encode, keep the encoded flag. The
+  // key content view points into the old blob and is copied before the old blob is freed; the
+  // rebuilt blob keeps the same value buffer.
+  const std::string_view content{header.key_content, header.key.content_size};
+  TaggedPtr rebuilt = BuildBlob(content, header.key.len, value_ptr, header.value_size, expiry);
   OAHPair(rebuilt).SetExtHash(saved_hash);
   zfree(Raw());
   SetTaggedPtr(rebuilt);

--- a/src/core/oah_pair.h
+++ b/src/core/oah_pair.h
@@ -32,7 +32,10 @@ class OAHPair {
  public:
   using TaggedPtr = oah::TaggedPtr;
 
-  static TaggedPtr Create(std::string_view key, std::string_view value,
+  // Creates a pair blob storing `key` (already-encoded content) verbatim plus a fresh copy of
+  // `value`. The header records `real_size`; whether the key is encoded is derived from
+  // key.size() != real_size.
+  static TaggedPtr Create(std::string_view key, uint32_t real_size, std::string_view value,
                           uint32_t expiry = UINT32_MAX);
   static void Destroy(TaggedPtr tagged_ptr);
 
@@ -55,9 +58,11 @@ class OAHPair {
     return result;
   }
 
-  std::string_view Key() const {
+  // Deserializes the stored key: its codec header plus a pointer to the stored content bytes. The
+  // table decodes/compares this (OAHPair itself never ascii-encodes or decodes).
+  oah::key::Stored StoredKey() const {
     const Header header = ParseHeader();
-    return {header.key, header.key_size};
+    return {header.key, header.key_content};
   }
 
   std::string_view Value() const {
@@ -65,9 +70,17 @@ class OAHPair {
     return {ReadValuePtr(header), header.value_size};
   }
 
-  std::pair<std::string_view, std::string_view> KeyValue() const {
+  // Stored key content (ascii-packed or raw) used for hashing. Not the logical key.
+  std::string_view KeyContent() const {
     const Header header = ParseHeader();
-    return {{header.key, header.key_size}, {ReadValuePtr(header), header.value_size}};
+    return {header.key_content, header.key.content_size};
+  }
+
+  // Compares this pair's key against a query key (content bytes + logical length). Reads the header
+  // inline (not via StoredKey) to stay register-friendly on the hot path.
+  bool KeyMatches(std::string_view content, uint32_t len) const {
+    const Header header = ParseHeader();
+    return oah::key::Matches(header.key, header.key_content, content, len);
   }
 
   bool HasExpiry() const {
@@ -106,18 +119,18 @@ class OAHPair {
  protected:
   struct Header {
     char* value_ptr_field;
-    char* key;
-    uint32_t key_size;
+    char* key_content;  // packed/raw key content bytes (stored after value_ptr)
     uint32_t value_size;
+    oah::key::Header key;  // encoded flag, logical length, header/content sizes
   };
 
   Header ParseHeader() const {
     char* p = Raw() + GetExpirySize();
-    const oah::size::Decoded key = oah::size::Read(p);
+    const oah::key::Header key = oah::key::ReadHeader(p);
     p += key.field_size;
     const oah::size::Decoded value = oah::size::Read(p);
     p += value.field_size;
-    return {p, p + sizeof(char*), key.size, value.size};
+    return {p, p + sizeof(char*), value.size, key};
   }
 
   static char* ReadValuePtr(const Header& header) {
@@ -130,10 +143,12 @@ class OAHPair {
     return ReadValuePtr(ParseHeader());
   }
 
-  // Builds a blob that takes ownership of `value_ptr` (null for an empty value): Create allocates a
-  // fresh value buffer, Rebuild passes the existing one through unchanged.
-  static TaggedPtr BuildBlob(std::string_view key, char* value_ptr, size_t value_size,
-                             uint32_t expiry);
+  // Builds a blob that takes ownership of `value_ptr` (null for an empty value), storing the
+  // already-encoded `key` content verbatim. The header records `real_size`; whether the key is
+  // encoded is derived from key.size() != real_size. Create allocates a fresh value buffer; Rebuild
+  // passes the existing key/value through unchanged.
+  static TaggedPtr BuildBlob(std::string_view key, uint32_t real_size, char* value_ptr,
+                             size_t value_size, uint32_t expiry);
 
   // Reallocates the blob with `expiry`, preserving key, value and the cached ext-hash.
   void Rebuild(uint32_t expiry);

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -23,7 +23,8 @@ class OAHSet : public OAHTable<OAHEntry> {
  public:
   // Inserts `str` (optional TTL); returns false if already present.
   bool Add(std::string_view str, uint32_t ttl_sec = UINT32_MAX) {
-    return AddImpl(str, ttl_sec);
+    const ASCIIStr key(str);
+    return AddImpl(key.content(), key.len(), ttl_sec);
   }
 
   // keepttl=true: existing entries are left alone (current/legacy behavior).
@@ -34,10 +35,11 @@ class OAHSet : public OAHTable<OAHEntry> {
     unsigned res = 0;
     const bool has_ttl = ttl_sec != UINT32_MAX;
     for (auto& s : span) {
-      if (AddImpl(s, ttl_sec)) {
+      const ASCIIStr key(s);
+      if (AddImpl(key.content(), key.len(), ttl_sec)) {
         ++res;
       } else if (has_ttl && !keepttl) {
-        auto it = Find(s);
+        auto it = Find(key.content(), key.len());
         if (it != end())
           it.SetExpiryTime(ttl_sec);
       }
@@ -51,18 +53,21 @@ class OAHSet : public OAHTable<OAHEntry> {
     other->Reserve(UpperBoundSize());
     other->set_time(time_now());
     for (auto it = begin(), it_end = end(); it != it_end; ++it) {
-      other->Add(it->Key(), it.HasExpiry() ? it.ExpiryTime() - time_now() : UINT32_MAX);
+      // Copy the stored (already-encoded) content verbatim -- no decode/re-encode round-trip.
+      const oah::key::Stored s = (*it).StoredKey();
+      const uint32_t ttl = it.HasExpiry() ? it.ExpiryTime() - time_now() : UINT32_MAX;
+      other->AddImpl({s.content, s.header.content_size}, s.header.len, ttl);
     }
   }
 
  private:
-  bool AddImpl(std::string_view str, uint32_t ttl_sec) {
+  bool AddImpl(std::string_view content, uint32_t len, uint32_t ttl_sec) {
     if (size_ >= entries_.size()) [[unlikely]] {
       Reserve(BucketCount() * 2);
     }
     assert(Capacity() >= kDisplacementSize);
 
-    uint64_t hash = Hash(str);
+    uint64_t hash = Hash(content);
     auto bucket_id = BucketId(hash, capacity_log_);
     oah::PrefetchRead(entries_.data() + bucket_id);
 
@@ -70,7 +75,7 @@ class OAHSet : public OAHTable<OAHEntry> {
     const uint64_t shifted_ext_hash = ext_hash << oah::kExtHashShift;
 
     const ssize_t mem_before = zmalloc_used_memory_tl;
-    TaggedPtr entry_tagged_ptr = OAHEntry::Create(str, EntryTTL(ttl_sec));
+    TaggedPtr entry_tagged_ptr = OAHEntry::Create(content, len, EntryTTL(ttl_sec));
     OAHEntry(entry_tagged_ptr).SetShiftedExtHash(shifted_ext_hash);  // reuse the shifted value
     if (ttl_sec != UINT32_MAX)
       expiration_used_ = true;
@@ -87,13 +92,13 @@ class OAHSet : public OAHTable<OAHEntry> {
     TaggedPtr* base = entries_.data();
     for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
       TaggedPtr* cell = &base[bucket_id + std::countr_zero(cand_bits)];
-      if (OAHEntry(*cell).Key() == str) {
+      if (OAHEntry(*cell).KeyMatches(content, len)) {
         matched = cell;
         break;
       }
     }
     if (!matched && At(ext_bid).IsVector())
-      matched = ProbeExtensionVector(ext_bid, str, ext_hash);
+      matched = ProbeExtensionVector(ext_bid, content, len, ext_hash);
 
     if (matched) {
       OAHEntry dup(*matched);
@@ -129,15 +134,32 @@ template <typename Fn> auto VisitSet(void* ptr, Fn&& fn) {
   return g_use_oah_set ? fn(static_cast<OAHSet*>(ptr)) : fn(static_cast<StringSet*>(ptr));
 }
 
-// Current member as a string_view from either iterator type. Free functions so
-// generic code (e.g. VisitSet lambdas) can write `Key(it)` uniformly.
+// Current member from either iterator type. OAHSet returns a small owning/view object: it
+// references raw entry bytes directly and owns decoded ASCII bytes inline. Callers keep that object
+// alive while using GetKeyView(), so decoded views remain valid across nested calls and fiber
+// yields.
 inline std::string_view Key(StringSet::iterator it) {
   sds s = *it;
   return {s, sdslen(s)};
 }
 
-inline std::string_view Key(OAHSet::iterator it) {
-  return it->Key();
+inline oah::key::Decoded Key(OAHSet::iterator it) {
+  return OAHSet::DecodeKey(*it);
 }
+
+inline std::string_view GetKeyView(std::string_view key) {
+  return key;
+}
+
+inline std::string_view GetKeyView(sds key) {
+  return {key, sdslen(key)};
+}
+
+inline std::string_view GetKeyView(const oah::key::Decoded& key) {
+  return key.view();
+}
+
+inline std::string_view GetKeyView(oah::key::Decoded&&) = delete;
+inline std::string_view GetKeyView(const oah::key::Decoded&&) = delete;
 
 }  // namespace dfly

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -14,6 +14,7 @@
 
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "core/detail/bitpacking.h"
 #include "core/mi_memory_resource.h"
 #include "core/page_usage/page_usage_stats.h"
 
@@ -24,6 +25,18 @@ extern "C" {
 namespace dfly {
 
 using namespace std;
+
+// Encodes a logical key the way OAHSet does, then serializes it into an entry blob.
+static uint64_t CreateEntry(string_view key, uint32_t expiry = UINT32_MAX) {
+  const ASCIIStr ek(key);
+  return OAHEntry::Create(ek.content(), ek.len(), expiry);
+}
+
+// Decodes an entry's logical key (production does this at the table level, via OAHSet::DecodeKey).
+static string KeyOf(OAHEntry e) {
+  const oah::key::Decoded key = OAHSet::DecodeKey(e);
+  return string{key.view()};
+}
 
 class OAHSetTest : public ::testing::Test {
  protected:
@@ -62,6 +75,139 @@ static string random_string(mt19937& rand, unsigned len) {
   }
 
   return ret;
+}
+
+TEST(OAHKeyCodec, HeaderContentMatchesDecode) {
+  auto check = [](const string& key) {
+    const ASCIIStr ek(key);
+    const uint32_t hdr = oah::size::FieldSize(ek.len());
+    vector<char> blob(hdr + ek.content().size() + 1, 0);
+    const uint8_t encoded_bit = ek.encoded() * oah::key::kEncodedBit;
+    const uint32_t fs = oah::key::WriteHeader(encoded_bit, ek.len(), blob.data());
+    EXPECT_EQ(fs, hdr) << key.size();
+    memcpy(blob.data() + fs, ek.content().data(), ek.content().size());
+
+    const oah::key::Header h = oah::key::ReadHeader(blob.data());
+    EXPECT_EQ(h.field_size, fs) << key.size();
+    EXPECT_EQ(h.len, key.size()) << key.size();
+    EXPECT_EQ(h.encoded, ASCIIStr(key).encoded()) << key.size();
+    EXPECT_EQ(h.content_size, ek.content().size()) << key.size();
+
+    const char* content = blob.data() + h.field_size;
+    const oah::key::Stored stored{h, content};
+    const oah::key::Decoded decoded = oah::key::Decode(stored);
+    EXPECT_EQ(decoded.view(), key) << key.size();
+    if (!h.encoded) {
+      EXPECT_EQ(decoded.data(), content) << key.size();
+    }
+
+    EXPECT_TRUE(oah::key::Matches(h, content, ek.content(), ek.len())) << key.size();
+
+    const ASCIIStr other(key + "Z");
+    EXPECT_FALSE(oah::key::Matches(h, content, other.content(), other.len())) << key.size();
+  };
+  for (uint32_t len : {0u, 1u, 7u, 8u, 63u, 64u, 127u, 128u, 500u})
+    check(string(len, 'a'));
+
+  string non_ascii = "abc";
+  non_ascii.push_back(static_cast<char>(0x80));
+  check(non_ascii);
+}
+
+TEST_F(OAHSetTest, AsciiEncoding) {
+  string ascii_key(80, 'a');                // 80 ascii chars -> 70 packed bytes
+  string boundary(128, 'b');                // largest ascii-encodable key
+  string too_long(129, 'c');                // one over -> raw
+  string non_ascii(80, 'd');                //
+  non_ascii[40] = static_cast<char>(0xC3);  // a non-ascii byte -> raw
+
+  for (string* k : {&ascii_key, &boundary, &too_long, &non_ascii})
+    EXPECT_TRUE(ss_->Add(*k)) << k->size();
+
+  // Duplicate detection runs in the encoded state.
+  EXPECT_FALSE(ss_->Add(ascii_key));
+  EXPECT_FALSE(ss_->Add(boundary));
+
+  // Encodable keys are packed; the others stay raw.
+  auto it = ss_->Find(ascii_key);
+  ASSERT_NE(it, ss_->end());
+  EXPECT_EQ(it->KeyContent().size(), detail::binpacked_len(80));
+  EXPECT_LT(it->KeyContent().size(), ascii_key.size());
+  EXPECT_EQ(ss_->Find(boundary)->KeyContent().size(), detail::binpacked_len(128));
+  EXPECT_EQ(ss_->Find(too_long)->KeyContent().size(), too_long.size());
+  EXPECT_EQ(ss_->Find(non_ascii)->KeyContent().size(), non_ascii.size());
+
+  // Lookups distinguish keys that would pack to the same byte count but differ in length.
+  EXPECT_FALSE(ss_->Contains(string(79, 'a')));
+  EXPECT_FALSE(ss_->Contains(string(81, 'a')));
+
+  // Iteration reconstructs the logical keys.
+  unordered_set<string> seen;
+  for (auto e = ss_->begin(); e != ss_->end(); ++e)
+    seen.insert(string{KeyOf(*e)});
+  for (string* k : {&ascii_key, &boundary, &too_long, &non_ascii})
+    EXPECT_TRUE(seen.count(*k)) << k->size();
+
+  for (string* k : {&ascii_key, &boundary, &too_long, &non_ascii}) {
+    EXPECT_TRUE(ss_->Erase(*k)) << k->size();
+    EXPECT_FALSE(ss_->Contains(*k)) << k->size();
+  }
+}
+
+TEST_F(OAHSetTest, DecodedKeyLifetimeAndRawZeroCopy) {
+  const string first(80, 'a');
+  const string second(80, 'b');
+  const string raw(129, 'c');  // exceeds the ASCII codec limit, so it stays raw
+  ASSERT_TRUE(ss_->Add(first));
+  ASSERT_TRUE(ss_->Add(second));
+  ASSERT_TRUE(ss_->Add(raw));
+
+  auto first_it = ss_->Find(first);
+  auto second_it = ss_->Find(second);
+  auto raw_it = ss_->Find(raw);
+  ASSERT_NE(first_it, ss_->end());
+  ASSERT_NE(second_it, ss_->end());
+  ASSERT_NE(raw_it, ss_->end());
+
+  // Each encoded handle owns its decoded bytes, so decoding another key cannot overwrite it.
+  auto first_key = Key(first_it);
+  const string_view first_view = first_key.view();
+  auto second_key = Key(second_it);
+  EXPECT_EQ(first_view, first);
+  EXPECT_EQ(second_key.view(), second);
+  const uintptr_t first_addr = reinterpret_cast<uintptr_t>(&first_key);
+  const uintptr_t first_data = reinterpret_cast<uintptr_t>(first_key.data());
+  EXPECT_GE(first_data, first_addr);
+  EXPECT_LT(first_data, first_addr + sizeof(first_key));
+
+  // Raw keys remain a direct view into the entry instead of being copied into scratch storage.
+  auto raw_key = Key(raw_it);
+  EXPECT_EQ(raw_key.view(), raw);
+  EXPECT_EQ(raw_key.data(), raw_it->KeyContent().data());
+
+  // Scan views are valid in the callback; callers copy them when retaining results. Raw keys stay
+  // entry-backed during the callback.
+  unordered_set<string> scanned;
+  uint32_t cursor = 0;
+  do {
+    cursor = ss_->Scan(cursor, [&](string_view key) {
+      scanned.emplace(key);
+      if (key == raw) {
+        EXPECT_EQ(key.data(), raw_it->KeyContent().data());
+      }
+    });
+  } while (cursor != 0);
+  EXPECT_EQ(scanned, (unordered_set<string>{first, second, raw}));
+
+  // Encoded handles remain self-contained when copied and outlive the entry storage.
+  vector<oah::key::Decoded> retained_encoded{first_key, second_key};
+  ss_->Clear();
+  EXPECT_EQ(first_key.view(), first);
+  EXPECT_EQ(second_key.view(), second);
+  unordered_set<string> retained_views;
+  for (const auto& key : retained_encoded)
+    retained_views.emplace(key.view());
+  EXPECT_EQ(retained_views, (unordered_set<string>{first, second}));
 }
 
 TEST_F(OAHSetTest, PtrVectorLinearThenDouble) {
@@ -135,10 +281,10 @@ TEST_F(OAHSetTest, PtrVectorDestroysAllElements) {
 }
 
 TEST_F(OAHSetTest, OAHEntryTest) {
-  uint64_t bits = OAHEntry::Create("0123456789", 2);
+  uint64_t bits = CreateEntry("0123456789", 2);
   OAHEntry test(bits);
 
-  EXPECT_EQ(test.Key(), "0123456789"sv);
+  EXPECT_EQ(KeyOf(test), "0123456789"sv);
   EXPECT_EQ(test.GetExpiry(), 2);
 
   OAHEntry::Destroy(test.Release());
@@ -156,9 +302,9 @@ TEST_F(OAHSetTest, KeySizeEncoding) {
     keys.push_back(key);
 
     for (uint32_t expiry : {UINT32_MAX, 7u}) {
-      uint64_t bits = OAHEntry::Create(key, expiry);
+      uint64_t bits = CreateEntry(key, expiry);
       OAHEntry e(bits);
-      EXPECT_EQ(e.Key(), key);
+      EXPECT_EQ(KeyOf(e), key);
       EXPECT_EQ(e.HasExpiry(), expiry != UINT32_MAX);
       if (expiry != UINT32_MAX) {
         EXPECT_EQ(e.GetExpiry(), expiry);
@@ -184,13 +330,14 @@ TEST_F(OAHSetTest, OAHPtrInsertRemove) {
   // the leftover collision array explicitly at the end.
   uint64_t slot = 0;
   OAHPtr<OAHEntry> test{slot};
-  test.Assign(OAHEntry::Create("0123456789", 2));
+  test.Assign(CreateEntry("0123456789", 2));
 
-  EXPECT_EQ(test[0].Key(), "0123456789"sv);
+  EXPECT_EQ(KeyOf(test[0]), "0123456789"sv);
   EXPECT_EQ(test[0].GetExpiry(), 2);
 
-  EXPECT_EQ(test.Insert(OAHEntry::Create("123456789")), 16);  // promote to a 2-element vector
-  EXPECT_EQ(test.Insert(OAHEntry::Create("23456789")), 16);   // linear grow 2 -> 4
+  EXPECT_EQ(test.Insert(CreateEntry("123456789")),
+            16);                                        // promote to a 2-element vector
+  EXPECT_EQ(test.Insert(CreateEntry("23456789")), 16);  // linear grow 2 -> 4
 
   uint64_t removed0 = test.Remove(0);
   EXPECT_TRUE(removed0);
@@ -199,8 +346,8 @@ TEST_F(OAHSetTest, OAHPtrInsertRemove) {
 
   uint64_t removed2 = test.Remove(2);
   uint64_t removed1 = test.Remove(1);
-  EXPECT_EQ(OAHEntry(removed2).Key(), "23456789");
-  EXPECT_EQ(OAHEntry(removed1).Key(), "123456789");
+  EXPECT_EQ(KeyOf(OAHEntry(removed2)), "23456789");
+  EXPECT_EQ(KeyOf(OAHEntry(removed1)), "123456789");
   OAHEntry::Destroy(removed2);
   OAHEntry::Destroy(removed1);
 
@@ -221,7 +368,7 @@ TEST_F(OAHSetTest, OAHSetAddFindTest) {
 
   for (const auto& s : test_set) {
     auto e = ss.Find(s);
-    EXPECT_EQ(e->Key(), s);
+    EXPECT_EQ(KeyOf(*e), s);
   }
 
   // ~10000 elements at load factor 1 (grow when size_ >= table size).
@@ -278,7 +425,7 @@ TEST_F(OAHSetTest, NoDuplicateInsertion) {
   std::unordered_set<std::string> seen;
   size_t total = 0;
   for (auto it = ss_->begin(); it != ss_->end(); ++it) {
-    EXPECT_TRUE(seen.insert(std::string(it->Key())).second) << "duplicate: " << it->Key();
+    EXPECT_TRUE(seen.insert(std::string(KeyOf(*it))).second) << "duplicate: " << KeyOf(*it);
     ++total;
   }
   EXPECT_EQ(seen.size(), keys.size());
@@ -407,7 +554,7 @@ TEST_F(OAHSetTest, SimdFindEraseStress) {
   for (const auto& s : live) {
     auto it = ss_->Find(s);
     ASSERT_NE(it, ss_->end()) << s;
-    EXPECT_EQ(it->Key(), s);
+    EXPECT_EQ(KeyOf(*it), s);
     EXPECT_FALSE(it.HasExpiry());
   }
   for (const auto& s : ttl_alive) {
@@ -466,7 +613,7 @@ TEST_F(OAHSetTest, Resizing) {
 
 TEST_F(OAHSetTest, SimpleScan) {
   unordered_set<string_view> info = {"foo", "bar"};
-  unordered_set<string_view> seen;
+  unordered_set<string> seen;
 
   for (auto str : info) {
     EXPECT_TRUE(ss_->Add(str));
@@ -476,12 +623,13 @@ TEST_F(OAHSetTest, SimpleScan) {
   do {
     cursor = ss_->Scan(cursor, [&](std::string_view str) {
       EXPECT_TRUE(info.count(str));
-      seen.insert(str);
+      seen.insert(string{str});
     });
   } while (cursor != 0);
 
   EXPECT_EQ(seen.size(), info.size());
-  EXPECT_EQ(seen, info);
+  for (string_view s : info)
+    EXPECT_TRUE(seen.count(string{s})) << s;
 }
 
 // // Ensure REDIS scan guarantees are met
@@ -490,13 +638,13 @@ TEST_F(OAHSetTest, ScanGuarantees) {
   unordered_set<string_view> not_be_seen = {"AAA", "BBB"};
   unordered_set<string_view> maybe_seen = {"AA@@@@@@@@@@@@@@", "AAA@@@@@@@@@@@@@",
                                            "AAAAAAAAA@@@@@@@", "AAAAAAAAAA@@@@@@"};
-  unordered_set<string_view> seen;
+  unordered_set<string> seen;
 
   auto scan_callback = [&](std::string_view str) {
     EXPECT_TRUE(to_be_seen.count(str) || maybe_seen.count(str));
     EXPECT_FALSE(not_be_seen.count(str));
     if (to_be_seen.count(str)) {
-      seen.insert(str);
+      seen.insert(string{str});
     }
   };
 
@@ -643,7 +791,7 @@ TEST_F(OAHSetTest, Iteration) {
   }
 
   for (const auto& ptr : *ss_) {
-    std::string str(ptr.Key());
+    std::string str(KeyOf(ptr));
     EXPECT_TRUE(to_insert.count(str));
     to_insert.erase(str);
   }
@@ -685,7 +833,7 @@ TEST_F(OAHSetTest, Ttl) {
   }
   EXPECT_EQ(101u, ss_->UpperBoundSize());
   it = ss_->Find("foo50");
-  EXPECT_EQ("foo50"sv, it->Key());
+  EXPECT_EQ("foo50"sv, KeyOf(*it));
   EXPECT_EQ(2u, it.ExpiryTime());
 
   ss_->set_time(2);
@@ -703,8 +851,8 @@ TEST_F(OAHSetTest, Ttl) {
   EXPECT_FALSE(it.HasExpiry());
 
   for (auto it = ss_->begin(); it != ss_->end(); ++it) {
-    ASSERT_TRUE(absl::StartsWith(it->Key(), "bar")) << it->Key();
-    string str(it->Key());
+    ASSERT_TRUE(absl::StartsWith(KeyOf(*it), "bar")) << KeyOf(*it);
+    string str(KeyOf(*it));
     VLOG(1) << *it;
   }
 }
@@ -744,7 +892,7 @@ TEST_F(OAHSetTest, Fill) {
   ss_->Fill(&s2);
   EXPECT_EQ(s2.UpperBoundSize(), ss_->UpperBoundSize());
   for (const auto& s : *ss_) {
-    EXPECT_TRUE(s2.Contains(s.Key()));
+    EXPECT_TRUE(s2.Contains(KeyOf(s)));
   }
 }
 
@@ -833,9 +981,9 @@ TEST_F(OAHSetTest, ReallocIfNeededVectorEntry) {
   // OAHPtr is a non-owning view; the test owns `slot` and frees it at the end.
   uint64_t slot = 0;
   OAHPtr<OAHEntry> e{slot};
-  e.Assign(OAHEntry::Create("first_entry_payload"));
-  (void)e.Insert(OAHEntry::Create("second_entry_payload"));
-  (void)e.Insert(OAHEntry::Create("third_entry_payload"));
+  e.Assign(CreateEntry("first_entry_payload"));
+  (void)e.Insert(CreateEntry("second_entry_payload"));
+  (void)e.Insert(CreateEntry("third_entry_payload"));
   ASSERT_TRUE(e.IsVector());
 
   // Snapshot inner-entry buffer pointers so we can assert each one moved.
@@ -864,7 +1012,7 @@ TEST_F(OAHSetTest, ReallocIfNeededVectorEntry) {
   for (uint32_t i = 0; i < vec.Size(); ++i) {
     OAHEntry cell(vec[i]);
     if (cell) {
-      seen.insert(std::string(cell.Key()));
+      seen.insert(std::string(KeyOf(cell)));
       new_inner_ptrs.push_back(cell.Raw());
     }
   }
@@ -961,7 +1109,7 @@ TEST_F(OAHSetTest, GetRandomMemberSingle) {
   EXPECT_TRUE(ss_->Add("only"sv));
   auto it = ss_->GetRandomMember();
   ASSERT_NE(it, ss_->end());
-  EXPECT_EQ(it->Key(), "only"sv);
+  EXPECT_EQ(KeyOf(*it), "only"sv);
 }
 
 TEST_F(OAHSetTest, GetRandomMemberSkipsExpired) {
@@ -974,7 +1122,7 @@ TEST_F(OAHSetTest, GetRandomMemberSkipsExpired) {
     auto it = ss_->GetRandomMember();
     if (it == ss_->end())
       continue;
-    EXPECT_EQ(it->Key(), "alive"sv);
+    EXPECT_EQ(KeyOf(*it), "alive"sv);
   }
 }
 
@@ -1059,7 +1207,7 @@ void BM_Clone(benchmark::State& state) {
   ss2.Reserve(ss1.UpperBoundSize());
   while (state.KeepRunning()) {
     for (auto src : ss1) {
-      ss2.Add(src.Key());
+      ss2.Add(KeyOf(src));
     }
     state.PauseTiming();
     ss2.Clear();
@@ -1266,7 +1414,7 @@ void BM_Scan(benchmark::State& state) {
     uint32_t cursor = 0;
     size_t seen = 0;
     do {
-      cursor = ss.Scan(cursor, [&](auto key) {
+      cursor = ss.Scan(cursor, [&](const auto& key) {
         // Reading the key size dereferences the key blob, simulating real usage where the
         // scanned key is actually consumed (a bare no-op callback would hide that memory cost).
         benchmark::DoNotOptimize(key.size());

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -282,6 +282,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
    * cursor = 0 - initiates a new scan.
    */
 
+  // The view is valid for the duration of the callback.
   using ItemCb = std::function<void(std::string_view)>;
 
   uint32_t Scan(uint32_t cursor, const ItemCb& cb) {
@@ -306,7 +307,8 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   bool Erase(std::string_view str) {
     if (entries_.empty())
       return false;
-    const uint64_t hash = Hash(str);
+    const ASCIIStr key(str);
+    const uint64_t hash = Hash(key.content());
     const uint32_t bid = BucketId(hash, capacity_log_);
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
     const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << oah::kExtHashShift);
@@ -316,7 +318,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     TaggedPtr* base = entries_.data();
     for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
       TaggedPtr* cell = &base[bid + std::countr_zero(cand_bits)];
-      if (Entry(*cell).Key() == str) {
+      if (Entry(*cell).KeyMatches(key.content(), key.len())) {
         matched = cell;
         break;
       }
@@ -324,7 +326,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     const uint32_t ext_bid = GetExtensionPoint(bid);
     bool in_vector = false;
     if (!matched && At(ext_bid).IsVector()) {
-      matched = ProbeExtensionVector(ext_bid, str, ext_hash);
+      matched = ProbeExtensionVector(ext_bid, key.content(), key.len(), ext_hash);
       in_vector = matched != nullptr;
     }
     if (!matched)
@@ -351,14 +353,18 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   iterator Find(std::string_view member) {
     if (entries_.empty())
       return end();
-    const uint64_t hash = Hash(member);
-    const uint32_t bid = BucketId(hash, capacity_log_);
-    return expiration_used_ ? FindInternal<true>(bid, member, hash)
-                            : FindInternal<false>(bid, member, hash);
+    const ASCIIStr key(member);
+    return Find(key.content(), key.len());
   }
 
   bool Contains(std::string_view member) {
     return Find(member) != end();
+  }
+
+  // Returns an allocation-free logical key: raw content is viewed in place and encoded content is
+  // decoded into bounded inline storage.
+  static oah::key::Decoded DecodeKey(Entry e) {
+    return oah::key::Decode(e.StoredKey());
   }
 
   // Iterator to a uniformly random non-empty entry, or end() if empty (SPOP/SRANDMEMBER).
@@ -696,7 +702,8 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
         if (e.Empty())
           continue;
       }
-      cb(e.Key());
+      const oah::key::Decoded key = DecodeKey(e);
+      cb(key.view());
       reported = true;
     }
 
@@ -717,7 +724,8 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
             if (el.Empty())
               continue;
           }
-          cb(el.Key());
+          const oah::key::Decoded key = DecodeKey(el);
+          cb(key.view());
           reported = true;
         }
       }
@@ -726,10 +734,10 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     return reported;
   }
 
-  // Searches the extension-point vector for `str`. Returns the matched slot, or nullptr if absent.
-  // Callers derive the vector position (Find) or the in-vector flag (Erase) from the result; it
-  // does not expire, so the returned entry may be live or already-expired.
-  TaggedPtr* ProbeExtensionVector(uint32_t ext_bid, std::string_view str, uint64_t ext_hash) {
+  // Searches the extension-point vector for the query key. Returns the matched slot, or nullptr.
+  // Does not expire, so the returned entry may be live or already-expired.
+  TaggedPtr* ProbeExtensionVector(uint32_t ext_bid, std::string_view content, uint32_t len,
+                                  uint64_t ext_hash) {
     auto vec = At(ext_bid).AsVector();
     TaggedPtr* raw_arr = vec.Raw();
     const size_t size = vec.Size();
@@ -744,26 +752,34 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
       while (cand_bits) {
         const uint32_t j = std::countr_zero(cand_bits);
         cand_bits &= cand_bits - 1;
-        if (Entry(raw_arr[base + j]).Key() == str)
+        if (Entry(raw_arr[base + j]).KeyMatches(content, len))
           return &raw_arr[base + j];
       }
     }
     return nullptr;
   }
 
-  // Probes for `str`; returns an iterator to the live entry or end(). Used by Find. Templated on
-  // Expire: when no TTLs exist a key match is provably live, so the empty re-check is dropped.
-  template <bool Expire> iterator FindInternal(uint32_t bid, std::string_view str, uint64_t hash) {
+  // Probes for an already-encoded query key (content bytes + logical length); assumes entries_ is
+  // non-empty. Overload so OAHMap's insert path doesn't re-encode.
+  iterator Find(std::string_view content, uint32_t len) {
+    const uint64_t hash = Hash(content);
+    const uint32_t bid = BucketId(hash, capacity_log_);
+    return expiration_used_ ? FindInternal<true>(bid, content, len, hash)
+                            : FindInternal<false>(bid, content, len, hash);
+  }
+
+  // Probes for the query key; returns an iterator to the live entry or end(). Templated on Expire:
+  // with no TTLs a key match is provably live, so the expiry re-check is compiled out.
+  template <bool Expire>
+  iterator FindInternal(uint32_t bid, std::string_view content, uint32_t len, uint64_t hash) {
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
     const LaneMasks masks = ProbeWindowShifted(&entries_[bid], ext_hash << oah::kExtHashShift);
 
-    // Find returns an iterator built straight from the match. With no TTLs a key match is always
-    // live, so ExpireIfNeeded and the resulting empty re-check are compiled out.
     TaggedPtr* base = entries_.data();
     for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
       const uint32_t bucket_id = bid + std::countr_zero(cand_bits);
       Entry e(base[bucket_id]);
-      if (e.Key() == str) {
+      if (e.KeyMatches(content, len)) {
         if constexpr (Expire) {
           ExpireIfNeeded(e);
           if (e.Empty())
@@ -774,7 +790,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     }
     const uint32_t ext_bid = GetExtensionPoint(bid);
     if (At(ext_bid).IsVector()) {
-      if (TaggedPtr* hit = ProbeExtensionVector(ext_bid, str, ext_hash)) {
+      if (TaggedPtr* hit = ProbeExtensionVector(ext_bid, content, len, ext_hash)) {
         if constexpr (Expire) {
           Entry e(*hit);
           ExpireIfNeeded(e);
@@ -799,7 +815,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
 
   // Recomputes the entry's hash, refreshes its stored ext-hash, and returns its new bucket.
   uint32_t RehashEntry(Entry entry) {
-    uint64_t hash = Hash(entry.Key());
+    uint64_t hash = Hash(entry.KeyContent());
     entry.SetExtHash(CalcExtHash(hash, capacity_log_));
     return BucketId(hash, capacity_log_);
   }

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -225,8 +225,9 @@ bool IterateSet(const PrimeValue& pv, const IterateFunc& func, bool allow_yield)
     VisitSet(pv.RObjPtr(), [&](auto* set) {
       for (auto it = set->begin(); it != set->end(); ++it) {
         YieldLongIteration(allow_yield);
-        std::string_view key = Key(it);
-        if (!func(ContainerEntry{key.data(), key.size()})) {
+        auto key = Key(it);
+        const std::string_view key_view = GetKeyView(key);
+        if (!func(ContainerEntry{key_view.data(), key_view.size()})) {
           success = false;
           break;
         }

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -225,6 +225,8 @@ bool IterateSet(const PrimeValue& pv, const IterateFunc& func, bool allow_yield)
     VisitSet(pv.RObjPtr(), [&](auto* set) {
       for (auto it = set->begin(); it != set->end(); ++it) {
         YieldLongIteration(allow_yield);
+        // `key` owns the decoded bytes for OAH-encoded members; the ContainerEntry only views them,
+        // so it is valid for the duration of the `func` call. `func` must copy to retain it.
         auto key = Key(it);
         const std::string_view key_view = GetKeyView(key);
         if (!func(ContainerEntry{key_view.data(), key_view.size()})) {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -457,7 +457,8 @@ error_code RdbSerializer::SaveSetObject(const PrimeValue& obj) {
       const bool has_expiry = set->ExpirationUsed();
       RETURN_ON_ERR(SaveLen(set->UpperBoundSize()));
       for (auto it = set->begin(); it != set->end();) {
-        RETURN_ON_ERR(SaveString(Key(it)));
+        auto key = Key(it);
+        RETURN_ON_ERR(SaveString(GetKeyView(key)));
         if (has_expiry) {
           int64_t expiry = it.HasExpiry() ? int64_t{it.ExpiryTime()} : -1;
           RETURN_ON_ERR(SaveLongLongAsString(expiry));

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -148,12 +148,8 @@ struct StringSetWrapper {
     };
     do {
       curs = VisitSet(obj_, [&](auto* s) {
-        return s->Scan(static_cast<uint32_t>(curs), [&](auto key) {
-          if constexpr (std::is_same_v<decltype(key), sds>)
-            record(string_view{key, sdslen(key)});
-          else
-            record(key);
-        });
+        return s->Scan(static_cast<uint32_t>(curs),
+                       [&](const auto& key) { record(GetKeyView(key)); });
       });
     } while (curs && maxiterations-- && res->size() < count &&
              (base::CycleClock::Now() - start_cycles) < timeout_cycles);
@@ -162,8 +158,10 @@ struct StringSetWrapper {
 
   template <typename Cb> void ForEach(Cb&& cb) const {
     VisitSet(obj_, [&](auto* s) {
-      for (auto it = s->begin(); it != s->end(); ++it)
-        cb(Key(it));
+      for (auto it = s->begin(); it != s->end(); ++it) {
+        auto key = Key(it);
+        cb(GetKeyView(key));
+      }
     });
   }
 
@@ -314,9 +312,11 @@ void RandMemberUnique(const StringSetWrapper& strset, size_t count, cmn::BackedA
       auto it = s->GetRandomMember();
       if (it == s->end())
         break;
-      auto [_, inserted] = picks.insert(string{Key(it)});
+      auto key = Key(it);
+      const string_view key_view = GetKeyView(key);
+      auto [_, inserted] = picks.insert(string{key_view});
       if (inserted)
-        dest->PushArg(Key(it));
+        dest->PushArg(key_view);
     }
   });
 }
@@ -327,7 +327,8 @@ void RandMemberRepeat(const StringSetWrapper& strset, size_t count, cmn::BackedA
       auto it = s->GetRandomMember();
       if (it == s->end())
         break;
-      dest->PushArg(Key(it));
+      auto key = Key(it);
+      dest->PushArg(GetKeyView(key));
     }
   });
 }


### PR DESCRIPTION
Summary: Adds an ASCII 7-bit packing layer for OAH (open-addressing hash) keys to reduce in-memory key footprint while keeping hashing/comparison on stored bytes and decoding only when returning logical keys.

Changes:

- Introduced ASCIIStr (7-bit pack/unpack + fused “try-pack”) in src/core/str_codec.h.
- Added oah::key header/codec in src/core/oah_base.h, reusing size header bit 7 as an “encoded” flag without affecting size decoding.
- Updated OAHEntry/OAHPair blobs to store a key header + packed/raw content; added StoredKey, KeyContent, and KeyMatches.
- Adjusted OAHTable to hash/compare on stored content, provide DecodeKey, and support both ephemeral Scan and retainable ScanDecoded.
- Modified OAHSet/OAHMap insertion/find/erase paths to encode query keys consistently via ASCIIStr.
- Updated set-related server code paths (iteration, SCAN, RDB save, randmember) to use Key() + GetKeyView().

Technical Notes: Encoded keys are limited to 8..128 bytes of pure 7-bit ASCII; the encoding flag is stored in the key header’s control byte (bit 7), and decoding happens only when producing logical key views.