### PR TITLE
fix(pytest): Drop flaky soft_limit assert and skip test for IoLoopV2

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -504,6 +504,10 @@ async def _open_stuck_subscriber(port: int):
     }
 )
 async def test_pubsub_slow_subscriber_closed(df_server: DflyInstance, async_client: aioredis.Redis):
+    # TODO: re-enable for V2 once the IoLoopV2 fix lands.
+    if is_resp_io_loop_v2(df_server):
+        pytest.skip("On V2 loop test timeouts.")
+
     reader, writer = await _open_stuck_subscriber(df_server.port)
 
     stop = False
@@ -529,10 +533,6 @@ async def test_pubsub_slow_subscriber_closed(df_server: DflyInstance, async_clie
 
         assert stats["forced_disconnect"] >= 1
         assert stats["messages_discarded"] >= 1
-
-        # We force disconnect the subscriber before we reach the per-thread soft limit
-        # (i.e. based on connection memory threshold).
-        assert stats["soft_limit"] == 0
 
         # Let the publishers finish - they must not stay parked once the budget was released.
         stop = True


### PR DESCRIPTION
* The test times out on IoLoopV2.
* soft_limit assert is racy and depends on scheduling. The test can produce
  more than 32MB of data within the 100ms timeout.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
