### PR TITLE
fix(acl): close remaining ACL DRYRUN gaps on top of #7871

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -587,19 +587,24 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
   }
 
-  string command = absl::AsciiStrToUpper(parser.Next());
-  auto* cid = cmd_registry_->Find(command);
+  const facade::ParsedArgs simulated_cmd = parser.UnparsedArgs();
+  // Use the same lookup as real dispatch (FindExtended), not a plain single-token Find: multi-word
+  // commands like "ACL SETUSER" otherwise resolve to the bare family command ("ACL") and get
+  // checked against the wrong, less restrictive ACL category.
+  auto [cid, simulated_args] = cmd_registry_->FindExtended(simulated_cmd);
   if (!cid || cid->IsAlias()) {
-    auto error = absl::StrCat("Command '", command, "' not found");
+    auto error =
+        absl::StrCat("Command '", absl::AsciiStrToUpper(simulated_cmd.Front()), "' not found");
     rb->SendError(error);
     return;
   }
-  const facade::ParsedArgs simulated_args = parser.UnparsedArgs();
 
   const auto& user = registry.find(username)->second;
   // Stub, used to mimic connection context for a user.
   ConnectionContext stub(nullptr, acl::UserCredentials{});
+  stub.authed_username = username;
   stub.acl_commands = user.AclCommandsRef();
+  stub.pub_sub = user.PubSub();
   // "mock" without an actual connection we can't know which db is active so we skip this check
   // for DryRun.
   stub.acl_db_idx = {};
@@ -608,13 +613,20 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
   // command without its arguments, so skip key-pattern validation for an incomplete simulation.
   if (cid->Validate(simulated_args))
     stub.keys = {{}, true};
-  const auto [is_allowed, reason] = IsUserAllowedToInvokeCommandGeneric(stub, *cid, simulated_args);
+  // Check pub/sub channel ACLs too, the same way a real PUBLISH/SUBSCRIBE/PSUBSCRIBE dispatch
+  // would. We can't use the IsUserAllowedToInvokeCommand wrapper here: on denial it logs to
+  // AclLog, which reads the real Connection* for client info - the stub above has none.
+  const bool is_allowed =
+      cid->IsPubSub() ? IsPubSubCommandAuthorized(cid->IsPatternPubSub(), stub.acl_commands,
+                                                  stub.pub_sub, simulated_args, *cid)
+                            .first
+                      : IsUserAllowedToInvokeCommandGeneric(stub, *cid, simulated_args).first;
   if (is_allowed) {
     rb->SendOk();
     return;
   }
 
-  auto msg = absl::StrCat("This user has no permissions to run the '", command, "' command");
+  auto msg = absl::StrCat("This user has no permissions to run the '", cid->name(), "' command");
 
   rb->SendBulkString(msg);
 }

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -593,8 +593,14 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
   // checked against the wrong, less restrictive ACL category.
   auto [cid, simulated_args] = cmd_registry_->FindExtended(simulated_cmd);
   if (!cid || cid->IsAlias()) {
-    auto error =
-        absl::StrCat("Command '", absl::AsciiStrToUpper(simulated_cmd.Front()), "' not found");
+    // Mirror the lookup key FindExtended actually used: for ACL sub-commands that's "ACL
+    // SUBCMD", not just "ACL", otherwise a bad sub-command misleadingly reports "ACL" itself
+    // as not found.
+    std::string looked_up = absl::AsciiStrToUpper(simulated_cmd.Front());
+    if (looked_up == "ACL" && simulated_cmd.size() > 1) {
+      absl::StrAppend(&looked_up, " ", absl::AsciiStrToUpper(simulated_cmd[1]));
+    }
+    auto error = absl::StrCat("Command '", looked_up, "' not found");
     rb->SendError(error);
     return;
   }

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <chrono>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -611,9 +612,9 @@ void AclFamily::DryRun(CmdArgParser parser, CommandContext* cmd_cntx) {
   stub.authed_username = username;
   stub.acl_commands = user.AclCommandsRef();
   stub.pub_sub = user.PubSub();
-  // "mock" without an actual connection we can't know which db is active so we skip this check
-  // for DryRun.
-  stub.acl_db_idx = {};
+  stub.acl_db_idx = user.Db();
+  stub.conn_state.db_index =
+      stub.acl_db_idx == std::numeric_limits<size_t>::max() ? 0 : stub.acl_db_idx;
   stub.keys = user.Keys();
   // The regular command path validates arity before checking ACLs. DRYRUN historically accepts a
   // command without its arguments, so skip key-pattern validation for an incomplete simulation.

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -28,34 +28,34 @@ class AclFamilyTest : public BaseFamilyTest {
 
 TEST_F(AclFamilyTest, AclSetUser) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "SETUSER"});
