### PR TITLE
ci(docker): drop gha cache from image builds

### DIFF
--- a/.github/workflows/docker-dev-release.yml
+++ b/.github/workflows/docker-dev-release.yml
@@ -1,5 +1,9 @@
 name: Development Docker Build
 
+# Note: do not add a GitHub Actions cache (type=gha) here when running in the
+# dragonflydb/dragonfly repo: the shared 10 GB cache is limited and better used
+# by the far more frequent CI builds. This runs only on a daily schedule.
+
 on:
   schedule:
     - cron: '15 0 * * *'
@@ -88,8 +92,6 @@ jobs:
             ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           file: tools/packaging/Dockerfile.${{ matrix.flavor }}-dev
-          cache-from: type=gha,scope=tagged${{ matrix.flavor }}
-          cache-to: type=gha,scope=tagged${{ matrix.flavor }},mode=max
           load: true  # Load the build images into the local docker.
       - name: Test Image
         run: |

--- a/.github/workflows/docker-release2.yml
+++ b/.github/workflows/docker-release2.yml
@@ -1,5 +1,9 @@
 name: Docker Release-v2
 
+# Note: do not add a GitHub Actions cache (type=gha) here when running in the
+# dragonflydb/dragonfly repo: the shared 10 GB cache is limited and better used
+# by the far more frequent CI builds. This runs only on release / manual dispatch.
+
 on:
   workflow_dispatch:
     inputs:
@@ -107,8 +111,6 @@ jobs:
             ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           file: tools/packaging/Dockerfile.${{ matrix.flavor }}-prod
-          cache-from: type=gha,scope=prod-${{ matrix.flavor }}
-          cache-to: type=gha,scope=prod-${{ matrix.flavor }},mode=max
           load: true  # Load the build images into the local docker.
 
       - name: Test Image


### PR DESCRIPTION
The daily dev and monthly release Docker image builds cache their BuildKit layers with type=gha,mode=max - about 7-8 GB - into the repo's shared 10 GB Actions cache. These two infrequent builds nearly fill the quota on their own, so the far more valuable (newly introduced)  caching for PRs, integration runs, and other frequent workflows can't cache efficiently, and their ccache entries kept getting evicted.

These images build only on a schedule / on release (daily, monthly), so a cold build is an acceptable trade-off for freeing the shared budget for much more valuable caching related to the core development cycle.

Remove cache-from/cache-to from both workflows and add a top-of-file note so the cache isn't reintroduced.
