### PR TITLE
fix(search): unescape quoted tag values

### DIFF
--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -154,9 +154,8 @@ string UnescapeTerm(string_view src) {
       res.push_back(c);
     }
   }
-  // The {term_part}+ pattern always pairs `\\` with a following char, so a
-  // trailing lone backslash is unreachable.
-  DCHECK(!escaped);
+  // A trailing lone backslash (reachable from quoted tag/wildcard values, e.g. a
+  // Windows path `C:\`) is dropped, matching make_Tag and SplitWithEscapes.
   return res;
 }
 

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -68,6 +68,8 @@ using namespace std;
 
 uint32_t toUint32(string_view src);
 double toDouble(string_view src);
+// Defined in lexer.lex: strips backslashes from \X sequences.
+string UnescapeTerm(string_view src);
 
 }
 
@@ -460,12 +462,13 @@ tag_list:
 tag_list_element:
   TERM        { $$ = AstTermNode(std::move($1));   }
   | PHRASE {
-      /* Inside {..}, quoted strings are literal tag values. ~N slop is only meaningful for
-         phrases, so reject it here rather than silently dropping it. */
+      /* Inside {..}, quoted strings are literal tag values with one layer of `\X` escapes,
+         matching the unquoted tag path (make_Tag). ~N slop is only meaningful for phrases,
+         so reject it here rather than silently dropping it. */
       auto p = std::move($1);
       if (p.slop != 0)
         throw Parser::syntax_error(@$, "slop is not allowed in tag values");
-      $$ = AstTermNode(std::move(p.raw));
+      $$ = AstTermNode(UnescapeTerm(p.raw));
     }
   | PREFIX    { $$ = AstPrefixNode(std::move($1)); }
   | SUFFIX    { $$ = AstSuffixNode(std::move($1)); }

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -622,6 +622,37 @@ TEST_F(SearchParserTest, PhraseSlopRejectedInTagContext) {
   EXPECT_NE(0, Parse("@t:{\"foo\"~2}"));
 }
 
+// Quoted tag values must process one layer of \X escapes, mirroring the unquoted tag path,
+// so values containing backslashes or quotes round-trip between HSET and FT.SEARCH.
+TEST_F(SearchParserTest, QuotedTagEscapes) {
+  auto tag_affix = [this](const string& query) -> string {
+    EXPECT_EQ(0, Parse(query));
+    AstExpr e = query_driver_.Take();
+    EXPECT_TRUE(std::holds_alternative<AstFieldNode>(e));
+    const AstNode& tags = *std::get<AstFieldNode>(e).node;
+    EXPECT_TRUE(std::holds_alternative<AstTagsNode>(tags));
+    const auto& tn = std::get<AstTagsNode>(tags);
+    EXPECT_EQ(tn.tags.size(), 1u);
+    EXPECT_TRUE(std::holds_alternative<AstTermNode>(tn.tags[0]));
+    return std::get<AstTermNode>(tn.tags[0]).affix;
+  };
+
+  // Recognized escapes \\ and \" resolve to their single-character values.
+  EXPECT_EQ(tag_affix(R"(@t:{"tnt\\backslash"})"), R"(tnt\backslash)");
+  EXPECT_EQ(tag_affix(R"(@t:{"tnt\"quote"})"), "tnt\"quote");
+
+  // Characterization: one layer of \X is stripped for any X, mirroring the unquoted make_Tag
+  // path, so an unrecognized escape drops its backslash rather than passing through verbatim.
+  // This is an intentional policy change from v1.39's verbatim behavior; pinning it keeps a
+  // future reader from "restoring" the old semantics.
+  EXPECT_EQ(tag_affix(R"(@t:{"ACME\jdoe"})"), "ACMEjdoe");
+
+  // A trailing lone backslash (e.g. a Windows path) must not abort — it previously tripped the
+  // DCHECK in UnescapeTerm — and drops the dangling backslash; the doubled form is a literal `\`.
+  EXPECT_EQ(tag_affix(R"(@t:{"C:\"})"), "C:");
+  EXPECT_EQ(tag_affix(R"(@t:{"C:\\"})"), R"(C:\)");
+}
+
 TEST_F(SearchParserTest, PhraseParse) {
   // Top-level phrase.
   ASSERT_EQ(0, Parse("\"machine learning\""));
@@ -675,6 +706,16 @@ TEST_F(SearchParserTest, WildcardLex) {
 
   SetInput("w\"h?o\"");
   NEXT_EQ(TOK_WILDCARD, string, "h?o");
+  NEXT_TOK(TOK_YYEOF);
+
+  // A trailing lone backslash must not abort (previously tripped a DCHECK in UnescapeTerm); the
+  // dangling backslash is dropped, so `w"a\"` and `w'a\'` both yield `a`.
+  SetInput(R"(w"a\")");
+  NEXT_EQ(TOK_WILDCARD, string, "a");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput(R"(w'a\')");
+  NEXT_EQ(TOK_WILDCARD, string, "a");
   NEXT_TOK(TOK_YYEOF);
 
   // Uppercase `W` is not a wildcard: it rewinds to a term followed by a phrase.

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -926,6 +926,57 @@ TEST_F(SearchFamilyTest, SymbolsInTag) {
   EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{\"fourth})"}), AreDocIds("doc:4"));
 }
 
