### PR TITLE
refactor: drop runtime parser

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cmath>
 #include <concepts>
+#include <limits>
 #include <optional>
 #include <string_view>
 #include <tuple>
@@ -56,25 +57,50 @@ namespace facade {
 //                                       "DESC", Dir::DESC);     // nullopt (no error) on miss
 //
 // Compile-time grammar for CmdArgParser: a `static constexpr` grammar built from consteval
-// factories (Compile/Args/Options/OneOf/Flag/Exist/Field/Map/Choice/Action/If) bound to members of
-// a target struct T. Nothing is built per call; Apply keeps only a tiny stack state. The factories
-// live in `facade`; Exist/OneOf overload the runtime combinators.
+// factories (Compile/Args/Options/OneOf/Flags/Exist/Field/Map/Choice/TagValue/Action/If) bound to
+// members of a target struct T. Nothing is built per call; Apply keeps only a tiny stack state.
 //
 //   struct P { std::string_view key; uint16_t flags = 0; uint32_t mc = 0; int64_t ttl = 0; };
 //   enum : uint16_t { kNx = 1, kXx = 2 };
 //   static constexpr auto kGrammar = Compile(
 //       Args(&P::key),
 //       Options(OneOf("NX and XX are incompatible",
-//                     Flag("NX", &P::flags, kNx), Flag("XX", &P::flags, kXx)),
-//               Action("EX", +[](CmdArgParser* p, P* o) { o->ttl = p->Next<int64_t>(); }),
+//                     Flags(&P::flags, "NX", kNx, "XX", kXx)),
+//               Field<Positive<int64_t>>("EX", &P::ttl, "EX must be positive"),
 //               Field("MCFLAGS", &P::mc)));
-//   P o;
-//   kGrammar.Apply(&parser, &o);
+//   P o = kGrammar.Apply(&parser);
 //   if (!parser.Finalize()) ...
 //
+// Field reads the next argument as the member's exact type. Field<Parsed> reads it as Parsed and
+// then converts it into the member type. Use the explicit Parsed type when the result struct should
+// keep a plain storage type while parsing needs validation, a narrower range, or a custom error.
+//
+// Grammar factory reference:
+//   Compile(elements...)                  sequence elements into an Apply-able grammar
+//   Args(&T::a, &T::b, ...)               read positional arguments into members
+//   Options(rules...)                     repeatedly match rules until none accepts the next token
+//   Options(n, rules...)                  Options that leaves at least n trailing arguments
+//   OneOf(error, alternatives...)         allow one match; report error on a second match
+//
+// Tagged and token-mapping rules:
+//   Exist(tag, &T::flag)                  set a bool member when tag is present
+//   Field(tag, &T::a, ...)                read values after tag into the listed members
+//   Field<Parsed>(tag, &T::a, error)      parse as Parsed, then convert into the member type
+//   Action(tag, fn)                       call fn(CmdArgParser*, T*) after consuming tag
+//   TagValue(tag, &T::kind, k, &T::val)   set a discriminant and read the following value
+//   TagValue<Parsed>(...)                 TagValue with an explicit parsed value type
+//   Map(&T::value, tag, value, ...)       map any matching tag directly into a member
+//   Flags(&T::bits, tag, bit, ...)        OR the value for each matching tag into an integer
+//   Choice(tag, &T::value, key, value...) consume tag, then map the following token
+//
+// Composition and control rules:
+//   If(&T::condition, rule)               enable rule only when the bool member is true
+//   IfNot(&T::condition, rule)            enable rule only when the bool member is false
+//   Into(&T::nested, rule)                apply a rule to a nested member (engages an optional one)
+//   Skip(n)                               consume n positional args, or act as an option fallback
+//
 // Options stops at the first unmatched argument; pair the grammar with Finalize() to reject
-// leftovers. The legacy parser.Apply(Exist(...), Tag(...), Map(...), OneOf(...), If(...)) runtime
-// combinators remain until their callers migrate.
+// leftovers. For a handful of options, direct Check/TryMapNext calls in a loop may be simpler.
 //
 // Navigating manually:
 //   if (parser.HasNext()) { ... }                               // is there another arg?
@@ -110,11 +136,20 @@ struct CmdArgParser;
 // A parser callable for Next(fn), taking either fn(CmdArgParser*) (drives the parser, may consume
 // several args) or fn(std::string_view, RuleError&) (converts the next arg, sets err on failure).
 template <class F>
-concept ParserFn =
-    std::is_invocable_v<F, CmdArgParser*> || std::is_invocable_v<F, std::string_view, RuleError&>;
+concept ParserDriver = std::is_invocable_v<F, CmdArgParser*>;
+
+template <class F>
+concept TokenParser = std::is_invocable_v<F, std::string_view, RuleError&> &&
+    std::default_initializable<std::invoke_result_t<F, std::string_view, RuleError&>> &&
+    !std::is_reference_v<std::invoke_result_t<F, std::string_view, RuleError&>>;
+
+template <class F>
+concept ParserFn = ParserDriver<F> || TokenParser<F>;
 
 // Numeric conversion core shared by Num and Number; false if `arg` isn't a round-trippable T.
-template <class T> bool TryParseNum(std::string_view arg, T* out) {
+template <class T>
+requires std::integral<T> || std::same_as<T, float> || std::same_as<T, double>
+bool TryParseNum(std::string_view arg, T* out) {
   if constexpr (std::is_same_v<T, float>) {
     return absl::SimpleAtof(arg, out);
   } else if constexpr (std::is_same_v<T, double>) {
@@ -122,7 +157,6 @@ template <class T> bool TryParseNum(std::string_view arg, T* out) {
   } else if constexpr (std::is_integral_v<T> && sizeof(T) >= sizeof(int32_t)) {
     return absl::SimpleAtoi(arg, out);
   } else {
-    static_assert(std::is_integral_v<T> && sizeof(T) < sizeof(int32_t));
     int32_t tmp;
     if (!absl::SimpleAtoi(arg, &tmp))
       return false;
@@ -143,14 +177,14 @@ template <class T> struct VNum {
 // ones take the message as a reference-to-constexpr NTTP.
 
 // Out of [min, max] -> generic type error (FInt is the idiomatic spelling).
-template <auto min, auto max> RuleError InRange(decltype(min) v) {
-  static_assert(std::is_same_v<decltype(min), decltype(max)>, "inconsistent types");
+template <auto min, auto max>
+requires std::same_as<decltype(min), decltype(max)> RuleError InRange(decltype(min) v) {
   return {v < min || v > max, {}};
 }
 
 // Out of [min, max] -> custom Msg. Integer bounds only (float NTTPs need clang 18+).
-template <auto min, auto max, const auto& Msg> RuleError Bounded(decltype(min) v) {
-  static_assert(std::is_same_v<decltype(min), decltype(max)>, "inconsistent types");
+template <auto min, auto max, const auto& Msg>
+requires std::same_as<decltype(min), decltype(max)> RuleError Bounded(decltype(min) v) {
   return {!(v >= min && v <= max), Msg};
 }
 
@@ -183,9 +217,16 @@ template <class T, RuleError (*... Rules)(T)> struct Validated : VNum<T> {
 
 template <auto min, auto max> using FInt = Validated<decltype(min), InRange<min, max>>;
 
+template <std::integral T> using Positive = FInt<T{1}, std::numeric_limits<T>::max()>;
+template <std::integral T> using NonNegativeInt = FInt<T{0}, std::numeric_limits<T>::max()>;
+
 template <class T> constexpr bool is_optional = false;
 
 template <class U> constexpr bool is_optional<std::optional<U>> = true;
+
+template <class T>
+concept ParsedArg = std::is_arithmetic_v<T> || std::constructible_from<T, std::string_view> ||
+    as_vnum<T> || is_optional<T>;
 
 struct CmdArgParser {
   enum ErrorType {
@@ -309,7 +350,7 @@ struct CmdArgParser {
     return SVAt(cur_i_);
   }
 
-  template <class T = std::string_view, class... Ts> auto Next() {
+  template <ParsedArg T = std::string_view, ParsedArg... Ts> auto Next() {
     if (cur_i_ + sizeof...(Ts) >= size_) {
       ReportCode(OUT_OF_BOUNDS, cur_i_);
       return std::conditional_t<sizeof...(Ts) == 0, decltype(Convert<T>(0)),
@@ -338,8 +379,6 @@ struct CmdArgParser {
       return std::forward<F>(fn)(this);
     } else {
       using R = std::invoke_result_t<F, std::string_view, RuleError&>;
-      static_assert(std::is_default_constructible_v<R> && !std::is_reference_v<R>,
-                    "token parser must return a default-constructible value type");
       if (cur_i_ >= size_) {
         Report(OUT_OF_BOUNDS, cur_i_);
         return R{};
@@ -423,8 +462,7 @@ struct CmdArgParser {
   // Consumes the next arg as integer T, allowing an optional leading `prefix` (sets *prefixed when
   // present). Reports INVALID_INT if the remaining text isn't an integer. Use for offsets like
   // BITFIELD's "#index" form.
-  template <class T> T NextWithPrefix(std::string_view prefix, bool* prefixed) {
-    static_assert(std::is_integral_v<T>);
+  template <std::integral T> T NextWithPrefix(std::string_view prefix, bool* prefixed) {
     if (cur_i_ >= size_) {
       Report(OUT_OF_BOUNDS, cur_i_);
       return {};
@@ -484,21 +522,6 @@ struct CmdArgParser {
     ((*args = Next<Args>()), ...);
 
     return true;
-  }
-
-  // TODO: remove — superseded by the compile-time cap grammar (Compile/Options/...). Greedily
-  // matches remaining args against the options, stopping at the first unmatched arg.
-  template <class... Opts> void Apply(Opts... opts) {
-    while (HasNext() && (opts.TryApply(this) || ...)) {
-    }
-  }
-
-  // TODO: remove. Like Apply, but silently skips unmatched args one at a time instead of stopping.
-  template <class... Opts> void ApplyOrSkip(Opts... opts) {
-    while (HasNext()) {
-      if (!(opts.TryApply(this) || ...))
-        Skip(1);
-    }
   }
 
   CmdArgParser& Skip(size_t n) {
@@ -603,10 +626,7 @@ struct CmdArgParser {
       NextImpl<next>(t, base);
   }
 
-  template <class T> T Convert(size_t idx) {
-    static_assert(std::is_arithmetic_v<T> || std::is_constructible_v<T, std::string_view> ||
-                      as_vnum<T> || is_optional<T>,
-                  "incorrect type");
+  template <ParsedArg T> T Convert(size_t idx) {
     if constexpr (is_optional<T>) {
       return T{Convert<typename T::value_type>(idx)};
     } else if constexpr (std::is_arithmetic_v<T>) {
@@ -662,147 +682,85 @@ template <class T> T Number(CmdArgParser* parser) {
   return parser->Next<T>();
 }
 
-// TODO: remove — the runtime combinator family (the options below and their Exist/Tag/Map/If/OneOf
-// factories) is superseded by the compile-time cap grammar; kept until the last parser.Apply
-// callers migrate.
-namespace detail {
-
-// CRTP base for Apply() options: a fluent .Err(msg) surfaced by ReportErr() on failure, else the
-// generic INVALID_CASES error.
-template <class Derived> struct OptBase {
-  std::string err = {};
-
-  Derived&& Err(std::string msg) && {
-    err = std::move(msg);
-    return std::move(static_cast<Derived&>(*this));
-  }
-
- protected:
-  void ReportErr(CmdArgParser* parser) const {
-    if (err.empty())
-      parser->Report(CmdArgParser::INVALID_CASES);
-    else
-      parser->ReportCustom(err);
-  }
-};
-
-struct ExistOpt : OptBase<ExistOpt> {
-  std::string_view tag;
-  bool* field;
-
-  bool TryApply(CmdArgParser* parser) const {
-    if (parser->Check(tag)) {
-      *field = true;
-      return true;
-    }
-    return false;
-  }
-};
-
-template <class... Args> struct TagOpt : OptBase<TagOpt<Args...>> {
-  std::string_view tag;
-  std::tuple<Args*...> args;
-
-  bool TryApply(CmdArgParser* parser) const {
-    // Match the tag first, then read fields via Next<>() — so a missing value surfaces
-    // OUT_OF_BOUNDS instead of being swallowed by ApplyOrSkip as "no match".
-    if (!parser->Check(tag))
-      return false;
-    std::apply(
-        [&](auto*... ptrs) {
-          (((*ptrs) = parser->template Next<std::remove_pointer_t<decltype(ptrs)>>()), ...);
-        },
-        args);
-    return true;
-  }
-};
-
-template <class Func> struct LambdaOpt : OptBase<LambdaOpt<Func>> {
-  std::string_view tag;
-  Func func;
-
-  bool TryApply(CmdArgParser* parser) const {
-    if (parser->Check(tag)) {
-      func(parser);
-      return true;
-    }
-    return false;
-  }
-};
-
-template <class T, class... Cases> struct MapOpt : OptBase<MapOpt<T, Cases...>> {
-  static_assert(sizeof...(Cases) % 2 == 0, "Map expects alternating tag/value pairs");
-
-  T* field;
-  std::tuple<Cases...> cases;
-
-  bool TryApply(CmdArgParser* parser) const {
-    return TryMatch<0>(parser);
-  }
-
- private:
-  template <size_t I> bool TryMatch(CmdArgParser* parser) const {
-    if constexpr (I >= sizeof...(Cases)) {
-      return false;
-    } else if (parser->Check(std::get<I>(cases))) {
-      *field = std::get<I + 1>(cases);
-      return true;
-    } else {
-      return TryMatch<I + 2>(parser);
-    }
-  }
-};
-
-template <class Inner> struct IfOpt : OptBase<IfOpt<Inner>> {
-  bool cond;
-  Inner inner;
-
-  bool TryApply(CmdArgParser* parser) const {
-    return cond && inner.TryApply(parser);
-  }
-};
-
-template <class... Opts> struct OneOfOpt : OptBase<OneOfOpt<Opts...>> {
-  std::tuple<Opts...> opts;
-  mutable bool matched = false;
-
-  bool TryApply(CmdArgParser* parser) const {
-    bool any = std::apply([&](auto&... os) { return (os.TryApply(parser) || ...); }, opts);
-    if (!any)
-      return false;
-    if (matched)
-      this->ReportErr(parser);
-    matched = true;
-    return true;
-  }
-};
-
-// Outer tag consumes one arg, then the inner option must match the next; otherwise reports
-// .Err(msg) or INVALID_CASES.
-template <class Inner> struct TagNestedOpt : OptBase<TagNestedOpt<Inner>> {
-  std::string_view tag;
-  Inner inner;
-
-  bool TryApply(CmdArgParser* parser) const {
-    if (!parser->Check(tag))
-      return false;
-    if (!inner.TryApply(parser))
-      this->ReportErr(parser);
-    return true;
-  }
-};
-
-// Concept matching any of the Apply options (has a TryApply(CmdArgParser*) method).
-template <class T>
-concept ParseOption = requires(const T& t, CmdArgParser* p) {
-  { t.TryApply(p) } -> std::same_as<bool>;
-};
-
-}  // namespace detail
-
 namespace cap_detail {
 
 struct NoState {};
+
+template <class... Rules> struct FirstTarget;
+
+template <> struct FirstTarget<> { using type = void; };
+
+template <class Rule, class... Rules> struct FirstTarget<Rule, Rules...> {
+  using type = std::conditional_t<std::is_void_v<typename Rule::Target>,
+                                  typename FirstTarget<Rules...>::type, typename Rule::Target>;
+};
+
+template <class... Rules> using FirstTargetT = typename FirstTarget<Rules...>::type;
+
+template <class Rule>
+concept GrammarRule = requires {
+  typename Rule::Target;
+  typename Rule::State;
+};
+
+template <class Rule, class Target>
+concept RuleFor =
+    std::same_as<typename Rule::Target, void> || std::same_as<typename Rule::Target, Target>;
+
+template <class... Rules>
+concept CompatibleRules = sizeof...(Rules) > 0 && (GrammarRule<Rules> && ...) &&
+                          !std::same_as<FirstTargetT<Rules...>, void> &&
+                          (RuleFor<Rules, FirstTargetT<Rules...>> && ...);
+
+template <class M, class... Cases> consteval bool IsTagValuePack() {
+  if constexpr (sizeof...(Cases) == 0 || sizeof...(Cases) % 2 != 0) {
+    return false;
+  } else {
+    using Tuple = std::tuple<Cases...>;
+    return []<size_t... I>(std::index_sequence<I...>) {
+      return ((std::convertible_to<std::tuple_element_t<2 * I, Tuple>, std::string_view> &&
+               std::convertible_to<std::tuple_element_t<2 * I + 1, Tuple>, M>)&&...);
+    }
+    (std::make_index_sequence<sizeof...(Cases) / 2>{});
+  }
+}
+
+template <class M, class... Cases>
+concept TagValuePack = IsTagValuePack<M, Cases...>();
+
+// Splits alternating tag/value arguments (t0, v0, t1, v1, ...) into parallel arrays.
+template <class M, class... Cs> consteval auto SplitTagValues(Cs... cs) {
+  constexpr size_t N = sizeof...(Cs) / 2;
+  std::array<std::string_view, N> tags{};
+  std::array<M, N> values{};
+  auto cases = std::tuple{cs...};
+  [&]<size_t... I>(std::index_sequence<I...>) {
+    ((tags[I] = std::get<2 * I>(cases), values[I] = std::get<2 * I + 1>(cases)), ...);
+  }
+  (std::make_index_sequence<N>{});
+  return std::pair{tags, values};
+}
+
+struct Skip {
+  using Target = void;
+  using State = NoState;
+  consteval explicit Skip(size_t count) : count_(count) {
+    if (count == 0)
+      throw "Skip count must be positive";
+  }
+
+  template <class T> void Consume(CmdArgParser* p, T*, State&) const {
+    p->Skip(count_);
+  }
+
+  template <class T> bool Consume(CmdArgParser* p, std::string_view, T*, State&) const {
+    p->Skip(count_);
+    return true;
+  }
+
+ private:
+  size_t count_;
+};
 
 template <class T, class... M>
 void ReadMembers(CmdArgParser* p, T* o, const std::tuple<M T::*...>& fields) {
@@ -842,20 +800,6 @@ template <class Derived, class T> struct TaggedRule {
   std::string_view tag_;
 };
 
-template <class T, class M> struct Flag : TaggedRule<Flag<T, M>, T> {
-  consteval Flag(const char* tag, M T::*field, M value)
-      : TaggedRule<Flag<T, M>, T>(tag), field_(field), value_(value) {
-  }
-
-  void OnMatch(CmdArgParser*, T* o) const {
-    o->*field_ |= value_;
-  }
-
- private:
-  M T::*field_;
-  M value_;
-};
-
 template <class T> struct Exist : TaggedRule<Exist<T>, T> {
   consteval Exist(const char* tag, bool T::*field) : TaggedRule<Exist<T>, T>(tag), field_(field) {
   }
@@ -881,6 +825,20 @@ template <class T, class... M> struct Field : TaggedRule<Field<T, M...>, T> {
   std::tuple<M T::*...> fields_;
 };
 
+template <class P, class T, class M> struct ParsedField : TaggedRule<ParsedField<P, T, M>, T> {
+  consteval ParsedField(const char* tag, std::string_view err, M T::*field)
+      : TaggedRule<ParsedField<P, T, M>, T>(tag), err_(err), field_(field) {
+  }
+
+  void OnMatch(CmdArgParser* p, T* o) const {
+    o->*field_ = err_.empty() ? p->Next<P>() : p->Next<P>(err_);
+  }
+
+ private:
+  std::string_view err_;
+  M T::*field_;
+};
+
 template <class T> struct Action : TaggedRule<Action<T>, T> {
   consteval Action(const char* tag, void (*fn)(CmdArgParser*, T*))
       : TaggedRule<Action<T>, T>(tag), fn_(fn) {
@@ -894,17 +852,41 @@ template <class T> struct Action : TaggedRule<Action<T>, T> {
   void (*fn_)(CmdArgParser*, T*);
 };
 
-template <class T, class M, size_t N> struct Map {
+// tag -> set a discriminant member to a compile-time value, then read the following arg into
+// another member (e.g. the EX/PX/EXAT/PXAT expiry keywords: pick a unit enum + read the amount).
+template <class P, class T, class D, class M>
+struct TagValue : TaggedRule<TagValue<P, T, D, M>, T> {
+  consteval TagValue(const char* tag, D T::*disc, D disc_val, M T::*value)
+      : TaggedRule<TagValue<P, T, D, M>, T>(tag), disc_(disc), disc_val_(disc_val), value_(value) {
+  }
+
+  void OnMatch(CmdArgParser* p, T* o) const {
+    o->*disc_ = disc_val_;
+    o->*value_ = p->Next<P>();
+  }
+
+ private:
+  D T::*disc_;
+  D disc_val_;
+  M T::*value_;
+};
+
+// Matches any of its tags and writes the paired value into a member. Map assigns the value; Flags
+// OR-accumulates it (kAccumulate, integral members only).
+template <class T, class M, size_t N, bool kAccumulate> struct TagMap {
   using Target = T;
   using State = NoState;
-  consteval Map(M T::*field, std::array<std::string_view, N> tags, std::array<M, N> values)
+  consteval TagMap(M T::*field, std::array<std::string_view, N> tags, std::array<M, N> values)
       : field_(field), tags_(tags), values_(values) {
   }
   bool Consume(CmdArgParser* p, std::string_view cur, T* o, State&) const {
     for (size_t i = 0; i < N; ++i) {
       if (TagMatch(cur, tags_[i])) {
         p->AdvanceUnchecked();
-        o->*field_ = values_[i];
+        if constexpr (kAccumulate)
+          o->*field_ |= values_[i];
+        else
+          o->*field_ = values_[i];
         return true;
       }
     }
@@ -924,7 +906,7 @@ template <class T, class M, size_t N> struct Choice : TaggedRule<Choice<T, M, N>
   }
 
   void OnMatch(CmdArgParser* p, T* o) const {
-    std::string_view val = p->template Next<std::string_view>();
+    std::string_view val = p->Next<std::string_view>();
     for (size_t i = 0; i < N; ++i) {
       if (TagMatch(val, keys_[i])) {
         o->*field_ = values_[i];
@@ -955,6 +937,33 @@ template <class T, class Inner> struct If {
   Inner inner_;
 };
 
+// Applies the inner rule to a nested member. A plain member is targeted directly; an optional
+// member has the rule target its contained value, and the optional is engaged only when the rule
+// matches (an existing value is preserved), so its engaged state signals that the keyword was seen.
+template <class T, class Member, class Inner> struct Into {
+  using Target = T;
+  using State = typename Inner::State;
+  consteval Into(Member T::*field, Inner inner) : field_(field), inner_(inner) {
+  }
+  bool Consume(CmdArgParser* p, std::string_view cur, T* o, State& st) const {
+    if constexpr (is_optional<Member>) {
+      using Value = typename Member::value_type;
+      Member& opt = o->*field_;
+      Value scratch = opt.value_or(Value{});
+      if (!inner_.Consume(p, cur, &scratch, st))
+        return false;
+      opt = std::move(scratch);
+      return true;
+    } else {
+      return inner_.Consume(p, cur, &(o->*field_), st);
+    }
+  }
+
+ private:
+  Member T::*field_;
+  Inner inner_;
+};
+
 template <class T, class... M> struct Args {
   using Target = T;
   using State = NoState;
@@ -971,7 +980,7 @@ template <class T, class... M> struct Args {
 template <class T, class... Alts> struct OneOf {
   using Target = T;
   struct State {
-    signed char matched = -1;
+    bool matched = false;
   };
   consteval OneOf(std::string_view err, Alts... alts) : err_(err), alts_(alts...) {
   }
@@ -986,9 +995,9 @@ template <class T, class... Alts> struct OneOf {
     } else {
       typename std::tuple_element_t<I, std::tuple<Alts...>>::State alt_st{};
       if (std::get<I>(alts_).Consume(p, cur, o, alt_st)) {
-        if (st.matched >= 0 && st.matched != static_cast<signed char>(I))
+        if (st.matched)  // a second match (same or different alt) is a conflict, like Redis
           ReportConflict(p);
-        st.matched = static_cast<signed char>(I);
+        st.matched = true;
         return true;
       }
       return TryAt<I + 1>(p, cur, o, st);
@@ -1007,10 +1016,12 @@ template <class T, class... Alts> struct OneOf {
 template <class T, class... Rules> struct Options {
   using Target = T;
   using State = std::tuple<typename Rules::State...>;
-  consteval explicit Options(Rules... rules) : rules_(rules...) {
+  consteval explicit Options(Rules... rules) : Options(0, rules...) {
+  }
+  consteval Options(size_t tail, Rules... rules) : tail_(tail), rules_(rules...) {
   }
   void Consume(CmdArgParser* p, T* o, State& st) const {
-    while (p->InBounds()) {
+    while (p->HasAtLeast(tail_ + 1)) {
       std::string_view cur = p->CurrentUnchecked();
       if (!Match(p, cur, o, st, std::index_sequence_for<Rules...>{}))
         break;
@@ -1023,6 +1034,7 @@ template <class T, class... Rules> struct Options {
              std::index_sequence<I...>) const {
     return (std::get<I>(rules_).Consume(p, cur, o, std::get<I>(st)) || ...);
   }
+  size_t tail_;
   std::tuple<Rules...> rules_;
 };
 
@@ -1033,6 +1045,11 @@ template <class T, class... Elems> struct Grammar {
   void Apply(CmdArgParser* p, T* o) const {
     std::tuple<typename Elems::State...> st{};
     Run(p, o, st, std::index_sequence_for<Elems...>{});
+  }
+  T Apply(CmdArgParser* p) const {
+    T out{};
+    Apply(p, &out);
+    return out;
   }
 
  private:
@@ -1046,44 +1063,50 @@ template <class T, class... Elems> struct Grammar {
 
 }  // namespace cap_detail
 
-template <class T, class M>
-consteval auto Flag(const char* tag, M T::*field, std::type_identity_t<M> value) {
-  return cap_detail::Flag<T, M>{tag, field, value};
-}
 template <class T> consteval auto Exist(const char* tag, bool T::*field) {
   return cap_detail::Exist<T>{tag, field};
 }
-template <class T, class... M> consteval auto Field(const char* tag, M T::*... fields) {
-  static_assert(sizeof...(M) > 0, "Field expects at least one member");
+template <class T, class... M>
+requires(sizeof...(M) > 0 && (ParsedArg<M> && ...)) consteval auto Field(const char* tag,
+                                                                         M T::*... fields) {
   return cap_detail::Field<T, M...>{tag, fields...};
+}
+template <class P, class T, class M>
+requires std::convertible_to<P, M>
+consteval auto Field(const char* tag, M T::*field, std::string_view err = {}) {
+  return cap_detail::ParsedField<P, T, M>{tag, err, field};
 }
 template <class T> consteval auto Action(const char* tag, void (*fn)(CmdArgParser*, T*)) {
   return cap_detail::Action<T>{tag, fn};
 }
-template <class T, class M, class... Cs> consteval auto Map(M T::*field, Cs... cs) {
-  static_assert(sizeof...(Cs) % 2 == 0, "Map expects alternating tag/value pairs");
-  constexpr size_t N = sizeof...(Cs) / 2;
-  std::array<std::string_view, N> tags{};
-  std::array<M, N> values{};
-  auto cases = std::tuple{cs...};
-  [&]<size_t... I>(std::index_sequence<I...>) {
-    ((tags[I] = std::get<2 * I>(cases), values[I] = std::get<2 * I + 1>(cases)), ...);
-  }
-  (std::make_index_sequence<N>{});
-  return cap_detail::Map<T, M, N>{field, tags, values};
+template <class P, class T, class D, class M>
+requires std::convertible_to<P, M>
+consteval auto TagValue(const char* tag, D T::*disc, std::type_identity_t<D> disc_val,
+                        M T::*value) {
+  return cap_detail::TagValue<P, T, D, M>{tag, disc, disc_val, value};
+}
+template <class T, class D, class M>
+consteval auto TagValue(const char* tag, D T::*disc, std::type_identity_t<D> disc_val,
+                        M T::*value) {
+  return TagValue<M>(tag, disc, disc_val, value);
 }
 template <class T, class M, class... Cs>
+requires cap_detail::TagValuePack<M, Cs...>
+consteval auto Map(M T::*field, Cs... cs) {
+  auto [tags, values] = cap_detail::SplitTagValues<M>(cs...);
+  return cap_detail::TagMap<T, M, sizeof...(Cs) / 2, false>{field, tags, values};
+}
+template <class T, std::integral M, class... Cs>
+requires cap_detail::TagValuePack<M, Cs...>
+consteval auto Flags(M T::*field, Cs... cs) {
+  auto [tags, values] = cap_detail::SplitTagValues<M>(cs...);
+  return cap_detail::TagMap<T, M, sizeof...(Cs) / 2, true>{field, tags, values};
+}
+template <class T, class M, class... Cs>
+requires cap_detail::TagValuePack<M, Cs...>
 consteval auto Choice(const char* tag, M T::*field, Cs... cs) {
-  static_assert(sizeof...(Cs) % 2 == 0, "Choice expects alternating key/value pairs");
-  constexpr size_t N = sizeof...(Cs) / 2;
-  std::array<std::string_view, N> keys{};
-  std::array<M, N> values{};
-  auto cases = std::tuple{cs...};
-  [&]<size_t... I>(std::index_sequence<I...>) {
-    ((keys[I] = std::get<2 * I>(cases), values[I] = std::get<2 * I + 1>(cases)), ...);
-  }
-  (std::make_index_sequence<N>{});
-  return cap_detail::Choice<T, M, N>{tag, field, keys, values};
+  auto [keys, values] = cap_detail::SplitTagValues<M>(cs...);
+  return cap_detail::Choice<T, M, sizeof...(Cs) / 2>{tag, field, keys, values};
 }
 template <class T, class Inner> consteval auto If(bool T::*cond, Inner inner) {
   return cap_detail::If<T, Inner>{cond, true, inner};
@@ -1091,53 +1114,41 @@ template <class T, class Inner> consteval auto If(bool T::*cond, Inner inner) {
 template <class T, class Inner> consteval auto IfNot(bool T::*cond, Inner inner) {
   return cap_detail::If<T, Inner>{cond, false, inner};
 }
-template <class T, class... M> consteval auto Args(M T::*... fields) {
-  static_assert(sizeof...(M) > 0, "Args expects at least one member");
+template <class T, class Member, class Inner>
+requires std::same_as<Member, typename Inner::Target> ||
+    std::same_as<Member, std::optional<typename Inner::Target>>
+consteval auto Into(Member T::*field, Inner inner) {
+  return cap_detail::Into<T, Member, Inner>{field, inner};
+}
+template <class T, class... M>
+requires(sizeof...(M) > 0) consteval auto Args(M T::*... fields) {
   return cap_detail::Args<T, M...>{fields...};
 }
-template <class... Alts> consteval auto OneOf(std::string_view err, Alts... alts) {
-  using T = typename std::tuple_element_t<0, std::tuple<Alts...>>::Target;
+template <class... Alts>
+requires cap_detail::CompatibleRules<Alts...>
+consteval auto OneOf(std::string_view err, Alts... alts) {
+  using T = cap_detail::FirstTargetT<Alts...>;
   return cap_detail::OneOf<T, Alts...>{err, alts...};
 }
-template <class... Rules> consteval auto Options(Rules... rules) {
-  using T = typename std::tuple_element_t<0, std::tuple<Rules...>>::Target;
-  return cap_detail::Options<T, Rules...>{rules...};
+template <class... Rules>
+requires cap_detail::CompatibleRules<Rules...>
+consteval auto Options(size_t tail, Rules... rules) {
+  using T = cap_detail::FirstTargetT<Rules...>;
+  return cap_detail::Options<T, Rules...>{tail, rules...};
 }
-template <class... Elems> consteval auto Compile(Elems... elems) {
-  using T = typename std::tuple_element_t<0, std::tuple<Elems...>>::Target;
+template <class... Rules>
+requires cap_detail::CompatibleRules<Rules...>
+consteval auto Options(Rules... rules) {
+  return Options(0, rules...);
+}
+template <class... Elems>
+requires cap_detail::CompatibleRules<Elems...>
+consteval auto Compile(Elems... elems) {
+  using T = cap_detail::FirstTargetT<Elems...>;
   return cap_detail::Grammar<T, Elems...>{elems...};
 }
-
-// TODO: remove — runtime combinator factories, superseded by the consteval cap factories above.
-inline detail::ExistOpt Exist(std::string_view tag, bool* field) {
-  return {{}, tag, field};
-}
-
-template <class... Args> detail::TagOpt<Args...> Tag(std::string_view tag, Args*... args) {
-  return {{}, tag, std::make_tuple(args...)};
-}
-
-template <class Func>
-requires std::is_invocable_v<Func, CmdArgParser*> detail::LambdaOpt<Func> Tag(std::string_view tag,
-                                                                              Func func) {
-  return {{}, tag, std::move(func)};
-}
-
-template <detail::ParseOption Inner>
-detail::TagNestedOpt<Inner> Tag(std::string_view tag, Inner inner) {
-  return {{}, tag, std::move(inner)};
-}
-
-template <class T, class... Cases> detail::MapOpt<T, Cases...> Map(T* field, Cases... cases) {
-  return {{}, field, std::make_tuple(std::move(cases)...)};
-}
-
-template <class Inner> detail::IfOpt<Inner> If(bool cond, Inner inner) {
-  return {{}, cond, std::move(inner)};
-}
-
-template <detail::ParseOption... Opts> detail::OneOfOpt<Opts...> OneOf(Opts... opts) {
-  return {{}, {std::move(opts)...}};
+consteval auto Skip(size_t count = 1) {
+  return cap_detail::Skip{count};
 }
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -79,7 +79,6 @@ namespace facade {
 //   Compile(elements...)                  sequence elements into an Apply-able grammar
 //   Args(&T::a, &T::b, ...)               read positional arguments into members
 //   Options(rules...)                     repeatedly match rules until none accepts the next token
-//   Options(n, rules...)                  Options that leaves at least n trailing arguments
 //   OneOf(error, alternatives...)         allow one match; report error on a second match
 //
 // Tagged and token-mapping rules:
@@ -1016,12 +1015,10 @@ template <class T, class... Alts> struct OneOf {
 template <class T, class... Rules> struct Options {
   using Target = T;
   using State = std::tuple<typename Rules::State...>;
-  consteval explicit Options(Rules... rules) : Options(0, rules...) {
-  }
-  consteval Options(size_t tail, Rules... rules) : tail_(tail), rules_(rules...) {
+  consteval explicit Options(Rules... rules) : rules_(rules...) {
   }
   void Consume(CmdArgParser* p, T* o, State& st) const {
-    while (p->HasAtLeast(tail_ + 1)) {
+    while (p->HasAtLeast(1)) {
       std::string_view cur = p->CurrentUnchecked();
       if (!Match(p, cur, o, st, std::index_sequence_for<Rules...>{}))
         break;
@@ -1034,7 +1031,6 @@ template <class T, class... Rules> struct Options {
              std::index_sequence<I...>) const {
     return (std::get<I>(rules_).Consume(p, cur, o, std::get<I>(st)) || ...);
   }
-  size_t tail_;
   std::tuple<Rules...> rules_;
 };
 
@@ -1132,14 +1128,9 @@ consteval auto OneOf(std::string_view err, Alts... alts) {
 }
 template <class... Rules>
 requires cap_detail::CompatibleRules<Rules...>
-consteval auto Options(size_t tail, Rules... rules) {
-  using T = cap_detail::FirstTargetT<Rules...>;
-  return cap_detail::Options<T, Rules...>{tail, rules...};
-}
-template <class... Rules>
-requires cap_detail::CompatibleRules<Rules...>
 consteval auto Options(Rules... rules) {
-  return Options(0, rules...);
+  using T = cap_detail::FirstTargetT<Rules...>;
+  return cap_detail::Options<T, Rules...>{rules...};
 }
 template <class... Elems>
 requires cap_detail::CompatibleRules<Elems...>

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -206,125 +206,6 @@ TEST_F(CmdArgParserTest, IgnoreCase) {
   EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "world"sv);
 }
 
-TEST_F(CmdArgParserTest, Apply) {
-  // All option shapes: Exist sets a bool, Tag-with-one-field, Tag-with-two-fields.
-  {
-    auto parser = Make({"FLAG", "COUNT", "5", "LIMIT", "10", "20"});
-
-    bool flag = false;
-    uint32_t count = 0;
-    uint32_t offset = 0;
-    uint32_t limit = 0;
-
-    parser.Apply(Exist("FLAG", &flag), Tag("COUNT", &count), Tag("LIMIT", &offset, &limit));
-
-    EXPECT_TRUE(flag);
-    EXPECT_EQ(count, 5u);
-    EXPECT_EQ(offset, 10u);
-    EXPECT_EQ(limit, 20u);
-    EXPECT_FALSE(parser.HasError());
-  }
-
-  // Unknown option is left unconsumed (no error). The caller decides what to do next.
-  {
-    auto parser = Make({"COUNT", "5", "BOGUS"});
-
-    uint32_t count = 0;
-    parser.Apply(Tag("COUNT", &count));
-
-    EXPECT_EQ(count, 5u);
-    EXPECT_FALSE(parser.HasError());
-    EXPECT_TRUE(parser.HasNext());
-    EXPECT_EQ(parser.Peek(), "BOGUS");
-  }
-
-  // Case-insensitive matching (consistent with Check).
-  {
-    auto parser = Make({"count", "7"});
-
-    uint32_t count = 0;
-    parser.Apply(Tag("COUNT", &count));
-
-    EXPECT_EQ(count, 7u);
-    EXPECT_FALSE(parser.HasError());
-  }
-
-  // Invalid integer in a Tag arg propagates the error.
-  {
-    auto parser = Make({"COUNT", "NAN"});
-
-    uint32_t count = 0;
-    parser.Apply(Tag("COUNT", &count));
-
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
-  }
-}
-
-TEST_F(CmdArgParserTest, ApplyOrSkip) {
-  // ApplyOrSkip silently skips any unknown arg (1 at a time) and keeps going.
-  {
-    auto parser = Make({"BOGUS", "COUNT", "5", "MORE_BOGUS", "STUFF"});
-
-    uint32_t count = 0;
-    parser.ApplyOrSkip(Tag("COUNT", &count));
-
-    EXPECT_EQ(count, 5u);
-    EXPECT_FALSE(parser.HasError());
-    EXPECT_FALSE(parser.HasNext());  // everything consumed
-  }
-  // Empty input — no error, no work.
-  {
-    auto parser = Make({});
-    uint32_t count = 0;
-    parser.ApplyOrSkip(Tag("COUNT", &count));
-    EXPECT_FALSE(parser.HasError());
-    EXPECT_FALSE(parser.HasNext());
-  }
-  // Trailing unknown at end-of-args: the skip must not trip OUT_OF_BOUNDS.
-  {
-    auto parser = Make({"BOGUS"});
-    uint32_t count = 0;
-    parser.ApplyOrSkip(Tag("COUNT", &count));
-    EXPECT_FALSE(parser.HasError());
-    EXPECT_FALSE(parser.HasNext());
-  }
-}
-
-TEST_F(CmdArgParserTest, ApplyTagMissingValue) {
-  // A matched tag with missing trailing value(s) must surface an error, not be silently skipped.
-  // This guards against a subtle interaction with ApplyOrSkip: if TagOpt treated "tag matches,
-  // values missing" as "no match", the skip path would swallow the malformed option.
-  {
-    auto parser = Make({"COUNT"});  // tag matches, value missing
-    uint32_t count = 0;
-    parser.Apply(Tag("COUNT", &count));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
-  }
-  {
-    auto parser = Make({"COUNT"});
-    uint32_t count = 0;
-    parser.ApplyOrSkip(Tag("COUNT", &count));
-    // Tag must have been consumed (not left for Skip to swallow silently).
-    EXPECT_FALSE(parser.HasNext());
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
-  }
-  // Also guard the two-field case: LIMIT with only one trailing value.
-  {
-    auto parser = Make({"LIMIT", "10"});  // needs offset + limit
-    uint32_t offset = 0, limit = 0;
-    parser.Apply(Tag("LIMIT", &offset, &limit));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
-  }
-}
-
 TEST_F(CmdArgParserTest, ReportBeforeAnyNext) {
   // Report(code) at cur_i_ == 0 must clamp the error index to 0 rather than underflow to SIZE_MAX.
   auto parser = Make({"x"});
@@ -332,253 +213,6 @@ TEST_F(CmdArgParserTest, ReportBeforeAnyNext) {
   auto err = parser.TakeError();
   EXPECT_TRUE(err);
   EXPECT_EQ(err.index, 0u);
-}
-
-TEST_F(CmdArgParserTest, ApplyLambda) {
-  // Tag() with a lambda lets callers run custom parsing on match. Useful for side-effectful cases
-  // like push_back or toggling a bool to false.
-  auto parser = Make({"GET", "p1", "ASC", "GET", "p2"});
-
-  std::vector<std::string_view> patterns;
-  bool reversed = true;
-
-  parser.Apply(
-      Tag("ASC", [&](CmdArgParser*) { reversed = false; }),
-      Tag("GET", [&](CmdArgParser* p) { patterns.push_back(p->Next<std::string_view>()); }));
-
-  EXPECT_FALSE(reversed);
-  ASSERT_EQ(patterns.size(), 2u);
-  EXPECT_EQ(patterns[0], "p1");
-  EXPECT_EQ(patterns[1], "p2");
-  EXPECT_FALSE(parser.HasError());
-}
-
-TEST_F(CmdArgParserTest, ApplyMap) {
-  // Map(&field, tag, value, ...) — matches any tag and writes the corresponding value.
-  // Standalone Map allows repeated matches (last wins); wrap in OneOf to require at most one.
-  {
-    auto parser = Make({"DESC"});
-    bool reversed = false;
-    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
-    EXPECT_TRUE(reversed);
-    EXPECT_FALSE(parser.HasError());
-  }
-  {
-    auto parser = Make({"ASC"});
-    bool reversed = true;
-    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
-    EXPECT_FALSE(reversed);
-    EXPECT_FALSE(parser.HasError());
-  }
-  // Unrelated tag leaves field untouched and stops Apply.
-  {
-    auto parser = Make({"OTHER"});
-    bool reversed = false;
-    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
-    EXPECT_FALSE(reversed);
-    EXPECT_TRUE(parser.HasNext());
-  }
-  // Standalone Map allows repeated matches — last wins, no error. This matches Redis SORT
-  // semantics where "ASC DESC" is equivalent to "DESC".
-  {
-    auto parser = Make({"DESC", "ASC"});
-    bool reversed = true;
-    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
-    EXPECT_FALSE(reversed);  // ASC came last
-    EXPECT_FALSE(parser.HasError());
-  }
-  {
-    auto parser = Make({"ASC", "DESC"});
-    bool reversed = false;
-    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
-    EXPECT_TRUE(reversed);  // DESC came last
-    EXPECT_FALSE(parser.HasError());
-  }
-  // OneOf + Map — DESC followed by ASC is a mutex violation.
-  {
-    auto parser = Make({"DESC", "ASC"});
-    bool reversed = false;
-    parser.Apply(OneOf(Map(&reversed, "DESC", true, "ASC", false)));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
-  }
-}
-
-TEST_F(CmdArgParserTest, ApplyTagNested) {
-  // Tag(tag, inner_opt) — outer tag matches, then inner option runs against the next arg.
-  // If the inner doesn't match, INVALID_CASES is reported (the inner keyword is required).
-  enum class Mode { A, B, C };
-  {
-    auto parser = Make({"MODE", "B"});
-    Mode mode = Mode::A;
-    parser.Apply(Tag("MODE", Map(&mode, "A", Mode::A, "B", Mode::B, "C", Mode::C)));
-    EXPECT_EQ(mode, Mode::B);
-    EXPECT_FALSE(parser.HasError());
-  }
-  // Unknown inner tag -> INVALID_CASES.
-  {
-    auto parser = Make({"MODE", "BOGUS"});
-    Mode mode = Mode::A;
-    parser.Apply(Tag("MODE", Map(&mode, "A", Mode::A, "B", Mode::B)));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
-  }
-  // Outer tag absent -> no effect, no error.
-  {
-    auto parser = Make({});
-    Mode mode = Mode::A;
-    parser.Apply(Tag("MODE", Map(&mode, "A", Mode::A, "B", Mode::B)));
-    EXPECT_EQ(mode, Mode::A);
-    EXPECT_FALSE(parser.HasError());
-  }
-}
-
-TEST_F(CmdArgParserTest, ApplyTagIf) {
-  // If(cond, opt) behaves like `opt` when cond is true, and never matches when false.
-  // Use to gate an option on a runtime flag (e.g. is_read_only).
-
-  // cond=true -> delegate to inner (matches and sets field).
-  {
-    auto parser = Make({"STORE", "dest"});
-    std::string_view store;
-    parser.Apply(If(true, Tag("STORE", &store)));
-    EXPECT_EQ(store, "dest");
-    EXPECT_FALSE(parser.HasError());
-  }
-
-  // cond=false -> inner is skipped. Apply stops at the (now unmatched) arg; Finalize reports
-  // UNPROCESSED so the caller can surface a syntax error.
-  {
-    auto parser = Make({"STORE", "dest"});
-    std::string_view store;
-    parser.Apply(If(false, Tag("STORE", &store)));
-    EXPECT_EQ(store, "");
-    EXPECT_FALSE(parser.HasError());
-    EXPECT_TRUE(parser.HasNext());
-    EXPECT_FALSE(parser.Finalize());
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::UNPROCESSED);
-  }
-
-  // Composes: cond=false + Exist - does not toggle the bool even when the tag is present.
-  {
-    auto parser = Make({"FLAG"});
-    bool flag = false;
-    parser.Apply(If(false, Exist("FLAG", &flag)));
-    EXPECT_FALSE(flag);
-  }
-}
-
-TEST_F(CmdArgParserTest, ApplyOneOf) {
-  // OneOf groups mutually-exclusive options. Zero or one may match across the Apply loop.
-  // A second match reports an error instead of being quietly accepted.
-
-  // Zero matches — fine.
-  {
-    auto parser = Make({});
-    bool nx = false, xx = false;
-    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
-    EXPECT_FALSE(nx);
-    EXPECT_FALSE(xx);
-    EXPECT_FALSE(parser.HasError());
-  }
-
-  // Single match — fine.
-  {
-    auto parser = Make({"NX"});
-    bool nx = false, xx = false;
-    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
-    EXPECT_TRUE(nx);
-    EXPECT_FALSE(xx);
-    EXPECT_FALSE(parser.HasError());
-  }
-
-  // Two different members of the group match -> error.
-  {
-    auto parser = Make({"NX", "XX"});
-    bool nx = false, xx = false;
-    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
-  }
-
-  // Same member twice also counts as a second match -> error.
-  {
-    auto parser = Make({"NX", "NX"});
-    bool nx = false, xx = false;
-    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
-  }
-
-  // OneOf composes with other Apply options. Unrelated tags are not affected.
-  {
-    auto parser = Make({"NX", "COUNT", "5"});
-    bool nx = false, xx = false;
-    uint32_t count = 0;
-    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)), Tag("COUNT", &count));
-    EXPECT_TRUE(nx);
-    EXPECT_EQ(count, 5u);
-    EXPECT_FALSE(parser.HasError());
-  }
-
-  // .Err(msg) reports a custom conflict message instead of the generic syntax error.
-  {
-    auto parser = Make({"NX", "XX"});
-    bool nx = false, xx = false;
-    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)).Err("NX and XX are incompatible"));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::CUSTOM_ERROR);
-    EXPECT_EQ(err.MakeReply().ToSv(), "NX and XX are incompatible");
-  }
-
-  // .Err() owns the message: a temporary/short-lived source may be destroyed before Apply runs.
-  {
-    bool nx = false, xx = false;
-    auto opt = [&] {
-      std::string tmp = "dynamic conflict";  // destroyed when this lambda returns
-      return OneOf(Exist("NX", &nx), Exist("XX", &xx)).Err(tmp);
-    }();
-    auto parser = Make({"NX", "XX"});
-    parser.Apply(opt);
-    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "dynamic conflict");
-  }
-}
-
-TEST_F(CmdArgParserTest, ApplyOptional) {
-  // Tag present -> optional engaged.
-  {
-    auto parser = Make({"COUNT", "5"});
-    std::optional<uint32_t> count;
-    parser.Apply(Tag("COUNT", &count));
-    ASSERT_TRUE(count.has_value());
-    EXPECT_EQ(*count, 5u);
-    EXPECT_FALSE(parser.HasError());
-  }
-  // Tag absent -> optional stays empty.
-  {
-    auto parser = Make({});
-    std::optional<uint32_t> count;
-    parser.Apply(Tag("COUNT", &count));
-    EXPECT_FALSE(count.has_value());
-    EXPECT_FALSE(parser.HasError());
-  }
-  // Invalid value -> INVALID_INT reported. The optional's state on error is undefined; callers
-  // must check for the parse error first.
-  {
-    auto parser = Make({"COUNT", "NAN"});
-    std::optional<uint32_t> count;
-    parser.Apply(Tag("COUNT", &count));
-    auto err = parser.TakeError();
-    EXPECT_TRUE(err);
-    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
-  }
 }
 
 TEST_F(CmdArgParserTest, ValidatedRules) {
@@ -738,6 +372,42 @@ TEST_F(CmdArgParserTest, FixedRangeInt) {
     EXPECT_TRUE(err);
     EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
     EXPECT_EQ(err.index, 0);
+  }
+}
+
+TEST_F(CmdArgParserTest, PositiveInt) {
+  {
+    auto parser = Make({"1", "42"});
+    EXPECT_EQ(parser.Next<Positive<int64_t>>().value, 1);
+    EXPECT_EQ(parser.Next<Positive<int64_t>>().value, 42);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  {
+    auto parser = Make({"0"});
+    parser.Next<Positive<int64_t>>();
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
+  }
+
+  {
+    auto parser = Make({"256"});
+    parser.Next<Positive<uint8_t>>();
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
+  }
+}
+
+TEST_F(CmdArgParserTest, NonNegativeInt) {
+  {
+    auto parser = Make({"0", "42"});
+    EXPECT_EQ(parser.Next<NonNegativeInt<int64_t>>().value, 0);
+    EXPECT_EQ(parser.Next<NonNegativeInt<int64_t>>().value, 42);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  {
+    auto parser = Make({"-1"});
+    parser.Next<NonNegativeInt<int64_t>>();
+    EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
   }
 }
 
@@ -1014,17 +684,17 @@ struct SetLike {
 enum SetLikeFlags : uint16_t { kNx = 1 << 0, kXx = 1 << 1, kGet = 1 << 2 };
 
 consteval auto MakeSetLikeGrammar() {
-  return Compile(Args(&SetLike::key, &SetLike::value),
-                 Options(OneOf("NX and XX are incompatible", Flag("NX", &SetLike::flags, kNx),
-                               Flag("XX", &SetLike::flags, kXx)),
-                         Action(
-                             "EX",
-                             +[](CmdArgParser* p, SetLike* o) {
-                               o->ttl = p->Next<int64_t>();
-                               o->ttl_set = true;
-                             }),
-                         Flag("GET", &SetLike::flags, kGet), Field("MCFLAGS", &SetLike::mc),
-                         Field("LIMIT", &SetLike::offset, &SetLike::count)));
+  return Compile(
+      Args(&SetLike::key, &SetLike::value),
+      Options(OneOf("NX and XX are incompatible", Flags(&SetLike::flags, "NX", kNx, "XX", kXx)),
+              Action(
+                  "EX",
+                  +[](CmdArgParser* p, SetLike* o) {
+                    o->ttl = p->Next<int64_t>();
+                    o->ttl_set = true;
+                  }),
+              Flags(&SetLike::flags, "GET", kGet), Field("MCFLAGS", &SetLike::mc),
+              Field("LIMIT", &SetLike::offset, &SetLike::count)));
 }
 }  // namespace
 
@@ -1067,10 +737,11 @@ TEST_F(CmdArgParserTest, CapGrammar) {
     EXPECT_TRUE(err);
     EXPECT_EQ(err.MakeReply().ToSv(), "NX and XX are incompatible");
   }
-  {
+  {  // the same alternative twice is also a conflict (OneOf rejects any second match, like Redis)
     SetLike o;
-    EXPECT_FALSE(apply({"k", "v", "NX", "NX"}, &o));
-    EXPECT_EQ(o.flags, kNx);
+    auto err = apply({"k", "v", "NX", "NX"}, &o);
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.MakeReply().ToSv(), "NX and XX are incompatible");
   }
   {
     SetLike o;
@@ -1118,6 +789,9 @@ consteval auto MakeHeadTailGrammar() {
 
 TEST_F(CmdArgParserTest, CapGrammarPositionalAfterOptions) {
   static constexpr auto kGrammar = MakeHeadTailGrammar();
+  static constexpr auto kSkipGrammar = Compile(Skip(), Args(&HeadTail::tail));
+  static constexpr auto kFallbackSkipGrammar =
+      Compile(Options(Exist("F", &HeadTail::flag), Skip()));
   auto run = [&](std::initializer_list<std::string_view> args, HeadTail* o) {
     auto parser = Make(args);
     kGrammar.Apply(&parser, o);
@@ -1139,17 +813,32 @@ TEST_F(CmdArgParserTest, CapGrammarPositionalAfterOptions) {
     EXPECT_FALSE(o.flag);
     EXPECT_EQ(o.tail, "t");
   }
+  {
+    auto parser = Make({"ignored", "tail"});
+    auto target = kSkipGrammar.Apply(&parser);
+    EXPECT_TRUE(parser.Finalize());
+    EXPECT_EQ(target.tail, "tail");
+  }
+  {
+    auto parser = Make({"unknown", "F", "another"});
+    auto target = kFallbackSkipGrammar.Apply(&parser);
+    EXPECT_TRUE(parser.Finalize());
+    EXPECT_TRUE(target.flag);
+  }
 }
 
 namespace {
-enum class Dir { kAsc, kDesc };
+enum class Dir { kUnset, kAsc, kDesc };
 struct MapIf {
   Dir dir = Dir::kAsc;
+  Dir switched_dir = Dir::kUnset;
   bool read_only = false;
   std::string_view store;
 };
 consteval auto MakeMapIfGrammar() {
   return Compile(Options(Map(&MapIf::dir, "ASC", Dir::kAsc, "DESC", Dir::kDesc),
+                         OneOf("direction conflict", Map(&MapIf::switched_dir, "UP", Dir::kAsc),
+                               Map(&MapIf::switched_dir, "DOWN", Dir::kDesc)),
                          IfNot(&MapIf::read_only, Field("STORE", &MapIf::store))));
 }
 }  // namespace
@@ -1179,6 +868,68 @@ TEST_F(CmdArgParserTest, CapGrammarMapIf) {
     o.read_only = true;
     EXPECT_TRUE(run({"STORE", "dst"}, &o));
     EXPECT_EQ(o.store, "");
+  }
+  {  // OneOf(Map) selects once and writes the mapped value
+    MapIf o;
+    EXPECT_FALSE(run({"DOWN"}, &o));
+    EXPECT_EQ(o.switched_dir, Dir::kDesc);
+  }
+  {  // repeating the same option is now a conflict, matching Redis
+    MapIf o;
+    auto err = run({"DOWN", "DOWN"}, &o);
+    EXPECT_EQ(err.MakeReply().ToSv(), "direction conflict");
+  }
+  {
+    MapIf o;
+    auto err = run({"DOWN", "UP"}, &o);
+    EXPECT_EQ(err.MakeReply().ToSv(), "direction conflict");
+  }
+}
+
+namespace {
+struct IntoOptTarget {
+  struct Limit {
+    uint32_t offset = 0;
+    uint32_t count = 0;
+  };
+  std::optional<Limit> limit;
+  bool alpha = false;
+};
+consteval auto MakeIntoOptionalGrammar() {
+  return Compile(Options(Exist("ALPHA", &IntoOptTarget::alpha),
+                         Into(&IntoOptTarget::limit, Field("LIMIT", &IntoOptTarget::Limit::offset,
+                                                           &IntoOptTarget::Limit::count))));
+}
+}  // namespace
+
+TEST_F(CmdArgParserTest, CapGrammarIntoOptional) {
+  static constexpr auto kGrammar = MakeIntoOptionalGrammar();
+  auto run = [&](std::initializer_list<std::string_view> args, IntoOptTarget* o) {
+    auto parser = Make(args);
+    kGrammar.Apply(&parser, o);
+    parser.Finalize();
+    return parser.TakeError();
+  };
+
+  {  // keyword absent -> optional stays disengaged
+    IntoOptTarget o;
+    EXPECT_FALSE(run({"ALPHA"}, &o));
+    EXPECT_TRUE(o.alpha);
+    EXPECT_FALSE(o.limit.has_value());
+  }
+  {  // keyword present -> optional engaged and members read
+    IntoOptTarget o;
+    EXPECT_FALSE(run({"LIMIT", "2", "5"}, &o));
+    ASSERT_TRUE(o.limit.has_value());
+    EXPECT_EQ(o.limit->offset, 2u);
+    EXPECT_EQ(o.limit->count, 5u);
+  }
+  {  // repeated keyword -> last wins, still a single engaged value
+    IntoOptTarget o;
+    EXPECT_FALSE(run({"LIMIT", "1", "1", "LIMIT", "3", "4"}, &o));
+    ASSERT_TRUE(o.limit.has_value());
+    EXPECT_EQ(o.limit->offset, 3u);
+    EXPECT_EQ(o.limit->count, 4u);
   }
 }
 
@@ -1235,40 +986,113 @@ TEST_F(CmdArgParserTest, CapGrammarChoice) {
   }
 }
 
+// TagValue: a keyword sets a discriminant member to a compile-time value and reads the next arg
+// into another member (e.g. the EX/PX expiry keywords). Wrapped in OneOf for mutual exclusion.
+namespace {
+enum class Unit { kSec, kMs };
+struct TvTarget {
+  Unit unit = Unit::kSec;
+  std::optional<int64_t> amount;
+};
+consteval auto MakeTagValueGrammar() {
+  return Compile(Options(OneOf("", TagValue("EX", &TvTarget::unit, Unit::kSec, &TvTarget::amount),
+                               TagValue("PX", &TvTarget::unit, Unit::kMs, &TvTarget::amount))));
+}
+}  // namespace
+
+TEST_F(CmdArgParserTest, CapGrammarTagValue) {
+  static constexpr auto kGrammar = MakeTagValueGrammar();
+  auto run = [&](std::initializer_list<std::string_view> args, TvTarget* o) {
+    auto parser = Make(args);
+    kGrammar.Apply(&parser, o);
+    parser.Finalize();
+    return parser.TakeError();
+  };
+
+  {  // sets both the unit discriminant and the amount
+    TvTarget o;
+    EXPECT_FALSE(run({"PX", "1500"}, &o));
+    EXPECT_EQ(o.unit, Unit::kMs);
+    EXPECT_EQ(o.amount, 1500);
+  }
+  {  // a second (different) option conflicts
+    TvTarget o;
+    EXPECT_TRUE(run({"EX", "1", "PX", "2"}, &o));
+  }
+  {  // repeating the same option also conflicts
+    TvTarget o;
+    EXPECT_TRUE(run({"EX", "1", "EX", "2"}, &o));
+  }
+  {  // missing value -> error
+    TvTarget o;
+    EXPECT_TRUE(run({"EX"}, &o));
+  }
+}
+
 namespace {
 
 enum BenchFlags : uint16_t { kBNx = 1 << 0, kBXx = 1 << 1, kBGet = 1 << 2 };
-enum class BenchDir : uint8_t { kAsc, kDesc };
+enum class BenchUnit : uint8_t { kNone, kSec, kMs };
+enum class BenchSelection : uint8_t { kUnset, kFirst, kSecond };
 
-struct BenchTarget {
-  std::string_view key;
-  std::string_view value;
-  uint16_t flags = 0;
-  bool stick = false;
-  bool keepttl = false;
-  int64_t ttl = 0;
-  bool ttl_set = false;
-  uint32_t mc = 0;
-  BenchDir dir = BenchDir::kAsc;
-  bool read_only = false;
-  std::string_view store;
+struct BenchNested {
+  uint32_t value = 0;
 };
 
+// One member per cap rule so the benchmark grammar exercises every primitive exactly once.
+struct BenchTarget {
+  std::string_view head;
+  std::string_view tail;
+  bool one = false;
+  bool one_alt = false;
+  bool if_enabled = true;
+  bool if_disabled = false;
+  bool if_seen = false;
+  bool if_not_seen = false;
+  uint16_t flags = 0;
+  uint32_t field = 0;
+  uint32_t pair_first = 0;
+  uint32_t pair_second = 0;
+  uint32_t positive = 0;
+  uint32_t action = 0;
+  int64_t ttl = 0;
+  int64_t positive_ttl = 0;
+  BenchUnit unit = BenchUnit::kNone;
+  BenchUnit positive_unit = BenchUnit::kNone;
+  BenchSelection mapped = BenchSelection::kUnset;
+  BenchSelection choice = BenchSelection::kUnset;
+  BenchNested nested;
+  std::optional<BenchNested> opt_nested;
+};
+
+void ParseBenchAction(CmdArgParser* parser, BenchTarget* target) {
+  target->action += parser->Next<uint32_t>();
+}
+
+// Uses every cap rule once: Args, Options with a reserved tail, OneOf, Exist, Field, multi-member
+// Field, Field<Parsed>, Action, TagValue, TagValue<Parsed>, Map, Flags, Choice, If, IfNot, Into
+// into a plain and an optional member, and a Skip fallback.
 consteval auto MakeBenchGrammar() {
-  auto expiry = +[](CmdArgParser* p, BenchTarget* o) {
-    o->ttl = p->Next<int64_t>();
-    o->ttl_set = true;
-  };
   return Compile(
-      Args(&BenchTarget::key, &BenchTarget::value),
-      Options(
-          OneOf("", Flag("NX", &BenchTarget::flags, kBNx), Flag("XX", &BenchTarget::flags, kBXx)),
-          Action("EX", expiry), Action("PX", expiry), Action("EXAT", expiry),
-          Action("PXAT", expiry), Flag("GET", &BenchTarget::flags, kBGet),
-          Map(&BenchTarget::dir, "ASC", BenchDir::kAsc, "DESC", BenchDir::kDesc),
-          IfNot(&BenchTarget::read_only, Field("STORE", &BenchTarget::store)),
-          Exist("STICK", &BenchTarget::stick), Exist("KEEPTTL", &BenchTarget::keepttl),
-          Field("MCFLAGS", &BenchTarget::mc)));
+      Args(&BenchTarget::head),
+      Options(1,
+              OneOf("", Exist("ONE", &BenchTarget::one), Exist("ONE_ALT", &BenchTarget::one_alt)),
+              Field("FIELD", &BenchTarget::field),
+              Field("PAIR", &BenchTarget::pair_first, &BenchTarget::pair_second),
+              Field<Positive<uint32_t>>("POSITIVE", &BenchTarget::positive, "positive"),
+              Action("ACTION", ParseBenchAction),
+              TagValue("TV", &BenchTarget::unit, BenchUnit::kSec, &BenchTarget::ttl),
+              TagValue<Positive<int64_t>>("TVP", &BenchTarget::positive_unit, BenchUnit::kMs,
+                                          &BenchTarget::positive_ttl),
+              Map(&BenchTarget::mapped, "MAP", BenchSelection::kFirst),
+              Flags(&BenchTarget::flags, "FLAG", kBNx),
+              Choice("CHOICE", &BenchTarget::choice, "FIRST", BenchSelection::kFirst, "SECOND",
+                     BenchSelection::kSecond),
+              If(&BenchTarget::if_enabled, Exist("IF", &BenchTarget::if_seen)),
+              IfNot(&BenchTarget::if_disabled, Exist("IF_NOT", &BenchTarget::if_not_seen)),
+              Into(&BenchTarget::nested, Field("NESTED", &BenchNested::value)),
+              Into(&BenchTarget::opt_nested, Field("OPT_NESTED", &BenchNested::value)), Skip()),
+      Args(&BenchTarget::tail));
 }
 
 cmn::BackedArguments MakeStorage(std::initializer_list<std::string_view> args) {
@@ -1278,146 +1102,176 @@ cmn::BackedArguments MakeStorage(std::initializer_list<std::string_view> args) {
   return s;
 }
 
-CmdArgParser BenchArgs(bool with_options) {
-  static const cmn::BackedArguments kNoOpts = MakeStorage({"mykey", "myval"});
-  static const cmn::BackedArguments kOpts = MakeStorage(
-      {"mykey", "myval", "NX", "EX", "100", "GET", "DESC", "STORE", "dst", "MCFLAGS", "7"});
-  return CmdArgParser{with_options ? kOpts : kNoOpts};
+// The single input that exercises every rule of MakeBenchGrammar once (SKIP hits the Skip
+// fallback).
+CmdArgParser BenchArgs() {
+  static const cmn::BackedArguments kArgs = MakeStorage(
+      {"head",   "ONE", "FIELD",  "1",      "PAIR", "2",          "3",   "POSITIVE", "4",
+       "ACTION", "5",   "TV",     "6",      "TVP",  "7",          "MAP", "FLAG",     "CHOICE",
+       "FIRST",  "IF",  "IF_NOT", "NESTED", "8",    "OPT_NESTED", "9",   "SKIP",     "tail"});
+  return CmdArgParser{kArgs};
 }
 
 }  // namespace
 
-static void BM_RuntimeParse(benchmark::State& state) {
-  CmdArgParser proto = BenchArgs(state.range(0));
-  for (auto _ : state) {
-    CmdArgParser parser = proto;
-    BenchTarget o;
-    o.key = parser.Next();
-    o.value = parser.Next();
-    auto expiry = [&](CmdArgParser* p) {
-      o.ttl = p->Next<int64_t>();
-      o.ttl_set = true;
-    };
-    parser.Apply(OneOf(Tag("NX", [&](CmdArgParser*) { o.flags |= kBNx; }),
-                       Tag("XX", [&](CmdArgParser*) { o.flags |= kBXx; })),
-                 OneOf(Tag("EX", expiry), Tag("PX", expiry), Tag("EXAT", expiry),
-                       Tag("PXAT", expiry), Exist("KEEPTTL", &o.keepttl)),
-                 Tag("GET", [&](CmdArgParser*) { o.flags |= kBGet; }),
-                 Map(&o.dir, "ASC", BenchDir::kAsc, "DESC", BenchDir::kDesc),
-                 If(!o.read_only, Tag("STORE", &o.store)), Exist("STICK", &o.stick),
-                 Tag("MCFLAGS", &o.mc));
-    benchmark::DoNotOptimize(parser.Finalize());
-    benchmark::DoNotOptimize(o);
-  }
+TEST_F(CmdArgParserTest, BenchGrammar) {
+  static constexpr auto kGrammar = MakeBenchGrammar();
+  CmdArgParser parser = BenchArgs();
+  BenchTarget t = kGrammar.Apply(&parser);
+  EXPECT_TRUE(parser.Finalize());
+  EXPECT_EQ(t.head, "head");
+  EXPECT_EQ(t.tail, "tail");
+  EXPECT_TRUE(t.one);
+  EXPECT_EQ(t.field, 1u);
+  EXPECT_EQ(t.pair_first, 2u);
+  EXPECT_EQ(t.pair_second, 3u);
+  EXPECT_EQ(t.positive, 4u);
+  EXPECT_EQ(t.action, 5u);
+  EXPECT_EQ(t.ttl, 6);
+  EXPECT_EQ(t.positive_ttl, 7);
+  EXPECT_EQ(t.mapped, BenchSelection::kFirst);
+  EXPECT_EQ(t.flags, kBNx);
+  EXPECT_EQ(t.choice, BenchSelection::kFirst);
+  EXPECT_TRUE(t.if_seen);
+  EXPECT_TRUE(t.if_not_seen);
+  EXPECT_EQ(t.nested.value, 8u);
+  ASSERT_TRUE(t.opt_nested.has_value());
+  EXPECT_EQ(t.opt_nested->value, 9u);
 }
-BENCHMARK(BM_RuntimeParse)->Arg(0)->Arg(1);
 
+// The same grammar parsed three ways: the cap grammar, a raw index-based hand parser, and a hand
+// parser using the CmdArgParser navigation API. All three produce the same BenchTarget.
 static void BM_CapParse(benchmark::State& state) {
-  CmdArgParser proto = BenchArgs(state.range(0));
+  CmdArgParser proto = BenchArgs();
   static constexpr auto kGrammar = MakeBenchGrammar();
   for (auto _ : state) {
     CmdArgParser parser = proto;
-    BenchTarget o;
-    kGrammar.Apply(&parser, &o);
+    BenchTarget t = kGrammar.Apply(&parser);
     benchmark::DoNotOptimize(parser.Finalize());
-    benchmark::DoNotOptimize(o);
+    benchmark::DoNotOptimize(t);
   }
 }
-BENCHMARK(BM_CapParse)->Arg(0)->Arg(1);
+BENCHMARK(BM_CapParse);
 
 static void BM_ManualParse(benchmark::State& state) {
-  CmdArgParser proto = BenchArgs(state.range(0));
+  CmdArgParser proto = BenchArgs();
   for (auto _ : state) {
     CmdArgParser parser = proto;
     ParsedArgs args = parser.UnparsedArgs();
-    BenchTarget o;
+    BenchTarget t;
     bool ok = true;
     size_t n = args.size();
-    o.key = args[0];
-    o.value = args[1];
-    for (size_t i = 2; i < n; ++i) {
+    t.head = args[0];
+    t.tail = args[n - 1];
+    for (size_t i = 1; i + 1 < n; ++i) {  // leave the last arg for tail, like Options(1, ...)
       std::string_view a = args[i];
-      if (absl::EqualsIgnoreCase(a, "NX")) {
-        o.flags |= kBNx;
-      } else if (absl::EqualsIgnoreCase(a, "XX")) {
-        o.flags |= kBXx;
-      } else if (absl::EqualsIgnoreCase(a, "GET")) {
-        o.flags |= kBGet;
-      } else if (absl::EqualsIgnoreCase(a, "ASC")) {
-        o.dir = BenchDir::kAsc;
-      } else if (absl::EqualsIgnoreCase(a, "DESC")) {
-        o.dir = BenchDir::kDesc;
-      } else if (!o.read_only && absl::EqualsIgnoreCase(a, "STORE")) {
-        if (++i >= n) {
+      if (absl::EqualsIgnoreCase(a, "ONE"))
+        t.one = true;
+      else if (absl::EqualsIgnoreCase(a, "ONE_ALT"))
+        t.one_alt = true;
+      else if (absl::EqualsIgnoreCase(a, "FIELD"))
+        ok = ++i < n && absl::SimpleAtoi(args[i], &t.field);
+      else if (absl::EqualsIgnoreCase(a, "PAIR")) {
+        ok = i + 2 < n && absl::SimpleAtoi(args[i + 1], &t.pair_first) &&
+             absl::SimpleAtoi(args[i + 2], &t.pair_second);
+        i += 2;
+      } else if (absl::EqualsIgnoreCase(a, "POSITIVE"))
+        ok = ++i < n && absl::SimpleAtoi(args[i], &t.positive) && t.positive >= 1;
+      else if (absl::EqualsIgnoreCase(a, "ACTION")) {
+        uint32_t v = 0;
+        ok = ++i < n && absl::SimpleAtoi(args[i], &v);
+        t.action += v;
+      } else if (absl::EqualsIgnoreCase(a, "TV")) {
+        t.unit = BenchUnit::kSec;
+        ok = ++i < n && absl::SimpleAtoi(args[i], &t.ttl);
+      } else if (absl::EqualsIgnoreCase(a, "TVP")) {
+        t.positive_unit = BenchUnit::kMs;
+        ok = ++i < n && absl::SimpleAtoi(args[i], &t.positive_ttl) && t.positive_ttl >= 1;
+      } else if (absl::EqualsIgnoreCase(a, "MAP"))
+        t.mapped = BenchSelection::kFirst;
+      else if (absl::EqualsIgnoreCase(a, "FLAG"))
+        t.flags |= kBNx;
+      else if (absl::EqualsIgnoreCase(a, "CHOICE")) {
+        if (++i >= n)
           ok = false;
-          break;
-        }
-        o.store = args[i];
-      } else if (absl::EqualsIgnoreCase(a, "STICK")) {
-        o.stick = true;
-      } else if (absl::EqualsIgnoreCase(a, "KEEPTTL")) {
-        o.keepttl = true;
-      } else if (absl::EqualsIgnoreCase(a, "EX") || absl::EqualsIgnoreCase(a, "PX") ||
-                 absl::EqualsIgnoreCase(a, "EXAT") || absl::EqualsIgnoreCase(a, "PXAT")) {
-        if (++i >= n || !absl::SimpleAtoi(args[i], &o.ttl)) {
+        else if (absl::EqualsIgnoreCase(args[i], "FIRST"))
+          t.choice = BenchSelection::kFirst;
+        else if (absl::EqualsIgnoreCase(args[i], "SECOND"))
+          t.choice = BenchSelection::kSecond;
+        else
           ok = false;
-          break;
-        }
-        o.ttl_set = true;
-      } else if (absl::EqualsIgnoreCase(a, "MCFLAGS")) {
-        if (++i >= n || !absl::SimpleAtoi(args[i], &o.mc)) {
-          ok = false;
-          break;
-        }
-      } else {
-        ok = false;
-        break;
+      } else if (t.if_enabled && absl::EqualsIgnoreCase(a, "IF"))
+        t.if_seen = true;
+      else if (!t.if_disabled && absl::EqualsIgnoreCase(a, "IF_NOT"))
+        t.if_not_seen = true;
+      else if (absl::EqualsIgnoreCase(a, "NESTED"))
+        ok = ++i < n && absl::SimpleAtoi(args[i], &t.nested.value);
+      else if (absl::EqualsIgnoreCase(a, "OPT_NESTED")) {
+        uint32_t v = 0;
+        ok = ++i < n && absl::SimpleAtoi(args[i], &v);
+        t.opt_nested = BenchNested{v};
       }
+      // else: unknown token skipped, matching the Skip() fallback
     }
     benchmark::DoNotOptimize(ok);
-    benchmark::DoNotOptimize(o);
+    benchmark::DoNotOptimize(t);
   }
 }
-BENCHMARK(BM_ManualParse)->Arg(0)->Arg(1);
+BENCHMARK(BM_ManualParse);
 
 static void BM_ManualWithParser(benchmark::State& state) {
-  CmdArgParser proto = BenchArgs(state.range(0));
+  CmdArgParser proto = BenchArgs();
   for (auto _ : state) {
     CmdArgParser parser = proto;
-    BenchTarget o;
-    o.key = parser.Next();
-    o.value = parser.Next();
-    while (parser.HasNext()) {
-      if (parser.Check("NX"))
-        o.flags |= kBNx;
-      else if (parser.Check("XX"))
-        o.flags |= kBXx;
-      else if (parser.Check("GET"))
-        o.flags |= kBGet;
-      else if (parser.Check("ASC"))
-        o.dir = BenchDir::kAsc;
-      else if (parser.Check("DESC"))
-        o.dir = BenchDir::kDesc;
-      else if (!o.read_only && parser.Check("STORE"))
-        o.store = parser.Next();
-      else if (parser.Check("STICK"))
-        o.stick = true;
-      else if (parser.Check("KEEPTTL"))
-        o.keepttl = true;
-      else if (parser.Check("EX") || parser.Check("PX") || parser.Check("EXAT") ||
-               parser.Check("PXAT")) {
-        o.ttl = parser.Next<int64_t>();
-        o.ttl_set = true;
-      } else if (parser.Check("MCFLAGS")) {
-        o.mc = parser.Next<uint32_t>();
-      } else {
-        break;
-      }
+    BenchTarget t;
+    t.head = parser.Next();
+    while (parser.HasAtLeast(2)) {  // leave one trailing arg for tail, like Options(1, ...)
+      if (parser.Check("ONE"))
+        t.one = true;
+      else if (parser.Check("ONE_ALT"))
+        t.one_alt = true;
+      else if (parser.Check("FIELD"))
+        t.field = parser.Next<uint32_t>();
+      else if (parser.Check("PAIR"))
+        std::tie(t.pair_first, t.pair_second) = parser.Next<uint32_t, uint32_t>();
+      else if (parser.Check("POSITIVE"))
+        t.positive = parser.Next<Positive<uint32_t>>("positive");
+      else if (parser.Check("ACTION"))
+        t.action += parser.Next<uint32_t>();
+      else if (parser.Check("TV")) {
+        t.unit = BenchUnit::kSec;
+        t.ttl = parser.Next<int64_t>();
+      } else if (parser.Check("TVP")) {
+        t.positive_unit = BenchUnit::kMs;
+        t.positive_ttl = parser.Next<Positive<int64_t>>();
+      } else if (parser.Check("MAP"))
+        t.mapped = BenchSelection::kFirst;
+      else if (parser.Check("FLAG"))
+        t.flags |= kBNx;
+      else if (parser.Check("CHOICE")) {
+        std::string_view v = parser.Next();
+        if (absl::EqualsIgnoreCase(v, "FIRST"))
+          t.choice = BenchSelection::kFirst;
+        else if (absl::EqualsIgnoreCase(v, "SECOND"))
+          t.choice = BenchSelection::kSecond;
+        else
+          parser.Report(CmdArgParser::INVALID_CASES);
+      } else if (t.if_enabled && parser.Check("IF"))
+        t.if_seen = true;
+      else if (!t.if_disabled && parser.Check("IF_NOT"))
+        t.if_not_seen = true;
+      else if (parser.Check("NESTED"))
+        t.nested.value = parser.Next<uint32_t>();
+      else if (parser.Check("OPT_NESTED"))
+        t.opt_nested = BenchNested{parser.Next<uint32_t>()};
+      else
+        parser.Skip(1);  // Skip() fallback: consume an unknown token
     }
+    t.tail = parser.Next();
     benchmark::DoNotOptimize(parser.Finalize());
-    benchmark::DoNotOptimize(o);
+    benchmark::DoNotOptimize(t);
   }
 }
-BENCHMARK(BM_ManualWithParser)->Arg(0)->Arg(1);
+BENCHMARK(BM_ManualWithParser);
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -1042,7 +1042,6 @@ struct BenchNested {
 // One member per cap rule so the benchmark grammar exercises every primitive exactly once.
 struct BenchTarget {
   std::string_view head;
-  std::string_view tail;
   bool one = false;
   bool one_alt = false;
   bool if_enabled = true;
@@ -1069,14 +1068,13 @@ void ParseBenchAction(CmdArgParser* parser, BenchTarget* target) {
   target->action += parser->Next<uint32_t>();
 }
 
-// Uses every cap rule once: Args, Options with a reserved tail, OneOf, Exist, Field, multi-member
-// Field, Field<Parsed>, Action, TagValue, TagValue<Parsed>, Map, Flags, Choice, If, IfNot, Into
-// into a plain and an optional member, and a Skip fallback.
+// Uses every cap rule once: Args, Options, OneOf, Exist, Field, multi-member Field, Field<Parsed>,
+// Action, TagValue, TagValue<Parsed>, Map, Flags, Choice, If, IfNot, Into into a plain and an
+// optional member, and a Skip fallback.
 consteval auto MakeBenchGrammar() {
   return Compile(
       Args(&BenchTarget::head),
-      Options(1,
-              OneOf("", Exist("ONE", &BenchTarget::one), Exist("ONE_ALT", &BenchTarget::one_alt)),
+      Options(OneOf("", Exist("ONE", &BenchTarget::one), Exist("ONE_ALT", &BenchTarget::one_alt)),
               Field("FIELD", &BenchTarget::field),
               Field("PAIR", &BenchTarget::pair_first, &BenchTarget::pair_second),
               Field<Positive<uint32_t>>("POSITIVE", &BenchTarget::positive, "positive"),
@@ -1091,8 +1089,7 @@ consteval auto MakeBenchGrammar() {
               If(&BenchTarget::if_enabled, Exist("IF", &BenchTarget::if_seen)),
               IfNot(&BenchTarget::if_disabled, Exist("IF_NOT", &BenchTarget::if_not_seen)),
               Into(&BenchTarget::nested, Field("NESTED", &BenchNested::value)),
-              Into(&BenchTarget::opt_nested, Field("OPT_NESTED", &BenchNested::value)), Skip()),
-      Args(&BenchTarget::tail));
+              Into(&BenchTarget::opt_nested, Field("OPT_NESTED", &BenchNested::value)), Skip()));
 }
 
 cmn::BackedArguments MakeStorage(std::initializer_list<std::string_view> args) {
@@ -1108,7 +1105,7 @@ CmdArgParser BenchArgs() {
   static const cmn::BackedArguments kArgs = MakeStorage(
       {"head",   "ONE", "FIELD",  "1",      "PAIR", "2",          "3",   "POSITIVE", "4",
        "ACTION", "5",   "TV",     "6",      "TVP",  "7",          "MAP", "FLAG",     "CHOICE",
-       "FIRST",  "IF",  "IF_NOT", "NESTED", "8",    "OPT_NESTED", "9",   "SKIP",     "tail"});
+       "FIRST",  "IF",  "IF_NOT", "NESTED", "8",    "OPT_NESTED", "9",   "SKIP"});
   return CmdArgParser{kArgs};
 }
 
@@ -1120,7 +1117,6 @@ TEST_F(CmdArgParserTest, BenchGrammar) {
   BenchTarget t = kGrammar.Apply(&parser);
   EXPECT_TRUE(parser.Finalize());
   EXPECT_EQ(t.head, "head");
-  EXPECT_EQ(t.tail, "tail");
   EXPECT_TRUE(t.one);
   EXPECT_EQ(t.field, 1u);
   EXPECT_EQ(t.pair_first, 2u);
@@ -1162,8 +1158,7 @@ static void BM_ManualParse(benchmark::State& state) {
     bool ok = true;
     size_t n = args.size();
     t.head = args[0];
-    t.tail = args[n - 1];
-    for (size_t i = 1; i + 1 < n; ++i) {  // leave the last arg for tail, like Options(1, ...)
+    for (size_t i = 1; i < n; ++i) {
       std::string_view a = args[i];
       if (absl::EqualsIgnoreCase(a, "ONE"))
         t.one = true;
@@ -1225,7 +1220,7 @@ static void BM_ManualWithParser(benchmark::State& state) {
     CmdArgParser parser = proto;
     BenchTarget t;
     t.head = parser.Next();
-    while (parser.HasAtLeast(2)) {  // leave one trailing arg for tail, like Options(1, ...)
+    while (parser.HasNext()) {
       if (parser.Check("ONE"))
         t.one = true;
       else if (parser.Check("ONE_ALT"))
@@ -1267,7 +1262,6 @@ static void BM_ManualWithParser(benchmark::State& state) {
       else
         parser.Skip(1);  // Skip() fallback: consume an unknown token
     }
-    t.tail = parser.Next();
     benchmark::DoNotOptimize(parser.Finalize());
     benchmark::DoNotOptimize(t);
   }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -839,11 +839,8 @@ void DebugCmd::Shutdown() {
 }
 
 void DebugCmd::Reload(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  bool no_save = false;
-
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  // TODO: remove runtime parsing (single option -> Check).
-  parser.Apply(Exist("NOSAVE", &no_save));
+  bool no_save = parser.Check("NOSAVE");
   if (!parser.Finalize()) {
     (void)parser.TakeError();
     return cmd_cntx->SendError("DEBUG RELOAD only supports the NOSAVE options.");

--- a/src/server/family_utils.h
+++ b/src/server/family_utils.h
@@ -8,10 +8,13 @@
 #include <absl/random/random.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 
+#include "facade/cmd_arg_parser.h"
 #include "facade/facade_types.h"
+#include "server/common_types.h"
 #include "server/engine_shard.h"
 #include "server/search/doc_index.h"
 #include "server/table.h"
@@ -24,6 +27,31 @@ typedef struct streamConsumer streamConsumer;
 typedef struct streamCG streamCG;
 
 namespace dfly {
+
+struct ExpiryOption {
+  ExpT type = ExpT::EX;
+  std::optional<int64_t> value;
+};
+
+struct ExpiryOrPersistOptions {
+  ExpiryOption expiry;
+  bool persist = false;
+};
+
+template <class P = int64_t> consteval auto ExpiryOneOf() {
+  using namespace facade;
+  using T = ExpiryOption;
+  return OneOf("", TagValue<P>("EX", &T::type, ExpT::EX, &T::value),
+               TagValue<P>("PX", &T::type, ExpT::PX, &T::value),
+               TagValue<P>("EXAT", &T::type, ExpT::EXAT, &T::value),
+               TagValue<P>("PXAT", &T::type, ExpT::PXAT, &T::value));
+}
+
+template <class P = int64_t> consteval auto ExpiryOrPersist() {
+  using namespace facade;
+  using T = ExpiryOrPersistOptions;
+  return OneOf("", Into(&T::expiry, ExpiryOneOf<P>()), Exist("PERSIST", &T::persist));
+}
 
 // Compute XXH3 hash and return as 16-character hex string
 std::string XXH3_Digest(std::string_view s);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -8,7 +8,6 @@
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_cat.h>
 
-#include <limits>
 #include <optional>
 
 #include "facade/cmd_arg_parser.h"
@@ -62,7 +61,6 @@ using namespace facade;
 
 namespace {
 
-constexpr uint32_t kMaxTtl = (1UL << 26);
 constexpr size_t DUMP_FOOTER_SIZE = sizeof(uint64_t) + sizeof(uint16_t);  // version number and crc
 
 std::optional<RdbVersion> GetRdbVersion(std::string_view msg, bool ignore_crc = false) {
@@ -126,50 +124,51 @@ class InMemSource : public ::io::Source {
   return read_total;
 }
 
-class RestoreArgs {
- private:
+struct RestoreArgs {
   static constexpr int64_t NO_EXPIRATION = 0;
 
-  int64_t expiration_ = NO_EXPIRATION;
-  bool abs_time_ = false;
-  bool replace_ = false;  // if true, over-ride existing key
-  bool sticky_ = false;
+  string_view key;
+  NonNegativeInt<int64_t> expiration;
+  string_view serialized_value;
+  bool abs_time = false;
+  bool replace = false;  // if true, over-ride existing key
+  bool sticky = false;
+  NonNegativeInt<int64_t> idle_time;
+  NonNegativeInt<uint8_t> freq;
 
- public:
   RestoreArgs() = default;
 
   RestoreArgs(int64_t expiration, bool abs_time, bool replace)
-      : expiration_(expiration), abs_time_(abs_time), replace_(replace) {
+      : abs_time(abs_time), replace(replace) {
+    this->expiration.value = expiration;
   }
 
   bool Replace() const {
-    return replace_;
+    return replace;
   }
 
   bool Sticky() const {
-    return sticky_;
+    return sticky;
   }
 
-  void SetSticky(bool sticky) {
-    sticky_ = sticky;
+  void SetSticky(bool value) {
+    sticky = value;
   }
 
   uint64_t ExpirationTime() const {
-    DCHECK_GE(expiration_, 0);
-    return expiration_;
+    DCHECK_GE(expiration.value, 0);
+    return expiration.value;
   }
 
   bool Expired() const {
-    return expiration_ < 0;
+    return expiration.value < 0;
   }
 
   bool HasExpiration() const {
-    return expiration_ != NO_EXPIRATION;
+    return expiration.value != NO_EXPIRATION;
   }
 
   [[nodiscard]] bool UpdateExpiration(int64_t now_msec);
-
-  static OpResult<RestoreArgs> TryFrom(facade::ParsedArgs args);
 };
 
 class RdbRestoreValue : protected RdbLoaderBase {
@@ -255,47 +254,13 @@ OpResult<DbSlice::ItAndUpdater> RdbRestoreValue::Add(string_view key, string_vie
 
 [[nodiscard]] bool RestoreArgs::UpdateExpiration(int64_t now_msec) {
   if (HasExpiration()) {
-    int64_t ttl = abs_time_ ? expiration_ - now_msec : expiration_;
+    int64_t ttl = abs_time ? expiration.value - now_msec : expiration.value;
     if (ttl > kMaxExpireDeadlineMs)
       ttl = kMaxExpireDeadlineMs;
 
-    expiration_ = ttl < 0 ? -1 : ttl + now_msec;
+    expiration.value = ttl < 0 ? -1 : ttl + now_msec;
   }
   return true;
-}
-
-// The structure that we are expecting is:
-// args[0] == "key"
-// args[1] == "ttl"
-// args[2] == serialized value (list of chars that are used for the actual restore).
-// args[3] .. args[n]: optional arguments that can be [REPLACE] [ABSTTL] [IDLETIME seconds]
-//            [FREQ frequency], in any order
-OpResult<RestoreArgs> RestoreArgs::TryFrom(facade::ParsedArgs args) {
-  using namespace facade;
-  RestoreArgs out_args;
-  CmdArgParser parser(args);
-
-  // args[0] = key (skip); args[1] = ttl; args[2] = serialized value (skip).
-  parser.Skip(1);
-  out_args.expiration_ = parser.Next<FInt<int64_t{0}, std::numeric_limits<int64_t>::max()>>();
-  if (parser.TakeError())
-    return OpStatus::INVALID_INT;
-  parser.Skip(1);
-
-  // IDLETIME and FREQ are parsed (for compat with Redis) but not used currently. Both are
-  // range-checked at parse time via FInt — out-of-range values surface as INVALID_INT.
-  FInt<int64_t{0}, std::numeric_limits<int64_t>::max()> idle_time{};
-  FInt<0, 255> freq{};
-  // TODO: remove runtime parsing (migrate to cap grammar).
-  parser.Apply(Exist("REPLACE", &out_args.replace_), Exist("ABSTTL", &out_args.abs_time_),
-               Exist("STICK", &out_args.sticky_), Tag("IDLETIME", &idle_time), Tag("FREQ", &freq));
-
-  if (!parser.Finalize()) {
-    auto err = parser.TakeError();
-    return err.type == CmdArgParser::INVALID_INT ? OpStatus::INVALID_INT : OpStatus::SYNTAX_ERR;
-  }
-
-  return out_args;
 }
 
 OpResult<string> DumpToString(string_view key, const PrimeValue& pv, const OpArgs& op_args) {
@@ -1125,20 +1090,26 @@ void TtlGeneric(string_view key, TimeUnit unit, CommandContext* cmd_cntx) {
   }
 }
 
-int32_t ParseExpireOptions(CmdArgParser* parser) {
+struct ExpireArgs {
+  string_view key;
+  int64_t value = 0;
   int32_t flags = ExpireFlags::EXPIRE_ALWAYS;
-  parser->Apply(Tag("NX", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_NX; }),
-                Tag("XX", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_XX; }),
-                Tag("GT", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_GT; }),
-                Tag("LT", [&](CmdArgParser*) { flags |= ExpireFlags::EXPIRE_LT; }));
+};
+
+ExpireArgs ParseExpireArgs(CmdArgParser* parser) {
+  static constexpr auto kGrammar =
+      Compile(Args(&ExpireArgs::key, &ExpireArgs::value),
+              Options(Flags(&ExpireArgs::flags, "NX", int32_t{ExpireFlags::EXPIRE_NX}, "XX",
+                            int32_t{ExpireFlags::EXPIRE_XX}, "GT", int32_t{ExpireFlags::EXPIRE_GT},
+                            "LT", int32_t{ExpireFlags::EXPIRE_LT})));
+  auto args = kGrammar.Apply(parser);
   parser->Finalize("Unsupported option: ");
 
-  // NX/XX and GT/LT are mutually exclusive; duplicate flags (e.g. NX NX) are tolerated like Redis.
-  if ((flags & ExpireFlags::EXPIRE_NX) && (flags & ExpireFlags::EXPIRE_XX))
+  if ((args.flags & ExpireFlags::EXPIRE_NX) && (args.flags & ExpireFlags::EXPIRE_XX))
     parser->ReportCustom("NX and XX options at the same time are not compatible");
-  if ((flags & ExpireFlags::EXPIRE_GT) && (flags & ExpireFlags::EXPIRE_LT))
+  if ((args.flags & ExpireFlags::EXPIRE_GT) && (args.flags & ExpireFlags::EXPIRE_LT))
     parser->ReportCustom("GT and LT options at the same time are not compatible");
-  return flags;
+  return args;
 }
 
 // New version of OpDel with possible journal omits - autojournaling must be disabled
@@ -1389,18 +1360,17 @@ void GenericFamily::Persist(facade::CmdArgParser parser, CommandContext* cmd_cnt
 }
 
 void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  auto args = parser.Next(ParseExpireArgs);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     auto op_args = t->GetOpArgs(shard);
-    DbSlice::ExpireParams params{TimeUnit::SEC, int_arg, op_args.db_cntx.time_now_ms,
+    DbSlice::ExpireParams params{TimeUnit::SEC, args.value, op_args.db_cntx.time_now_ms,
                                  /*cap=*/true};
-    params.expire_options = expire_options;
-    return OpExpire(op_args, key, params);
+    params.expire_options = args.flags;
+    return OpExpire(op_args, args.key, params);
   };
 
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
@@ -1408,18 +1378,17 @@ void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx
 }
 
 void GenericFamily::ExpireAt(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  auto args = parser.Next(ParseExpireArgs);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
 
   // ExpireParams normalizes 0/negative inputs internally.
-  DbSlice::ExpireParams params{TimeUnit::SEC, int_arg};
-  params.expire_options = expire_options;
+  DbSlice::ExpireParams params{TimeUnit::SEC, args.value};
+  params.expire_options = args.flags;
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpExpire(t->GetOpArgs(shard), key, params);
+    return OpExpire(t->GetOpArgs(shard), args.key, params);
   };
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 
@@ -1453,18 +1422,17 @@ void GenericFamily::Keys(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
 }
 
 void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  auto args = parser.Next(ParseExpireArgs);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
 
   // ExpireParams normalizes 0/negative inputs internally.
-  DbSlice::ExpireParams params{TimeUnit::MSEC, int_arg};
-  params.expire_options = expire_options;
+  DbSlice::ExpireParams params{TimeUnit::MSEC, args.value};
+  params.expire_options = args.flags;
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpExpire(t->GetOpArgs(shard), key, params);
+    return OpExpire(t->GetOpArgs(shard), args.key, params);
   };
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 
@@ -1476,18 +1444,17 @@ void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_c
 }
 
 void GenericFamily::Pexpire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, int_arg] = parser.Next<string_view, int64_t>();
-  int32_t expire_options = parser.Next(ParseExpireOptions);
+  auto args = parser.Next(ParseExpireArgs);
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     auto op_args = t->GetOpArgs(shard);
-    DbSlice::ExpireParams params{TimeUnit::MSEC, int_arg, op_args.db_cntx.time_now_ms,
+    DbSlice::ExpireParams params{TimeUnit::MSEC, args.value, op_args.db_cntx.time_now_ms,
                                  /*cap=*/true};
-    params.expire_options = expire_options;
-    return OpExpire(op_args, key, params);
+    params.expire_options = args.flags;
+    return OpExpire(op_args, args.key, params);
   };
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 
@@ -1752,6 +1719,11 @@ OpResult<uint32_t> OpStore(const OpArgs& op_args, std::string_view key, Iterator
   return len;
 }
 
+struct SortBounds {
+  uint32_t offset = 0;
+  uint32_t count = 0;
+};
+
 struct SortParams {
   bool alpha = false;
   bool reversed = false;
@@ -1759,22 +1731,23 @@ struct SortParams {
   bool to_sort = true;
 
   optional<string_view> store_key;
-
-  // first is offset, second is count
-  optional<pair<uint32_t, uint32_t>> bounds;
+  optional<SortBounds> bounds;
 
   // These options are parsed but currently not fully supported or used by the visitor.
   optional<string_view> by_pattern;
   vector<string_view> get_patterns;
 };
 
-template <typename C>
-auto GetSortRange(const C& entries, const optional<pair<uint32_t, uint32_t>>& bounds) {
+void ParseSortGet(CmdArgParser* parser, SortParams* params) {
+  params->get_patterns.push_back(parser->Next<string_view>());
+}
+
+template <typename C> auto GetSortRange(const C& entries, const optional<SortBounds>& bounds) {
   auto start_it = entries.begin();
   auto end_it = entries.end();
   if (bounds) {
-    start_it += std::min<uint32_t>(bounds->first, entries.size());
-    end_it = entries.begin() + std::min<uint32_t>(bounds->first + bounds->second, entries.size());
+    start_it += std::min<uint32_t>(bounds->offset, entries.size());
+    end_it = entries.begin() + std::min<uint32_t>(bounds->offset + bounds->count, entries.size());
   }
 
   return std::make_pair(start_it, end_it);
@@ -1882,7 +1855,7 @@ struct SortVisitor {
     if (params.bounds) {
       auto sort_it =
           entries.begin() +
-          std::min<uint32_t>(params.bounds->first + params.bounds->second, entries.size());
+          std::min<uint32_t>(params.bounds->offset + params.bounds->count, entries.size());
       std::partial_sort(entries.begin(), sort_it, entries.end(), cmp);
     } else {
       rng::sort(entries, cmp);
@@ -2004,18 +1977,9 @@ void SortGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_read_onl
 
   static constexpr auto kGrammar = Compile(Options(
       Exist("ALPHA", &SortParams::alpha), Map(&SortParams::reversed, "DESC", true, "ASC", false),
-      Action(
-          "LIMIT",
-          +[](CmdArgParser* p, SortParams* o) {
-            auto [offset, limit] = p->Next<uint32_t, uint32_t>();
-            o->bounds = std::pair{offset, limit};
-          }),
+      Into(&SortParams::bounds, Field("LIMIT", &SortBounds::offset, &SortBounds::count)),
       IfNot(&SortParams::is_read_only, Field("STORE", &SortParams::store_key)),
-      Field("BY", &SortParams::by_pattern),
-      Action(
-          "GET", +[](CmdArgParser* p, SortParams* o) {
-            o->get_patterns.push_back(p->Next<string_view>());
-          })));
+      Field("BY", &SortParams::by_pattern), Action("GET", ParseSortGet)));
   kGrammar.Apply(&parser, &params);
 
   if (!parser.Finalize()) {
@@ -2227,31 +2191,33 @@ void GenericFamily::Sort_RO(facade::CmdArgParser parser, CommandContext* cmd_cnt
 }
 
 void GenericFamily::Restore(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
-  std::string_view key = parser.Next();
-  parser.Skip(1);
-  std::string_view serialized_value = parser.Next();
-  if (auto err = parser.TakeError(); err) {
-    return cmd_cntx->SendError(err.MakeReply());
+  static constexpr auto kGrammar = Compile(
+      Args(&RestoreArgs::key, &RestoreArgs::expiration, &RestoreArgs::serialized_value),
+      Options(Exist("REPLACE", &RestoreArgs::replace), Exist("ABSTTL", &RestoreArgs::abs_time),
+              Exist("STICK", &RestoreArgs::sticky), Field("IDLETIME", &RestoreArgs::idle_time),
+              Field("FREQ", &RestoreArgs::freq)));
+  auto restore_args = kGrammar.Apply(&parser);
+  parser.Finalize();
+  auto parse_error = parser.TakeError();
+  if (parse_error.type == CmdArgParser::OUT_OF_BOUNDS) {
+    return cmd_cntx->SendError(parse_error.MakeReply());
   }
 
   auto rdb_version =
-      GetRdbVersion(serialized_value, cmd_cntx->server_conn_cntx()->journal_emulated);
+      GetRdbVersion(restore_args.serialized_value, cmd_cntx->server_conn_cntx()->journal_emulated);
   if (!rdb_version) {
     return cmd_cntx->SendError(kInvalidDumpValueErr);
   }
 
-  OpResult<RestoreArgs> restore_args = RestoreArgs::TryFrom(cmd_cntx->tail_args());
-  if (!restore_args) {
-    if (restore_args.status() == OpStatus::OUT_OF_RANGE) {
-      return cmd_cntx->SendError("Invalid IDLETIME value, must be >= 0");
-    } else {
-      return cmd_cntx->SendError(restore_args.status());
-    }
+  if (parse_error) {
+    OpStatus status = parse_error.type == CmdArgParser::INVALID_INT ? OpStatus::INVALID_INT
+                                                                    : OpStatus::SYNTAX_ERR;
+    return cmd_cntx->SendError(status);
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpRestore(t->GetOpArgs(shard), key, serialized_value, restore_args.value(),
-                     rdb_version.value());
+    return OpRestore(t->GetOpArgs(shard), restore_args.key, restore_args.serialized_value,
+                     restore_args, rdb_version.value());
   };
 
   OpStatus result = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
@@ -2270,7 +2236,7 @@ void GenericFamily::Restore(facade::CmdArgParser parser, CommandContext* cmd_cnt
 
 void GenericFamily::FieldExpire(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  uint32_t ttl_sec = parser.Next<FInt<1u, kMaxTtl>>();
+  uint32_t ttl_sec = parser.Next<FInt<uint32_t{1}, uint32_t{kMaxExpireDeadlineSec}>>();
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -42,11 +42,11 @@ enum Errors {
 };
 
 const char kNxXxErr[] = "XX and NX options at the same time are not compatible";
-const char kFromMemberLonglatErr[] =
+constexpr char kFromMemberLonglatErr[] =
     "FROMMEMBER and FROMLONLAT options at the same time are not compatible";
-const char kByRadiusBoxErr[] = "BYRADIUS and BYBOX options at the same time are not compatible";
-const char kAscDescErr[] = "ASC and DESC options at the same time are not compatible";
-const char kStoreTypeErr[] = "STORE and STOREDIST options at the same time are not compatible";
+constexpr char kByRadiusBoxErr[] = "BYRADIUS and BYBOX options at the same time are not compatible";
+constexpr char kAscDescErr[] = "ASC and DESC options at the same time are not compatible";
+constexpr char kStoreTypeErr[] = "STORE and STOREDIST options at the same time are not compatible";
 const char kStoreCompatRadErr[] =
     "STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORDS options";
 const char kStoreCompatByMemberErr[] =
@@ -77,9 +77,16 @@ struct GeoPoint {
 };
 using GeoArray = std::vector<GeoPoint>;
 
-enum class Sorting { kUnsorted, kAsc, kDesc, kError };
-enum class GeoStoreType { kNoStore, kStoreHash, kStoreDist, kError };
+enum class Sorting { kUnsorted, kAsc, kDesc };
+enum class GeoStoreType { kNoStore, kStoreHash, kStoreDist };
+enum class GeoSearchSource { kMember, kLonLat };
 struct GeoSearchOpts {
+  GeoSearchOpts() = default;
+
+  explicit GeoSearchOpts(bool allow_store, string_view count_err = {})
+      : allow_store(allow_store), count_err(count_err) {
+  }
+
   double conversion = 0;
   uint64_t count = std::numeric_limits<uint64_t>::max();
   Sorting sorting = Sorting::kUnsorted;
@@ -89,10 +96,19 @@ struct GeoSearchOpts {
   bool withhash = 0;
   GeoStoreType store = GeoStoreType::kNoStore;
   string_view store_key;
+  bool allow_store = false;
+  string_view count_err;
 
   bool HasWithStatement() const {
     return withdist || withcoord || withhash;
   }
+};
+
+struct GeoSearchParse {
+  GeoSearchOpts geo_ops;
+  optional<GeoSearchSource> source;
+  string_view member;
+  GeoShape shape{};
 };
 
 bool ValidateLongLat(double longitude, double latitude) {
@@ -209,35 +225,69 @@ bool HandleGeoParserFinalize(const GeoShape& shape, CmdArgParser* parser,
   return true;
 }
 
-void SetSorting(GeoSearchOpts* geo_ops, Sorting sorting) {
-  geo_ops->sorting = geo_ops->sorting == Sorting::kUnsorted ? sorting : Sorting::kError;
-}
-
 void ParseCount(CmdArgParser* parser, GeoSearchOpts* geo_ops, string_view err_msg = {}) {
   geo_ops->count = parser->Next<uint64_t>(err_msg);
   geo_ops->any = parser->Check("ANY");
 }
 
-void SetStore(GeoSearchOpts* geo_ops, GeoStoreType store, string_view key) {
-  geo_ops->store_key = key;
-  geo_ops->store = geo_ops->store == GeoStoreType::kNoStore ? store : GeoStoreType::kError;
+void ParseGeoResultCount(CmdArgParser* parser, GeoSearchOpts* geo_ops) {
+  ParseCount(parser, geo_ops, geo_ops->count_err);
 }
 
-void ParseGeoResultOptions(CmdArgParser* parser, GeoSearchOpts* geo_ops, bool allow_store,
-                           string_view count_err = {}) {
-  parser->Apply(Tag("ASC", [&](CmdArgParser*) { SetSorting(geo_ops, Sorting::kAsc); }),
-                Tag("DESC", [&](CmdArgParser*) { SetSorting(geo_ops, Sorting::kDesc); }),
-                Tag("COUNT", [&](CmdArgParser* p) { ParseCount(p, geo_ops, count_err); }),
-                Exist("WITHCOORD", &geo_ops->withcoord), Exist("WITHDIST", &geo_ops->withdist),
-                Exist("WITHHASH", &geo_ops->withhash),
-                If(allow_store, Tag("STORE",
-                                    [&](CmdArgParser* p) {
-                                      SetStore(geo_ops, GeoStoreType::kStoreHash, p->Next());
-                                    })),
-                If(allow_store, Tag("STOREDIST", [&](CmdArgParser* p) {
-                     SetStore(geo_ops, GeoStoreType::kStoreDist, p->Next());
-                   })));
+void ParseGeoResultOptions(CmdArgParser* parser, GeoSearchOpts* geo_ops) {
+  static constexpr auto kGrammar = Compile(Options(
+      OneOf(kAscDescErr,
+            Map(&GeoSearchOpts::sorting, "ASC", Sorting::kAsc, "DESC", Sorting::kDesc)),
+      Action("COUNT", ParseGeoResultCount), Exist("WITHCOORD", &GeoSearchOpts::withcoord),
+      Exist("WITHDIST", &GeoSearchOpts::withdist), Exist("WITHHASH", &GeoSearchOpts::withhash),
+      If(&GeoSearchOpts::allow_store,
+         OneOf(kStoreTypeErr,
+               TagValue("STORE", &GeoSearchOpts::store, GeoStoreType::kStoreHash,
+                        &GeoSearchOpts::store_key),
+               TagValue("STOREDIST", &GeoSearchOpts::store, GeoStoreType::kStoreDist,
+                        &GeoSearchOpts::store_key)))));
+  kGrammar.Apply(parser, geo_ops);
 }
+
+void ParseGeoSearchFromMember(CmdArgParser* parser, GeoSearchParse* opts) {
+  opts->source = GeoSearchSource::kMember;
+  opts->member = parser->Next<string_view>();
+}
+
+void ParseLongLat(CmdArgParser* parser, GeoSearchParse* opts) {
+  opts->source = GeoSearchSource::kLonLat;
+  ParseLongLat(parser, opts->shape.xy);
+}
+
+void ParseGeoSearchByRadius(CmdArgParser* parser, GeoSearchParse* opts) {
+  GeoShape& shape = opts->shape;
+  shape.t.radius = parser->Next<double>();
+  opts->geo_ops.conversion = shape.conversion = parser->Next(ParseGeoUnit);
+  shape.type = CIRCULAR_TYPE;
+}
+
+void ParseGeoSearchByBox(CmdArgParser* parser, GeoSearchParse* opts) {
+  GeoShape& shape = opts->shape;
+  std::tie(shape.t.r.width, shape.t.r.height) = parser->Next<double, double>();
+  opts->geo_ops.conversion = shape.conversion = parser->Next(ParseGeoUnit);
+  shape.type = RECTANGLE_TYPE;
+}
+
+void ParseGeoSearchCount(CmdArgParser* parser, GeoSearchParse* opts) {
+  ParseCount(parser, &opts->geo_ops);
+}
+
+constexpr auto kGeoSearchGrammar = Compile(Options(
+    OneOf(kFromMemberLonglatErr, Action("FROMMEMBER", ParseGeoSearchFromMember),
+          Action<GeoSearchParse>("FROMLONLAT", ParseLongLat)),
+    OneOf(kByRadiusBoxErr, Action("BYRADIUS", ParseGeoSearchByRadius),
+          Action("BYBOX", ParseGeoSearchByBox)),
+    Into(&GeoSearchParse::geo_ops, OneOf(kAscDescErr, Map(&GeoSearchOpts::sorting, "ASC",
+                                                          Sorting::kAsc, "DESC", Sorting::kDesc))),
+    Action("COUNT", ParseGeoSearchCount),
+    Into(&GeoSearchParse::geo_ops, Exist("WITHCOORD", &GeoSearchOpts::withcoord)),
+    Into(&GeoSearchParse::geo_ops, Exist("WITHDIST", &GeoSearchOpts::withdist)),
+    Into(&GeoSearchParse::geo_ops, Exist("WITHHASH", &GeoSearchOpts::withhash))));
 
 void CmdGeoAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
@@ -453,19 +503,19 @@ void SortIfNeeded(GeoArray* ga, Sorting sorting, uint64_t count) {
 }
 
 void GeoSearchStoreGeneric(Transaction* tx, facade::SinkReplyBuilder* builder,
-                           const GeoShape& shape_ref, string_view key, string_view member,
+                           const GeoShape& shape_ref, string_view key, optional<string_view> member,
                            const GeoSearchOpts& geo_ops) {
   GeoShape* shape = &(const_cast<GeoShape&>(shape_ref));
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
 
   ShardId from_shard = Shard(key, shard_set->size());
 
-  if (!member.empty()) {
+  if (member) {
     // get shape.xy from member
     OpResult<double> member_score;
     auto cb = [&](Transaction* t, EngineShard* shard) {
       if (shard->shard_id() == from_shard) {
-        member_score = ZSetFamily::OpScore(t->GetOpArgs(shard), key, member);
+        member_score = ZSetFamily::OpScore(t->GetOpArgs(shard), key, *member);
       }
       return OpStatus::OK;
     };
@@ -617,65 +667,33 @@ void GeoSearchStoreGeneric(Transaction* tx, facade::SinkReplyBuilder* builder,
 }  // namespace
 
 void CmdGeoSearch(CmdArgParser parser, CommandContext* cmd_cntx) {
-  GeoShape shape = {};
-  GeoSearchOpts geo_ops;
-  string_view member;
-  bool from_set = false, by_set = false;
   auto* builder = cmd_cntx->rb();
 
   string_view key = parser.Next();
+  auto st = kGeoSearchGrammar.Apply(&parser);
 
-  // TODO: remove runtime parsing (migrate to cap grammar).
-  parser.Apply(OneOf(Tag("FROMMEMBER",
-                         [&](CmdArgParser* p) {
-                           from_set = true;
-                           member = p->Next();
-                         }),
-                     Tag("FROMLONLAT",
-                         [&](CmdArgParser* p) {
-                           from_set = true;
-                           ParseLongLat(p, shape.xy);
-                         }))
-                   .Err(kFromMemberLonglatErr),
-               OneOf(Tag("BYRADIUS",
-                         [&](CmdArgParser* p) {
-                           by_set = true;
-                           ParseCircularShape(p, &shape, &geo_ops);
-                         }),
-                     Tag("BYBOX",
-                         [&](CmdArgParser* p) {
-                           by_set = true;
-                           std::tie(shape.t.r.width, shape.t.r.height) = p->Next<double, double>();
-                           geo_ops.conversion = shape.conversion = p->Next(ParseGeoUnit);
-                           shape.type = RECTANGLE_TYPE;
-                         }))
-                   .Err(kByRadiusBoxErr),
-               Tag("ASC", [&](CmdArgParser*) { SetSorting(&geo_ops, Sorting::kAsc); }),
-               Tag("DESC", [&](CmdArgParser*) { SetSorting(&geo_ops, Sorting::kDesc); }),
-               Tag("COUNT", [&](CmdArgParser* p) { ParseCount(p, &geo_ops); }),
-               Exist("WITHCOORD", &geo_ops.withcoord), Exist("WITHDIST", &geo_ops.withdist),
-               Exist("WITHHASH", &geo_ops.withhash));
-
-  if (HandleGeoParserFinalize(shape, &parser, cmd_cntx)) {
+  if (HandleGeoParserFinalize(st.shape, &parser, cmd_cntx)) {
     return;
   }
 
   // check mandatory options
-  if (!from_set || !by_set) {
+  if (!st.source || st.shape.type == 0) {
     return builder->SendError(kSyntaxErr);
-  } else if (geo_ops.sorting == Sorting::kError) {
-    return builder->SendError(kAscDescErr);
-  } else if (geo_ops.count == 0) {
+  } else if (st.geo_ops.count == 0) {
     return builder->SendError(kCountError);
   }
 
-  geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;
-  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, member, geo_ops);
+  st.geo_ops.count = (st.geo_ops.count == UINT64_MAX) ? 0 : st.geo_ops.count;
+  optional<string_view> member;
+  if (*st.source == GeoSearchSource::kMember) {
+    member = st.member;
+  }
+  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, st.shape, key, member, st.geo_ops);
 }
 
 void GeoRadiusByMemberGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool read_only) {
   GeoShape shape = {};
-  GeoSearchOpts geo_ops;
+  GeoSearchOpts geo_ops{!read_only, kSyntaxErr};
   // parse arguments
   string_view key = parser.Next();
   // member to latlong, set shape.xy
@@ -684,29 +702,26 @@ void GeoRadiusByMemberGeneric(CmdArgParser parser, CommandContext* cmd_cntx, boo
   auto* builder = cmd_cntx->rb();
   ParseCircularShape(&parser, &shape, &geo_ops);
 
-  ParseGeoResultOptions(&parser, &geo_ops, !read_only, kSyntaxErr);
+  ParseGeoResultOptions(&parser, &geo_ops);
 
   if (HandleGeoParserFinalize(shape, &parser, cmd_cntx)) {
     return;
   }
 
-  if (geo_ops.sorting == Sorting::kError) {
-    return builder->SendError(kAscDescErr);
-  } else if (geo_ops.store == GeoStoreType::kError) {
-    return builder->SendError(kStoreTypeErr);
-  } else if (geo_ops.count == 0) {
+  if (geo_ops.count == 0) {
     return builder->SendError(kCountError);
   } else if (geo_ops.HasWithStatement() && geo_ops.store != GeoStoreType::kNoStore) {
     return builder->SendError(kStoreCompatByMemberErr);
   }
 
   geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;
-  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, member, geo_ops);
+  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, optional<string_view>{member},
+                        geo_ops);
 }
 
 void GeoRadiusGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool read_only) {
   GeoShape shape = {};
-  GeoSearchOpts geo_ops;
+  GeoSearchOpts geo_ops{!read_only};
 
   auto* builder = cmd_cntx->rb();
 
@@ -714,17 +729,13 @@ void GeoRadiusGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool read_o
   ParseLongLat(&parser, shape.xy);
   ParseCircularShape(&parser, &shape, &geo_ops);
 
-  ParseGeoResultOptions(&parser, &geo_ops, !read_only);
+  ParseGeoResultOptions(&parser, &geo_ops);
 
   if (HandleGeoParserFinalize(shape, &parser, cmd_cntx)) {
     return;
   }
 
-  if (geo_ops.sorting == Sorting::kError) {
-    return builder->SendError(kAscDescErr);
-  } else if (geo_ops.store == GeoStoreType::kError) {
-    return builder->SendError(kStoreTypeErr);
-  } else if (geo_ops.count == 0) {
+  if (geo_ops.count == 0) {
     return builder->SendError(kCountError);
   }
 
@@ -733,7 +744,7 @@ void GeoRadiusGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool read_o
   }
 
   geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;
-  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, "", geo_ops);
+  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, nullopt, geo_ops);
 }
 
 void CmdGeoRadiusByMember(CmdArgParser parser, CommandContext* cmd_cntx) {

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -718,8 +718,21 @@ OpResult<bool> CheckHSetExCondition(const OpArgs& op_args, string_view key,
 
 struct HSetExParams {
   OpSetParams op_sp;
+  ExpiryOption expiry;
   CmdArgParser::Range fields;  // field/value pairs; valid only when the parser has no error.
 };
+
+optional<DbSlice::ExpireParams> MakeFieldExpireParams(ExpT type, int64_t value, uint64_t now_ms,
+                                                      bool allow_expired) {
+  if (value < 0)
+    return nullopt;
+
+  DbSlice::ExpireParams params{type, value, now_ms};
+  auto [ttl_ms, expire_at_ms] = params.Calculate(now_ms, false);
+  if (expire_at_ms < 0 || ttl_ms > kMaxExpireDeadlineMs || (!allow_expired && ttl_ms <= 0))
+    return nullopt;
+  return params;
+}
 
 // Parses HSETEX arguments after the key, reporting any error into `parser` (surfaced by the caller
 // via RETURN_ON_PARSE_ERROR). `cmd_name` is only used to format error messages.
@@ -732,53 +745,42 @@ struct HSetExParams {
 // mandatory FIELDS keyword, the Dragonfly format a bare numeric ttl_sec. NX (per-field skip) and
 // the collective FNX/FXX condition are mutually exclusive; FNX/FXX behave identically in both
 // syntaxes (set all-or-nothing). Only the reported value differs (see OpSetParams::Format).
-HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
+HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name, uint64_t now_ms) {
   using Mode = OpSetParams::Mode;
   using Format = OpSetParams::Format;
-  constexpr int kMaxTtl = 1 << 26;
 
-  HSetExParams res;
+  static constexpr auto kGrammar = Compile(
+      Options(Into(&HSetExParams::op_sp, OneOf("", Map(&OpSetParams::mode, "NX", Mode::kNX, "FNX",
+                                                       Mode::kFNX, "FXX", Mode::kFXX))),
+              Into(&HSetExParams::op_sp, OneOf("", Exist("KEEPTTL", &OpSetParams::keepttl))),
+              Into(&HSetExParams::expiry, ExpiryOneOf())));
+  HSetExParams res = kGrammar.Apply(parser);
   OpSetParams& op_sp = res.op_sp;
+  ExpiryOption& expiry = res.expiry;
 
-  bool has_exp = false;
-
-  // EX/PX are relative (now = 0), EXAT/PXAT absolute (now = current time); ms = true for PX/PXAT.
-  // The value must land in (now, now + kMaxTtl] so the resulting ttl_sec stays in [1, kMaxTtl].
-  const int64_t now_ms = GetCurrentTimeMs();
-  const auto expiry = [&](int64_t now, bool ms) {
-    return [&, now, ms](CmdArgParser* p) {
-      has_exp = true;
-      int64_t span = ms ? int64_t(kMaxTtl) * 1000 : kMaxTtl;
-      int64_t v = p->Next<int64_t>();
-      if (v <= now || v > now + span)
-        p->ReportCustom(
-            InvalidExpireTime(cmd_name));  // no-op if Next already reported a non-integer
-      else
-        op_sp.ttl = ms ? (v - now + 999) / 1000 : v - now;
-    };
-  };
-
-  // A single Map makes the set modes (NX/FNX/FXX) mutually exclusive; OneOf also rejects a repeated
-  // flag. Parsing stops at the first non-flag token (ttl_sec or FIELDS).
-  parser->Apply(
-      OneOf(Map(&op_sp.mode, "NX", Mode::kNX, "FNX", Mode::kFNX, "FXX", Mode::kFXX)),
-      OneOf(Exist("KEEPTTL", &op_sp.keepttl)),
-      OneOf(Tag("EX", expiry(0, false)), Tag("PX", expiry(0, true)),
-            Tag("EXAT", expiry(now_ms / 1000, false)), Tag("PXAT", expiry(now_ms, true))));
+  if (expiry.value) {
+    auto expire_params = MakeFieldExpireParams(expiry.type, *expiry.value, now_ms, false);
+    if (!expire_params) {
+      parser->ReportCustom(InvalidExpireTime(cmd_name));
+    } else {
+      int64_t ttl_ms = expire_params->Calculate(now_ms, false).first;
+      op_sp.ttl = (ttl_ms + 999) / 1000;
+    }
+  }
 
   // FIELDS marks the Redis format, a bare ttl_sec the Dragonfly format. The parser short-circuits
   // once errored, so the steps below need no per-step checks.
   if (parser->Check("FIELDS")) {
     op_sp.format = Format::kRedis;
-    if (op_sp.mode == Mode::kNX || (op_sp.keepttl && has_exp))
+    if (op_sp.mode == Mode::kNX || (op_sp.keepttl && expiry.value))
       parser->Report(CmdArgParser::CUSTOM_ERROR);  // NX is Dragonfly-only; one expiry option max
     res.fields = parser->NextRange(2, kNumFieldsMismatch, /*consume_all=*/true);
-  } else if (has_exp) {
+  } else if (expiry.value) {
     // EX/PX/EXAT/PXAT belong to the Redis form; without FIELDS the command is malformed.
     parser->Report(CmdArgParser::CUSTOM_ERROR);
   } else {
     op_sp.format = Format::kDragonfly;
-    op_sp.ttl = parser->Next<FInt<1, kMaxTtl>>();
+    op_sp.ttl = parser->Next<FInt<int64_t{1}, kMaxExpireDeadlineSec>>();
 
     res.fields = parser->RemainingRange();
     if (res.fields.empty() || res.fields.size() % 2 != 0)
@@ -789,7 +791,8 @@ HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
 
 void HSetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  HSetExParams parsed = ParseHSetEx(&parser, cmd_cntx->cid()->name());
+  uint64_t now_ms = cmd_cntx->tx()->GetDbContext().time_now_ms;
+  HSetExParams parsed = ParseHSetEx(&parser, cmd_cntx->cid()->name(), now_ms);
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   // Evaluate the FNX/FXX condition (if any), then let OpSet set the fields and report the
@@ -849,7 +852,7 @@ void CmdHDel(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdHExpire(CmdArgParser parser, CommandContext* cmd_cntx) {
-  using MinMaxTtl = FInt<0, (1 << 26)>;
+  using MinMaxTtl = FInt<int64_t{0}, kMaxExpireDeadlineSec>;
   auto [key, ttl_sec] = parser.Next<string_view, MinMaxTtl>();
 
   ExpireFlags flags = parser
@@ -1018,36 +1021,29 @@ OpResult<vector<OptStr>> OpHGetEx(const OpArgs& op_args, string_view key, const 
   return values;
 }
 
+DbSlice::ExpireParams BuildHGetExpiry(CmdArgParser* p, const ExpiryOrPersistOptions& o,
+                                      uint64_t now_ms, string_view cmd_name) {
+  DbSlice::ExpireParams out;
+  out.persist = o.persist;  // PERSIST and an expiry are mutually exclusive (OneOf)
+  if (!o.expiry.value)
+    return out;
+
+  auto params = MakeFieldExpireParams(o.expiry.type, *o.expiry.value, now_ms, true);
+  if (!params)
+    p->ReportCustom(InvalidExpireTime(cmd_name));
+  return params.value_or(out);
+}
+
 void CmdHGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  string_view cmd_name = cmd_cntx->cid()->name();
-  // The transaction clock the op applies the TTL against, so a relative EX/PX resolves against the
-  // same time the op uses rather than a separate wall-clock read.
-  const uint64_t now_ms = cmd_cntx->tx()->GetDbContext().time_now_ms;
 
-  // At most one of EX/PX/EXAT/PXAT/PERSIST is accepted before FIELDS; OneOf rejects a second option
-  // as a syntax error (Redis instead reports a misplaced-FIELDS error here).
-  DbSlice::ExpireParams exp_params;
-  auto read_expiry = [&](ExpT type) {
-    return [&, type](CmdArgParser* p) {
-      // HGETEX accepts 0 (expire now -> delete the field) but rejects negatives, unlike SET/GETEX.
-      // A non-integer leaves the parser's own error in place (ReportCustom won't overwrite it).
-      int64_t value = p->Next<int64_t>();
-      if (value < 0)
-        return p->ReportCustom("invalid expire time, must be >= 0");
+  uint64_t now_ms = cmd_cntx->tx()->GetDbContext().time_now_ms;
+  static constexpr auto kGrammar = Compile(Options(ExpiryOrPersist()));
+  auto opts = kGrammar.Apply(&parser);
 
-      // Reject overflow and values past the hash-field TTL cap (1<<26 s, as for HEXPIRE/HSETEX).
-      exp_params = DbSlice::ExpireParams{type, value, now_ms};
-      constexpr int64_t kMaxTtlMs = (int64_t{1} << 26) * 1000;
-      auto [rel_msec, abs_msec] = exp_params.Calculate(now_ms, false);
-      if (abs_msec < 0 || rel_msec > kMaxTtlMs)
-        return p->ReportCustom(InvalidExpireTime(cmd_name));
-    };
-  };
-  // TODO: remove runtime parsing (migrate to cap grammar).
-  parser.Apply(OneOf(Tag("EX", read_expiry(ExpT::EX)), Tag("PX", read_expiry(ExpT::PX)),
-                     Tag("EXAT", read_expiry(ExpT::EXAT)), Tag("PXAT", read_expiry(ExpT::PXAT)),
-                     Exist("PERSIST", &exp_params.persist)));
+  DbSlice::ExpireParams exp_params =
+      BuildHGetExpiry(&parser, opts, now_ms, cmd_cntx->cid()->name());
+
   parser.ExpectTag("FIELDS", "Mandatory argument FIELDS is missing or not at the right position");
   CmdArgParser::Range fields =
       parser.NextRange(1, kNumFieldsMismatch, /*consume_all=*/true, kInvalidNumFields);

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1311,21 +1311,23 @@ void CmdLLen(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdLPos(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, elem] = parser.Next<string_view, string_view>();
 
-  int rank = 1;
-  std::optional<uint32_t> count;
-  uint32_t max_len = 0;
+  struct LposOpts {
+    int rank = 1;
+    std::optional<uint32_t> count;
+    uint32_t max_len = 0;
+  };
 
-  // TODO: remove runtime parsing (migrate to cap grammar).
-  parser.ApplyOrSkip(Tag("RANK", &rank), Tag("COUNT", &count), Tag("MAXLEN", &max_len));
-
-  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+  static constexpr auto kGrammar = Compile(
+      Options(Field<Validated<int, NotEq<0, facade::kInvalidIntErr>>>("RANK", &LposOpts::rank),
+              Field("COUNT", &LposOpts::count), Field("MAXLEN", &LposOpts::max_len)));
+  auto opts = kGrammar.Apply(&parser);
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (rank == 0)
-    return rb->SendError(kInvalidIntErr);
+  if (!parser.Finalize())
+    return rb->SendError(parser.TakeError().MakeReply());
 
   auto cb = [&, &key = key, &elem = elem](Transaction* t, EngineShard* shard) {
-    return OpPos(t->GetOpArgs(shard), key, elem, rank, count.value_or(1), max_len);
+    return OpPos(t->GetOpArgs(shard), key, elem, opts.rank, opts.count.value_or(1), opts.max_len);
   };
 
   Transaction* trans = cmd_cntx->tx();
@@ -1337,7 +1339,7 @@ void CmdLPos(CmdArgParser parser, CommandContext* cmd_cntx) {
     return rb->SendError(result.status());
   }
 
-  if (!count.has_value()) {
+  if (!opts.count.has_value()) {
     if (result->empty()) {
       rb->SendNull();
     } else {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -186,22 +186,21 @@ ParseResult<std::string> ParseLanguageArg(CmdArgParser* parser) {
   return lang;
 }
 
+using TP = search::SchemaField::TextParams;
+
 struct ValidTextWeight : facade::VNum<double> {
   static facade::RuleError validate(double v) {
-    return {!search::SchemaField::TextParams::IsValidWeight(v), {}};
+    return {!TP::IsValidWeight(v), {}};
   }
 };
 
-void ParseTextWeight(CmdArgParser* parser, search::SchemaField::TextParams* params) {
+void ParseTextWeight(CmdArgParser* parser, TP* params) {
   params->weight = parser->Next<ValidTextWeight>("Invalid WEIGHT value");
 }
 
-ParseResult<search::SchemaField::TextParams> ParseTextParams(CmdArgParser* parser) {
-  search::SchemaField::TextParams params{};
-  parser->Apply(Exist("WITHSUFFIXTRIE", &params.with_suffixtrie), Exist("NOSTEM", &params.no_stem),
-                Tag("WEIGHT", [&](CmdArgParser* p) { ParseTextWeight(p, &params); }));
-  return params;
-}
+constexpr auto kTextParamsGrammar =
+    Compile(Options(Exist("WITHSUFFIXTRIE", &TP::with_suffixtrie), Exist("NOSTEM", &TP::no_stem),
+                    Field<ValidTextWeight>("WEIGHT", &TP::weight, "Invalid WEIGHT value")));
 
 search::SchemaField::NumericParams ParseNumericParams(CmdArgParser* parser) {
   search::SchemaField::NumericParams params{};
@@ -228,10 +227,7 @@ ParsedSchemaField ParseTag(CmdArgParser* parser) {
 }
 
 ParsedSchemaField ParseText(CmdArgParser* parser) {
-  auto text_params = ParseTextParams(parser);
-  if (!text_params)
-    return make_unexpected(text_params.error());
-  return std::make_pair(search::SchemaField::TEXT, std::move(text_params).value());
+  return std::make_pair(search::SchemaField::TEXT, kTextParamsGrammar.Apply(parser));
 }
 
 ParsedSchemaField ParseNumeric(CmdArgParser* parser) {
@@ -539,12 +535,12 @@ std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser) {
 }
 
 constexpr string_view kBM25StdTanhFactorErr = "BM25STD_TANH_FACTOR must be a positive integer";
+using BM25StdTanhFactor = facade::Positive<uint64_t>;
 
 // Parses a BM25STD_TANH_FACTOR value: an integer >= 1 (no upper bound). On a missing or invalid
 // value the parser reports kBM25StdTanhFactorErr, surfaced by the caller's error handling.
 uint64_t ParseBM25StdTanhFactor(CmdArgParser* parser) {
-  using TanhFactorInt = facade::FInt<uint64_t{1}, std::numeric_limits<uint64_t>::max()>;
-  return parser->Next<TanhFactorInt>(kBM25StdTanhFactorErr);
+  return parser->Next<BM25StdTanhFactor>(kBM25StdTanhFactorErr);
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -1758,6 +1754,7 @@ struct HybridSearchParams {
   string text_query;
   string yield_text_score_as;
   std::optional<search::ScorerSpec> scorer;  // carries the BM25STD.TANH factor when applicable
+  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
 
   string vsim_field;
   string vsim_param;
@@ -1776,6 +1773,7 @@ struct HybridSearchParams {
 
   size_t num_candidates = 0;
   std::optional<uint32_t> ef_runtime;
+  float shard_k_ratio = 1.0f;
 
   size_t limit_offset = 0;
   size_t limit_total = 10;
@@ -1812,25 +1810,45 @@ struct HnswRangeEpsilon : facade::VNum<double> {
   }
 };
 
+void ParseScorerInto(CmdArgParser* sub, HybridSearchParams* p) {
+  if (p->scorer) {
+    sub->Next();
+    return;
+  }
+  auto scorer_fn = ParseScorer(sub);
+  if (!scorer_fn)
+    sub->ReportCustom(absl::StrCat("No such scorer: ", sub->Peek()));
+  else
+    p->scorer = *scorer_fn;
+}
+
+void ParseHybridLoad(CmdArgParser* parser, HybridSearchParams* params) {
+  if (parser->Check("*")) {
+    params->load_all_fields = true;
+    return;
+  }
+
+  const size_t count = parser->Next<size_t>();
+  std::vector<FieldReference> fields;
+  fields.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    string_view field = parser->Next();
+    if (absl::StartsWith(field, "@"))
+      field.remove_prefix(1);
+    string_view alias;
+    parser->Check("AS", &alias);
+    fields.emplace_back(field, alias);
+  }
+  params->return_fields = std::move(fields);
+}
+
+void ParseHybridQueryParams(CmdArgParser* parser, HybridSearchParams* params) {
+  params->query_params = ParseQueryParams(parser);
+}
+
 ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
-  using facade::Map;
-  using facade::Tag;
-
   HybridSearchParams p;
-  uint64_t tanh_factor = search::kDefaultBM25StdTanhFactor;
 
-  auto parse_scorer = [&](CmdArgParser* sub) {
-    if (p.scorer) {
-      sub->Next();
-      return;
-    }
-    auto scorer_fn = ParseScorer(sub);
-    if (!scorer_fn)
-      sub->ReportCustom(absl::StrCat("No such scorer: ", sub->Peek()));
-    else
-      p.scorer = *scorer_fn;
-  };
-  auto parse_tanh_factor = [&](CmdArgParser* sub) { tanh_factor = ParseBM25StdTanhFactor(sub); };
   auto read_range_epsilon = [&](CmdArgParser* sub) {
     double epsilon = sub->Next<HnswRangeEpsilon>("Invalid EPSILON value");
     if (!sub->HasError())
@@ -1879,28 +1897,36 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
 
   parser->ExpectTag("SEARCH", "expected SEARCH keyword");
   p.text_query = parser->Next<string>();
-  parser->Apply(Tag("SCORER", parse_scorer), Tag("BM25STD_TANH_FACTOR", parse_tanh_factor),
-                Tag("YIELD_SCORE_AS", &p.yield_text_score_as));
+  static constexpr auto kScorerGrammar = Compile(Options(
+      Action("SCORER", &ParseScorerInto),
+      Field<BM25StdTanhFactor>("BM25STD_TANH_FACTOR", &HybridSearchParams::bm25std_tanh_factor,
+                               kBM25StdTanhFactorErr),
+      Field("YIELD_SCORE_AS", &HybridSearchParams::yield_text_score_as)));
+  kScorerGrammar.Apply(parser, &p);
   if (p.scorer)
-    p.scorer->bm25std_tanh_factor = tanh_factor;
+    p.scorer->bm25std_tanh_factor = p.bm25std_tanh_factor;
 
   parser->ExpectTag("VSIM", "expected VSIM keyword");
   p.vsim_field = string{parser->ExpectStartsWith("@", "VSIM field must start with @")};
   p.vsim_param = string{parser->ExpectStartsWith("$", "VSIM parameter must start with $")};
 
-  float shard_k_ratio = 1.0f;
   if (parser->Check("KNN", &p.num_candidates)) {
-    parser->Apply(Tag("K", &p.num_candidates), Tag("EF_RUNTIME", &p.ef_runtime),
-                  Tag("SHARD_K_RATIO", &shard_k_ratio));
+    static constexpr auto kGrammar =
+        Compile(Options(Field("K", &HybridSearchParams::num_candidates),
+                        Field("EF_RUNTIME", &HybridSearchParams::ef_runtime),
+                        Field("SHARD_K_RATIO", &HybridSearchParams::shard_k_ratio)));
+    kGrammar.Apply(parser, &p);
     p.num_candidates =
-        static_cast<size_t>(std::ceil(static_cast<float>(p.num_candidates) * shard_k_ratio));
+        static_cast<size_t>(std::ceil(static_cast<float>(p.num_candidates) * p.shard_k_ratio));
   } else if (parser->Check("RANGE")) {
     parse_hybrid_range(parser);
   }
 
   if (parser->Check("FILTER", &p.vsim_filter) && p.use_range)
     parser->ReportCustom("VSIM RANGE cannot be combined with FILTER");
-  parser->Apply(Tag("YIELD_SCORE_AS", &p.yield_vsim_score_as));
+  static constexpr auto kYieldGrammar =
+      Compile(Options(Field("YIELD_SCORE_AS", &HybridSearchParams::yield_vsim_score_as)));
+  kYieldGrammar.Apply(parser, &p);
 
   if (parser->Check("COMBINE")) {
     using CM = HybridSearchParams::CombineMethod;
@@ -1908,40 +1934,27 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
       p.combine_method = *method;
       parser->Next<size_t>();  // nargs hint, not validated -- key/value pairs drive parsing.
       if (p.combine_method == CM::LINEAR) {
-        parser->Apply(Tag("ALPHA", &p.alpha), Tag("BETA", &p.beta),
-                      Tag("YIELD_SCORE_AS", &p.yield_combined_score_as));
+        static constexpr auto kGrammar = Compile(Options(
+            Field("ALPHA", &HybridSearchParams::alpha), Field("BETA", &HybridSearchParams::beta),
+            Field("YIELD_SCORE_AS", &HybridSearchParams::yield_combined_score_as)));
+        kGrammar.Apply(parser, &p);
       } else {
-        parser->Apply(Tag("CONSTANT", &p.rrf_constant), Tag("WINDOW", &p.rrf_window),
-                      Tag("YIELD_SCORE_AS", &p.yield_combined_score_as));
+        static constexpr auto kGrammar =
+            Compile(Options(Field("CONSTANT", &HybridSearchParams::rrf_constant),
+                            Field("WINDOW", &HybridSearchParams::rrf_window),
+                            Field("YIELD_SCORE_AS", &HybridSearchParams::yield_combined_score_as)));
+        kGrammar.Apply(parser, &p);
       }
     } else {
       parser->ReportCustom(absl::StrCat("unsupported COMBINE method: ", parser->Peek()));
     }
   }
 
-  auto parse_load = [&](CmdArgParser* sub) {
-    if (sub->Check("*")) {
-      p.load_all_fields = true;
-      return;
-    }
-    const size_t n = sub->Next<size_t>();
-    std::vector<FieldReference> fields;
-    fields.reserve(n);
-    for (size_t i = 0; i < n; i++) {
-      string_view f = sub->Next();
-      if (absl::StartsWith(f, "@"))
-        f.remove_prefix(1);
-      string_view alias;
-      sub->Check("AS", &alias);
-      fields.emplace_back(f, alias);
-    }
-    p.return_fields = std::move(fields);
-  };
-
-  auto parse_params = [&](CmdArgParser* sub) { p.query_params = ParseQueryParams(sub); };
-
-  parser->ApplyOrSkip(Tag("SCORER", parse_scorer), Tag("LOAD", parse_load),
-                      Tag("LIMIT", &p.limit_offset, &p.limit_total), Tag("PARAMS", parse_params));
+  static constexpr auto kTailGrammar = Compile(
+      Options(Action("SCORER", &ParseScorerInto), Action("LOAD", &ParseHybridLoad),
+              Field("LIMIT", &HybridSearchParams::limit_offset, &HybridSearchParams::limit_total),
+              Action("PARAMS", &ParseHybridQueryParams), Skip()));
+  kTailGrammar.Apply(parser, &p);
 
   if (parser->HasError())
     return make_unexpected(parser->TakeError().MakeReply());

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1376,37 +1376,24 @@ cmd::CmdR CmdGetSet(CmdArgParser parser, CommandContext* cmd_cntx) {
 cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
-  ExpT exp_type_value = ExpT::EX;
-  int64_t int_arg = 0;
-  bool persist = false;
-  bool defined = false;
+  static constexpr char kGetExExpiryErr[] = "invalid expire time in 'getex' command";
+  using ExpiryValue = Validated<int64_t, Bounded<int64_t{1}, INT64_MAX, kGetExExpiryErr>>;
+  static constexpr auto kGrammar = Compile(Options(ExpiryOrPersist<ExpiryValue>()));
+  auto opts = kGrammar.Apply(&parser);
 
-  auto expiry = [&](ExpT type) {
-    return [&, type](CmdArgParser* p) {
-      exp_type_value = type;
-      int_arg = p->Next<int64_t>();
-      defined = true;
-    };
-  };
-  // TODO: remove runtime parsing (migrate to cap grammar).
-  parser.Apply(OneOf(Tag("EX", expiry(ExpT::EX)), Tag("PX", expiry(ExpT::PX)),
-                     Tag("EXAT", expiry(ExpT::EXAT)), Tag("PXAT", expiry(ExpT::PXAT)),
-                     Exist("PERSIST", &persist)));
   if (!parser.Finalize()) {
     co_return parser.TakeError().MakeReply();
-  }
-  if (defined && int_arg <= 0) {
-    co_return facade::ErrorReply{InvalidExpireTime("getex")};
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<StringResult> {
     auto op_args = t->GetOpArgs(shard);
 
     DbSlice::ExpireParams exp_params;
-    if (defined) {
-      exp_params = DbSlice::ExpireParams{exp_type_value, int_arg, op_args.db_cntx.time_now_ms};
+    if (opts.expiry.value) {
+      exp_params =
+          DbSlice::ExpireParams{opts.expiry.type, *opts.expiry.value, op_args.db_cntx.time_now_ms};
     }
-    exp_params.persist = persist;
+    exp_params.persist = opts.persist;
 
     auto it_res = op_args.GetDbSlice().FindMutable(op_args.db_cntx, key, OBJ_STRING);
     if (!it_res)

--- a/src/server/topk_family.cc
+++ b/src/server/topk_family.cc
@@ -352,10 +352,7 @@ void TopkFamily::Count(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 void TopkFamily::List(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  bool with_count = false;
-
-  // TODO: remove runtime parsing (single option -> Check).
-  parser.Apply(OneOf(Exist("WITHCOUNT", &with_count)));
+  bool with_count = parser.Check("WITHCOUNT");
 
   if (!parser.Finalize())
     return rb->SendError(parser.TakeError().MakeReply());

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1780,23 +1780,18 @@ void ZRangeGeneric(facade::ParsedArgs args, ZSetFamily::RangeParams range_params
   facade::CmdArgParser parser{args.Tail().Tail().Tail()};
   using RP = ZSetFamily::RangeParams;
 
-  auto set_interval = [&](RP::IntervalType interval) {
-    return [&, interval](CmdArgParser* p) {
-      if (exchange(range_params.interval_type, interval) ==
-          (interval == RP::SCORE ? RP::LEX : RP::SCORE)) {
-        p->ReportCustom("BYSCORE and BYLEX options are not compatible");
-      }
-    };
-  };
-
-  // TODO: remove runtime parsing (migrate to cap grammar).
-  parser.Apply(Tag("BYSCORE", set_interval(RP::SCORE)), Tag("BYLEX", set_interval(RP::LEX)),
-               Exist("REV", &range_params.reverse), Exist("WITHSCORES", &range_params.with_scores),
-               Tag("LIMIT", [&](CmdArgParser* p) {
-                 auto [offset, limit] = p->Next<int32_t, int32_t>();
-                 range_params.limit = limit < 0 ? UINT32_MAX : static_cast<uint32_t>(limit);
-                 range_params.offset = offset < 0 ? UINT32_MAX : static_cast<uint32_t>(offset);
-               }));
+  static constexpr auto kGrammar =
+      Compile(Options(OneOf("BYSCORE and BYLEX options are not compatible",
+                            Map(&RP::interval_type, "BYSCORE", RP::SCORE),
+                            Map(&RP::interval_type, "BYLEX", RP::LEX)),
+                      Exist("REV", &RP::reverse), Exist("WITHSCORES", &RP::with_scores),
+                      facade::Action(
+                          "LIMIT", +[](CmdArgParser* p, RP* rp) {
+                            auto [offset, limit] = p->Next<int32_t, int32_t>();
+                            rp->limit = limit < 0 ? UINT32_MAX : static_cast<uint32_t>(limit);
+                            rp->offset = offset < 0 ? UINT32_MAX : static_cast<uint32_t>(offset);
+                          })));
+  kGrammar.Apply(&parser, &range_params);
 
   parser.Finalize("unsupported option ");
 
@@ -2081,38 +2076,24 @@ void CmdBZPopMax(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
-  facade::ParsedArgs args = parser.UnparsedArgs();
-  string_view key = args[0];
+  string_view key = parser.Next();
 
-  ZSetFamily::ZParams zparams;
-  size_t i = 1;
-  for (; i < args.size() - 1; ++i) {
-    string cur_arg = absl::AsciiStrToUpper(args[i]);
-
-    if (cur_arg == "XX") {
-      zparams.flags |= ZADD_IN_XX;  // update only
-    } else if (cur_arg == "NX") {
-      zparams.flags |= ZADD_IN_NX;  // add new only.
-    } else if (cur_arg == "GT") {
-      zparams.flags |= ZADD_IN_GT;
-    } else if (cur_arg == "LT") {
-      zparams.flags |= ZADD_IN_LT;
-    } else if (cur_arg == "CH") {
-      zparams.ch = true;
-    } else if (cur_arg == "INCR") {
-      zparams.flags |= ZADD_IN_INCR;
-    } else {
-      break;
-    }
-  }
+  static constexpr auto kGrammar = Compile(
+      Options(1,
+              Flags(&ZSetFamily::ZParams::flags, "NX", unsigned{ZADD_IN_NX}, "XX",
+                    unsigned{ZADD_IN_XX}, "GT", unsigned{ZADD_IN_GT}, "LT", unsigned{ZADD_IN_LT}),
+              Exist("CH", &ZSetFamily::ZParams::ch),
+              Flags(&ZSetFamily::ZParams::flags, "INCR", unsigned{ZADD_IN_INCR})));
+  auto zparams = kGrammar.Apply(&parser);
+  auto args = parser.RemainingRange();
 
   auto* builder = cmd_cntx->rb();
-  if ((args.size() - i) % 2 != 0) {
+  if (args.size() % 2 != 0) {
     builder->SendError(kSyntaxErr);
     return;
   }
 
-  if ((zparams.flags & ZADD_IN_INCR) && (i + 2 < args.size())) {
+  if ((zparams.flags & ZADD_IN_INCR) && args.size() > 2) {
     builder->SendError("INCR option supports a single increment-element pair");
     return;
   }
@@ -2133,7 +2114,7 @@ void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   absl::flat_hash_set<string_view> members_set;
   absl::InlinedVector<ScoredMemberView, 4> members;
 
-  unsigned num_members = (args.size() - i) / 2;
+  unsigned num_members = args.size() / 2;
 
   // We sort the fields if the expected encoding could be listpack.
   bool to_sort_fields = false;
@@ -2145,7 +2126,7 @@ void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
     to_sort_fields = true;
   }
 
-  for (; i < args.size(); i += 2) {
+  for (size_t i = 0; i < args.size(); i += 2) {
     string_view cur_arg = args[i];
     double val = 0;
 

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1780,6 +1780,10 @@ void ZRangeGeneric(facade::ParsedArgs args, ZSetFamily::RangeParams range_params
   facade::CmdArgParser parser{args.Tail().Tail().Tail()};
   using RP = ZSetFamily::RangeParams;
 
+  // Legacy handlers (ZRANGEBYSCORE/ZRANGEBYLEX and their REV variants) preset a fixed interval
+  // type; a BYSCORE/BYLEX option that flips it to the opposite type must be rejected.
+  const RP::IntervalType fixed_type = range_params.interval_type;
+
   static constexpr auto kGrammar =
       Compile(Options(OneOf("BYSCORE and BYLEX options are not compatible",
                             Map(&RP::interval_type, "BYSCORE", RP::SCORE),
@@ -1792,6 +1796,9 @@ void ZRangeGeneric(facade::ParsedArgs args, ZSetFamily::RangeParams range_params
                             rp->offset = offset < 0 ? UINT32_MAX : static_cast<uint32_t>(offset);
                           })));
   kGrammar.Apply(&parser, &range_params);
+
+  if (fixed_type != RP::RANK && range_params.interval_type != fixed_type)
+    parser.ReportCustom("BYSCORE and BYLEX options are not compatible");
 
   parser.Finalize("unsupported option ");
 
@@ -2079,8 +2086,7 @@ void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   static constexpr auto kGrammar = Compile(
-      Options(1,
-              Flags(&ZSetFamily::ZParams::flags, "NX", unsigned{ZADD_IN_NX}, "XX",
+      Options(Flags(&ZSetFamily::ZParams::flags, "NX", unsigned{ZADD_IN_NX}, "XX",
                     unsigned{ZADD_IN_XX}, "GT", unsigned{ZADD_IN_GT}, "LT", unsigned{ZADD_IN_LT}),
               Exist("CH", &ZSetFamily::ZParams::ch),
               Flags(&ZSetFamily::ZParams::flags, "INCR", unsigned{ZADD_IN_INCR})));
@@ -2088,7 +2094,7 @@ void CmdZAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto args = parser.RemainingRange();
 
   auto* builder = cmd_cntx->rb();
-  if (args.size() % 2 != 0) {
+  if (args.empty() || args.size() % 2 != 0) {
     builder->SendError(kSyntaxErr);
     return;
   }

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -510,6 +510,27 @@ TEST_F(ZSetFamilyTest, ZRange) {
   ASSERT_THAT(resp, RespElementsAre("foo", "great", "hill", "omega"));
 }
 
+TEST_F(ZSetFamilyTest, RangeFixedTypeByOptionConflict) {
+  Run({"zadd", "z", "1", "a", "2", "b", "3", "c"});
+
+  // Legacy fixed-type handlers must reject a BY* option that flips their preset interval type.
+  EXPECT_THAT(Run({"zrangebylex", "z", "0", "10", "BYSCORE"}),
+              ErrArg("BYSCORE and BYLEX options are not compatible"));
+  EXPECT_THAT(Run({"zrangebyscore", "z", "0", "10", "BYLEX"}),
+              ErrArg("BYSCORE and BYLEX options are not compatible"));
+  EXPECT_THAT(Run({"zrevrangebylex", "z", "10", "0", "BYSCORE"}),
+              ErrArg("BYSCORE and BYLEX options are not compatible"));
+  EXPECT_THAT(Run({"zrevrangebyscore", "z", "10", "0", "BYLEX"}),
+              ErrArg("BYSCORE and BYLEX options are not compatible"));
+
+  // A redundant same-type option is tolerated (does not change the preset type).
+  EXPECT_THAT(Run({"zrangebyscore", "z", "1", "3", "BYSCORE"}), RespElementsAre("a", "b", "c"));
+
+  // The unified ZRANGE still enforces mutual exclusion of the two options.
+  EXPECT_THAT(Run({"zrange", "z", "-", "+", "BYLEX", "BYSCORE"}),
+              ErrArg("BYSCORE and BYLEX options are not compatible"));
+}
+
 TEST_F(ZSetFamilyTest, ZRevRange) {
   Run({"zadd", "key", "-inf", "a", "1", "b", "2", "c"});
   auto resp = Run({"zrevrangebyscore", "key", "2", "-inf"});


### PR DESCRIPTION
Summary: This PR refactors command argument parsing by removing the legacy runtime “Apply” combinators and consolidating parsing on the compile-time (consteval) grammar API.

Changes:

- Extends CmdArgParser’s compile-time grammar with new primitives: Flags, Switch, TagValue, Into, Skip, and parsed-field support (Field<Parsed>).
- Tightens parsing/type constraints via ParsedArg, TokenParser, and numeric helper aliases like Positive/NonNegativeInt.
- Removes runtime parsing helpers (Apply/ApplyOrSkip and related option factories) and updates unit tests accordingly.
- Migrates multiple commands to the compile-time grammar style (e.g., DEBUG RELOAD, TOPK LIST, RESTORE, EXPIRE*, SORT, GEOSEARCH/GEORADIUS*, HSETEX/HGETEX, GETEX, ZRANGE options, ZADD, and hybrid search parsing).
- Adds/updates tests and micro-bench parsing coverage to exercise the new grammar primitives.

Technical Notes: The new approach keeps parsing rules static/constexpr, reduces per-call construction, and centralizes option conflict handling (e.g. via OneOf/Switch).