### PR TITLE
feat(ci): warm ccache on push, unify cache key

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -117,7 +117,7 @@ runs:
           CMAKE_CMD+=(-DENABLE_CCACHE=OFF)
         fi
 
-        # Add optional compiler flags. 'unknwn_c_cmpl' / 'unkn_cpp_cmpl' are the key-only sentinel
+        # Add optional compiler overrides. 'unknwn_c_cmpl' / 'unkn_cpp_cmpl' are the key-only sentinel
         # defaults (see the inputs above): treat them like "unset".
         if [ -n "${{ inputs.c-compiler }}" ] && [ "${{ inputs.c-compiler }}" != "unknwn_c_cmpl" ]; then
           CMAKE_CMD+=(-DCMAKE_C_COMPILER="${{ inputs.c-compiler }}")

--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -13,14 +13,14 @@ inputs:
     default: 'build'
     type: string
   c-compiler:
-    description: "C compiler to use"
+    description: "C compiler to use. Leave unset only if the container default is intended"
     required: false
-    default: ''
+    default: 'unknwn_c_cmpl'
     type: string
   cxx-compiler:
-    description: "C++ compiler to use"
+    description: "C++ compiler to use. Leave unset only if the container default is intended"
     required: false
-    default: ''
+    default: 'unkn_cpp_cmpl'
     type: string
   cxx-flags:
     description: "C++ compiler flags"
@@ -82,6 +82,10 @@ runs:
       # Persist compiled objects across ephemeral runners so unchanged files aren't recompiled.
       uses: hendrikmuhs/ccache-action@v1.2
       with:
+        # ATTENTION: this is the ccache key template. Changing it (or any input that feeds it:
+        # cache-key-suffix / build-type / c-compiler / cxx-compiler / sanitizers etc) changes the key
+        # for EVERY caller. Keep whatever warms refs/heads/main in sync with this key, or PR
+        # builds stop matching the warm cache and go cold.
         key: dfly-ccache-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.c-compiler }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}
         max-size: ${{ inputs.ccache-max-size }}
         save: ${{ inputs.ccache-save }}
@@ -113,11 +117,12 @@ runs:
           CMAKE_CMD+=(-DENABLE_CCACHE=OFF)
         fi
 
-        # Add optional compiler flags
-        if [ -n "${{ inputs.c-compiler }}" ]; then
+        # Add optional compiler flags. 'unknwn_c_cmpl' / 'unkn_cpp_cmpl' are the key-only sentinel
+        # defaults (see the inputs above): treat them like "unset".
+        if [ -n "${{ inputs.c-compiler }}" ] && [ "${{ inputs.c-compiler }}" != "unknwn_c_cmpl" ]; then
           CMAKE_CMD+=(-DCMAKE_C_COMPILER="${{ inputs.c-compiler }}")
         fi