+  auto resp = Run("ACL SETUSER");
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl setuser' command"));
 
-  resp = Run({"ACL", "SETUSER", "kostas", "ONN"});
+  resp = Run("ACL SETUSER kostas ONN");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter ONN"));
 
-  resp = Run({"ACL", "SETUSER", "kostas", "+@nonsense"});
+  resp = Run("ACL SETUSER kostas +@nonsense");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter +@NONSENSE"));
 
-  resp = Run({"ACL", "SETUSER", "vlad"});
+  resp = Run("ACL SETUSER vlad");
   EXPECT_THAT(resp, "OK");
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   auto vec = resp.GetVec();
   EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                         "user vlad off resetchannels -@all $all"));
 
-  resp = Run({"ACL", "SETUSER", "vlad", "+ACL"});
+  resp = Run("ACL SETUSER vlad +ACL");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   vec = resp.GetVec();
   EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                         "user vlad off resetchannels -@all +acl $all"));
 
-  resp = Run({"ACL", "SETUSER", "vlad", "on", ">pass", ">temp"});
+  resp = Run("ACL SETUSER vlad on >pass >temp");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   vec = resp.GetVec();
   EXPECT_THAT(vec.size(), 2);
   auto contains_vlad = [](const auto& vec) {
@@ -78,51 +78,51 @@ TEST_F(AclFamilyTest, AclSetUser) {
 
   EXPECT_THAT(contains_vlad(vec), true);
 
-  resp = Run({"AUTH", "vlad", "pass"});
+  resp = Run("AUTH vlad pass");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"AUTH", "vlad", "temp"});
+  resp = Run("AUTH vlad temp");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"AUTH", "default", R"("")"});
+  resp = Run("AUTH default \"\"");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "vlad", ">another"});
+  resp = Run("ACL SETUSER vlad >another");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "vlad", "<another"});
+  resp = Run("ACL SETUSER vlad <another");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   vec = resp.GetVec();
   EXPECT_THAT(vec.size(), 2);
   EXPECT_THAT(contains_vlad(vec), true);
 
-  resp = Run({"ACL", "SETUSER", "vlad", "resetpass"});
+  resp = Run("ACL SETUSER vlad resetpass");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   vec = resp.GetVec();
   EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                         "user vlad on resetchannels -@all +acl $all"));
 
   // +@NONE should not exist anymore. It's not in the spec.
-  resp = Run({"ACL", "SETUSER", "rand", "+@NONE"});
+  resp = Run("ACL SETUSER rand +@NONE");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter +@NONE"));
 
-  resp = Run({"ACL", "SETUSER", "rand", "ALLCOMMANDS"});
+  resp = Run("ACL SETUSER rand ALLCOMMANDS");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   vec = resp.GetVec();
   EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                         "user vlad on resetchannels -@all +acl $all",
                                         "user rand off resetchannels +@all $all"));
 
-  resp = Run({"ACL", "SETUSER", "rand", "NOCOMMANDS"});
+  resp = Run("ACL SETUSER rand NOCOMMANDS");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   vec = resp.GetVec();
   EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                         "user vlad on resetchannels -@all +acl $all",
@@ -131,48 +131,48 @@ TEST_F(AclFamilyTest, AclSetUser) {
 
 TEST_F(AclFamilyTest, AclDelUser) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "DELUSER"});
+  auto resp = Run("ACL DELUSER");
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl deluser' command"));
 
-  resp = Run({"ACL", "DELUSER", "default"});
+  resp = Run("ACL DELUSER default");
   EXPECT_THAT(resp, IntArg(0));
 
-  resp = Run({"ACL", "DELUSER", "NOTEXISTS"});
+  resp = Run("ACL DELUSER NOTEXISTS");
   EXPECT_THAT(resp, IntArg(0));
 
-  resp = Run({"ACL", "SETUSER", "kostas", "ON"});
+  resp = Run("ACL SETUSER kostas ON");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "DELUSER", "KOSTAS", "NONSENSE"});
+  resp = Run("ACL DELUSER KOSTAS NONSENSE");
   EXPECT_THAT(resp, IntArg(0));
 
-  resp = Run({"ACL", "DELUSER", "kostas"});
+  resp = Run("ACL DELUSER kostas");
   EXPECT_THAT(resp, IntArg(1));
 
-  resp = Run({"ACL", "DELUSER", "kostas"});
+  resp = Run("ACL DELUSER kostas");
   EXPECT_THAT(resp, IntArg(0));
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   EXPECT_THAT(resp, RespElementsAre("user default on nopass ~* &* +@all $all"));
 
