### PR TITLE
chore(tests): run upstream Valkey stream TCL suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,21 @@ jobs:
           name: regression_logs
           path: /tmp/failed/*
 
+      - name: Run Valkey TCL stream tests
+        # Same gating as the regression tests above: runs the upstream Valkey stream TCL suites
+        # (unit/type/stream[-cgroups]) in external-server mode against the just-built binary,
+        # on both Debug and Release. continue-on-error keeps it a canary for now — flip to a
+        # blocking step once proven stable in CI. See tests/dragonfly/valkey_tcl/README.md.
+        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers'
+        continue-on-error: true
+        timeout-minutes: 20
+        run: |
+          # tcl runs the harness; redis-tools + iproute2 (ss) for the fail-closed readiness probe.
+          apt-get update && apt-get install -y --no-install-recommends tcl redis-tools iproute2
+          cd ${GITHUB_WORKSPACE}/tests/dragonfly/valkey_tcl
+          ./sync-valkey-tcl-tests.sh
+          ./run-stream-tests.sh ${GITHUB_WORKSPACE}/build/dragonfly 6399
+
       - name: Prepare JUnit artifact name
         if: always()
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ tools/replay/traffic-replay
 .claude/skills/benchmark-workspace/
 # Valkey-search integration tests (synced from external repo)
 tests/dragonfly/valkey_search/integration/
+# Valkey TCL tests (harness + stream suites synced from external repo)
+tests/dragonfly/valkey_tcl/upstream/
 _codeql_build_dir/
 # CocoIndex Code (ccc)
 /.cocoindex_code/

--- a/tests/dragonfly/valkey_tcl/README.md
+++ b/tests/dragonfly/valkey_tcl/README.md
@@ -1,0 +1,61 @@
+# Valkey TCL stream tests on Dragonfly
+
+Runs the upstream [Valkey](https://github.com/valkey-io/valkey) TCL test suite (the
+classic Redis-era tests) against Dragonfly in **external-server mode** — the harness
+connects to an already-running Dragonfly over `--host/--port` instead of spawning a
+server. Currently scoped to the two stream suites:
+`unit/type/stream` and `unit/type/stream-cgroups`.
+
+## Layout
+
+```
+tests/dragonfly/valkey_tcl/
+├── sync-valkey-tcl-tests.sh   # clone Valkey @ pinned SHA → copy harness + stream files (committed)
+├── run-stream-tests.sh        # start Dragonfly + run the harness with the skiplist (committed)
+├── skiplist.txt               # documented, tracked list of known-failing tests (committed)
+├── README.md                  # this file (committed)
+└── upstream/                  # synced harness + tests — GITIGNORED, not committed
+```
+
+The test code is never committed; it is synced from upstream at a pinned revision,
+mirroring `tests/dragonfly/valkey_search/`.
+
+## Run locally
+
+```bash
+cd tests/dragonfly/valkey_tcl
+./sync-valkey-tcl-tests.sh                       # sync harness + stream tests (pinned SHA)
+./run-stream-tests.sh ../../../build-dbg/dragonfly   # start DF + run suites
+```
+
+Requirements: `tclsh` 8.6, and (optionally) `redis-cli` for the readiness probe.
+The run script exits non-zero if any non-skipped test fails.
+
+## How it works
+
+- **External mode**: `run-stream-tests.sh` starts Dragonfly (`--dbfilename= --dbnum=16`),
+  waits for `PING`, then runs `tclsh test_helper.tcl --host … --port …`. In external mode
+  the harness runs `FLUSHALL`/`FUNCTION FLUSH` before each block and applies overrides via
+  `CONFIG SET`; it never spawns or kills the server.
+- **Binary stub**: the harness's `set_executable_path.tcl` aborts unless
+  `src/valkey-server` exists and is executable — even though external mode never runs it.
+  The run script symlinks `upstream/src/valkey-server` to the Dragonfly binary to satisfy
+  the check.
+- **Tag skiplist**: `--tags "-needs:debug -needs:repl -external:skip -large-memory"` drops
+  the AOF/`debug loadaof` blocks (Dragonfly has no AOF), replication blocks, and
+  process-control blocks.
+- **Test skiplist**: `skiplist.txt` lists individual known-failing tests (each a tracked
+  Dragonfly gap) so the suite stays green over the passing subset. Remove an entry once the
+  underlying gap is fixed.
+
+Each skiplist bucket carries a one-line reason inline; the categorized baseline lives in
+the bucket comments of `skiplist.txt` itself.
+
+## CI
+
+Runs as the `Run Valkey TCL stream tests` step of the `build` job in
+`.github/workflows/ci.yml`, right after the Python regression tests and under the same
+gating (`ubuntu-dev:24` + `NoSanitizers`, both Debug and Release), against the just-built
+binary. The step installs `tcl`/`redis-tools`, syncs the harness, and runs the suites.
+The step is a non-blocking canary (`continue-on-error`) until it proves stable in CI;
+flip it to blocking to make the suite a required regression gate.

--- a/tests/dragonfly/valkey_tcl/run-stream-tests.sh
+++ b/tests/dragonfly/valkey_tcl/run-stream-tests.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Run the Valkey stream TCL suites against a Dragonfly binary in external-server mode.
+# Exits 0 only if every non-skipped test passes (harness returns 1 on any failure).
+#
+# Usage: ./run-stream-tests.sh <path-to-dragonfly-binary> [port]
+# Fail fast on any setup error; -e is relaxed only around the harness to capture its status.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPSTREAM="$SCRIPT_DIR/upstream"
+SKIPLIST="$SCRIPT_DIR/skiplist.txt"
+
+DRAGONFLY_BIN="${1:?usage: run-stream-tests.sh <dragonfly-binary> [port]}"
+PORT="${2:-6399}"
+
+if [ ! -d "$UPSTREAM/tests" ]; then
+  echo "ERROR: $UPSTREAM not found. Run ./sync-valkey-tcl-tests.sh first." >&2
+  exit 2
+fi
+DRAGONFLY_BIN="$(cd "$(dirname "$DRAGONFLY_BIN")" && pwd)/$(basename "$DRAGONFLY_BIN")"  # absolute
+if [ ! -x "$DRAGONFLY_BIN" ]; then
+  echo "ERROR: dragonfly binary not executable: $DRAGONFLY_BIN" >&2
+  exit 2
+fi
+
+# The harness's set_executable_path.tcl requires an executable src/valkey-server to exist,
+# even though external mode never runs it. Point it at the Dragonfly binary.
+mkdir -p "$UPSTREAM/src"
+ln -sf "$DRAGONFLY_BIN" "$UPSTREAM/src/valkey-server"
+
+# Port-ownership verification is mandatory (fail-closed): without it a PONG could come from a
+# FOREIGN server already on $PORT and the suite would FLUSHALL it.
+if command -v ss >/dev/null 2>&1; then
+  port_listeners() { ss -ltnp "sport = :$PORT" 2>/dev/null | tail -n +2; }
+  port_owned_by_child() { port_listeners | grep -q "pid=$DF_PID,"; }
+elif command -v lsof >/dev/null 2>&1; then
+  port_listeners() { lsof -nP -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | tail -n +2; }
+  port_owned_by_child() { lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | grep -qx "$DF_PID"; }
+else
+  echo "ERROR: need ss or lsof to verify port ownership; refusing to run (fail-closed)" >&2
+  exit 2
+fi
+
+# The readiness probe must confirm the server answers commands, not merely accepts TCP.
+if ! command -v redis-cli >/dev/null 2>&1; then
+  echo "ERROR: redis-cli is required for the readiness PING; refusing to run (fail-closed)" >&2
+  exit 2
+fi
+
+# Refuse to start if anything is already listening on the port.
+if [ -n "$(port_listeners)" ]; then
+  echo "ERROR: something is already listening on port $PORT, refusing to run against it" >&2
+  port_listeners >&2
+  exit 3
+fi
+
+LOGDIR="$(mktemp -d)"
+DF_LOG="$LOGDIR/dragonfly.log"
+"$DRAGONFLY_BIN" --bind 127.0.0.1 --port "$PORT" --dbfilename= --dbnum=16 --noversion_check \
+  --logtostderr > "$DF_LOG" 2>&1 &
+DF_PID=$!
+cleanup() {
+  local rc=$?
+  kill "$DF_PID" 2>/dev/null || true
+  for _ in $(seq 1 25); do kill -0 "$DF_PID" 2>/dev/null || break; sleep 0.2; done
+  kill -9 "$DF_PID" 2>/dev/null || true
+  wait "$DF_PID" 2>/dev/null || true
+  # Keep the logs for diagnosis on failure; don't accumulate temp dirs on success.
+  if [ "$rc" -eq 0 ]; then
+    rm -rf "$LOGDIR"
+  else
+    echo "Logs kept at $LOGDIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+ping_ok() {
+  timeout 2 redis-cli -p "$PORT" ping 2>/dev/null | grep -q PONG
+}
+up=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$DF_PID" 2>/dev/null; then
+    echo "ERROR: Dragonfly (pid $DF_PID) exited during startup" >&2
+    cat "$DF_LOG" >&2 || true
+    exit 3
+  fi
+  # Verify the listener is OUR child before the first PING (fail-closed ordering).
+  if port_owned_by_child && ping_ok; then up=1; break; fi
+  sleep 0.2
+done
+if [ "$up" -ne 1 ]; then
+  echo "ERROR: Dragonfly did not become ready on port $PORT" >&2
+  cat "$DF_LOG" >&2 || true
+  exit 3
+fi
+echo "Dragonfly ready on port $PORT (pid $DF_PID)"
+
+# Feed the harness a clean skipfile (strip comments and blank lines). A missing skiplist would
+# run the known-HANGING tests and wedge the whole suite, so fail hard instead.
+if [ ! -f "$SKIPLIST" ]; then
+  echo "ERROR: skiplist not found: $SKIPLIST" >&2
+  exit 2
+fi
+CLEAN_SKIP="$LOGDIR/skiplist.clean"
+grep -vE '^[[:space:]]*(#|$)' "$SKIPLIST" > "$CLEAN_SKIP" || true
+if [ ! -s "$CLEAN_SKIP" ]; then
+  echo "ERROR: skiplist $SKIPLIST produced no entries - refusing to run the hanging tests" >&2
+  exit 2
+fi
+echo "Skipping $(wc -l < "$CLEAN_SKIP") known-failing test(s) (see skiplist.txt)"
+
+# --timeout bounds a single stuck test (the harness aborts the run on timeout); the outer
+# `timeout` is a hard backstop so a hung blocking test can never wedge CI indefinitely
+# (--kill-after escalates to SIGKILL if tclsh ignores the TERM).
+cd "$UPSTREAM"
+set +e  # capture the harness exit status instead of dying mid-report
+timeout --kill-after=30 900 tclsh tests/test_helper.tcl \
+  --host 127.0.0.1 --port "$PORT" \
+  --single unit/type/stream \
+  --single unit/type/stream-cgroups \
+  --tags "-needs:debug -needs:repl -external:skip -large-memory" \
+  --skipfile "$CLEAN_SKIP" \
+  --timeout 120 \
+  --durable
+STATUS=$?
+set -e
+
+echo "TCL harness exit status: $STATUS"
+exit $STATUS

--- a/tests/dragonfly/valkey_tcl/skiplist.txt
+++ b/tests/dragonfly/valkey_tcl/skiplist.txt
@@ -1,0 +1,90 @@
+# Known-failing Valkey stream tests on Dragonfly, skipped so the suite is a green
+# regression gate over the passing subset. One test name per line (a line starting
+# with '/' is treated as a regexp by the harness). Comments (#) and blank lines are
+# stripped before the list is passed to --skipfile.
+#
+# Each entry is a tracked gap, NOT a permanent exclusion — remove it once fixed.
+# Validated against Valkey unstable @ 79fc841577be18d5e789f741ca92a4157e8315fa.
+# Baseline PoC (truncated partial run before the wake fixes): 65 pass / 27 fail.
+
+# --- Missing runtime CONFIG `stream-node-max-entries` (test setup fails) ---
+XADD with MAXLEN option and the '~' argument
+XADD with LIMIT consecutive calls
+XTRIM with ~ is limited
+XTRIM without ~ is not limited
+XTRIM without ~ and with LIMIT
+XTRIM with LIMIT delete entries no more than limit
+XTRIM MINID marking last entry in listpack as deleted
+
+# --- `XREAD ... STREAMS key +` (read last element, Valkey 7.4+) unsupported ---
+XREAD last element from non-empty stream
+XREAD last element from empty stream
+XREAD last element blocking from empty stream
+XREAD last element blocking from non-empty stream
+XREAD last element from multiple streams
+XREAD last element with count > 1
+
+# --- `XSETID ... ENTRIESADDED/MAXDELETEDID/offset` extended syntax unsupported ---
+XSETID cannot run with an offset but without a maximal tombstone
+XSETID cannot run with a maximal tombstone but without an offset
+XSETID errors on negative offset
+XSETID cannot set the maximal tombstone with larger ID
+XSETID cannot set the offset to less than the length
+
+# --- Blocking XREAD not registered as a blocked client (wait_for_blocked_clients timeout) ---
+XREAD with same stream name multiple times should work
+XREAD + multiple XADD inside transaction
+Blocking XREAD for stream that ran dry (issue #5299)
+# Woken blocking XREAD replies an empty set ({x {}}) instead of the newly added entry.
+XREAD streamID edge (blocking)
+
+# --- Ran-dry XREADGROUP replies {stream {}} instead of nil (issue #5299 shape) ---
+Blocking XREADGROUP for stream that ran dry (issue #5299)
+
+# --- Blocked-client accounting: INFO lacks `total_blocking_keys`(+`_on_nokey`); multi-client ---
+# blocked-count scenarios don't converge. NOTE: these tests abort mid-way and LEAK blocked
+# clients, which then poison the following RENAME/XCLAIM tests (cascade failures) — so they
+# must stay skipped together.
+Blocking XREADGROUP for stream key that has clients blocked on list
+Blocking XREADGROUP for stream key that has clients blocked on stream - avoid endless loop
+Blocking XREADGROUP for stream key that has clients blocked on stream - reprocessing command
+
+# --- XGROUP/XINFO HELP extra-arg handling differs (cosmetic) ---
+XGROUP HELP should not have unexpected options
+XINFO HELP should not have unexpected options
+
+# --- XGROUP CREATE does not validate a negative ENTRIESREAD ---
+XGROUP CREATE: with ENTRIESREAD parameter
+
+# --- XGROUP SETID rejects the `-` special id ---
+PEL NACK reassignment after XGROUP SETID event
+
+# --- HANGS: blocked XREADGROUP is not woken when the key is mutated (BLOCK 0). ---
+# A group-blocked client is not woken by DEL/SET(retype)/FLUSHALL/SWAPDB, so `$rd read`
+# blocks forever. These MUST stay skipped or the whole run wedges. Remove once
+# wake-on-key-invalidation for blocked XREADGROUP lands.
+# (XGROUP DESTROY and RENAME *do* wake correctly.)
+Blocking XREADGROUP: key deleted
+Blocking XREADGROUP: key type changed with SET
+Blocking XREADGROUP: key type changed with transaction
+Blocking XREADGROUP: flushed DB
+Blocking XREADGROUP: swapped DB, key doesn't exist
+Blocking XREADGROUP: swapped DB, key is not a stream
+
+# --- Errorstats naming/format differs from Valkey (pre-existing, unrelated to wake) ---
+# The XREADGROUP wake to -NOGROUP works; this test also asserts `errorstat_NOGROUP:count=1`,
+# but Dragonfly emits its internal type tag (`no_group_error:N`) with a different format.
+XGROUP DESTROY should unblock XREADGROUP with -NOGROUP
+
+# --- XCLAIM with trimming: needs `config set stream-node-max-entries` (two tests share this name) ---
+XCLAIM with trimming
+
+# --- XPENDING ignores the <consumer> filter argument ---
+# `XPENDING key group - + 10 consumer2` returns other consumers' entries instead of an
+# empty array (live-verified), so the pre-claim asserts fail.
+XCLAIM can claim PEL items from another consumer
+
+# --- Error-message text differs from Valkey (assert_error exact-match) ---
+XREAD and XREADGROUP against wrong parameter
+XAUTOCLAIM COUNT must be > 0
+XAUTOCLAIM with out of range count

--- a/tests/dragonfly/valkey_tcl/sync-valkey-tcl-tests.sh
+++ b/tests/dragonfly/valkey_tcl/sync-valkey-tcl-tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Sync the Valkey TCL test harness + stream test files into ./upstream (gitignored),
+# pinned to a specific revision. Mirrors tests/dragonfly/valkey_search/sync-valkey-search-tests.sh.
+#
+# Usage: ./sync-valkey-tcl-tests.sh [<git-sha-or-tag>]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST="$SCRIPT_DIR/upstream"
+REPO="https://github.com/valkey-io/valkey.git"
+# Pinned revision the skiplist was validated against. Override via arg 1.
+REV="${1:-79fc841577be18d5e789f741ca92a4157e8315fa}"
+
+echo "Syncing Valkey TCL tests from $REPO @ $REV"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Shallow-fetch just the pinned revision instead of cloning the whole repo.
+git init --quiet "$TMP"
+git -C "$TMP" remote add origin "$REPO"
+git -C "$TMP" fetch --quiet --depth=1 origin "$REV"
+git -C "$TMP" checkout --quiet FETCH_HEAD
+
+rm -rf "$DEST"
+mkdir -p "$DEST/tests/unit/type"
+cp    "$TMP/tests/test_helper.tcl"               "$DEST/tests/"
+cp -r "$TMP/tests/support"                        "$DEST/tests/"
+cp -r "$TMP/tests/helpers"                        "$DEST/tests/"
+cp -r "$TMP/tests/assets"                         "$DEST/tests/"
+cp    "$TMP/tests/unit/type/stream.tcl"           "$DEST/tests/unit/type/"
+cp    "$TMP/tests/unit/type/stream-cgroups.tcl"   "$DEST/tests/unit/type/"
+echo "$REV" > "$DEST/TESTED_REVISION.txt"
+
+echo "Done. Synced harness + $(ls "$DEST"/tests/unit/type | wc -l) stream test file(s) to $DEST"


### PR DESCRIPTION
Integrates the upstream Valkey TCL test harness (external-server mode) for the two-stream suites (`unit/type/stream`, `unit/type/stream-cgroups`) as a green regression gate: 89 passed / 0 failed on the pinned revision, with every known-failing test skiplisted and annotated with its root cause.