### PR TITLE
fix(squash): avoid mutable cross-thread access on shared reply builder

### DIFF
--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -91,6 +91,10 @@ class ParsedCommand : public cmn::BackedArguments {
     return rb_;
   }
 
+  SinkReplyBuilder* SwapReplyBuilder(SinkReplyBuilder* rb) {
+    return std::exchange(rb_, rb);
+  }
+
   ConnectionContext* conn_cntx() const {
     return conn_cntx_;
   }

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -247,6 +247,11 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       else
         crb.ProvideInlineBuffer({});  // reset buffer
 
+      // For async commands we need to exchange the reply builder as they still can access it
+      // mutably (for example for last_error_ updates). Sync commands use the local context with the
+      // local one
+      SinkReplyBuilder* saved_rb = nullptr;
+
       // With tiered storage enabled, it makes sense to dispatch async commands concurrently
       // to allow concurrent disk operations. Tiered futures are only blocked on during replies
       bool do_async = es->tiered_storage() && !IsAtomic() && opts_.pipeline_mode &&
@@ -254,6 +259,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       if (do_async) {
         ctx = dispatched.cmd_cntx;
         ctx->SetDeferredReply();
+        saved_rb = ctx->SwapReplyBuilder(&crb);
       }
 
       ctx->SetupTx(dispatched.cid, local_cntx.tx());
@@ -266,8 +272,12 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       } else {
         ctx->UpdateCid(dispatched.cid);
         ctx->SetTailArgs(dispatched.args);
+
         service_->InvokeCmd(dispatched.args, ctx);
       }
