### PR TITLE
ci(cache): delete PR Actions caches on close

### DIFF
--- a/.github/workflows/cleanup-pr-cache.yml
+++ b/.github/workflows/cleanup-pr-cache.yml
@@ -34,8 +34,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Repo-wide cache usage (10 GB limit). Printed before and after the
-          # deletion so the log shows exactly how much this cleanup reclaimed.
+          # Repo-wide cache usage (10 GB limit). Printed before and after the deletion so the log shows how much was reclaimed.
           print_repo_cache_usage() {
             gh api "repos/$GH_REPO/actions/cache/usage" --jq \
               '"Repo cache: \(.active_caches_size_in_bytes/1048576|floor) MB used, "
@@ -44,23 +43,16 @@ jobs:
           }
 
           echo "== Before cleanup =="
-          print_repo_cache_usage
+          print_repo_cache_usage || true
           echo "Caches scoped to $PR_REF:"
-          gh cache list --ref "$PR_REF" --limit 100 --json id,key,sizeInBytes \
+          gh cache list --ref "$PR_REF" --limit 1000 --json id,key,sizeInBytes \
             --jq '.[] | "  \(.sizeInBytes/1048576|floor)MB  \(.key)"' || true
 
-          ids=$(gh cache list --ref "$PR_REF" --limit 100 --json id --jq '.[].id')
-          count=$(printf '%s' "$ids" | grep -c . || true)
-          echo "Found $count cache(s) to delete"
-
-          if [ -z "$ids" ]; then
-            echo "No caches found for $PR_REF; nothing to delete"
-          else
-            for id in $ids; do
-              echo "Deleting cache id=$id"
-              gh cache delete "$id"
-            done
+          # Delete all caches for this PR ref in one non-interactive call. --succeed-on-no-caches treats an empty result
+          # as success under `set -e`; the `||` guard keeps cleanup best-effort so a transient failure still reports below.
+          if ! gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches; then
+            echo "::warning::Some caches for $PR_REF may not have been deleted; the 7-day-unused / LRU policy will reclaim any leftovers."
           fi
 
           echo "== After cleanup =="
-          print_repo_cache_usage
+          print_repo_cache_usage || true

--- a/.github/workflows/cleanup-pr-cache.yml
+++ b/.github/workflows/cleanup-pr-cache.yml
@@ -49,7 +49,7 @@ jobs:
             --jq '.[] | "  \(.sizeInBytes/1048576|floor)MB  \(.key)"' || true
 
           # Delete all caches for this PR ref in one non-interactive call. --succeed-on-no-caches treats an empty result
-          # as success under `set -e`; the `||` guard keeps cleanup best-effort so a transient failure still reports below.
+          # as success under `set -e`; the `if !` wrapper keeps cleanup best-effort so a transient failure still reports below.
           if ! gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches; then
             echo "::warning::Some caches for $PR_REF may not have been deleted; the 7-day-unused / LRU policy will reclaim any leftovers."
           fi

--- a/.github/workflows/cleanup-pr-cache.yml
+++ b/.github/workflows/cleanup-pr-cache.yml
@@ -1,0 +1,66 @@
+# Deletes the GitHub Actions caches scoped to a pull request the moment it is closed or merged. PR caches live under
+# refs/pull/<N>/merge and are otherwise only reclaimed by the 7-day-unused / 10 GB LRU eviction policy. With a high PR
+# volume that can pin the repo near the 10 GB ceiling and cause cache thrashing. This event-driven cleanup keeps the
+# budget free for the caches that matter.
+# Scope: PR caches only. Caches from regression/heavy/etc. runs live on refs/heads/main (no "close" event) and are not
+# touched here; prune those via the manual ref-aware dedup command or a separate scheduled workflow.
+name: Cleanup PR caches
+
+on:
+  pull_request:
+    types: [closed]
+
+# One cleanup per PR, a later close/merge event supersedes an in-flight run.
+concurrency:
+  group: cleanup-pr-cache-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    # Fork PRs run with a read-only GITHUB_TOKEN and cannot delete caches (and
+    # generally cannot create them either), so restrict to same-repo PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Host runner (no container:) so the preinstalled gh CLI is available.
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write   # required to delete caches
+    steps:
+      - name: Delete caches for the closed PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+
+          # Repo-wide cache usage (10 GB limit). Printed before and after the
+          # deletion so the log shows exactly how much this cleanup reclaimed.
+          print_repo_cache_usage() {
+            gh api "repos/$GH_REPO/actions/cache/usage" --jq \
+              '"Repo cache: \(.active_caches_size_in_bytes/1048576|floor) MB used, "
+               + "\(.active_caches_count) caches "
+               + "(limit 10240 MB, \((10737418240 - .active_caches_size_in_bytes)/1048576|floor) MB free)"'
+          }
+
+          echo "== Before cleanup =="
+          print_repo_cache_usage
+          echo "Caches scoped to $PR_REF:"
+          gh cache list --ref "$PR_REF" --limit 100 --json id,key,sizeInBytes \
+            --jq '.[] | "  \(.sizeInBytes/1048576|floor)MB  \(.key)"' || true
+
+          ids=$(gh cache list --ref "$PR_REF" --limit 100 --json id --jq '.[].id')
+          count=$(printf '%s' "$ids" | grep -c . || true)
+          echo "Found $count cache(s) to delete"
+
+          if [ -z "$ids" ]; then
+            echo "No caches found for $PR_REF; nothing to delete"
+          else
+            for id in $ids; do
+              echo "Deleting cache id=$id"
+              gh cache delete "$id"
+            done
+          fi
+
+          echo "== After cleanup =="
+          print_repo_cache_usage


### PR DESCRIPTION
Add a workflow that deletes the Actions caches scoped to a pull request as soon as it is closed or merged, so PR caches don't linger until 7-day / 10 GB LRU eviction and thrash the budget.

Scope is PR caches only (refs/pull/<N>/merge). Regression and other main-scoped caches have no close event and are pruned separately.

Runs on pull_request: closed, same-repo PRs only (fork PRs get a read-only token), on a host runner with actions: write. Logs repo cache usage before and after so reclaimed space is visible.
