### PR TITLE
feat(rdb): Skip keys with unsupported module types instead of failing

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -3234,7 +3234,7 @@ io::Result<bool> RdbLoader::ReadAndDispatchObject(int object_type, std::string& 
   // Read a part of the object. Updates remaining items
   if (auto ec = ReadObj(object_type, &item->val); ec) {
     if (ec == RdbError(errc::feature_not_supported)) {
-      LOG(WARNING) << "Skipping unsupported key '" << key;
+      LOG(WARNING) << "Skipping unsupported key: " << key;
       pending_read_ = {};
       return true;
     }

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1301,7 +1301,7 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
       }
       break;
     case RDB_TYPE_MODULE_2:
-      iores = ReadRedisJson();
+      iores = ReadRedisModule2();
       break;
     case RDB_TYPE_SBF:
       iores = ReadSBF();
@@ -1828,20 +1828,25 @@ auto RdbLoaderBase::ReadStreams(int rdbtype) -> io::Result<OpaqueObj> {
   return OpaqueObj{std::move(load_trace), RDB_TYPE_STREAM_LISTPACKS};
 }
 
-auto RdbLoaderBase::ReadRedisJson() -> io::Result<OpaqueObj> {
-  auto json_magic_number = LoadLen(nullptr);
-  if (!json_magic_number) {
+auto RdbLoaderBase::ReadRedisModule2() -> io::Result<OpaqueObj> {
+  auto module_id = LoadLen(nullptr);
+  if (!module_id) {
     return Unexpected(errc::rdb_file_corrupted);
   }
 
   constexpr string_view kJsonModule = "ReJSON-RL"sv;
-  string module_name = ModuleTypeName(*json_magic_number);
+  string module_name = ModuleTypeName(*module_id);
   if (module_name != kJsonModule) {
-    LOG(ERROR) << "Unsupported module: " << module_name;
-    return Unexpected(errc::unsupported_operation);
+    // We don't support any other module type except ReJSON, so we skip the key instead of
+    // failing the load.
+    LOG(WARNING) << "Skipping key with unsupported module type: " << module_name;
+    if (error_code ec = SkipModuleKeyData(); ec) {
+      return make_unexpected(ec);
+    }
+    return Unexpected(errc::feature_not_supported);
   }
 
-  int encver = *json_magic_number & 1023;
+  int encver = *module_id & 1023;
   if (encver != 3) {
     LOG(ERROR) << "Unsupported ReJSON version: " << encver;
     return Unexpected(errc::unsupported_operation);
@@ -2468,7 +2473,7 @@ error_code RdbLoader::Load(io::Source* src) {
       string module_name = ModuleTypeName(module_id);
 
       LOG(WARNING) << "WARNING: Skipping data for module " << module_name;
-      RETURN_ON_ERR(SkipModuleData());
+      RETURN_ON_ERR(SkipModuleAuxData());
       continue;
     }
 
@@ -2695,12 +2700,20 @@ error_code RdbLoaderBase::AllocateDecompressOnce(int op_type) {
   return {};
 }
 
-error_code RdbLoaderBase::SkipModuleData() {
+error_code RdbLoaderBase::SkipModuleAuxData() {
   uint64_t opcode;
   SET_OR_RETURN(LoadLen(nullptr), opcode);  // ignore field 'when_opcode'
+
   if (opcode != RDB_MODULE_OPCODE_UINT)
     return RdbError(errc::rdb_file_corrupted);
+
   SET_OR_RETURN(LoadLen(nullptr), opcode);  // ignore field 'when'
+
+  return SkipModuleKeyData();
+}
+
+error_code RdbLoaderBase::SkipModuleKeyData() {
+  uint64_t opcode;
 
   while (true) {
     SET_OR_RETURN(LoadLen(nullptr), opcode);
@@ -3219,8 +3232,14 @@ io::Result<bool> RdbLoader::ReadAndDispatchObject(int object_type, std::string& 
   const bool was_appending = pending_read_.remaining != 0;
 
   // Read a part of the object. Updates remaining items
-  if (auto ec = ReadObj(object_type, &item->val); ec)
+  if (auto ec = ReadObj(object_type, &item->val); ec) {
+    if (ec == RdbError(errc::feature_not_supported)) {
+      LOG(WARNING) << "Skipping unsupported key '" << key;
+      pending_read_ = {};
+      return true;
+    }
     return make_unexpected(ec);
+  }
 
   const bool finalized = pending_read_.remaining == 0;
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -224,7 +224,7 @@ class RdbLoaderBase {
   ::io::Result<OpaqueObj> ReadZSet(int rdbtype);
   ::io::Result<OpaqueObj> ReadListQuicklist(int rdbtype);
   ::io::Result<OpaqueObj> ReadStreams(int rdbtype);
-  ::io::Result<OpaqueObj> ReadRedisJson();
+  ::io::Result<OpaqueObj> ReadRedisModule2();
   ::io::Result<OpaqueObj> ReadSBFImpl(bool filter_is_chunked);
   ::io::Result<OpaqueObj> ReadSBF();
   ::io::Result<OpaqueObj> ReadSBF2();
@@ -232,7 +232,8 @@ class RdbLoaderBase {
   ::io::Result<OpaqueObj> ReadTOPK();
   ::io::Result<OpaqueObj> ReadCuckoo();
 
-  std::error_code SkipModuleData();
+  std::error_code SkipModuleAuxData();
+  std::error_code SkipModuleKeyData();
   std::error_code HandleCompressedBlob(int op_type);
   std::error_code HandleCompressedBlobFinish();
   std::error_code AllocateDecompressOnce(int op_type);

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -50,6 +50,22 @@ ABSL_DECLARE_FLAG(bool, deserialize_hnsw_index);
 ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes);
 ABSL_DECLARE_FLAG(std::string, dbfilename);
 
+namespace {
+
+uint64_t EncodeModuleId(std::string_view name, int ver) {
+  CHECK_LE(name.size(), 9u) << "Module names are encoded in at most 9 chars";
+  constexpr std::string_view kCharset =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  uint64_t bits = 0;
+  for (char c : name) {
+    size_t idx = kCharset.find(c);
+    bits = (bits << 6) | idx;
+  }
+  return (bits << 10) | static_cast<uint64_t>(ver);
+}
+
+}  // namespace
+
 namespace dfly {
 
 static const auto kMatchNil = ArgType(RespExpr::NIL);
@@ -2001,6 +2017,32 @@ TEST_F(RdbTest, JournalDelWaitsForShardLoads) {
   ASSERT_FALSE(ec) << ec.message();
 
   EXPECT_THAT(Run({"GET", key}), ArgType(RespExpr::NIL));
+}
+
+// Test that an unsupported module type is skipped, and that the keys before and after it are
+// loaded correctly.
+TEST_F(RdbTest, ModuleUnsupportedTypeSkipped) {
+  std::string body;
+
+  body.push_back(RDB_TYPE_STRING);
+  AddKV(&body, "key_before", "val_before");
+
+  body.push_back(RDB_TYPE_MODULE_2);
+  AppendString(&body, "key_with_unsupported_module");
+  AppendLen(&body, EncodeModuleId("invalid", 1));
+  AppendLen(&body, RDB_MODULE_OPCODE_STRING);
+  AppendString(&body, "value");
+  AppendLen(&body, RDB_MODULE_OPCODE_EOF);
+
+  body.push_back(RDB_TYPE_STRING);
+  AddKV(&body, "key_after", "val_after");
+
+  auto ec = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body)); });
+  ASSERT_FALSE(ec) << ec.message();
+
+  EXPECT_EQ(Run({"GET", "key_before"}), "val_before");
+  EXPECT_THAT(Run({"EXISTS", "key_with_unsupported_module"}), IntArg(0));
+  EXPECT_EQ(Run({"GET", "key_after"}), "val_after");
 }
 
 // Integration test for snapshot egress throttling (--snapshot_egress_limit_bytes).


### PR DESCRIPTION
RDB_TYPE_MODULE_2 values for module types we don't support were aborting the whole load. 
Detect unsupported module types, skip their value bytes via the generic module opcode format, 
and skip just that key instead.

- Split SkipModuleData into SkipModuleAuxData (aux opcode, has a leading timestamp field) 
  and SkipModuleKeyData (per-key module values).
- Rename ReadRedisJson to ReadRedisModule2 since it handles RDB_TYPE_MODULE_2 type.

Closes #7848

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