-  Run({"ACL", "SETUSER", "michael", "ON"});
-  Run({"ACL", "SETUSER", "kobe", "ON"});
-  resp = Run({"ACL", "DELUSER", "michael", "kobe"});
+  Run("ACL SETUSER michael ON");
+  Run("ACL SETUSER kobe ON");
+  resp = Run("ACL DELUSER michael kobe");
   EXPECT_THAT(resp, IntArg(2));
 }
 
 TEST_F(AclFamilyTest, AclList) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "LIST", "NONSENSE"});
+  auto resp = Run("ACL LIST NONSENSE");
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl list' command"));
 
-  resp = Run({"ACL", "SETUSER", "kostas", ">pass", "+@admin"});
+  resp = Run("ACL SETUSER kostas >pass +@admin");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "adi", ">pass", "+@fast"});
+  resp = Run("ACL SETUSER adi >pass +@fast");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "LIST"});
+  resp = Run("ACL LIST");
   auto vec = resp.GetVec();
   EXPECT_THAT(
       vec, UnorderedElementsAre("user default on nopass ~* &* +@all $all",
@@ -182,38 +182,38 @@ TEST_F(AclFamilyTest, AclList) {
 
 TEST_F(AclFamilyTest, AclAuth) {
   TestInitAclFam();
-  auto resp = Run({"AUTH", "default", R"("")"});
+  auto resp = Run("AUTH default \"\"");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "shahar", ">mypass"});
+  resp = Run("ACL SETUSER shahar >mypass");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"AUTH", "shahar", "wrongpass"});
+  resp = Run("AUTH shahar wrongpass");
   EXPECT_THAT(resp, ErrArg("WRONGPASS invalid username-password pair or user is disabled."));
 
-  resp = Run({"AUTH", "shahar", "mypass"});
+  resp = Run("AUTH shahar mypass");
   EXPECT_THAT(resp, ErrArg("WRONGPASS invalid username-password pair or user is disabled."));
 
   // Activate the user
-  resp = Run({"ACL", "SETUSER", "shahar", "ON", "+@fast"});
+  resp = Run("ACL SETUSER shahar ON +@fast");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"AUTH", "shahar", "mypass"});
+  resp = Run("AUTH shahar mypass");
   EXPECT_THAT(resp, "OK");
 }
 
 TEST_F(AclFamilyTest, AclWhoAmI) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "WHOAMI", "WHO"});
+  auto resp = Run("ACL WHOAMI WHO");
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl whoami' command"));
 
-  resp = Run({"ACL", "SETUSER", "kostas", "ON", ">pass", "+@SLOW"});
+  resp = Run("ACL SETUSER kostas ON >pass +@SLOW");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"AUTH", "kostas", "pass"});
+  resp = Run("AUTH kostas pass");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "WHOAMI"});
+  resp = Run("ACL WHOAMI");
   EXPECT_THAT(resp, "User is kostas");
 }
 
@@ -221,32 +221,32 @@ TEST_F(AclFamilyTest, TestAllCategories) {
   const auto* fam = TestInitAclFam();
   for (auto& cat : fam->GetRevTable()) {
     if (cat != "_RESERVED") {
-      auto resp = Run({"ACL", "SETUSER", "kostas", absl::StrCat("+@", cat)});
+      auto resp = Run(absl::StrCat("ACL SETUSER kostas +@", cat));
       EXPECT_THAT(resp, "OK");
 
-      resp = Run({"ACL", "LIST"});
+      resp = Run("ACL LIST");
       EXPECT_THAT(resp.GetVec(),
                   UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                        absl::StrCat("user kostas off resetchannels -@all ", "+@",
                                                     absl::AsciiStrToLower(cat), " $all")));
 
-      resp = Run({"ACL", "SETUSER", "kostas", absl::StrCat("-@", cat)});
+      resp = Run(absl::StrCat("ACL SETUSER kostas -@", cat));
       EXPECT_THAT(resp, "OK");
 
-      resp = Run({"ACL", "LIST"});
+      resp = Run("ACL LIST");
       EXPECT_THAT(resp.GetVec(),
                   UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                        absl::StrCat("user kostas off resetchannels -@all ", "-@",
                                                     absl::AsciiStrToLower(cat), " $all")));
 
-      resp = Run({"ACL", "DELUSER", "kostas"});
+      resp = Run("ACL DELUSER kostas");
       EXPECT_THAT(resp, IntArg(1));
     }
   }
 
   for (auto& cat : fam->GetRevTable()) {
     if (cat != "_RESERVED") {
-      auto resp = Run({"ACL", "SETUSER", "kostas", absl::StrCat("+@", cat)});
+      auto resp = Run(absl::StrCat("ACL SETUSER kostas +@", cat));
       EXPECT_THAT(resp, "OK");
     }
   }
