### PR TITLE
ci(builder): enable ccache in shared build action

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -42,10 +42,51 @@ inputs:
     required: false
     default: 'src/all'
     type: string
+  enable-ccache:
+    description: "Use ccache. 'true' restores/saves the cache; 'false' (default) skips it and builds with -DENABLE_CCACHE=OFF"
+    required: false
+    default: 'false'
+    type: string
+  ccache-save:
+    description: "When ccache is on, set to 'true' to save the updated cache back; 'false' (default) restores read-only"
+    required: false
+    default: 'false'
+    type: string
+  ccache-max-size:
+    description: "Max ccache size per config (e.g. 1G, 2G, 500M)"
+    required: false
+    default: '1G'
+    type: string
+  cache-key-suffix:
+    description: "Extra token mixed into the cache key; callers pass the container so glibc/musl caches don't collide"
+    required: false
+    default: 'default'
+    type: string
 
 runs:
   using: "composite"
   steps:
+    - name: Check ccache cache-key-suffix
+      if: ${{ inputs.enable-ccache == 'true' && inputs.ccache-save == 'true' }}
+      shell: bash
+      run: |
+        # Refuse to write to a shared cache scope: reject an empty/whitespace suffix or the literal "default".
+        suffix="${{ inputs.cache-key-suffix }}"
+        if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
+          echo "::error title=ccache::ccache-save is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so writes don't collide across configs."
+          exit 1
+        fi
+
+    - name: Setup ccache
+      if: ${{ inputs.enable-ccache == 'true' }}
+      # Persist compiled objects across ephemeral runners so unchanged files aren't recompiled.
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: dfly-ccache-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.c-compiler }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}
+        max-size: ${{ inputs.ccache-max-size }}
+        save: ${{ inputs.ccache-save }}
+        verbose: 1
+
     - name: Configure CMake
       shell: bash
       run: |
@@ -64,6 +105,13 @@ runs:
           -DCMAKE_BUILD_TYPE="${{ inputs.build-type }}"
           -GNinja
         )
+
+        # Pass ccache on/off explicitly so the build never depends on the CMake default.
+        if [ "${{ inputs.enable-ccache }}" = "true" ]; then
+          CMAKE_CMD+=(-DENABLE_CCACHE=ON)
+        else
+          CMAKE_CMD+=(-DENABLE_CCACHE=OFF)
+        fi
 
         # Add optional compiler flags
         if [ -n "${{ inputs.c-compiler }}" ]; then
@@ -97,4 +145,11 @@ runs:
       run: |
         cd ${GITHUB_WORKSPACE}/${{ inputs.build-dir }}
         echo "Building target: ${{ inputs.targets }}"
+        if [ "${{ inputs.enable-ccache }}" = "true" ]; then
+          ccache -z || true   # zero stats so the summary below reflects only this build
+        fi
         ninja ${{ inputs.targets }}
+        if [ "${{ inputs.enable-ccache }}" = "true" ]; then
+          echo "===== ccache stats (this build) ====="
+          ccache -s || true
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,18 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/lint-test-chart
 
+  list-caches:
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: List all Actions caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh cache list -R ${{ github.repository }} --limit 100 --sort size_in_bytes --order desc || true
+
   large-tests-arm:
     runs-on: CI-LARGE-ARM
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
             # https://maskray.me/blog/2023-08-25-clang-wunused-command-line-argument (search for compiler-rt)
             cxx_flags: "-Wno-error=unused-command-line-argument"
             sanitizers: "Sanitizers"
+            # Sanitizer builds produce larger objects, so give this job a bigger ccache.
+            ccache-max-size: "2G"
 
     runs-on: ubuntu-latest
     container:
@@ -114,7 +116,11 @@ jobs:
       - name: Build Dragonfly
         uses: ./.github/actions/builder
         with:
+          enable-ccache: 'true'
+          ccache-save: 'true'
           build-type: ${{matrix.build-type}}
+          cache-key-suffix: ${{ matrix.container }}
+          ccache-max-size: ${{ matrix.ccache-max-size || '1G' }}
           c-compiler: ${{matrix.compiler.c}}
           cxx-compiler: ${{matrix.compiler.cxx}}
           cxx-flags: ${{matrix.cxx_flags}}
