### PR TITLE
refactor: unify TTL limitation for different commands

### DIFF
--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -1026,8 +1026,8 @@ TEST_F(HSetFamilyTest, HGetExErrors) {
               ErrArg("invalid expire time"));
   EXPECT_THAT(Run({"HGETEX", "key", "EXAT", "9223372036854775807", "FIELDS", "1", "f1"}),
               ErrArg("invalid expire time"));
-  // A far-future absolute timestamp beyond the hash-field TTL cap (1<<26 s, as for HEXPIRE/HSETEX)
-  // is rejected even though it does not overflow.
+  // A far-future absolute timestamp beyond the hash-field TTL cap (kMaxExpireDeadlineSec, shared by
+  // HEXPIRE/HSETEX) is rejected even though it does not overflow.
   EXPECT_THAT(Run({"HGETEX", "key", "EXAT", "9999999999", "FIELDS", "1", "f1"}),
               ErrArg("invalid expire time"));
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1604,10 +1604,9 @@ void CmdSScan(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 // Syntax: saddex key [KEEPTTL] ttl_sec member [member...]
 void CmdSAddEx(CmdArgParser parser, CommandContext* cmd_cntx) {
-  constexpr uint32_t kMaxTtl = (1UL << 26);
   const std::string_view key = parser.Next<std::string_view>();
   const bool keepttl = parser.Check("KEEPTTL");
-  const uint32_t ttl_sec = parser.Next<FInt<1u, kMaxTtl>>();
+  const uint32_t ttl_sec = parser.Next<FInt<uint32_t{1}, uint32_t{kMaxExpireDeadlineSec}>>();
   ParsedArgs vals = parser.RemainingRange(WrongNumArgsError("SADDEX"));
 
   if (auto err = parser.TakeError(); err) {

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -469,6 +469,15 @@ TEST_F(SetFamilyTest, SAddEx) {
   EXPECT_THAT(Run({"saddex", "key", "KEEPTTL", "2"}), ErrArg("wrong number of arguments"));
 }
 
+TEST_F(SetFamilyTest, SAddExTtlBoundary) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  // The member-TTL ceiling is the shared kMaxExpireDeadlineSec (same as HEXPIRE/HSETEX/HGETEX).
+  EXPECT_THAT(Run({"saddex", "key", absl::StrCat(kMaxExpireDeadlineSec), "at_cap"}), IntArg(1));
+  EXPECT_THAT(Run({"saddex", "key", absl::StrCat(kMaxExpireDeadlineSec + 1), "above_cap"}),
+              ErrArg("value is not an integer or out of range"));
+}
+
 TEST_F(SetFamilyTest, CheckSetLinkExpiryTransfer) {
   for (int i = 0; i < 10; i++) {
     EXPECT_THAT(Run(absl::StrCat("SADDEX key 5 ", i)), IntArg(1));


### PR DESCRIPTION
fixes: #7893

Summary: Unifies SADDEX member TTL validation to use the shared kMaxExpireDeadlineSec cap (8.5 years), matching the hash-field TTL commands.

Tests: Adds a boundary unit test verifying TTL at the cap is accepted and cap+1 is rejected.