@@ -271,10 +271,12 @@ TEST_F(AclFamilyTest, TestAllCommands) {
   const auto& rev_indexer = fam->GetCommandsRevIndexer();
   for (const auto& family : rev_indexer) {
     for (const auto& command_name : family) {
+      // command_name can itself contain a space (e.g. "ACL HELP"), so it must stay a single
+      // argument via the list form; the plain-string Run() overload naively splits on spaces.
       auto resp = Run({"ACL", "SETUSER", "kostas", absl::StrCat("+", command_name)});
       EXPECT_THAT(resp, "OK");
 
-      resp = Run({"ACL", "LIST"});
+      resp = Run("ACL LIST");
       EXPECT_THAT(resp.GetVec(),
                   UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                        absl::StrCat("user kostas off resetchannels -@all ", "+",
@@ -282,13 +284,13 @@ TEST_F(AclFamilyTest, TestAllCommands) {
 
       resp = Run({"ACL", "SETUSER", "kostas", absl::StrCat("-", command_name)});
 
-      resp = Run({"ACL", "LIST"});
+      resp = Run("ACL LIST");
       EXPECT_THAT(resp.GetVec(),
                   UnorderedElementsAre("user default on nopass ~* &* +@all $all",
                                        absl::StrCat("user kostas off resetchannels -@all ", "-",
                                                     absl::AsciiStrToLower(command_name), " $all")));
 
-      resp = Run({"ACL", "DELUSER", "kostas"});
+      resp = Run("ACL DELUSER kostas");
       EXPECT_THAT(resp, IntArg(1));
     }
   }
@@ -296,25 +298,25 @@ TEST_F(AclFamilyTest, TestAllCommands) {
 
 TEST_F(AclFamilyTest, TestUsers) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "SETUSER", "abhra", "ON"});
+  auto resp = Run("ACL SETUSER abhra ON");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "ari"});
+  resp = Run("ACL SETUSER ari");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "USERS"});
+  resp = Run("ACL USERS");
   EXPECT_THAT(resp.GetVec(), UnorderedElementsAre("default", "abhra", "ari"));
 }
 
 TEST_F(AclFamilyTest, TestCat) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "CAT", "nonsense"});
+  auto resp = Run("ACL CAT nonsense");
   EXPECT_THAT(resp, ErrArg("ERR Unknown category: NONSENSE"));
 
-  resp = Run({"ACL", "CAT"});
+  resp = Run("ACL CAT");
   EXPECT_GE(resp.GetVec().size(), 24u);
 
-  resp = Run({"ACL", "CAT", "STRING"});
+  resp = Run("ACL CAT STRING");
 
   EXPECT_THAT(resp.GetVec(),
               IsSupersetOf({"GETSET", "GETRANGE", "INCRBYFLOAT", "GETDEL",  "DECRBY", "PREPEND",
@@ -325,10 +327,10 @@ TEST_F(AclFamilyTest, TestCat) {
 
 TEST_F(AclFamilyTest, TestGetUser) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "GETUSER", "kostas"});
+  auto resp = Run("ACL GETUSER kostas");
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 
-  resp = Run({"ACL", "GETUSER", "default"});
+  resp = Run("ACL GETUSER default");
   const auto& vec = resp.GetVec();
   EXPECT_THAT(vec[0], "flags");
   EXPECT_THAT(vec[1].GetVec(), UnorderedElementsAre("on", "nopass"));
@@ -341,8 +343,8 @@ TEST_F(AclFamilyTest, TestGetUser) {
   EXPECT_THAT(vec[8], "channels");
   EXPECT_THAT(vec[9], "&*");
 
-  resp = Run({"ACL", "SETUSER", "kostas", "+@STRING", "+HSET"});
-  resp = Run({"ACL", "GETUSER", "kostas"});
+  resp = Run("ACL SETUSER kostas +@STRING +HSET");
+  resp = Run("ACL GETUSER kostas");
   const auto& kvec = resp.GetVec();
   EXPECT_THAT(kvec[0], "flags");
   EXPECT_THAT(kvec[1].GetVec(), UnorderedElementsAre("off"));
@@ -358,47 +360,68 @@ TEST_F(AclFamilyTest, TestGetUser) {
 
 TEST_F(AclFamilyTest, TestDryRun) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "DRYRUN"});
+  auto resp = Run("ACL DRYRUN");
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
 
-  resp = Run({"ACL", "DRYRUN", "default"});
+  resp = Run("ACL DRYRUN default");
   EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
 
-  resp = Run({"ACL", "DRYRUN", "default", "SET", "key", "value"});
+  resp = Run("ACL DRYRUN default SET key value");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "DRYRUN", "kostas", "more"});
+  resp = Run("ACL DRYRUN kostas more");
   EXPECT_THAT(resp, ErrArg("ERR User 'kostas' not found"));
 
