### PR TITLE
chore(search): dedup quoted/unquoted tag value unescaping

### DIFF
--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -155,32 +155,19 @@ string UnescapeTerm(string_view src) {
     }
   }
   // A trailing lone backslash (reachable from quoted tag/wildcard values, e.g. a
-  // Windows path `C:\`) is dropped, matching make_Tag and SplitWithEscapes.
+  // Windows path `C:\`) is dropped, matching the text path (SplitWithEscapes).
   return res;
 }
 
 Parser::symbol_type make_Tag(string_view src, TagType type, const Parser::location_type& loc) {
-  string res;
-  res.reserve(src.size());
-
-  // Determine processing boundaries
+  // Trim the glob markers, then share the single-layer `\X` unescape with terms via UnescapeTerm,
+  // so quoted and unquoted tag values can never diverge.
   size_t start = (type == TagType::SUFFIX || type == TagType::INFIX) ? 1 : 0;
   size_t end = src.size();
   if (type == TagType::PREFIX || type == TagType::INFIX) {
-    end--; // Skip the last '*' character
+    end--;  // Skip the last '*' character
   }
-
-    // Handle escaping
-  bool escaped = false;
-  for (size_t i = start; i < end; ++i) {
-    if (escaped) {
-      escaped = false;
-    } else if (src[i] == '\\') {
-      escaped = true;
-      continue;
-    }
-    res.push_back(src[i]);
-  }
+  string res = UnescapeTerm(src.substr(start, end - start));
 
   // Return the appropriate token type
   switch (type) {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -977,6 +977,22 @@ TEST_F(SearchFamilyTest, QuotedTagEscapesCaseSensitive) {
   EXPECT_THAT(Run({"FT.SEARCH", "cs_idx", R"(@tags:{"acme\\admin"})", "DIALECT", "2"}), kNoResults);
 }
 
+// The quoted (UnescapeTerm) and unquoted (make_Tag) tag paths share one unescape helper, so an
+// escaped value must be found identically by both query forms. Guards the make_Tag/UnescapeTerm
+// dedup: any divergence between the two paths would surface here. The colon steers the unquoted
+// form through make_Tag (TAG_VAL) rather than the TERM rule.
+TEST_F(SearchFamilyTest, QuotedUnquotedTagEscapeEquivalence) {
+  Run({"FT.CREATE", "eqv_idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "tags", "TAG"});
+  Run({"HSET", "doc:1", "tags", R"(a:b\c)"});  // stored value: a:b\c
+
+  EXPECT_THAT(Run({"FT.SEARCH", "eqv_idx", R"(@tags:{a:b\\c})", "DIALECT", "2"}),
+              AreDocIds("doc:1"));  // unquoted -> make_Tag
+  EXPECT_THAT(Run({"FT.SEARCH", "eqv_idx", R"(@tags:{"a:b\\c"})", "DIALECT", "2"}),
+              AreDocIds("doc:1"));  // quoted -> UnescapeTerm
+  EXPECT_THAT(Run({"FT.SEARCH", "eqv_idx", R"(@tags:{a:b\\c*})", "DIALECT", "2"}),
+              AreDocIds("doc:1"));  // prefix glob -> make_Tag marker-trim branch
+}
+
 TEST_F(SearchFamilyTest, TagNumbers) {
   Run({"hset", "d:1", "number", "1"});
   Run({"hset", "d:2", "number", "2"});


### PR DESCRIPTION
Follow-up to #7907. `make_Tag` carried its own byte-for-byte copy of the single-layer `\X` unescape loop already implemented in `UnescapeTerm`, so quoted (`UnescapeTerm`) and unquoted (`make_Tag`) tag values silently relied on two copies staying in sync. This collapses them to one source of truth.