+TEST_F(SearchFamilyTest, QuotedTagEscapes) {
+  Run({"FT.CREATE", "demo_idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "tags", "TAG"});
+  Run({"HSET", "doc:1", "tags", R"(tnt\backslash)"});
+  Run({"HSET", "doc:2", "tags", "tnt\"quote"});
+  Run({"HSET", "doc:3", "tags", "plain-value"});
+  Run({"HSET", "doc:4", "tags", "foo bar"});
+  Run({"HSET", "doc:5", "tags", R"(a\b)"});
+  Run({"HSET", "doc:6", "tags", "c"});
+  Run({"HSET", "doc:7", "tags", R"(C:\)"});
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"tnt\\backslash"})", "DIALECT", "2"}),
+              AreDocIds("doc:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"tnt\"quote"})", "DIALECT", "2"}),
+              AreDocIds("doc:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"plain-value"})", "DIALECT", "2"}),
+              AreDocIds("doc:3"));
+
+  // A quoted value may contain spaces, which the bare {foo bar} form cannot express.
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"foo bar"})", "DIALECT", "2"}),
+              AreDocIds("doc:4"));
+
+  // OR-list of quoted members, each unescaped independently.
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"a\\b"|"c"})", "DIALECT", "2"}),
+              AreDocIds("doc:5", "doc:6"));
+
+  // Value ending in a backslash: the doubled query matches the stored `C:\`, and the lone-backslash
+  // query must not abort the server (it unescapes to `C:`, which matches nothing here).
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"C:\\"})", "DIALECT", "2"}),
+              AreDocIds("doc:7"));
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{"C:\"})", "DIALECT", "2"}), kNoResults);
+  EXPECT_EQ(Run({"PING"}), "PONG");
+}
+
+TEST_F(SearchFamilyTest, QuotedTagEscapesJson) {
+  Run({"FT.CREATE", "json_idx", "ON", "JSON", "PREFIX", "1", "jdoc:", "SCHEMA", "$.tag", "AS",
+       "tag", "TAG"});
+  // JSON unescapes "a\\b" to the stored tag value a\b.
+  Run({"JSON.SET", "jdoc:1", "$", R"({"tag":"a\\b"})"});
+  EXPECT_THAT(Run({"FT.SEARCH", "json_idx", R"(@tag:{"a\\b"})", "DIALECT", "2"}),
+              AreDocIds("jdoc:1"));
+}
+
+TEST_F(SearchFamilyTest, QuotedTagEscapesCaseSensitive) {
+  Run({"FT.CREATE", "cs_idx", "ON", "HASH", "PREFIX", "1", "cs:", "SCHEMA", "tags", "TAG",
+       "CASESENSITIVE"});
+  Run({"HSET", "cs:1", "tags", R"(ACME\Admin)"});
+  // Exact case matches; wrong case does not.
+  EXPECT_THAT(Run({"FT.SEARCH", "cs_idx", R"(@tags:{"ACME\\Admin"})", "DIALECT", "2"}),
+              AreDocIds("cs:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "cs_idx", R"(@tags:{"acme\\admin"})", "DIALECT", "2"}), kNoResults);
+}
+
 TEST_F(SearchFamilyTest, TagNumbers) {
   Run({"hset", "d:1", "number", "1"});
   Run({"hset", "d:2", "number", "2"});


### PR DESCRIPTION
Fixes #7906.

**Problem**

Since v1.39.0, `FT.SEARCH` on a `TAG` field with the quoted dialect-2 syntax (`@field:{"..."}`) fails to match values containing escaped characters (`\`, `"`). The quoted value is looked up verbatim, so the query's escaping backslash is never stripped and the stored value can't be found:

```
FT.CREATE idx ON HASH PREFIX 1 doc: SCHEMA account TAG
HSET doc:1 account 'ACME\jdoe'
FT.SEARCH idx '@account:{"ACME\\jdoe"}' DIALECT 2   → 0 results   (should be 1)
```

The unquoted form `@account:{ACME\\jdoe}` still matches, which isolates it to the quoted-tag path.

**Cause**

#7438 made `make_PhraseTok` pass quoted content verbatim (moving `\X` handling into the TEXT phrase tokenizer) and added compensating unescape on the TEXT path only. Quoted strings inside `{...}` reach the tag grammar as `PHRASE` tokens, and `tag_list_element: PHRASE` handed `p.raw` straight to `AstTermNode` with no unescaping — so the lookup used the literal bytes `ACME\\jdoe` instead of `ACME\jdoe`. Tag indexing is unchanged; only the query-side lookup string diverged.

**Fix**

Run the tag-path phrase value through the existing `UnescapeTerm` helper before building the term node, mirroring the unquoted tag path (`make_Tag`), which already strips one layer of `\X` escapes. One behavioral line in `src/core/search/parser.y`.

I also removed the `DCHECK(!escaped)` at the end of `UnescapeTerm`. That assertion assumed input always came from the `{term_part}+` pattern, which never ends in a lone `\`. Quoted tag and wildcard values can, though — e.g. a Windows path `@t:{"C:\"}` or `w"a\"` — and on such input the helper hit `escaped == true` at the end and aborted in debug/ASAN builds (and silently dropped the backslash in release). It now drops the dangling backslash, matching what `make_Tag` and `SplitWithEscapes` already do. This also closes the same latent abort in `make_Wildcard`.

**Behavior change**

`UnescapeTerm` strips one layer of `\X` for *any* `X`, so a quoted query with an unrecognized escape now drops the backslash: `@t:{"ACME\jdoe"}` resolves to `ACMEjdoe` rather than passing `\j` through verbatim as v1.39 did. This is intentional — it matches Dragonfly's own unquoted `make_Tag` behavior, keeping the quoted and unquoted tag paths consistent. It differs from RediSearch, which passes unknown escapes through. A characterization test pins the `\X → X` rule so the semantics stay explicit. Happy to change the policy if you'd rather emulate RediSearch here.

**Tests**

- `SearchParserTest.QuotedTagEscapes` — AST-level: `\\`/`\"` resolve to their single char, an unrecognized `\X` drops the backslash, and a trailing lone `\` (`{"C:\"}` → `C:`, doubled `{"C:\\"}` → `C:\`) parses instead of aborting.
- `SearchParserTest.WildcardLex` — extended with `w"a\"` / `w'a\'` (trailing backslash → `a`), the wildcard side of the same abort.
- `SearchFamilyTest.QuotedTagEscapes` — end-to-end HSET/FT.SEARCH round-trip: backslash, quote, plain, value-with-space, an OR-list of quoted members, and a `C:\` value (the doubled query matches; the lone-backslash query returns nothing without crashing).
- `SearchFamilyTest.QuotedTagEscapesJson` — the same escaped query on an `ON JSON` tag index.
- `SearchFamilyTest.QuotedTagEscapesCaseSensitive` — exact-case escaped query matches, wrong case does not.

Everything fails before the change (or aborts, for the trailing-backslash cases) and passes after; the full `search_parser_test` and `search_family_test` suites remain green.

**Notes**

- `UnescapeTerm` is defined in `lexer.lex`; I added a forward declaration in `parser.y` to call it. If you'd prefer it promoted to a shared header instead of a cross-unit forward declaration, happy to adjust.

This PR is just my personal take on a fix — treat it as throwaway. Please feel free to close it and resolve the issue however you see fit. If you find it useful, I'm glad to carry it forward and address review feedback.