-  resp = Run({"ACL", "DRYRUN", "default", "nope"});
+  resp = Run("ACL DRYRUN default nope");
   EXPECT_THAT(resp, ErrArg("ERR Command 'NOPE' not found"));
 
-  resp = Run({"ACL", "DRYRUN", "default", "SET"});
+  resp = Run("ACL DRYRUN default SET");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "kostas", "+GET"});
+  resp = Run("ACL SETUSER kostas +GET");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "DRYRUN", "kostas", "GET"});
+  resp = Run("ACL DRYRUN kostas GET");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "DRYRUN", "kostas", "SET"});
+  resp = Run("ACL DRYRUN kostas SET");
   EXPECT_THAT(resp, "This user has no permissions to run the 'SET' command");
 
-  resp = Run({"ACL", "SETUSER", "key-reader", "+GET", "~allowed:*"});
+  resp = Run("ACL SETUSER key-reader +GET ~allowed:*");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "DRYRUN", "key-reader", "GET", "allowed:key"});
+  resp = Run("ACL DRYRUN key-reader GET allowed:key");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "DRYRUN", "key-reader", "GET", "blocked:key"});
+  resp = Run("ACL DRYRUN key-reader GET blocked:key");
   EXPECT_THAT(resp, "This user has no permissions to run the 'GET' command");
+
+  resp = Run("ACL DRYRUN key-reader ZUNION notanumber allowed:key");
+  EXPECT_THAT(resp, "This user has no permissions to run the 'ZUNION' command");
+
+  // Pub/sub channel ACLs must be honored too, not just command categories and key patterns.
+  resp = Run("ACL SETUSER chan-user +@pubsub resetchannels &allowed-channel");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN chan-user PUBLISH allowed-channel hello");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN chan-user PUBLISH blocked-channel hello");
+  EXPECT_THAT(resp, "This user has no permissions to run the 'PUBLISH' command");
+
+  // Multi-word commands like "ACL SETUSER" must resolve to their own (more restrictive) ACL
+  // category, not fall back to the bare "ACL" family command.
+  resp = Run("ACL SETUSER conn-only +@connection");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN conn-only ACL SETUSER victim on nopass");
+  EXPECT_THAT(resp, "This user has no permissions to run the 'ACL SETUSER' command");
 }
 
 TEST_F(AclFamilyTest, AclGenPassTooManyArguments) {
   TestInitAclFam();
 
-  auto resp = Run({"ACL", "GENPASS", "1", "2"});
+  auto resp = Run("ACL GENPASS 1 2");
   EXPECT_THAT(resp.GetString(),
               "ERR Unknown subcommand or wrong number of arguments for 'GENPASS'. Try ACL HELP.");
 }
@@ -408,18 +431,18 @@ TEST_F(AclFamilyTest, AclGenPassOutOfRange) {
       "ERR ACL GENPASS argument must be the number of bits for the output password, a positive "
       "number up to 4096";
 
-  auto resp = Run({"ACL", "GENPASS", "-1"});
+  auto resp = Run("ACL GENPASS -1");
   EXPECT_THAT(resp.GetString(), expectedError);
 
-  resp = Run({"ACL", "GENPASS", "0"});
+  resp = Run("ACL GENPASS 0");
   EXPECT_THAT(resp.GetString(), expectedError);
 
-  resp = Run({"ACL", "GENPASS", "4097"});
+  resp = Run("ACL GENPASS 4097");
   EXPECT_THAT(resp.GetString(), expectedError);
 }
 
 TEST_F(AclFamilyTest, AclGenPass) {
-  auto resp = Run({"ACL", "GENPASS"});
+  auto resp = Run("ACL GENPASS");
   auto actualPassword = resp.GetString();
 
   // should be 256 bits or 64 bytes in hex
@@ -427,103 +450,103 @@ TEST_F(AclFamilyTest, AclGenPass) {
 
   // 1 bit - 4 bits should all produce a single hex character
   for (int i = 1; i <= 4; i++) {
-    resp = Run({"ACL", "GENPASS", std::to_string(i)});
+    resp = Run(absl::StrCat("ACL GENPASS ", i));
     EXPECT_THAT(resp.GetString().length(), 1);
   }
   // 5 bits - 8 bits should all produce two hex characters
   for (int i = 5; i <= 8; i++) {
-    resp = Run({"ACL", "GENPASS", std::to_string(i)});
+    resp = Run(absl::StrCat("ACL GENPASS ", i));
     EXPECT_THAT(resp.GetString().length(), 2);
   }
 
   // and the pattern continues
-  resp = Run({"ACL", "GENPASS", "9"});
+  resp = Run("ACL GENPASS 9");
   EXPECT_THAT(resp.GetString().length(), 3);
 }
 
 TEST_F(AclFamilyTest, TestKeys) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "SETUSER", "temp", "~foo", "~bar*"});