+
+      if (saved_rb)
+        ctx->SwapReplyBuilder(saved_rb);
 
       if (!do_async) {
         move_reply(&dispatched);  // Async commands resolve the context directly

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -708,8 +708,12 @@ OpResult<TResultOrT<size_t>> OpExtend(const OpArgs& op_args, std::string_view ke
 
 // Helper for building replies for strings
 struct GetReplies {
-  GetReplies(SinkReplyBuilder* rb) : rb{static_cast<RedisReplyBuilder*>(rb)} {
-    DCHECK(dynamic_cast<RedisReplyBuilder*>(rb));
+  GetReplies(CommandContext* cmd_cntx) : cmd_cntx{cmd_cntx} {
+  }
+
+  // Fetch the reply builder lazily only after were allowed to reply (after await)
+  RedisReplyBuilder* rb() const {
+    return static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   }
 
   template <typename T> void Send(OpResult<T>&& res) const {
@@ -717,18 +721,18 @@ struct GetReplies {
       case OpStatus::OK:
         return Send(std::move(res.value()));
       case OpStatus::WRONG_TYPE:
-        return rb->SendError(kWrongTypeErr);
+        return rb()->SendError(kWrongTypeErr);
       case OpStatus::IO_ERROR:
-        return rb->SendError(kTieredIoError);
+        return rb()->SendError(kTieredIoError);
       default:
-        rb->SendNull();
+        rb()->SendNull();
     }
   }
 
   template <typename T> void Send(optional<T>&& res) const {
     if (res.has_value())
       return Send(std::move(*res));
-    return rb->SendNull();
+    return rb()->SendNull();
   }
 
   template <typename T> void Send(TResultOrT<T>&& res) const {
@@ -748,7 +752,7 @@ struct GetReplies {
     if (holds_alternative<cmn::BorrowedString>(res)) {
       // Move the BorrowedString into SendBulkStringBorrowed; the reply builder takes ownership
       // of the borrow (and associated pin) and parks the pin until all the writes complete.
-      rb->SendBulkStringBorrowed(std::move(get<cmn::BorrowedString>(res)));
+      rb()->SendBulkStringBorrowed(std::move(get<cmn::BorrowedString>(res)));
       return;
     }
     auto fut = get<TieredStorage::TResult<std::string>>(std::move(res));
@@ -760,20 +764,20 @@ struct GetReplies {
   }
 
   void Send(size_t val) const {
-    rb->SendLong(val);
+    rb()->SendLong(val);
   }
 
   // TODO: to remove.
   void Send(string_view str) const {
     LOG(FATAL) << "SHOULD NOT SEND STRINGVIEW DIRECTLY";
-    rb->SendBulkString(str);
+    rb()->SendBulkString(str);
   }
 
   void Send(const std::string& str) const {
-    rb->SendBulkString(str);
+    rb()->SendBulkString(str);
   }
 
-  RedisReplyBuilder* rb;
+  CommandContext* cmd_cntx;
 };
 
 cmd::CmdR ExtendGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
@@ -787,8 +791,7 @@ cmd::CmdR ExtendGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
       return OpExtend(t->GetOpArgs(shard), key, value, prepend);
     };
 
-    RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-    GetReplies{rb}.Send(co_await cmd::SingleHopT(cb));
+    GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   } else {
     // Memcached skips if key is missing
     auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1206,7 +1209,7 @@ cmd::CmdR CmdSet(CmdArgParser parser, CommandContext* cmd_cntx) {
   }
 
   if (sparams.flags & SetCmd::SET_GET) {
-    GetReplies{rb}.Send(std::move(prev));
+    GetReplies{cmd_cntx}.Send(std::move(prev));
     co_return std::nullopt;
   }
 
@@ -1293,7 +1296,7 @@ cmd::CmdR CmdGet(CmdArgParser parser, CommandContext* cmd_cntx) {
     return BorrowStringOrRead(tx->GetDbIndex(), key, (*it_res)->second, es);
   };
 
-  GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
+  GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 
@@ -1309,7 +1312,7 @@ cmd::CmdR CmdGetDel(CmdArgParser parser, CommandContext* cmd_cntx) {
     return value;
   };
 
-  GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
+  GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 
@@ -1368,7 +1371,7 @@ cmd::CmdR CmdGetSet(CmdArgParser parser, CommandContext* cmd_cntx) {
   if (status != OpStatus::OK) {
     cmd_cntx->rb()->SendError(status);
   } else {
-    GetReplies{cmd_cntx->rb()}.Send(std::move(prev));
+    GetReplies{cmd_cntx}.Send(std::move(prev));
   }
   co_return std::nullopt;
 }
@@ -1421,7 +1424,7 @@ cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
     return value;
   };
 
-  GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
+  GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 
@@ -1652,7 +1655,7 @@ cmd::CmdR CmdStrLen(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto cb = [key = parser.Next()](Transaction* t, EngineShard* shard) {
     return OpStrLen(t->GetOpArgs(shard), key);
   };
-  GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
+  GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 
@@ -1666,7 +1669,7 @@ cmd::CmdR CmdGetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
     return OpGetRange(t->GetOpArgs(shard), key, start, end);
   };
 
-  GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
+  GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 
@@ -1685,7 +1688,7 @@ cmd::CmdR CmdSetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto cb = [&, &key = key, &start = start, &value = value](Transaction* t, EngineShard* shard) {
     return OpSetRange(t->GetOpArgs(shard), key, start, value);
   };
-  GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
+  GetReplies{cmd_cntx}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -109,6 +109,24 @@ class PureDiskTSTest : public TieredStorageTest {
   optional<absl::FlagSaver> fs;
 };
 
+// Like PureDiskTSTest but multi-threaded, so squashed async commands are
+// dispatched concurrently across several shard threads.
+class PureDiskTSMTTest : public TieredStorageTest {
+ protected:
+  PureDiskTSMTTest() {
+    num_threads_ = 8;
+  }
+
+  void SetUp() override {
+    fs.emplace();
+    SetFlag(&FLAGS_tiered_offload_threshold, 1.0);
+    SetFlag(&FLAGS_tiered_experimental_cooling, false);
+    TieredStorageTest::SetUp();
+  }
+
+  optional<absl::FlagSaver> fs;
+};
+
 // Perform simple series of SET, GETSET and GET
 TEST_P(LatentCoolingTSTest, SimpleGetSet) {
   absl::FlagSaver saver;
@@ -1496,6 +1514,26 @@ TEST_F(PureDiskTSTest, SetNxSquashResult) {
   // SETNX still reports its own outcome, not a neighbour's status.
   EXPECT_EQ(CheckedInt({"SETNX", "fresh", "v"}), 1);
   EXPECT_EQ(CheckedInt({"SETNX", "fresh", "w"}), 0);
+}
+
+// Concurrent asynchronous tiered execution puts pressure on error handling
+// that often utilizes global mutable state. Verify no crashes occur
+TEST_F(PureDiskTSMTTest, SquashedVerifyFailConcurrent) {
+  const int kNum = 32;  // keys span all shards so every shard runs InvokeCmd
+  const string big(4000, 'A');
+  for (int rep = 0; rep < 400; ++rep) {
+    vector<vector<string>> batch;
+    // A malformed command (wrong arity) fails VerifyCommandState and yields a
+    // long, heap-allocated error string that poisons the shared last_error_.
+    batch.push_back({"SET", "k0"});
+    for (int i = 0; i < kNum; ++i)
+      batch.push_back({"SET", absl::StrCat("k", i), big});
+    for (int i = 0; i < kNum; ++i)
+      batch.push_back({"GET", absl::StrCat("k", i)});
+    RunMany(batch);
+  }
+
+  EXPECT_EQ(Run({"PING"}), "PONG");
 }
 
 }  // namespace dfly


### PR DESCRIPTION
1. `reply_builder->last_error_` is a mutable variable that is reset and read in InvokeCmd
2. In squashing, Regular commands use their own local context and a capturing reply builder
3. In squashing, Coroutine commands do not use the reply builder at all "in theory" as they keep the reply inside themselves - so we never exchange it and they keep the connection ones in the context
4. As a result, any access to the connection reply builder is unsafe as it would happen from many threads
5. The fact that they do not use the reply builder _to reply_, as we found out not, does not mean that it's never used in general - becuase of (1) - the last_error_ variable
6. Tiering is required because we run coroutine commands in squashing only when tiering is enabled (otherwise its pointless)

-> Multiple threads access the connections reply builder to modify last_error_