### PR TITLE
chore(facade): Track async_op_start_cycle_ in the V2 dispatch loop

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1753,7 +1753,9 @@ bool Connection::ProcessControlMessages(uint32_t quota) {
       break;
     }
 
+    async_op_start_cycle_ = base::CycleClock::Now();
     std::visit(AsyncOperations{reply_builder_.get(), this}, msg.handle);
+    async_op_start_cycle_ = 0;
   }
 
   return false;


### PR DESCRIPTION
ProcessControlMessages (the V2 dispatch_q_ loop) ran AsyncOperations without setting 
async_op_start_cycle_, so check in IsAsyncOpTimedOut was always false. Set/clear it 
around the visit, matching the existing pattern in V1 ProcessAdminMessage.

Closes #7897

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