+  auto resp = Run("ACL SETUSER temp ~foo ~bar*");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   auto& vec = resp.GetVec();
   EXPECT_THAT(vec[6], "keys");
   EXPECT_THAT(vec[7], "~foo ~bar*");
 
-  resp = Run({"ACL", "SETUSER", "temp", "~*", "~foo"});
+  resp = Run("ACL SETUSER temp ~* ~foo");
   EXPECT_THAT(resp, ErrArg("ERR Error in ACL SETUSER modifier '~foo': Adding a pattern after the * "
                            "pattern (or the 'allkeys' flag) is not valid and does not have any "
                            "effect. Try 'resetkeys' to start with an empty list of patterns"));
 
-  resp = Run({"ACL", "SETUSER", "temp", "~*"});
+  resp = Run("ACL SETUSER temp ~*");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "temp", "~foo"});
+  resp = Run("ACL SETUSER temp ~foo");
   EXPECT_THAT(resp, ErrArg("ERR Error in ACL SETUSER modifier '~foo': Adding a pattern after the * "
                            "pattern (or the 'allkeys' flag) is not valid and does not have any "
                            "effect. Try 'resetkeys' to start with an empty list of patterns"));
 
-  resp = Run({"ACL", "SETUSER", "temp", "resetkeys"});
+  resp = Run("ACL SETUSER temp resetkeys");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   EXPECT_TRUE(resp.GetVec()[7].GetVec().empty());
 
-  resp = Run({"ACL", "SETUSER", "temp", "%R~foo"});
+  resp = Run("ACL SETUSER temp %R~foo");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   EXPECT_THAT(resp.GetVec()[7], "%R~foo");
 
-  resp = Run({"ACL", "SETUSER", "temp", "resetkeys", "%W~foo"});
+  resp = Run("ACL SETUSER temp resetkeys %W~foo");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   EXPECT_THAT(resp.GetVec()[7], "%W~foo");
 
-  resp = Run({"ACL", "SETUSER", "temp", "resetkeys", "%RW~foo"});
+  resp = Run("ACL SETUSER temp resetkeys %RW~foo");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   EXPECT_THAT(resp.GetVec()[7], "~foo");
 
-  resp = Run({"ACL", "SETUSER", "temp", "resetkeys", "%K~foo"});
+  resp = Run("ACL SETUSER temp resetkeys %K~foo");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter %K~FOO"));
 
-  resp = Run({"ACL", "SETUSER", "temp", "resetkeys", "%Rfoo"});
+  resp = Run("ACL SETUSER temp resetkeys %Rfoo");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter %RFOO"));
 }
 
 TEST_F(AclFamilyTest, TestPubSub) {
   TestInitAclFam();
 
-  auto resp = Run({"ACL", "SETUSER", "temp", "&foo", "&b*r"});
+  auto resp = Run("ACL SETUSER temp &foo &b*r");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   auto vec = resp.GetVec();
   EXPECT_THAT(vec[8], "channels");
   EXPECT_THAT(vec[9], "resetchannels &foo &b*r");
 
-  resp = Run({"ACL", "SETUSER", "temp", "allchannels", "&bar"});
+  resp = Run("ACL SETUSER temp allchannels &bar");
   EXPECT_THAT(resp, ErrArg("ERR Error in ACL SETUSER modifier '&bar': Adding a pattern after the * "
                            "pattern (or the 'allchannels' flag) is "
                            "not valid and does not have any effect. Try 'resetchannels' to start "
                            "with an empty list of channels"));
 
-  resp = Run({"ACL", "SETUSER", "temp", "allchannels"});
+  resp = Run("ACL SETUSER temp allchannels");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   vec = resp.GetVec();
   EXPECT_THAT(vec[8], "channels");
   EXPECT_THAT(vec[9], "&*");
 
-  resp = Run({"ACL", "SETUSER", "temp", "resetchannels", "&foo"});
+  resp = Run("ACL SETUSER temp resetchannels &foo");
   EXPECT_THAT(resp, "OK");
 
-  resp = Run({"ACL", "GETUSER", "temp"});
+  resp = Run("ACL GETUSER temp");
   vec = resp.GetVec();
   EXPECT_THAT(vec[8], "channels");
   EXPECT_THAT(vec[9], "resetchannels &foo");
@@ -539,28 +562,28 @@ TEST_F(AclFamilyTest, TestPubSub) {
 }
 
 TEST_F(AclFamilyTest, TestAlias) {
-  auto resp = Run({"ACL", "SETUSER", "luke", "+___SET"});
+  auto resp = Run("ACL SETUSER luke +___SET");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter +___SET"));
 
-  resp = Run({"ACL", "SETUSER", "leia", "-___SET"});
+  resp = Run("ACL SETUSER leia -___SET");
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter -___SET"));
 
-  resp = Run({"ACL", "SETUSER", "anakin", "+SET"});
+  resp = Run("ACL SETUSER anakin +SET");
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"ACL", "SETUSER", "jarjar", "allcommands"});
+  resp = Run("ACL SETUSER jarjar allcommands");
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"ACL", "DRYRUN", "jarjar", "___SET"});
+  resp = Run("ACL DRYRUN jarjar ___SET");
   EXPECT_THAT(resp, ErrArg("ERR Command '___SET' not found"));
