### PR TITLE
fix: name idle tasks and evict stalled Pub/Sub subscribers

### DIFF
--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -420,15 +420,20 @@ records `async_op_start_cycle_` around the `std::visit` that runs the Pub/Sub
 send, so the connection knows how long its current send has been blocked.
 
 `SendPubMessageAsync` (which runs on the subscriber's thread while that send is
-parked) closes the subscriber only when **both** conditions hold:
+parked) closes the subscriber when its active send has been blocked continuously
+for at least `--pubsub_slow_subscriber_timeout_ms` and **either** of these
+conditions holds:
 
-1. the thread is in a soft-limit episode (`subscriber_bytes` above the soft
-   limit), and
-2. this connection's active send has been blocked continuously for at least
-   `--pubsub_slow_subscriber_timeout_ms`.
+1. this connection's queued Pub/Sub data has reached one-sixteenth of
+   `publish_buffer_limit`, or
+2. the thread is in a soft-limit episode (`subscriber_bytes` above the soft
+   limit).
 
-The conditions are conjunctive: a slow send below the budget, or a full budget
-with a still-progressing send, is left alone. When both hold,
+Thus, a slow connection cannot consume the entire per-thread budget before the
+policy can evict it, while a full thread can evict any subscriber with a
+timed-out send. A slow send below the per-connection threshold is left alone
+until the thread reaches its soft limit, and a full budget with a
+still-progressing send is also left alone. When the policy triggers,
 `RequestPubsubClose` discards the new message, evicts the connection's queued
 `PubMessage` items (immediately releasing their subscriber accounting and waking
 parked publishers), and calls the non-blocking `MarkForClose` — it never waits,

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -89,8 +89,9 @@ ABSL_FLAG(strings::MemoryBytesFlag, publish_buffer_limit, 196_MB,
 
 ABSL_FLAG(uint32_t, pubsub_slow_subscriber_timeout_ms, 0,
           "If a subscriber connection keeps a Pub/Sub socket write blocked for at least this many "
-          "milliseconds while the per-IO-thread subscriber memory is above the soft "
-          "publish_buffer_limit, Dragonfly closes that subscriber to release the back-pressure. "
+          "milliseconds, Dragonfly closes it when either its queued Pub/Sub memory reaches "
+          "one-sixteenth of publish_buffer_limit or the per-IO-thread subscriber memory is "
+          "above publish_buffer_limit. "
           "0 disables this slow-subscriber protection. Startup-only, like publish_buffer_limit.");
 
 ABSL_FLAG(uint32_t, pipeline_squash, 1,
@@ -2390,14 +2391,18 @@ bool Connection::IsCurrentlyDispatching() const {
   return cc_->async_dispatch || cc_->sync_dispatch;
 }
 
-bool Connection::IsAsyncOpOverdue(uint64_t timeout_cycles) const {
-  if (async_op_start_cycle_ == 0)
+bool Connection::IsAsyncOpOverdue() const {
+  if (pubsub_slow_subscriber_timeout_cycles_cached == 0 || async_op_start_cycle_ == 0)
     return false;
-  return base::CycleClock::Now() - async_op_start_cycle_ >= timeout_cycles;
+  return base::CycleClock::Now() >=
+         async_op_start_cycle_ + pubsub_slow_subscriber_timeout_cycles_cached;
 }
 
 void Connection::RequestPubsubClose() {
   QueueBackpressure& qbp = GetQueueBackpressure();
+  const size_t connection_subscriber_bytes = dispatch_q_subscriber_bytes_;
+
+  unsigned blocked_usec = base::CycleClock::ToUsec(base::CycleClock::Now() - async_op_start_cycle_);
 
   // Evict already-queued PubMessage items, releasing their per-thread subscriber accounting
   // immediately. Other control messages (checkpoints, migration, ...) are left for the normal
@@ -2426,12 +2431,10 @@ void Connection::RequestPubsubClose() {
   // not to a metric label.
   LOG_EVERY_T(WARNING, 1) << "Closing slow Pub/Sub subscriber " << DebugInfo()
                           << " tid=" << ProactorBase::me()->GetPoolIndex()
-                          << " publish_buffer_limit=" << qbp.publish_buffer_limit
                           << " thread_subscriber_bytes="
                           << qbp.subscriber_bytes.load(memory_order_relaxed)
-                          << " blocked_send_usec="
-                          << base::CycleClock::ToUsec(base::CycleClock::Now() -
-                                                      async_op_start_cycle_)
+                          << " connection_subscriber_bytes=" << connection_subscriber_bytes
+                          << " blocked_send_usec=" << blocked_usec
                           << " discarded_entries=" << discarded_msgs
                           << " discarded_bytes=" << discarded_bytes;
 
@@ -2448,14 +2451,23 @@ void Connection::SendPubMessageAsync(PubMessage msg) {
   if (request_shutdown_)
     return;
 
-  // Two conjunctive conditions: the thread is in a soft-limit back-pressure episode AND this
-  // connection's active Pub/Sub send has been blocked continuously past the configured deadline.
-  // A slow send below the budget, or a full budget with a still-progressing send, is left alone.
-  uint64_t timeout_cycles = pubsub_slow_subscriber_timeout_cycles_cached;
-  if (timeout_cycles > 0 && GetQueueBackpressure().IsSubscriberSoftLimited() &&
-      IsAsyncOpOverdue(timeout_cycles)) {
-    RequestPubsubClose();
-    return;  // discard the message that triggered the close
+  if (IsAsyncOpOverdue()) {
+    // A single blocked subscriber must not consume the whole per-thread Pub/Sub budget before the
+    // slow-subscriber policy can evict it.
+    constexpr uint32_t kPubSubConnectionLimitDivisor = 16;
+
+    // Close a subscriber only after its active Pub/Sub send has been blocked continuously past the
+    // configured deadline. Either its own queued Pub/Sub data has reached the per-connection limit,
+    // or the thread is in a soft-limit back-pressure episode. The local limit prevents one blocked
+    // connection from consuming the whole thread-wide budget before it becomes eligible for
+    // eviction.
+    QueueBackpressure& qbp = GetQueueBackpressure();
+
+    size_t conn_soft_limit = qbp.publish_buffer_limit / kPubSubConnectionLimitDivisor;
+    if (dispatch_q_subscriber_bytes_ >= conn_soft_limit || qbp.IsSubscriberSoftLimited()) {
+      RequestPubsubClose();
+      return;  // discard the message that triggered the close
+    }
   }
 
   SendAsync({make_unique<PubMessage>(std::move(msg))});

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -402,9 +402,9 @@ class Connection : public util::Connection {
   // Returns true if the fiber should terminate (e.g. Migration).
   bool ProcessAdminMessage(MessageHandle* msg, AsyncOperations* async_op);
 
-  // Returns true if a control-path async operation is currently running inside ProcessAdminMessage
-  // and has been in progress for at least `timeout_cycles` (base::CycleClock cycles).
-  bool IsAsyncOpOverdue(uint64_t timeout_cycles) const;
+  // Returns true if a control-path async operation is currently
+  // running inside ProcessAdminMessage and been stalled for longer than the configured threshold.
+  bool IsAsyncOpOverdue() const;
 
   // Slow-subscriber protection (RESP V1): evict queued PubMessage items from dispatch_q_ (releasing
   // their per-thread subscriber accounting immediately), account the discard metrics, log a

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -315,7 +315,7 @@ template <typename Set> void AsyncDeleter::EnqueDeletion(uint32_t next, Set* ds)
   DCHECK(pb);
   DVLOG(2) << "Adding async deletion task, thread " << pb->GetPoolIndex() << " " << launch_task;
   if (launch_task) {
-    pb->AddOnIdleTask(&IdleCb);
+    pb->AddOnIdleTask(&IdleCb, "async_deleter");
   }
 }
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -536,7 +536,7 @@ void EngineShard::StartPeriodicHeartbeatFiber(util::ProactorBase* pb) {
   fiber_heartbeat_periodic_ = fb2::Fiber(fb_opts, [this, period_ms, heartbeat]() mutable {
     RunFPeriodically(heartbeat, period_ms, "heartbeat", &fiber_heartbeat_periodic_done_);
   });
-  defrag_task_id_ = pb->AddOnIdleTask([this]() { return DefragTask(); });
+  defrag_task_id_ = pb->AddOnIdleTask([this]() { return DefragTask(); }, "defrag");
 }
 
 void EngineShard::StartPeriodicShardHandlerFiber(util::ProactorBase* pb,
@@ -828,15 +828,16 @@ void EngineShard::Heartbeat() {
         check_huffman = false;  // trigger only once.
 
         // launch the task
-        huffman_check_task_id_ =
-            ProactorBase::me()->AddOnIdleTask([task = HuffmanCheckTask{}]() mutable {
+        huffman_check_task_id_ = ProactorBase::me()->AddOnIdleTask(
+            [task = HuffmanCheckTask{}]() mutable {
               if (!shard_ || !namespaces) {
                 return -1;
               }
 
               DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_->shard_id());
               return task.Run(&db_slice);
-            });
+            },
+            "huffman_check");
       }
     }
   }

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -495,9 +495,7 @@ async def _open_stuck_subscriber(port: int):
     return reader, writer
 
 
-# publish_buffer_limit is the soft limit; the hard limit is 4x that. It is large relative to the
-# subscriber's socket buffer, so the server write blocks (and the stall timer starts) well before
-# the soft limit is crossed.
+# A single slow subscriber is evicted after its blocked send exceeds the per-connection limit.
 @dfly_args(
     {
         "proactor_threads": "1",
@@ -511,7 +509,7 @@ async def test_pubsub_slow_subscriber_closed(df_server: DflyInstance, async_clie
     stop = False
 
     async def pub_task():
-        payload = "msg" * 1000
+        payload = "msg" * 100
         while not stop:
             p = async_client.pipeline(transaction=False)
             for _ in range(200):
@@ -520,32 +518,42 @@ async def test_pubsub_slow_subscriber_closed(df_server: DflyInstance, async_clie
 
     publishers = [asyncio.create_task(pub_task()) for _ in range(20)]
 
-    # Wait until the policy force-closes the stuck subscriber.
-    stats = {}
-    for _ in range(150):
-        stats = await _pubsub_backpressure_stats(df_server)
-        if stats["forced_disconnect"] >= 1:
-            break
-        await asyncio.sleep(0.1)
-
-    assert stats["soft_limit"] >= 1
-    assert stats["forced_disconnect"] >= 1
-    assert stats["messages_discarded"] >= 1
-
-    # Let the publishers finish - they must not stay parked once the budget was released.
-    stop = True
-    await asyncio.wait_for(asyncio.gather(*publishers), timeout=20)
-
-    # Drain the subscriber socket so the parked write completes and the connection closes through
-    # the normal shutdown path.
     try:
-        while True:
-            data = await asyncio.wait_for(reader.read(65536), timeout=2)
-            if not data:
+        # Wait until the policy force-closes the stuck subscriber.
+        stats = {}
+        for _ in range(150):
+            stats = await _pubsub_backpressure_stats(df_server)
+            if stats["forced_disconnect"] >= 1:
                 break
-    except asyncio.TimeoutError:
-        pass
-    writer.close()
+            await asyncio.sleep(0.1)
+
+        assert stats["forced_disconnect"] >= 1
+        assert stats["messages_discarded"] >= 1
+
+        # We force disconnect the subscriber before we reach the per-thread soft limit
+        # (i.e. based on connection memory threshold).
+        assert stats["soft_limit"] == 0
+
+        # Let the publishers finish - they must not stay parked once the budget was released.
+        stop = True
+        await asyncio.wait_for(asyncio.gather(*publishers), timeout=20)
+
+        # Drain the subscriber socket so the parked write completes and the connection closes through
+        # the normal shutdown path.
+        try:
+            while True:
+                data = await asyncio.wait_for(reader.read(65536), timeout=2)
+                if not data:
+                    break
+        except asyncio.TimeoutError:
+            pass
+    finally:
+        stop = True
+        for publisher in publishers:
+            publisher.cancel()
+        await asyncio.gather(*publishers, return_exceptions=True)
+        writer.close()
+        await writer.wait_closed()
 
 
 # With the timeout disabled (0), a stuck subscriber is never force-closed even under back-pressure.


### PR DESCRIPTION
Name recurring idle tasks in diagnostics. Evict slow Pub/Sub subscribers at a per-connection queue threshold and ensure the regression test cleans up on failure.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
