### PR TITLE
feat(pubsub): close stuck subscribers to avoid publisher throttling

### DIFF
--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -216,7 +216,8 @@ SendMessages(channel, messages, sharded)
   3. Backpressure gate (per destination thread):
      For each unique subscriber thread:
        Connection::EnsureMemoryBudget(sub_thread)
-       → blocks fiber if that thread's subscriber_bytes > publish_buffer_limit
+       → blocks fiber if that thread's subscriber_bytes > hard limit
+         (publish_buffer_limit * kPubSubHardMultiplier)
 
   4. Build message payload:
      BuildSender copies channel + message into a single shared_ptr<char[]>
@@ -363,17 +364,24 @@ intentionally out of scope.
 
 Dragonfly does not block a publisher on an individual subscriber socket.
 Instead, published messages are placed on each subscriber connection's
-control-path dispatch queue. The server accounts the queued Pub/Sub message
-memory per I/O thread. Once that thread exceeds `publish_buffer_limit`,
-publishers targeting the thread park their fibers until queued subscriber
-messages are processed or the connections are closed.
+control-path dispatch queue, and the queued Pub/Sub memory is accounted per I/O
+thread in `QueueBackpressure::subscriber_bytes`. Two thresholds derive from
+`publish_buffer_limit`:
 
-The limit is a throttling point, not a strict allocation cap. A publish checks
-the budget before dispatching and does not reserve space, so concurrent
+- **Soft limit** — `publish_buffer_limit`. Crossing it starts a back-pressure
+  *episode* and enables slow-subscriber protection (see below), but does **not**
+  park publishers.
+- **Hard limit** — `publish_buffer_limit * kPubSubHardMultiplier` (hardcoded to `4`).
+  Publishers targeting the thread park their fibers only once
+  `subscriber_bytes` reaches this red line, until queued subscriber messages are
+  processed or the connections are closed.
+
+The hard limit is a throttling point, not a strict cap. A publish
+checks the budget before dispatching and does not reserve space, so concurrent
 publishers can add messages after the check and temporarily push the total
 above the configured value.
 
-### V1 delivery path
+### IoLoopV1 delivery path
 
 For `PUBLISH` and the non-cluster `SPUBLISH` path, the delivery sequence is:
 
@@ -381,8 +389,9 @@ For `PUBLISH` and the non-cluster `SPUBLISH` path, the delivery sequence is:
    them by their owning I/O thread.
 2. Before dispatching, it calls
    `Connection::EnsureMemoryBudget(thread_id)` once per destination thread.
-   `QueueBackpressure::EnsureBelowLimit` parks the publishing fiber while
-   `subscriber_bytes > publish_buffer_limit` (the equality case is allowed).
+   `QueueBackpressure::EnsureBelowLimit` parks the publishing fiber only while
+   `subscriber_bytes` exceeds the **hard** limit (the equality case is allowed);
+   being above the soft limit alone does not park publishers.
 3. `BuildSender` creates one shared payload containing the channel and message
    arguments. `DispatchBrief` runs on each I/O thread and calls
    `Connection::SendPubMessageAsync` for local subscribers.
@@ -403,33 +412,69 @@ single stuck subscriber can therefore throttle publishers sending to other
 subscribers assigned to the same thread, but it does not directly consume the
 budget of other I/O threads.
 
+### Slow-subscriber protection
+
+To keep one stuck subscriber from throttling publishers up to the hard limit,
+Dragonfly can close it once it is clearly the culprit. `ProcessAdminMessage`
+records `async_op_start_cycle_` around the `std::visit` that runs the Pub/Sub
+send, so the connection knows how long its current send has been blocked.
+
+`SendPubMessageAsync` (which runs on the subscriber's thread while that send is
+parked) closes the subscriber only when **both** conditions hold:
+
+1. the thread is in a soft-limit episode (`subscriber_bytes` above the soft
+   limit), and
+2. this connection's active send has been blocked continuously for at least
+   `--pubsub_slow_subscriber_timeout_ms`.
+
+The conditions are conjunctive: a slow send below the budget, or a full budget
+with a still-progressing send, is left alone. When both hold,
+`RequestPubsubClose` discards the new message, evicts the connection's queued
+`PubMessage` items (immediately releasing their subscriber accounting and waking
+parked publishers), and calls the non-blocking `MarkForClose` — it never waits,
+joins, or interrupts the in-flight write. `ProcessAdminMessage` observes
+`request_shutdown_` once the parked send returns and lets the normal shutdown
+path close the connection; further pub messages are dropped in the meantime.
+
+`--pubsub_slow_subscriber_timeout_ms` is startup-only (like
+`publish_buffer_limit`) and defaults to `0`, which disables the protection.
+
 ### Limits, cleanup, and observability
 
 Queued Pub/Sub messages are accounted both per connection and in the owning
 I/O thread's `QueueBackpressure::subscriber_bytes`. When a message is
 processed, or when a connection closes and its queue is drained, the bytes are