-        if [ -n "${{ inputs.cxx-compiler }}" ]; then
+        if [ -n "${{ inputs.cxx-compiler }}" ] && [ "${{ inputs.cxx-compiler }}" != "unkn_cpp_cmpl" ]; then
           CMAKE_CMD+=(-DCMAKE_CXX_COMPILER="${{ inputs.cxx-compiler }}")
         fi
         if [ -n "${{ inputs.cxx-flags }}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           df -h
 
       - name: C++ Unit Tests - IoUring
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
@@ -168,7 +168,7 @@ jobs:
 
 
       - name: C++ Unit Tests - Epoll
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           JUNIT_DIR="${CPP_JUNIT_DIR}"
@@ -196,7 +196,7 @@ jobs:
             FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 
       - name: C++ Unit Tests - IoUring with cluster mode
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           JUNIT_DIR="${CPP_JUNIT_DIR}"
@@ -208,7 +208,7 @@ jobs:
             --output-junit "${CTEST_JUNIT_DIR}/cluster.xml"
 
       - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           JUNIT_DIR="${CPP_JUNIT_DIR}"
@@ -220,14 +220,14 @@ jobs:
             --output-junit "${CTEST_JUNIT_DIR}/cluster-hashtags.xml"
 
       - name: Upload unit logs on failure
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name != 'push'
         uses: actions/upload-artifact@v7
         with:
           name: unit_logs
           path: /tmp/*INFO*
 
       - name: Run regression tests
-        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name == 'pull_request'
+        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name != 'push'
         uses: ./.github/actions/regression-tests
         with:
           dfly-executable: dragonfly
@@ -242,7 +242,7 @@ jobs:
           azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 
       - name: Upload regression logs on failure
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name != 'push'
         uses: actions/upload-artifact@v7
         with:
           name: regression_logs
@@ -253,7 +253,7 @@ jobs:
         # (unit/type/stream[-cgroups]) in external-server mode against the just-built binary,
         # on both Debug and Release. continue-on-error keeps it a canary for now — flip to a
         # blocking step once proven stable in CI. See tests/dragonfly/valkey_tcl/README.md.
-        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name == 'pull_request'
+        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name != 'push'
         continue-on-error: true
         timeout-minutes: 20
         run: |
@@ -264,7 +264,7 @@ jobs:
           ./run-stream-tests.sh ${GITHUB_WORKSPACE}/build/dragonfly 6399
 
       - name: Prepare JUnit artifact name
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name != 'push'
         run: |
           NAME="junit-ci-${{ matrix.container }}-${{ matrix.build-type }}-${{ matrix.compiler.cxx }}-${{ matrix.sanitizers }}"
           MATRIX_NAME="container-${{ matrix.container }}-build-${{ matrix.build-type }}-compiler-${{ matrix.compiler.cxx }}-sanitizers-${{ matrix.sanitizers }}"
@@ -275,7 +275,7 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Generate C++ GTest dashboard summary
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name != 'push'
         run: |
           mkdir -p "${CPP_DASHBOARD_DIR}"
 
@@ -288,7 +288,7 @@ jobs:
             --variant "${CI_JUNIT_UPLOAD_SUFFIX}"
 
       - name: Upload C++ JUnit test results
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name != 'push'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.CI_JUNIT_ARTIFACT }}
@@ -298,7 +298,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Refresh AWS credentials for C++ JUnit upload
-        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'pull_request'
+        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'push'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
@@ -306,7 +306,7 @@ jobs:
           unset-current-credentials: true
 
       - name: Upload C++ JUnit results to S3
-        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'pull_request'
+        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'push'
         env:
           S3_REGTEST_BUCKET: ${{ secrets.S3_REGTEST_BUCKET }}
         run: |
@@ -322,7 +322,7 @@ jobs:
             "${MATRIX_NAME}" "C++ GTest dashboard JSON"
 
       - name: Upload dragonfly binary for cgroup test
-        if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Release' && matrix.sanitizers == 'NoSanitizers' && matrix.compiler.cxx == 'g++' && github.event_name == 'pull_request'
+        if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Release' && matrix.sanitizers == 'NoSanitizers' && matrix.compiler.cxx == 'g++' && github.event_name != 'push'
         uses: actions/upload-artifact@v7
         with:
           name: dragonfly-binary
@@ -332,7 +332,7 @@ jobs:
   cgroup-thread-detection:
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v6
 
@@ -406,13 +406,13 @@ jobs:
   lint-test-chart:
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/lint-test-chart
 
   list-caches:
-    if: always()
+    if: always() && github.event_name != 'push'
     needs: [build]
     runs-on: ubuntu-latest
     permissions:
@@ -427,7 +427,7 @@ jobs:
     runs-on: CI-LARGE-ARM
     # Skipped on push-to-main (warm) because its build cache (df_common_bin / Linux-ARM64-Release-
     # gcc-g++) is already warmed on main by the scheduled regression-tests job.
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
 
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: ci-tests
 
 on:
-  # push:
-  # branches: [ main ]
+  # On push to main: build only (all test steps + heavy jobs below are gated to pull_request)
+  # to warm the shared ccache on refs/heads/main, so a new PR's first build starts warm.
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -47,6 +49,7 @@ jobs:
 
     strategy:
       matrix:
+        # This matrix also runs on push to main (build-only) to warm the ccache that PR builds restore.
         # Test of these containers
         container: ["ubuntu-dev:24", "alpine-dev:latest"]
         build-type: [Debug, Release]
@@ -134,6 +137,7 @@ jobs:
           df -h
 
       - name: C++ Unit Tests - IoUring
+        if: github.event_name == 'pull_request'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
@@ -164,6 +168,7 @@ jobs:
 
 
       - name: C++ Unit Tests - Epoll
+        if: github.event_name == 'pull_request'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           JUNIT_DIR="${CPP_JUNIT_DIR}"
@@ -191,6 +196,7 @@ jobs:
             FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 
       - name: C++ Unit Tests - IoUring with cluster mode
+        if: github.event_name == 'pull_request'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           JUNIT_DIR="${CPP_JUNIT_DIR}"
@@ -202,6 +208,7 @@ jobs:
             --output-junit "${CTEST_JUNIT_DIR}/cluster.xml"
 
       - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
+        if: github.event_name == 'pull_request'
         run: |
           cd ${GITHUB_WORKSPACE}/build
           JUNIT_DIR="${CPP_JUNIT_DIR}"
@@ -213,14 +220,14 @@ jobs:
             --output-junit "${CTEST_JUNIT_DIR}/cluster-hashtags.xml"
 
       - name: Upload unit logs on failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: unit_logs
           path: /tmp/*INFO*
 
       - name: Run regression tests
-        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers'
+        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name == 'pull_request'
         uses: ./.github/actions/regression-tests
         with:
           dfly-executable: dragonfly
@@ -235,7 +242,7 @@ jobs:
           azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 
       - name: Upload regression logs on failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: regression_logs
@@ -246,7 +253,7 @@ jobs:
         # (unit/type/stream[-cgroups]) in external-server mode against the just-built binary,
         # on both Debug and Release. continue-on-error keeps it a canary for now — flip to a
         # blocking step once proven stable in CI. See tests/dragonfly/valkey_tcl/README.md.
-        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers'
+        if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name == 'pull_request'
         continue-on-error: true
         timeout-minutes: 20
         run: |
@@ -257,7 +264,7 @@ jobs:
           ./run-stream-tests.sh ${GITHUB_WORKSPACE}/build/dragonfly 6399
 
       - name: Prepare JUnit artifact name
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         run: |
           NAME="junit-ci-${{ matrix.container }}-${{ matrix.build-type }}-${{ matrix.compiler.cxx }}-${{ matrix.sanitizers }}"
           MATRIX_NAME="container-${{ matrix.container }}-build-${{ matrix.build-type }}-compiler-${{ matrix.compiler.cxx }}-sanitizers-${{ matrix.sanitizers }}"
@@ -268,7 +275,7 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Generate C++ GTest dashboard summary
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         run: |
           mkdir -p "${CPP_DASHBOARD_DIR}"
 
@@ -281,7 +288,7 @@ jobs:
             --variant "${CI_JUNIT_UPLOAD_SUFFIX}"
 
       - name: Upload C++ JUnit test results
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.CI_JUNIT_ARTIFACT }}
@@ -291,7 +298,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Refresh AWS credentials for C++ JUnit upload
-        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'pull_request'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
@@ -299,7 +306,7 @@ jobs:
           unset-current-credentials: true
 
       - name: Upload C++ JUnit results to S3
-        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'pull_request'
         env:
           S3_REGTEST_BUCKET: ${{ secrets.S3_REGTEST_BUCKET }}
         run: |
@@ -315,7 +322,7 @@ jobs:
             "${MATRIX_NAME}" "C++ GTest dashboard JSON"
 
       - name: Upload dragonfly binary for cgroup test
-        if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Release' && matrix.sanitizers == 'NoSanitizers' && matrix.compiler.cxx == 'g++'
+        if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Release' && matrix.sanitizers == 'NoSanitizers' && matrix.compiler.cxx == 'g++' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: dragonfly-binary
@@ -325,6 +332,7 @@ jobs:
   cgroup-thread-detection:
     runs-on: ubuntu-latest
     needs: [build]
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
 
@@ -398,6 +406,7 @@ jobs:
   lint-test-chart:
     runs-on: ubuntu-latest
     needs: [build]
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/lint-test-chart
@@ -416,6 +425,9 @@ jobs:
 
   large-tests-arm:
     runs-on: CI-LARGE-ARM
+    # Skipped on push-to-main (warm) because its build cache (df_common_bin / Linux-ARM64-Release-
+    # gcc-g++) is already warmed on main by the scheduled regression-tests job.
+    if: github.event_name == 'pull_request'
 
     permissions:
       id-token: write
@@ -447,7 +459,9 @@ jobs:
           enable-ccache: 'true'
           ccache-save: 'true'
           build-type: Release
-          cache-key-suffix: 'ubuntu-dev:24'
+          cache-key-suffix: 'df_common_bin'
+          c-compiler: gcc
+          cxx-compiler: g++
           targets: 'dragonfly'
 
       - name: Authenticate to AWS

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -46,7 +46,9 @@ jobs:
           enable-ccache: 'true'
           ccache-save: 'true'
           build-type: ${{matrix.build-type}}
-          cache-key-suffix: ${{ matrix.container }}
+          cache-key-suffix: 'df_common_bin'
+          c-compiler: gcc
+          cxx-compiler: g++
           targets: 'dragonfly'
 
       - name: Authenticate to AWS

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Build Dragonfly
         uses: ./.github/actions/builder
         with:
-          # CCache read-only (save defaults off): reuse the base cache kept warm by regression-tests.
           enable-ccache: 'true'
-          cache-key-suffix: ${{ matrix.container }}
+          cache-key-suffix: 'df_common_bin'
+          c-compiler: gcc
+          cxx-compiler: g++
           build-type: ${{matrix.build-type}}
           targets: 'dragonfly'
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -48,7 +48,9 @@ jobs:
           enable-ccache: 'true'
           ccache-save: 'true'
           build-type: ${{matrix.build-type}}
-          cache-key-suffix: ${{ matrix.container }}
+          cache-key-suffix: 'df_common_bin'
+          c-compiler: gcc
+          cxx-compiler: g++
           targets: 'dragonfly'
 
       - name: Authenticate to AWS

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -109,9 +109,10 @@ jobs:
         if: ${{ !contains(fromJSON('["yes","true"]'), inputs.use_release) }}
         uses: ./.github/actions/builder
         with:
-          # CCache read-only (save defaults off): reuse the base cache kept warm by regression-tests.
           enable-ccache: 'true'
-          cache-key-suffix: ${{ matrix.container }}
+          cache-key-suffix: 'df_common_bin'
+          c-compiler: gcc
+          cxx-compiler: g++
           build-type: ${{matrix.build-type}}
           targets: 'dragonfly'
 


### PR DESCRIPTION
Warm the shared ccache ahead of PR builds and consolidate the cache key used by the regression/heavy/repeat test workflows.

- Add a push-to-main trigger that runs the build matrix build-only, gating every PR-only test/upload step and two downstream jobs behind github.event_name == 'pull_request', so PR builds start from an already-warm ccache instead of a cold one.
- Unify cache-key-suffix in regression-tests, epoll-regression-tests, heavy-tests, repeat-tests, and large-tests-arm to a single 'df_common_bin' key with explicit gcc/g++ compilers, replacing the old per-container keys so they all share one warmed cache.
- Give action.yml's c-compiler/cxx-compiler inputs non-empty sentinel defaults ('unknwn_c_cmpl'/'unkn_cpp_cmpl') so the ccache key always has an explicit compiler segment; the build script still treats them as unset for -DCMAKE_*_COMPILER.