@@ -411,7 +417,10 @@ jobs:
       - name: Build Dragonfly
         uses: ./.github/actions/builder
         with:
+          enable-ccache: 'true'
+          ccache-save: 'true'
           build-type: Release
+          cache-key-suffix: 'ubuntu-dev:24'
           targets: 'dragonfly'
 
       - name: Authenticate to AWS

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Build Dragonfly
         uses: ./.github/actions/builder
         with:
+          enable-ccache: 'true'
+          ccache-save: 'true'
           build-type: ${{matrix.build-type}}
+          cache-key-suffix: ${{ matrix.container }}
           targets: 'dragonfly'
 
       - name: Authenticate to AWS

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build Dragonfly
         uses: ./.github/actions/builder
         with:
+          # CCache read-only (save defaults off): reuse the base cache kept warm by regression-tests.
+          enable-ccache: 'true'
+          cache-key-suffix: ${{ matrix.container }}
           build-type: ${{matrix.build-type}}
           targets: 'dragonfly'
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Build Dragonfly
         uses: ./.github/actions/builder
         with:
+          enable-ccache: 'true'
+          ccache-save: 'true'
           build-type: ${{matrix.build-type}}
+          cache-key-suffix: ${{ matrix.container }}
           targets: 'dragonfly'
 
       - name: Authenticate to AWS

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -108,6 +108,9 @@ jobs:
         if: ${{ inputs.use_release != 'yes' }}
         uses: ./.github/actions/builder
         with:
+          # CCache read-only (save defaults off): reuse the base cache kept warm by regression-tests.
+          enable-ccache: 'true'
+          cache-key-suffix: ${{ matrix.container }}
           build-type: ${{matrix.build-type}}
           targets: 'dragonfly'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,40 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 project(DRAGONFLY C CXX)
 set(CMAKE_CXX_STANDARD 20)
 
+# Use ccache as the compiler launcher when available (local and CI).
+# Opt out with -DENABLE_CCACHE=OFF (or CCACHE_DISABLE=1 / ccache config).
+option(ENABLE_CCACHE "Use ccache as the compiler launcher when available" ON)
+set(_clear_launchers TRUE)
+if(ENABLE_CCACHE)
+  find_program(CCACHE_PROGRAM ccache)
+  if(CCACHE_PROGRAM)
+    message(STATUS "ccache is enabled: ${CCACHE_PROGRAM}")
+    # Wrap ccache in `env` to configure it without a config file; compress to save space.
+    set(_ccache_launcher env CCACHE_COMPRESS=true CCACHE_COMPRESSLEVEL=5)
+    # Local only: share one cache across worktrees. Skipped in CI, where paths are
+    # stable and CCACHE_BASEDIR can mangle dependency files.
+    if(NOT DEFINED ENV{CI})
+      list(APPEND _ccache_launcher CCACHE_BASEDIR=$ENV{HOME} CCACHE_NOHASHDIR=true)
+    endif()
+    set(CMAKE_C_COMPILER_LAUNCHER   ${_ccache_launcher} "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${_ccache_launcher} "${CCACHE_PROGRAM}")
+    set(_clear_launchers FALSE)
+  else()
+    message(STATUS "ccache is enabled but not found, disabling compiler launcher")
+  endif()
+else()
+  message(STATUS "ccache is disabled")
+endif()
+
+# When ccache isn't used (disabled or missing), clear any launcher a wrapper such as
+# blaze.sh injected via -D, so the build reliably falls back to native compilation.
+if(_clear_launchers)
+  unset(CMAKE_C_COMPILER_LAUNCHER CACHE)
+  unset(CMAKE_CXX_COMPILER_LAUNCHER CACHE)
+  set(CMAKE_C_COMPILER_LAUNCHER "")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "")
+endif()
+
 # Disabled because it has false positives with ref-counted intrusive pointers.
 CHECK_CXX_COMPILER_FLAG("-Wuse-after-free" HAS_USE_AFTER_FREE_WARN)
 if (HAS_USE_AFTER_FREE_WARN)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ SANITIZE_COMPILE_FLAGS = -fsanitize=address -Wno-maybe-uninitialized
 SANITIZE_LINK_FLAGS = -fsanitize=address
 endif
 