-released. Once the thread falls back to or below `publish_buffer_limit`, V1
-wakes waiting publishers. Messages are normally retained until they are
-processed or the subscriber disconnects; stale messages are dropped after the
-client leaves Pub/Sub mode.
+released. Once the thread falls back below the hard limit, V1 wakes waiting
+publishers. Messages are normally retained until they are processed or the
+subscriber disconnects; stale messages are dropped after the client leaves
+Pub/Sub mode.
 
-The main configuration knob is `publish_buffer_limit` (128 MB per I/O thread,
-startup-only). `proactor_threads` changes how subscribers and independent
-budgets are distributed. Other V1 pipeline and socket settings can affect
-processing or output latency, but do not change Pub/Sub admission directly.
+The main configuration knobs are `publish_buffer_limit` (196 MB per I/O thread,
+startup-only) and `pubsub_slow_subscriber_timeout_ms` (startup-only, `0`
+disables). `proactor_threads` changes how subscribers and independent budgets
+are distributed. Other V1 pipeline and socket settings can affect processing or
+output latency, but do not change Pub/Sub admission directly.
 
 For diagnosis, use:
 
 - `dispatch_queue_subscriber_bytes`: queued Pub/Sub bytes;
+- `pubsub_backpressure_events_total{event=...}`: back-pressure and
+  slow-subscriber events by type — `soft_limit` (soft-limit crossings),
+  `hard_limit` (publisher throttle episodes), `forced_disconnect` (subscribers
+  closed by the policy), and `messages_discarded`;
 - `send_delay_ms` / `send_delay_seconds`: age of the oldest pending send;
 - `total_net_output_bytes` and `total_writes_processed`: output progress; and
 - `cmdstat_publish`: indirect evidence of publisher waiting.
 
-These signals are aggregated and do not identify the specific subscriber
-holding the budget. `pipeline_queue_bytes` and `pipeline_throttle_total` can
-indicate competing data-path pressure. Existing coverage is
-`tests/dragonfly/connection_test.py::test_publish_stuck`, which verifies that
-publishers resume after the stuck subscriber disconnects.
+Aside from `pubsub_backpressure_events_total`, these signals are aggregated and
+do not identify the specific subscriber holding the budget; the policy also
+emits a rate-limited structured log naming the connection it closes.
+`pipeline_queue_bytes` and `pipeline_throttle_total` can indicate competing
+data-path pressure. Coverage is in
+`tests/dragonfly/connection_test.py`: `test_publish_stuck` (publishers resume
+after the stuck subscriber disconnects), `test_pubsub_slow_subscriber_closed`
+(the policy force-closes a stuck subscriber), and
+`test_pubsub_slow_subscriber_disabled` (a `0` timeout never closes).
 
 ## Cluster Mode Integration
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -82,8 +82,16 @@ ABSL_FLAG(uint32_t, pipeline_queue_limit, 10000,
           "may require increasing this limit to prevent the risk of deadlocking."
           "See https://github.com/dragonflydb/dragonfly/discussions/3997 for details");
 
-ABSL_FLAG(strings::MemoryBytesFlag, publish_buffer_limit, 128_MB,
-          "Amount of memory to use for storing pub commands in bytes - per IO thread");
+ABSL_FLAG(strings::MemoryBytesFlag, publish_buffer_limit, 196_MB,
+          "Amount of memory to use for storing pub commands in bytes - per IO thread. This is the "
+          "soft Pub/Sub back-pressure limit; publishers are only parked once the per-thread "
+          "subscriber memory reaches this value times the internal hard-limit multiplier.");
+
+ABSL_FLAG(uint32_t, pubsub_slow_subscriber_timeout_ms, 0,
+          "If a subscriber connection keeps a Pub/Sub socket write blocked for at least this many "
+          "milliseconds while the per-IO-thread subscriber memory is above the soft "
+          "publish_buffer_limit, Dragonfly closes that subscriber to release the back-pressure. "
+          "0 disables this slow-subscriber protection. Startup-only, like publish_buffer_limit.");
 
 ABSL_FLAG(uint32_t, pipeline_squash, 1,
           "Number of queued pipelined commands above which squashing is enabled, 0 means disabled");