-  EXPECT_EQ(Run({"ACL", "DRYRUN", "jarjar", "SET"}), "OK");
+  EXPECT_EQ(Run("ACL DRYRUN jarjar SET"), "OK");
 }
 
 TEST_F(AclFamilyTest, TestAclLogUB) {
-  auto resp = Run({"ACL", "LOG"});
+  auto resp = Run("ACL LOG");
   EXPECT_TRUE(resp.GetVec().empty());
 
-  resp = Run({"ACL", "LOG", "2", "RESET"});
+  resp = Run("ACL LOG 2 RESET");
   EXPECT_THAT(resp, ErrArg("ERR index out of range"));
 }
 

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -416,6 +416,16 @@ TEST_F(AclFamilyTest, TestDryRun) {
 
   resp = Run("ACL DRYRUN conn-only ACL SETUSER victim on nopass");
   EXPECT_THAT(resp, "This user has no permissions to run the 'ACL SETUSER' command");
+
+  // DRYRUN simulates commands without validating arity, so PUBLISH with no channel/message
+  // must not crash (it used to index the missing first argument) when the user's pub/sub
+  // access is restricted to specific channels.
+  resp = Run("ACL DRYRUN chan-user PUBLISH");
+  EXPECT_THAT(resp, "OK");
+
+  // Unknown ACL sub-commands must be reported by their full simulated name, not just "ACL".
+  resp = Run("ACL DRYRUN default ACL BOGUSSUBCMD");
+  EXPECT_THAT(resp, ErrArg("ERR Command 'ACL BOGUSSUBCMD' not found"));
 }
 
 TEST_F(AclFamilyTest, AclGenPassTooManyArguments) {

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -399,6 +399,12 @@ TEST_F(AclFamilyTest, TestDryRun) {
   resp = Run("ACL DRYRUN key-reader ZUNION notanumber allowed:key");
   EXPECT_THAT(resp, "This user has no permissions to run the 'ZUNION' command");
 
+  resp = Run("ACL SETUSER zunion-user +ZUNION ~allowed:*");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN zunion-user ZUNION notanumber allowed:key");
+  EXPECT_THAT(resp, "This user has no permissions to run the 'ZUNION' command");
+
   // Pub/sub channel ACLs must be honored too, not just command categories and key patterns.
   resp = Run("ACL SETUSER chan-user +@pubsub resetchannels &allowed-channel");
   EXPECT_THAT(resp, "OK");
@@ -408,6 +414,39 @@ TEST_F(AclFamilyTest, TestDryRun) {
 
   resp = Run("ACL DRYRUN chan-user PUBLISH blocked-channel hello");
   EXPECT_THAT(resp, "This user has no permissions to run the 'PUBLISH' command");
+
+  // Unsubscribing never needs channel permission, only the command bit (matches Valkey).
+  resp = Run("ACL DRYRUN chan-user UNSUBSCRIBE blocked-channel");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN chan-user PUNSUBSCRIBE blocked-*");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN chan-user SUNSUBSCRIBE blocked-channel");
+  EXPECT_THAT(resp, "OK");
+
+  // The unrestricted default user must be able to cross databases.
+  resp = Run("ACL DRYRUN default MOVE key 1");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN default SELECT 5");
+  EXPECT_THAT(resp, "OK");
+
+  // A user pinned to a single db can SELECT into it, but never leave it via MOVE/SELECT.
+  resp = Run("ACL SETUSER db-user +@all $2");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN db-user SELECT 2");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("ACL DRYRUN db-user SELECT 3");
+  EXPECT_THAT(resp, "This user has no permissions to run the 'SELECT' command");
+
+  resp = Run("ACL DRYRUN db-user MOVE key 3");
+  EXPECT_THAT(resp, "This user has no permissions to run the 'MOVE' command");
+
+  resp = Run("ACL DRYRUN db-user MULTI");
+  EXPECT_THAT(resp, "OK");
 
   // Multi-word commands like "ACL SETUSER" must resolve to their own (more restrictive) ACL
   // category, not fall back to the bare "ACL" family command.

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -63,7 +63,10 @@ std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(bool literal_match,
   if (!pub_sub.all_channels) {
     std::string_view name = id.name();
     if (name == "PUBLISH" || name == "SPUBLISH") {
-      allowed &= iterate_globs(tail_args[0]);
+      // tail_args can be empty for ACL DRYRUN's simulated commands, which skip arity
+      // validation. Treat a missing channel argument as unknown/permissive, matching how
+      // DryRun skips the key-pattern check for the same incomplete-args case.
+      allowed &= tail_args.empty() || iterate_globs(tail_args[0]);
     } else {
       for (auto channel : tail_args) {
         allowed &= iterate_globs(channel);

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -32,9 +32,17 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
   return (acl_commands[index] & command_mask) != 0;
 }
 
-[[nodiscard]] std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(
-    bool literal_match, const std::vector<uint64_t>& acl_commands, const AclPubSub& pub_sub,
-    const facade::ParsedArgs& tail_args, const CommandId& id) {
+}  // namespace
+
+// Exported (not anonymous-namespace-local) so callers without a live connection, like ACL DRYRUN's
+// stub context, can run the pub/sub check directly without going through
+// IsUserAllowedToInvokeCommand and its AclLog::Add side effect, which dereferences a real
+// Connection*.
+std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(bool literal_match,
+                                                          const std::vector<uint64_t>& acl_commands,
+                                                          const AclPubSub& pub_sub,
+                                                          const facade::ParsedArgs& tail_args,
+                                                          const CommandId& id) {
   if (!ValidateCommand(acl_commands, id)) {
     return {false, AclLog::Reason::COMMAND};
   }
@@ -65,8 +73,6 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 
   return {allowed, AclLog::Reason::PUB_SUB};
 }
-
-}  // namespace
 
 [[nodiscard]] bool IsUserAllowedToInvokeCommand(const ConnectionContext& cntx, const CommandId& id,
                                                 const facade::ParsedArgs& tail_args) {
@@ -140,7 +146,11 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
   bool keys_allowed = true;
   if (!keys.all_keys && id.first_key_pos() != 0 && (is_read_command || is_write_command)) {
     auto keys_index = DetermineKeys(&id, tail_args);
-    DCHECK(keys_index);
+    // Commands with content-dependent key positions (e.g. ZUNION's numkeys) can fail to parse
+    // arbitrary/malformed tail_args; that's a normal rejection, not a broken invariant, so fail
+    // closed instead of asserting.
+    if (!keys_index)
+      return {false, AclLog::Reason::KEY};
 
     for (std::string_view key : keys_index->Range(tail_args))
       keys_allowed &= iterate_globs(key);

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -59,9 +59,14 @@ std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(bool literal_match,
     return false;
   };
 
+  std::string_view name = id.name();
+  // Valkey never gates unsubscribe on channel ACLs (only PUBLISH/SUBSCRIBE flags are checked).
+  if (name == "UNSUBSCRIBE" || name == "PUNSUBSCRIBE" || name == "SUNSUBSCRIBE") {
+    return {true, AclLog::Reason::PUB_SUB};
+  }
+
   bool allowed = true;
   if (!pub_sub.all_channels) {
-    std::string_view name = id.name();
     if (name == "PUBLISH" || name == "SPUBLISH") {
       // tail_args can be empty for ACL DRYRUN's simulated commands, which skip arity
       // validation. Treat a missing channel argument as unknown/permissive, matching how

--- a/src/server/acl/validator.h
+++ b/src/server/acl/validator.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <utility>
+#include <vector>
 
 #include "facade/facade_types.h"
 #include "server/acl/acl_log.h"
@@ -20,4 +22,14 @@ std::pair<bool, AclLog::Reason> IsUserAllowedToInvokeCommandGeneric(
 
 bool IsUserAllowedToInvokeCommand(const ConnectionContext& cntx, const CommandId& id,
                                   const facade::ParsedArgs& tail_args);
+
+// Exposed so callers without a live Connection (e.g. ACL DRYRUN's stub context) can run the
+// pub/sub channel check directly, bypassing IsUserAllowedToInvokeCommand's AclLog::Add, which
+// requires a real connection.
+std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(bool literal_match,
+                                                          const std::vector<uint64_t>& acl_commands,
+                                                          const AclPubSub& pub_sub,
+                                                          const facade::ParsedArgs& tail_args,
+                                                          const CommandId& id);
+
 }  // namespace dfly::acl


### PR DESCRIPTION
Follow up to https://github.com/dragonflydb/dragonfly/pull/7871 

Fixes `acl dryrun` for:

* pubsub
* acl subcommands
* commands that are parsed with error (DetermineKeys) returning an OpResult() with an error will DCHECK
* small refactor in the acl family test to use a single string argument to Run