### PR TITLE
fix(rdb): enforce one-consumer-per-PEL-entry when loading stream groups

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -874,6 +874,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
       }
     }
 
+    uint64_t assigned = 0;
     for (const auto& cons : cg.cons_arr) {
       streamConsumer* consumer = StreamCreateConsumer(
           cgroup, ToSV(cons.name, &buf1_), cons.seen_time, SCC_NO_NOTIFY | SCC_NO_DIRTIFY);
@@ -896,17 +897,34 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
           return;
         }
 
+        // Each global PEL entry belongs to exactly one consumer; a second claim
+        // would share the NACK across consumer PELs and double-free it on delete.
+        if (nack->consumer != nullptr) {
+          LOG(ERROR) << "Global PEL entry already assigned to a consumer";
+          ec_ = RdbError(errc::rdb_file_corrupted);
+          return;
+        }
+
         /* Set the NACK consumer, that was left to NULL when
          * loading the global PEL. Then set the same shared
          * NACK structure also in the consumer-specific PEL. */
         nack->consumer = consumer;
+        ++assigned;
         if (!raxTryInsert(consumer->pel, ptr, rawid.size(), nack, NULL)) {
           LOG(ERROR) << "Duplicated consumer PEL entry loading a stream consumer group";
-          streamFreeNACK(nack);
+          // nack is owned by cgroup->pel and freed once during stream teardown.
           ec_ = RdbError(errc::duplicate_key);
           return;
         }
       }
+    }
+
+    // Every global PEL entry must be claimed by exactly one consumer; an
+    // unclaimed one leaves nack->consumer == nullptr for later dereference.
+    if (assigned != raxSize(cgroup->pel)) {
+      LOG(ERROR) << "Unclaimed global PEL entry loading a stream consumer group";
+      ec_ = RdbError(errc::rdb_file_corrupted);
+      return;
     }
   }
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -2045,6 +2045,90 @@ TEST_F(RdbTest, ModuleUnsupportedTypeSkipped) {
   EXPECT_EQ(Run({"GET", "key_after"}), "val_after");
 }
 
+// Every global-PEL entry of a loaded consumer group must be owned by exactly one
+// consumer. A crafted stream that violates this must be rejected: two consumers
+// sharing one entry leave a NACK double-freed on consumer deletion, and an
+// unclaimed entry leaves nack->consumer == nullptr for XACK/XCLAIM to dereference.
+TEST_F(RdbTest, RestoreStreamConsumerGroupCorruption) {
+  auto u64le = [](std::string* out, uint64_t v) {
+    uint8_t b[8];
+    absl::little_endian::Store64(b, v);
+    out->append(reinterpret_cast<const char*>(b), sizeof(b));
+  };
+
+  struct Consumer {
+    std::string name;
+    std::vector<std::string> pel;
+  };
+
+  // Builds a DUMP payload for a stream with an empty body and a single consumer
+  // group whose global PEL and consumers are as specified.
+  auto build = [&](const std::vector<std::string>& global_pel,
+                   const std::vector<Consumer>& consumers) {
+    std::string p;
+    p.push_back(RDB_TYPE_STREAM_LISTPACKS);
+    AppendLen(&p, 0);  // listpack node count: empty stream body
+    AppendLen(&p, 0);  // stream_len
+    AppendLen(&p, 0);  // last_id.ms
+    AppendLen(&p, 0);  // last_id.seq
+
+    AppendLen(&p, 1);       // one consumer group
+    AppendString(&p, "g");  // group name
+    AppendLen(&p, 0);       // group last_id.ms
+    AppendLen(&p, 0);       // group last_id.seq
+
+    AppendLen(&p, global_pel.size());
+    for (const auto& id : global_pel) {
+      p.append(id);
+      u64le(&p, 0);      // delivery_time
+      AppendLen(&p, 0);  // delivery_count
+    }
+
+    AppendLen(&p, consumers.size());
+    for (const auto& c : consumers) {
+      AppendString(&p, c.name);
+      u64le(&p, 0);  // seen_time
+      AppendLen(&p, c.pel.size());
+      for (const auto& id : c.pel)
+        p.append(id);
+    }
+
+    // DUMP footer: 2-byte version, then CRC64 over everything preceding it.
+    uint8_t ver[2];
+    absl::little_endian::Store16(ver, RDB_SER_VERSION);
+    p.append(reinterpret_cast<const char*>(ver), sizeof(ver));
+    uint64_t cs = crc64(0, reinterpret_cast<const uint8_t*>(p.data()), p.size());
+    u64le(&p, cs);
+    return p;
+  };
+
+  const std::string x(16, 'A');
+  const std::string y(16, 'B');
+
+  // Two consumers claim the same global-PEL entry: accepted by a vulnerable
+  // loader, then a double-free when both consumers are deleted.
+  EXPECT_THAT(Run({"RESTORE", "shared", "0", build({x}, {{"c1", {x}}, {"c2", {x}}})}),
+              ErrArg("Bad data format"));
+  EXPECT_THAT(Run({"EXISTS", "shared"}), IntArg(0));
+
+  // A global-PEL entry that no consumer claims: accepted by a vulnerable loader,
+  // leaving nack->consumer == nullptr.
+  EXPECT_THAT(Run({"RESTORE", "unclaimed", "0", build({x}, {{"c1", {}}})}),
+              ErrArg("Bad data format"));
+  EXPECT_THAT(Run({"EXISTS", "unclaimed"}), IntArg(0));
+
+  // One consumer lists the same id twice (duplicate consumer-PEL insert).
+  EXPECT_THAT(Run({"RESTORE", "dup", "0", build({x}, {{"c1", {x, x}}})}),
+              ErrArg("Bad data format"));
+  EXPECT_THAT(Run({"EXISTS", "dup"}), IntArg(0));
+
+  // Positive controls: well-formed groups must still load.
+  EXPECT_EQ(Run({"RESTORE", "ok1", "0", build({x}, {{"c1", {x}}})}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "ok1"}), IntArg(1));
+  EXPECT_EQ(Run({"RESTORE", "ok2", "0", build({x, y}, {{"c1", {x}}, {"c2", {y}}})}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "ok2"}), IntArg(1));
+}
+
 // Integration test for snapshot egress throttling (--snapshot_egress_limit_bytes).
 // Bandwidth limiting is inherently time-based, so this test runs a snapshot large enough
 // that the throttled run takes a few seconds. It asserts two robust properties:


### PR DESCRIPTION
Loading a stream consumer group from a crafted RESTORE payload could leave the group's pending-entries list (PEL) in a memory-unsafe state, all reachable pre-authentication:

- Two different consumers listing the same global-PEL id aliased one NACK across both consumer PELs; deleting the consumers freed it twice (double-free).
- A global-PEL id claimed by no consumer left nack->consumer == nullptr, which XACK/XCLAIM/XAUTOCLAIM/XPENDING/XREADGROUP/XINFO dereference (NULL-deref).

Enforce the invariant that every global-PEL entry is owned by exactly one consumer: reject a second consumer claiming an entry, and reject any entry left unclaimed after all consumers are loaded.