### PR TITLE
fix(facade): preserve pub/sub order on unsubscribe (v1 IO loop)

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2234,16 +2234,23 @@ void Connection::AsyncFiber() {
         }
       }
 
-      // We prioritize pipeline execution over the admin queue in two distinct cases (Pipeline queue
-      // must be non-empty for both cases):
-      // 1. A migration is requested (Redis only), but we must drain the existing
-      // pipeline first.
-      // 2.  The dispatch quota was reached, forcing a pipeline execution to prevent
-      // starvation.
+      // Prefer the pipeline over the admin queue when case 1 OR case 2 holds (pipeline non-empty):
+      // 1. Migration requested (Redis only): drain the pipeline first.
+      // 2. Anti-starvation, requires 2a AND 2b AND 2c to be all true:
+      //    2a. the dispatch quota was reached, and
+      //    2b. the pipeline head is STRICTLY older than the dispatch queue head (so UNSUBSCRIBE
+      //        never jumps ahead of pub/sub messages queued before it), and
+      //    2c. the head is not a checkpoint. Checkpoints are front-inserted so they can hide older
+      //        PubMessages; process the (cheap) checkpoint first and re-evaluate next round.
       bool prefer_pipeline_execution = false;
       if (parsed_head_ != nullptr) {
-        prefer_pipeline_execution =
-            quota_reached || (is_migration_req && (protocol_ == Protocol::REDIS));
+        const bool drain_for_migration = is_migration_req && (protocol_ == Protocol::REDIS);
+        const bool head_preserves_order =
+            dispatch_q_.empty() ||
+            (!dispatch_q_.front().IsCheckPoint() &&
+             parsed_head_->parsed_cycle < dispatch_q_.front().dispatch_cycle);
+        const bool quota_reached_while_preserves_order = quota_reached && head_preserves_order;
+        prefer_pipeline_execution = drain_for_migration || quota_reached_while_preserves_order;
       }
       if (dispatch_q_.empty() || prefer_pipeline_execution) {  // 2. Process pipeline Queue
         VLOG_IF(2, prefer_pipeline_execution)

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2236,12 +2236,12 @@ void Connection::AsyncFiber() {
 
       // Prefer the pipeline over the admin queue when case 1 OR case 2 holds (pipeline non-empty):
       // 1. Migration requested (Redis only): drain the pipeline first.
-      // 2. Anti-starvation, requires 2a AND 2b AND 2c to be all true:
+      // 2. Anti-starvation, requires all conditions below to be true:
       //    2a. the dispatch quota was reached, and
       //    2b. the pipeline head is STRICTLY older than the dispatch queue head (so UNSUBSCRIBE
       //        never jumps ahead of pub/sub messages queued before it), and
-      //    2c. the head is not a checkpoint. Checkpoints are front-inserted so they can hide older
-      //        PubMessages; process the (cheap) checkpoint first and re-evaluate next round.
+      //    2c. the head is not a checkpoint. Checkpoints are front-inserted, taking precedence over
+      //    older PubMessages.
       bool prefer_pipeline_execution = false;
       if (parsed_head_ != nullptr) {
         const bool drain_for_migration = is_migration_req && (protocol_ == Protocol::REDIS);

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -701,6 +701,8 @@ async def test_pubsub_unsubscribe_message_loss(
     message_token = b"$7\r\nmessage\r\n"
     unsubscribe_token = b"$11\r\nunsubscribe\r\n"
 
+    # Raw socket with a tiny recv buffer that stops reading, so the server's Pub/Sub writes block
+    # and messages pile up server-side. (_open_stuck_subscriber can't be actively drained here.)
     loop = asyncio.get_running_loop()
     subscriber = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     subscriber.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2048)
@@ -709,8 +711,8 @@ async def test_pubsub_unsubscribe_message_loss(
         await loop.sock_connect(subscriber, ("127.0.0.1", df_server.port))
         await loop.sock_sendall(subscriber, f"SUBSCRIBE {channel}\r\n".encode())
 
-        # Read only the subscribe confirmation, then stop reading so the server's
-        # Pub/Sub writes block and messages queue up on the server side.
+        # Read only the subscribe confirmation, then stop reading so the server's Pub/Sub writes
+        # block and messages queue up on the server side.
         subscribe_reply = b""
         while b":1\r\n" not in subscribe_reply:
             subscribe_reply += await loop.sock_recv(subscriber, 1024)
@@ -719,7 +721,6 @@ async def test_pubsub_unsubscribe_message_loss(
         for _ in range(message_count):
             assert await publisher.publish(channel, payload) == 1
 
-        # Unsubscribe
         await loop.sock_sendall(subscriber, f"UNSUBSCRIBE {channel}\r\n".encode())
 
         # Drain replies until the unsubscribe confirmation, then keep reading through a
@@ -742,12 +743,10 @@ async def test_pubsub_unsubscribe_message_loss(
         assert saw_unsubscribe, "never received the unsubscribe confirmation"
 
         unsub_at = stream.index(unsubscribe_token)
-        messages_before = stream[:unsub_at].count(
-            message_token
-        )  # must be message_count, if not -> messages were dropped
-        messages_after = stream[unsub_at:].count(
-            message_token
-        )  # must be 0, if messages_after > 0 -> replied were reordered
+        # must be message_count, if not -> messages were dropped
+        messages_before = stream[:unsub_at].count(message_token)
+        # must be 0, if > 0 -> replies were reordered
+        messages_after = stream[unsub_at:].count(message_token)
 
         assert (
             messages_after == 0

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -677,6 +677,89 @@ async def test_pubsub_unsubscribe(df_server: DflyInstance):
     await cl.aclose()
 
 
+# This test is written as as part of a bug fix (regression, v1.38): the async_dispatch_quota anti-starvation logic ran UNSUBSCRIBE
+# while earlier Pub/Sub messages were still queued, so the client saw messages after the unsubscribe confirmation (or lost them).
+# All messages must precede the confirmation.
+#
+# dfly_args: single proactor thread for deterministic reordering, and tiny quota to trigger anti starvation quickly
+@dfly_args({"proactor_threads": 1, "async_dispatch_quota": 4})
+async def test_pubsub_unsubscribe_message_loss(
+    df_server: DflyInstance, async_client: aioredis.Redis
+):
+    # The fix currently only covers the V1 io loop. The V2 loop (IoLoopV2) still reorders
+    # UNSUBSCRIBE ahead of queued Pub/Sub messages, so skip until V2 is fixed.
+    # TODO: re-enable for V2 once the IoLoopV2 fix lands (see linked GitHub issue).
+    if is_resp_io_loop_v2(df_server):
+        pytest.skip("V2 io loop still reorders UNSUBSCRIBE ahead of queued messages; fix pending")
+
+    publisher = async_client
+    channel = "ordering-channel"
+    # Well above async_dispatch_quota (and the socket buffer) so the surplus piles up
+    # in the server-side dispatch queue and the anti-starvation path triggers.
+    message_count = 60
+    payload = b"x" * 100_000  # large enough to fill the tiny receive window quickly
+    message_token = b"$7\r\nmessage\r\n"
+    unsubscribe_token = b"$11\r\nunsubscribe\r\n"
+
+    loop = asyncio.get_running_loop()
+    subscriber = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    subscriber.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2048)
+    subscriber.setblocking(False)
+    try:
+        await loop.sock_connect(subscriber, ("127.0.0.1", df_server.port))
+        await loop.sock_sendall(subscriber, f"SUBSCRIBE {channel}\r\n".encode())
+
+        # Read only the subscribe confirmation, then stop reading so the server's
+        # Pub/Sub writes block and messages queue up on the server side.
+        subscribe_reply = b""
+        while b":1\r\n" not in subscribe_reply:
+            subscribe_reply += await loop.sock_recv(subscriber, 1024)
+
+        # Publish all message_count messages before UNSUBSCRIBE so each is queued ahead of it.
+        for _ in range(message_count):
+            assert await publisher.publish(channel, payload) == 1
+
+        # Unsubscribe
+        await loop.sock_sendall(subscriber, f"UNSUBSCRIBE {channel}\r\n".encode())
+
+        # Drain replies until the unsubscribe confirmation, then keep reading through a
+        # short idle grace period to catch any message wrongly emitted after it.
+        stream = b""
+        saw_unsubscribe = False
+        async with async_timeout.timeout(60):
+            while True:
+                try:
+                    data = await asyncio.wait_for(loop.sock_recv(subscriber, 256 * 1024), 2.0)
+                except asyncio.TimeoutError:
+                    if saw_unsubscribe:
+                        break  # idle after the confirmation -> stream is complete
+                    continue
+                if not data:
+                    break
+                stream += data
+                saw_unsubscribe = saw_unsubscribe or unsubscribe_token in stream
+
+        assert saw_unsubscribe, "never received the unsubscribe confirmation"
+
+        unsub_at = stream.index(unsubscribe_token)
+        messages_before = stream[:unsub_at].count(
+            message_token
+        )  # must be message_count, if not -> messages were dropped
+        messages_after = stream[unsub_at:].count(
+            message_token
+        )  # must be 0, if messages_after > 0 -> replied were reordered
+
+        assert (
+            messages_after == 0
+        ), f"{messages_after} Pub/Sub messages were delivered AFTER the unsubscribe confirmation - replies were reordered"
+        assert messages_before == message_count, (
+            f"only {messages_before}/{message_count} Pub/Sub messages were delivered before "
+            "the unsubscribe confirmation - messages published before UNSUBSCRIBE were lost"
+        )
+    finally:
+        subscriber.close()
+
+
 async def produce_expiring_keys(async_client: aioredis.Redis):
     keys = []
     for i in range(10, 50):


### PR DESCRIPTION
Since v1.38 the async_dispatch_quota anti-starvation logic in AsyncFiber
could run a pipelined command such as UNSUBSCRIBE ahead of pub/sub
messages that were queued before it, once the quota was reached. Running
UNSUBSCRIBE early sets subscriptions to 0, so the still-queued messages
are discarded and the subscriber loses messages published before it
unsubscribed.

Gate the quota-based pipeline preference on FIFO order: only prefer the
pipeline when its head command is strictly older than the oldest queued
control message, so it never jumps ahead of pub/sub messages queued
before it.

dispatch_q_ is FIFO by dispatch_cycle except for checkpoints, which
SendAsync inserts at the front. A newer leading checkpoint would hide
older queued PubMessages, so when the head is a checkpoint we defer the
pipeline preference for one iteration: the checkpoint is processed first
and the decision is re-evaluated against the real oldest message.

Add regression test test_pubsub_unsubscribe_message_loss.

The V2 io loop (IoLoopV2) fix will be done in a separate commit; the
test is skipped under V2 until then.