+# Release binaries always compile natively (never through ccache) for reproducibility.
 HELIO_FLAGS = -DHELIO_RELEASE_FLAGS="-g" \
 			  -DCMAKE_CXX_FLAGS="$(SANITIZE_COMPILE_FLAGS)" \
 			  -DCMAKE_EXE_LINKER_FLAGS="$(LINKER_FLAGS) $(SANITIZE_LINK_FLAGS)" \
@@ -41,6 +42,7 @@ HELIO_FLAGS = -DHELIO_RELEASE_FLAGS="-g" \
               -DENABLE_GIT_VERSION=$(HELIO_ENABLE_GIT_VERSION) \
               -DWITH_SIMSIMD=$(WITH_SIMSIMD) \
               -DWITH_UNWIND=$(HELIO_WITH_UNWIND) \
+              -DENABLE_CCACHE=OFF \
               -DMARCH_OPT="$(HELIO_MARCH_OPT)" \
               -DLEGACY_GLOG=$(LEGACY_GLOG) \
 			  -DDF_ENABLE_MEMORY_TRACKING=$(TRACK_MEMORY_ALLOCS)

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -64,11 +64,29 @@ cd build-opt && ninja dragonfly
 | WITH_COLLECTION_CMDS | Include commands for collections (SET, HSET, ZSET)                                                                                                                                                                                       |
 | WITH_EXTENSION_CMDS  | Include extension commands (Bloom, HLL, JSON, ...)                                                                                                                                                                                       |
 | USE_MOLD             | Uses the mold linker to reduce link time overhead while enabling Link Time Optimization (LTO) for improved runtime performance. Recommended for benchmarking and production. |
+| ENABLE_CCACHE | Use ccache as the compiler launcher when it is installed (ON by default). Disable with -DENABLE_CCACHE=OFF |
 
 Minimal debug build:
 
 ```bash
 ./helio/blaze.sh -DWITH_GPERF=OFF -DWITH_AWS=OFF -DWITH_GCP=OFF -DWITH_TIERING=OFF -DWITH_SEARCH=OFF -DWITH_COLLECTION_CMDS=OFF -DWITH_EXTENSION_CMDS=OFF
+```
+
+### ccache
+
+For **local builds**, ccache is enabled automatically whenever the `ccache` binary is on your `PATH`, so incremental rebuilds recompile only the files you changed. (In CI it is enabled per-workflow, and the production `make release` build forces it off.) If you do **not** want ccache, disable it in any of these ways:
+
+- configure with `-DENABLE_CCACHE=OFF` (e.g. `./helio/blaze.sh -DENABLE_CCACHE=OFF`)
+- set the `CCACHE_DISABLE=1` environment variable
+- set `disable = true` in your ccache config (`ccache -o disable=true`)
+
+#### Cache size
+
+Dragonfly is large, so ccache's default size (5 GB, or ~5% of disk on ccache ≥ 4.10) fills up quickly - more so with several build configs or multiple worktrees — and hit rates drop once it's full. The right size depends on your free disk space and how many projects share the (per-user) cache, so it's left to you. If rebuilds feel slow, raise it (50 GB is a comfortable value):
+
+```bash
+ccache -M 50G              # per-user, global; applies to all projects
+ccache -p | grep max_size  # verify
 ```
 
 ## Step 4 - voilà


### PR DESCRIPTION
Wire ccache into the shared composite build action and add a matching
ENABLE_CCACHE CMake option so unchanged translation units are reused
across ephemeral CI runners instead of recompiled every run.

ccache is opt-in for CI: both enable-ccache and ccache-save default to
off, so no job caches or uploads anything unless it explicitly asks.
Callers fall into three modes:
- disabled: native build, no ccache (the default).
- read-only: restore the shared cache but never write back.
- read+write: restore and save, keeping the shared cache warm.

Read+write (major consumers, frequent enough to keep the cache warm):
ci.yml build, ci.yml large-tests-arm, regression-tests, and
epoll-regression-tests.

Read-only: heavy-tests and repeat-tests.

This affects test builds only. The release binary is always compiled
natively: make release forces -DENABLE_CCACHE=OFF, and no cache is
restored or uploaded on the release path.

Cache keys are scoped by container, arch, build type, compiler, and
sanitizers so glibc/musl objects never collide, and each scope is
capped (1G, 2G for the sanitizer build) to fit the Actions budget.

Rough impact: **~65-80% build-step reduction on an average warm PR from** ccache alone.