@@ -156,6 +164,11 @@ using nonstd::make_unexpected;
 namespace facade {
 
 namespace {
+
+// Multiplier applied to the soft publish_buffer_limit to derive the hard Pub/Sub back-pressure
+// limit. Publishers are only parked in EnsureMemoryBudget once the per-thread subscriber memory
+// reaches soft_limit * kPubSubHardMultiplier.
+constexpr uint32_t kPubSubHardMultiplier = 4;
 
 void SendProtocolError(RespSrvParser::Result pres, SinkReplyBuilder* builder) {
   constexpr string_view res = "-ERR Protocol error: "sv;
@@ -468,8 +481,27 @@ struct QueueBackpressure {
   QueueBackpressure() {
   }
 
-  // Block until subscriber memory usage is below limit, can be called from any thread.
+  // Block until subscriber memory usage is below the hard limit, can be called from any thread.
   void EnsureBelowLimit();
+
+  // Hard Pub/Sub back-pressure limit (soft publish_buffer_limit times kPubSubHardMultiplier).
+  // EnsureBelowLimit only parks publishers once subscriber memory reaches this value.
+  size_t PubSubHardLimit() const {
+    return publish_buffer_limit * kPubSubHardMultiplier;
+  }
+
+  // True while the per-thread subscriber memory is above the soft publish_buffer_limit, i.e. a
+  // Pub/Sub back-pressure episode is in progress. Read on the owning I/O thread.
+  bool IsSubscriberSoftLimited() const {
+    return subscriber_bytes.load(memory_order_relaxed) > publish_buffer_limit;
+  }
+
+  // Accounts `mem` subscriber bytes on this thread and, on an at/below-soft -> above-soft
+  // transition, counts one soft_limit_crossing event. Called only on the owning I/O thread.
+  void AddSubscriberBytes(size_t mem);
+
+  // Releases `mem` subscriber bytes on this thread. Called only on the owning I/O thread.
+  void SubSubscriberBytes(size_t mem);
 
   // Checks if backpressure should be applied.
   // 'size' should be the total bytes currently consumed by all connections on this thread.
@@ -523,8 +555,30 @@ struct QueueBackpressure {
 };
 
 void QueueBackpressure::EnsureBelowLimit() {
-  pubsub_ec.await(
-      [this] { return subscriber_bytes.load(memory_order_relaxed) <= publish_buffer_limit; });
+  const size_t hard_limit = PubSubHardLimit();
+  // Fast path: below the hard red line, publishers proceed without parking (they only get
+  // throttled by the soft limit via the slow-subscriber protection policy, not here).
+  if (subscriber_bytes.load(memory_order_relaxed) <= hard_limit)
+    return;
+
+  // We are about to park a publisher - count one hard-limit throttle episode. Incremented on the
+  // publisher's own thread-local stats, so it is safe even though this qbp belongs to another
+  // thread.
+  ++tl_facade_stats->conn_stats.pubsub_backpressure.hard_limit_throttled;
+  pubsub_ec.await([&] { return subscriber_bytes.load(memory_order_relaxed) <= hard_limit; });
+}
+
+void QueueBackpressure::AddSubscriberBytes(size_t mem) {
+  // subscriber_bytes is only written by the owning I/O thread, so the fetch_add result is the true
+  // previous value. Count one soft_limit_crossing on the at/below-soft -> above-soft transition.
+  size_t before = subscriber_bytes.fetch_add(mem, memory_order_relaxed);
+  if (before <= publish_buffer_limit && before + mem > publish_buffer_limit)
+    ++tl_facade_stats->conn_stats.pubsub_backpressure.soft_limit_crossing;
+}
+
+void QueueBackpressure::SubSubscriberBytes(size_t mem) {
+  DCHECK_GE(subscriber_bytes.load(memory_order_relaxed), mem);
+  subscriber_bytes.fetch_sub(mem, memory_order_relaxed);
 }
 
 // Global array for each io thread to keep track of the total memory usage of the dispatch queues.
@@ -554,6 +608,12 @@ thread_local bool pipeline_prioritize_large_batches_cached =
     absl::GetFlag(FLAGS_pipeline_prioritize_large_batches);
 thread_local bool pipeline_parse_in_proactor_cached =
     absl::GetFlag(FLAGS_pipeline_parse_in_proactor);
+
+// Cached deadline (in CycleClock cycles) after which a continuously blocked Pub/Sub send makes a
+// subscriber eligible for the slow-subscriber protection close. 0 means the protection is disabled.
+// Derived from the startup-only --pubsub_slow_subscriber_timeout_ms flag.
+thread_local uint64_t pubsub_slow_subscriber_timeout_cycles_cached = base::CycleClock::FromUsec(
+    uint64_t(absl::GetFlag(FLAGS_pubsub_slow_subscriber_timeout_ms)) * 1000);
 
 }  // namespace
 
@@ -2014,8 +2074,18 @@ bool Connection::ProcessAdminMessage(MessageHandle* msg, AsyncOperations* async_
   // Execution
   auto replies_recorded_before = reply_builder_->RepliesRecorded();
   cc_->async_dispatch = true;
+  // Track the control-path async operation so the slow-subscriber protection policy can observe how
+  // long the current Pub/Sub send has been blocked (see SendPubMessageAsync).
+  async_op_start_cycle_ = base::CycleClock::Now();
   std::visit(*async_op, msg->handle);
+  async_op_start_cycle_ = 0;
   cc_->async_dispatch = false;
+
+  // A slow-subscriber close may have been requested from SendPubMessageAsync while we were parked
+  // in the send above. Stop normal processing; MarkForClose() already set the reply-builder error,
+  // so the AsyncFiber loop will observe it and run the connection's shutdown path.
+  if (request_shutdown_)
+    return false;
 
   // Post-execution Flush
   // We force a flush If the message is supposed to reply (e.g. PubSub) but didn't write to the
@@ -2119,8 +2189,10 @@ void Connection::AsyncFiber() {
 
     reply_builder_->SetBatchMode(GetPendingMessageCount() > 1);
 
+    // Publishers park at the hard limit, so we only need to wake them when the subscriber memory
+    // transitions back below it.
     bool subscriber_over_limit =
-        conn_stats.dispatch_queue_subscriber_bytes >= qbp.publish_buffer_limit;
+        conn_stats.dispatch_queue_subscriber_bytes >= qbp.PubSubHardLimit();
 
     // The below if/else conditionally choose between 3 message processing policies:
     // 1. Pipeline squashing
@@ -2203,7 +2275,7 @@ void Connection::AsyncFiber() {
     }
 
     if (subscriber_over_limit &&
-        conn_stats.dispatch_queue_subscriber_bytes < qbp.publish_buffer_limit)
+        conn_stats.dispatch_queue_subscriber_bytes <= qbp.PubSubHardLimit())
       qbp.pubsub_ec.notify();
   }
 
@@ -2303,7 +2375,74 @@ bool Connection::IsCurrentlyDispatching() const {
   return cc_->async_dispatch || cc_->sync_dispatch;
 }
 
+bool Connection::IsAsyncOpOverdue(uint64_t timeout_cycles) const {
+  if (async_op_start_cycle_ == 0)
+    return false;
+  return base::CycleClock::Now() - async_op_start_cycle_ >= timeout_cycles;
+}
+
+void Connection::RequestPubsubClose() {
+  QueueBackpressure& qbp = GetQueueBackpressure();
+
+  // Evict already-queued PubMessage items, releasing their per-thread subscriber accounting
+  // immediately. Other control messages (checkpoints, migration, ...) are left for the normal
+  // connection cleanup so their waiters/statistics stay consistent.
+  size_t discarded_msgs = 0, discarded_bytes = 0;
+  for (auto it = dispatch_q_.begin(); it != dispatch_q_.end();) {
+    if (it->IsPubMsg()) {
+      ++discarded_msgs;
+      discarded_bytes += it->UsedMemory();
+      UpdateDispatchStats(*it, false /* subtract */);
+      it = dispatch_q_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  // The close is non-blocking but guaranteed: MarkForClose() sets the reply-builder error, so the
+  // AsyncFiber loop tears the connection down once the parked send returns. RequestPubsubClose runs
+  // at most once per connection (further pub messages are dropped via request_shutdown_), so the
+  // disconnect is counted exactly once here.
+  auto& bp = tl_facade_stats->conn_stats.pubsub_backpressure;
+  ++bp.forced_disconnect;
+  bp.messages_discarded += discarded_msgs;
+
+  // Rate-limited structured diagnostic. Bounded fields only - the connection id goes to the log,
+  // not to a metric label.
+  LOG_EVERY_T(WARNING, 1) << "Closing slow Pub/Sub subscriber " << DebugInfo()
+                          << " tid=" << ProactorBase::me()->GetPoolIndex()
+                          << " publish_buffer_limit=" << qbp.publish_buffer_limit
+                          << " thread_subscriber_bytes="
+                          << qbp.subscriber_bytes.load(memory_order_relaxed)
+                          << " blocked_send_usec="
+                          << base::CycleClock::ToUsec(base::CycleClock::Now() -
+                                                      async_op_start_cycle_)
+                          << " discarded_entries=" << discarded_msgs
+                          << " discarded_bytes=" << discarded_bytes;
+
+  // Non-blocking: only mark the reply builder error and request_shutdown_.
+  MarkForClose();
+
+  // The subscriber budget just dropped - wake every parked publisher so they can re-check.
+  qbp.pubsub_ec.notifyAll();
+}
+
 void Connection::SendPubMessageAsync(PubMessage msg) {
+  // Slow-subscriber protection (RESP V1): once a close was requested, drop further pub messages
+  // instead of repopulating the queue. Cleanup releases accounting and wakes publishers.
+  if (request_shutdown_)
+    return;
+
+  // Two conjunctive conditions: the thread is in a soft-limit back-pressure episode AND this
+  // connection's active Pub/Sub send has been blocked continuously past the configured deadline.
+  // A slow send below the budget, or a full budget with a still-progressing send, is left alone.
+  uint64_t timeout_cycles = pubsub_slow_subscriber_timeout_cycles_cached;
+  if (timeout_cycles > 0 && GetQueueBackpressure().IsSubscriberSoftLimited() &&
+      IsAsyncOpOverdue(timeout_cycles)) {
+    RequestPubsubClose();
+    return;  // discard the message that triggered the close
+  }
+
   SendAsync({make_unique<PubMessage>(std::move(msg))});
 }
 
@@ -2449,7 +2588,7 @@ void Connection::UpdateDispatchStats(const MessageHandle& msg, bool add) {
     conn_stats.dispatch_queue_bytes += mem;
     dispatch_q_bytes_ += mem;
     if (msg.IsPubMsg()) {
-      qbp.subscriber_bytes.fetch_add(mem, std::memory_order_relaxed);
+      qbp.AddSubscriberBytes(mem);
       conn_stats.dispatch_queue_subscriber_bytes += mem;
       dispatch_q_subscriber_bytes_ += mem;
     }
@@ -2462,7 +2601,7 @@ void Connection::UpdateDispatchStats(const MessageHandle& msg, bool add) {
     if (msg.IsPubMsg()) {
       DCHECK_GE(conn_stats.dispatch_queue_subscriber_bytes, mem);
       DCHECK_GE(qbp.subscriber_bytes.load(std::memory_order_relaxed), mem);
-      qbp.subscriber_bytes.fetch_sub(mem, std::memory_order_relaxed);
+      qbp.SubSubscriberBytes(mem);
       conn_stats.dispatch_queue_subscriber_bytes -= mem;
       dispatch_q_subscriber_bytes_ -= mem;
     }
@@ -2625,7 +2764,7 @@ void Connection::IncreaseConnStats() {
   if (dispatch_q_subscriber_bytes_ > 0) {
     auto& qbp = GetQueueBackpressure();
     conn_stats.dispatch_queue_subscriber_bytes += dispatch_q_subscriber_bytes_;
-    qbp.subscriber_bytes.fetch_add(dispatch_q_subscriber_bytes_, std::memory_order_relaxed);
+    qbp.AddSubscriberBytes(dispatch_q_subscriber_bytes_);
   }
 
   conn_stats_registered_ = true;
@@ -2668,7 +2807,7 @@ void Connection::DecreaseConnStats() {
     DCHECK_GE(conn_stats.dispatch_queue_subscriber_bytes, dispatch_q_subscriber_bytes_);
     conn_stats.dispatch_queue_subscriber_bytes -= dispatch_q_subscriber_bytes_;
     DCHECK_GE(qbp.subscriber_bytes.load(std::memory_order_relaxed), dispatch_q_subscriber_bytes_);
-    qbp.subscriber_bytes.fetch_sub(dispatch_q_subscriber_bytes_, std::memory_order_relaxed);
+    qbp.SubSubscriberBytes(dispatch_q_subscriber_bytes_);
   }
   DCHECK_GE(conn_stats.pipeline_queue_entries, parsed_cmd_q_len_);
   conn_stats.pipeline_queue_entries -= parsed_cmd_q_len_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -402,6 +402,17 @@ class Connection : public util::Connection {
   // Returns true if the fiber should terminate (e.g. Migration).
   bool ProcessAdminMessage(MessageHandle* msg, AsyncOperations* async_op);
 
+  // Returns true if a control-path async operation is currently running inside ProcessAdminMessage
+  // and has been in progress for at least `timeout_cycles` (base::CycleClock cycles).
+  bool IsAsyncOpOverdue(uint64_t timeout_cycles) const;
+
+  // Slow-subscriber protection (RESP V1): evict queued PubMessage items from dispatch_q_ (releasing
+  // their per-thread subscriber accounting immediately), account the discard metrics, log a
+  // rate-limited diagnostic, and MarkForClose() this connection. Non-blocking: it never waits,
+  // joins, or interrupts the in-flight send. The connection closes via the normal shutdown path
+  // once the pending send returns.
+  void RequestPubsubClose();
+
   // Processes the next Pipeline command from parsed_head_.
   void ProcessPipelineCommandV1();
 
@@ -746,12 +757,17 @@ class Connection : public util::Connection {
       // The recv callback cannot return a status, so IoLoopV2 observes this flag and surfaces
       // ParserStatus::ERROR to close the connection and send the protocol-error reply.
       bool proactor_parse_error_ : 1;
+
+      bool request_shutdown_ : 1;  // set when the connection is requested to shutdown
     };
   };
 
   ListenerType listener_type_ = ListenerType::MAIN_RESP;
 
-  bool request_shutdown_ = false;
+  // Monotonic start time (base::CycleClock::Now()) of the control-path async operation currently
+  // executing inside ProcessAdminMessage's std::visit, or 0 when none is in progress. Used by the
+  // slow-subscriber protection policy to detect a Pub/Sub send that has been blocked too long.
+  uint64_t async_op_start_cycle_ = 0;
 };
 
 }  // namespace facade

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -23,7 +23,7 @@ using namespace std;
 constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
-  static_assert(kSizeConnStats == 296);
+  static_assert(kSizeConnStats == 328);
 
   ADD(read_buf_capacity);
   ADD(connection_memory_bytes);
@@ -58,6 +58,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(pipeline_dispatch_flush_count);
   ADD(proactor_reads);
   ADD(proactor_parse);
+  ADD(pubsub_backpressure);
 
   return *this;
 }

--- a/src/facade/facade_stats.h
+++ b/src/facade/facade_stats.h
@@ -12,6 +12,31 @@
 #include "base/histogram.h"
 namespace facade {
 
+// Counters for the Pub/Sub back-pressure / slow-subscriber protection policy. Exported as the
+// prometheus counter `pubsub_backpressure_events_total` with a bounded `event` label.
+struct PubsubBackpressureStats {
+  // Transitions where a thread's queued Pub/Sub bytes crossed from at/below the soft limit to
+  // above.
+  uint64_t soft_limit_crossing = 0;
+  // Publisher wait episodes caused by reaching the hard limit.
+  uint64_t hard_limit_throttled = 0;
+
+  // Subscriber connections closed by the policy after the soft-limit and stuck-send conditions
+  // were met.
+  uint64_t forced_disconnect = 0;
+
+  // Queued Pub/Sub messages discarded during policy-driven disconnects.
+  uint64_t messages_discarded = 0;
+
+  PubsubBackpressureStats& operator+=(const PubsubBackpressureStats& o) {
+    soft_limit_crossing += o.soft_limit_crossing;
+    hard_limit_throttled += o.hard_limit_throttled;
+    forced_disconnect += o.forced_disconnect;
+    messages_discarded += o.messages_discarded;
+    return *this;
+  }
+};
+
 struct ConnectionStats {
   size_t read_buf_capacity = 0;  // total capacity of input buffers
   size_t connection_memory_bytes = 0;
@@ -71,6 +96,9 @@ struct ConnectionStats {
   // V2 Only: Number of times parse-in-proactor enqueued at least one command from the OnRecv
   // callback.
   uint64_t proactor_parse = 0;
+
+  // Pub/Sub back-pressure / slow-subscriber protection counters.
+  PubsubBackpressureStats pubsub_backpressure;
 
   ConnectionStats& operator+=(const ConnectionStats& o);
 };

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -149,6 +149,21 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
 
   AppendMetricWithoutLabels("pipeline_throttle_total", "", conn_stats.pipeline_throttle_count,
                             MetricType::COUNTER, &resp->body());
+
+  {
+    const auto& pbp = conn_stats.pubsub_backpressure;
+    AppendMetricHeader("pubsub_backpressure_events_total",
+                       "Pub/Sub back-pressure and slow-subscriber protection events by type",
+                       MetricType::COUNTER, &resp->body());
+    AppendMetricValue("pubsub_backpressure_events_total", pbp.soft_limit_crossing, {"event"},
+                      {"soft_limit"}, &resp->body());
+    AppendMetricValue("pubsub_backpressure_events_total", pbp.hard_limit_throttled, {"event"},
+                      {"hard_limit"}, &resp->body());
+    AppendMetricValue("pubsub_backpressure_events_total", pbp.forced_disconnect, {"event"},
+                      {"forced_disconnect"}, &resp->body());
+    AppendMetricValue("pubsub_backpressure_events_total", pbp.messages_discarded, {"event"},
+                      {"messages_discarded"}, &resp->body());
+  }
   AppendMetricWithoutLabels("pipeline_commands_total", "", conn_stats.pipelined_cmd_cnt,
                             MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("pipeline_dispatch_calls_total", "", conn_stats.pipeline_dispatch_calls,

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -467,53 +467,122 @@ async def test_publish_stuck(df_server: DflyInstance, async_client: aioredis.Red
         await pub
 
 
-@pytest.mark.large
-@dfly_args({"proactor_threads": "4"})
-async def test_pubsub_busy_connections(df_server: DflyInstance):
-    sleep = 60
+async def _pubsub_backpressure_stats(df_server: DflyInstance) -> dict[str, int]:
+    # Read the pubsub_backpressure_events_total counter by its `event` label from the
+    # Prometheus /metrics endpoint. prometheus_client strips the `_total` suffix from the family.
+    metrics = await df_server.metrics()
+    family = metrics.get("dragonfly_pubsub_backpressure_events")
+    if family is None:
+        return {}
+    return {sample.labels["event"]: int(sample.value) for sample in family.samples}
 
-    async def sub_thread():
-        i = 0
 
-        async def sub_task():
-            nonlocal i
-            sleep_task = asyncio.create_task(asyncio.sleep(sleep))
-            while not sleep_task.done():
-                client = df_server.client()
-                pubsub = client.pubsub()
-                await pubsub.subscribe("channel")
-                # await pubsub.unsubscribe("channel")
-                i = i + 1
-                await client.close()
+async def _open_stuck_subscriber(port: int):
+    """Open a raw subscriber connection with a tiny receive buffer that stops reading, so the
+    server's Pub/Sub socket write blocks quickly once the subscriber falls behind."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    sock = writer.get_extra_info("socket")
+    # Cap the receive window so the server-side write blocks after only a few KB.
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2048)
 
-        subs = [asyncio.create_task(sub_task()) for _ in range(10)]
-        for s in subs:
-            await s
-        logging.debug(f"Exiting thread after {i} subscriptions")
+    writer.write(b"SUBSCRIBE channel\r\n")
+    await writer.drain()
+    # Read only the subscribe confirmation, then never read again -> stuck subscriber.
+    await reader.readexactly(1)
+    writer.transport.pause_reading()
+
+    return reader, writer
+
+
+# publish_buffer_limit is the soft limit; the hard limit is 4x that. It is large relative to the
+# subscriber's socket buffer, so the server write blocks (and the stall timer starts) well before
+# the soft limit is crossed.
+@dfly_args(
+    {
+        "proactor_threads": "1",
+        "publish_buffer_limit": "32mb",
+        "pubsub_slow_subscriber_timeout_ms": "100",
+    }
+)
+async def test_pubsub_slow_subscriber_closed(df_server: DflyInstance, async_client: aioredis.Redis):
+    reader, writer = await _open_stuck_subscriber(df_server.port)
+
+    stop = False
 
     async def pub_task():
-        pub = df_server.client()
-        i = 0
-        sleep_task = asyncio.create_task(asyncio.sleep(sleep))
-        while not sleep_task.done():
-            await pub.publish("channel", f"message-{i}")
-            i = i + 1
+        payload = "msg" * 1000
+        while not stop:
+            p = async_client.pipeline(transaction=False)
+            for _ in range(200):
+                p.publish("channel", payload)
+            await p.execute()
 
-    def run_in_thread():
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(sub_thread())
+    publishers = [asyncio.create_task(pub_task()) for _ in range(20)]
 
-    threads = []
-    for _ in range(10):
-        thread = Thread(target=run_in_thread)
-        thread.start()
-        threads.append(thread)
+    # Wait until the policy force-closes the stuck subscriber.
+    stats = {}
+    for _ in range(150):
+        stats = await _pubsub_backpressure_stats(df_server)
+        if stats["forced_disconnect"] >= 1:
+            break
+        await asyncio.sleep(0.1)
 
-    await pub_task()
+    assert stats["soft_limit"] >= 1
+    assert stats["forced_disconnect"] >= 1
+    assert stats["messages_discarded"] >= 1
 
-    for thread in threads:
-        thread.join()
+    # Let the publishers finish - they must not stay parked once the budget was released.
+    stop = True
+    await asyncio.wait_for(asyncio.gather(*publishers), timeout=20)
+
+    # Drain the subscriber socket so the parked write completes and the connection closes through
+    # the normal shutdown path.
+    try:
+        while True:
+            data = await asyncio.wait_for(reader.read(65536), timeout=2)
+            if not data:
+                break
+    except asyncio.TimeoutError:
+        pass
+    writer.close()
+
+
+# With the timeout disabled (0), a stuck subscriber is never force-closed even under back-pressure.
+@dfly_args(
+    {
+        "proactor_threads": "1",
+        "publish_buffer_limit": "4mb",
+        "pubsub_slow_subscriber_timeout_ms": "0",
+    }
+)
+async def test_pubsub_slow_subscriber_disabled(
+    df_server: DflyInstance, async_client: aioredis.Redis
+):
+    reader, writer = await _open_stuck_subscriber(df_server.port)
+
+    async def pub_task():
+        payload = "msg" * 1000
+        p = async_client.pipeline(transaction=False)
+        for _ in range(2000):
+            p.publish("channel", payload)
+        await p.execute()
+
+    publishers = [asyncio.create_task(pub_task()) for _ in range(20)]
+
+    await asyncio.sleep(3)
+
+    stats = await _pubsub_backpressure_stats(df_server)
+    # The subscriber stays stuck: it is never force-closed and nothing is discarded.
+    assert stats["forced_disconnect"] == 0
+    assert stats["messages_discarded"] == 0
+
+    # Publishers are parked on the hard limit; closing the subscriber unblocks them.
+    writer.write(b"QUIT\r\n")
+    await writer.drain()
+    writer.close()
+
+    for pub in asyncio.as_completed(publishers):
+        await pub
 
 
 async def test_subscribers_with_active_publisher(df_server: DflyInstance, max_connections=100):


### PR DESCRIPTION
## Summary

**The problem** 
A slow (stuck or zombie) subscriber - blocks any publisher indefinitely until it either unblocks or closed. Publisher back-pressure does not pass reality test as such cases occur in production. 

**Solution**
This Pr splits the per-IO-thread Pub/Sub back-pressure budget into a **soft** limit (`publish_buffer_limit`) and a **hard** limit (`soft * kPubSubHardMultiplier`, hard-coded to 4), and adds a RESP IoLoop-V1 slow-subscriber protection policy that closes a subscriber whose socket write has been stuck long enough to throttle publishers. 

We still use throttling mechanism but its thershold grows to `publish_buffer_limit * 4`. In addition we force-close subscribers that are stuck for more than `pubsub_slow_subscriber_timeout_ms` AND the subsriber memory crossed the soft limit of `publish_buffer_limit`

And what's even more important - we add metrics covering pubsub behavior around both soft and hard limit states.

Fixes #7888.

## Changes
- `EnsureMemoryBudget` parks publishers only at the **hard** limit; crossing the **soft** limit starts a back-pressure episode (counted).
- New startup-only flag `--pubsub_slow_subscriber_timeout_ms` (default `0` = disabled). When a thread is above the soft limit **and** a connection's active Pub/Sub send has been blocked continuously past the timeout, `SendPubMessageAsync` discards the message, evicts the connection's queued `PubMessage`s (releasing the per-thread budget and waking parked publishers), and calls the non-blocking `MarkForClose`.
- `ProcessAdminMessage` tracks the async-op start time around `std::visit` and stops normal processing once `request_shutdown_` is set; the connection closes through the normal shutdown path when the parked send returns. No socket-write interruption.
- Metric `pubsub_backpressure_events_total` with a bounded `event` label: `soft_limit`, `hard_limit`, `forced_disconnect`, `messages_discarded`.
- remove slow and quite useless test `test_pubsub_busy_connections` that did not have any assertions and
did not provide any real coverage. Now with AI we should add better tests than that.

## Notes
- The soft/hard split is always active: with the policy disabled, publishers now park at `4 * publish_buffer_limit` instead of `publish_buffer_limit`.

## Testing
- `test_pubsub_slow_subscriber_closed` — stuck subscriber is force-closed, publishers unblock, counters/discards accounted.
- `test_pubsub_slow_subscriber_disabled` — with the timeout at 0, a stuck subscriber is never closed.
- Existing `test_publish_stuck` and other pubsub tests still pass.