### PR TITLE
tools: Add scripts and UI for ci dashboard

### DIFF
--- a/.github/scripts/download-ci-dashboard-results.sh
+++ b/.github/scripts/download-ci-dashboard-results.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ -z "${SOURCE_BUCKET:-}" ]]; then
+  echo "S3_REGTEST_BUCKET is empty"
+  exit 1
+fi
+
+if [[ ! "${LOOKBACK_DAYS:-}" =~ ^[0-9]+$ ]] || ((LOOKBACK_DAYS < 1)); then
+  echo "lookback_days must be a positive integer; got '${LOOKBACK_DAYS:-}'"
+  exit 2
+fi
+
+INPUT_DIR="${RUNNER_TEMP}/ci-test-dashboard/input"
+JUNIT_DIR="${INPUT_DIR}/junit"
+DASHBOARD_JSON_DIR="${INPUT_DIR}/dashboard"
+mkdir -p "${JUNIT_DIR}" "${DASHBOARD_JSON_DIR}"
+
+echo "INPUT_DIR=${INPUT_DIR}" >> "${GITHUB_ENV}"
+
+for offset in $(seq 0 "$((LOOKBACK_DAYS - 1))"); do
+  year=$(date -u -d "${offset} days ago" +%Y)
+  month=$(date -u -d "${offset} days ago" +%m)
+  day=$(date -u -d "${offset} days ago" +%d)
+
+  cpp_junit_source="s3://${SOURCE_BUCKET}/test-results/junit/cpp/year=${year}/month=${month}/day=${day}/"
+  cpp_junit_target="${JUNIT_DIR}/cpp/year=${year}/month=${month}/day=${day}/"
+  echo "Downloading C++ CTest XML from ${cpp_junit_source}"
+  aws s3 sync "${cpp_junit_source}" "${cpp_junit_target}" \
+    --exclude "*" \
+    --include "*/ctest/*.xml"
+
+  regression_source="s3://${SOURCE_BUCKET}/test-results/junit/regression/year=${year}/month=${month}/day=${day}/"
+  regression_target="${JUNIT_DIR}/regression/year=${year}/month=${month}/day=${day}/"
+  echo "Downloading regression JUnit XML from ${regression_source}"
+  aws s3 sync "${regression_source}" "${regression_target}" \
+    --exclude "*" \
+    --include "*.xml"
+
+  dashboard_source="s3://${SOURCE_BUCKET}/test-results/dashboard/cpp/year=${year}/month=${month}/day=${day}/"
+  dashboard_target="${DASHBOARD_JSON_DIR}/cpp/year=${year}/month=${month}/day=${day}/"
+  echo "Downloading C++ GTest dashboard JSON from ${dashboard_source}"
+  aws s3 sync "${dashboard_source}" "${dashboard_target}" \
+    --exclude "*" \
+    --include "*/gtest-summary.json"
+done
+
+echo "Downloaded XML files: $(find "${JUNIT_DIR}" -type f -name "*.xml" | wc -l)"
+echo "Downloaded dashboard JSON files: $(find "${DASHBOARD_JSON_DIR}" -type f -name "gtest-summary.json" | wc -l)"

--- a/.github/scripts/publish-ci-dashboard-site-to-s3.sh
+++ b/.github/scripts/publish-ci-dashboard-site-to-s3.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ -z "${PUBLISH_BUCKET:-}" ]]; then
+  echo "No publish bucket configured; skipping S3 publish."
+  exit 0
+fi
+
+destination="s3://${PUBLISH_BUCKET}"
+if [[ -n "${PUBLISH_PREFIX:-}" ]]; then
+  destination="${destination}/${PUBLISH_PREFIX%/}"
+fi
+
+gzip_dir="${RUNNER_TEMP}/ci-test-dashboard-gzip"
+mkdir -p "${gzip_dir}"
+
+while IFS= read -r -d '' json_file; do
+  relative_path="${json_file#${DASHBOARD_ROOT}/site/}"
+  gzip_file="${gzip_dir}/${relative_path}"
+  mkdir -p "$(dirname "${gzip_file}")"
+  gzip -9 -c "${json_file}" > "${gzip_file}"
+done < <(find "${DASHBOARD_ROOT}/site/data" -type f -name "*.json" -print0)
+
+manifest_file="${gzip_dir}/data/manifest.json"
+if [[ ! -f "${manifest_file}" ]]; then
+  echo "Missing generated manifest: ${manifest_file}"
+  exit 1
+fi
+
+echo "Publishing dashboard JSON to ${destination}/"
+while IFS= read -r -d '' gzip_file; do
+  relative_path="${gzip_file#${gzip_dir}/}"
+  if [[ "${relative_path}" == "data/manifest.json" ]]; then
+    continue
+  fi
+  aws s3 cp "${gzip_file}" "${destination}/${relative_path}" \
+    --content-type "application/json" \
+    --content-encoding "gzip" \
+    --cache-control "public,max-age=3600"
+done < <(find "${gzip_dir}" -type f -name "*.json" -print0 | sort -z)
+
+aws s3 cp "${manifest_file}" "${destination}/data/manifest.json" \
+  --content-type "application/json" \
+  --content-encoding "gzip" \
+  --cache-control "public,max-age=300"
+
+echo "Publishing dashboard assets to ${destination}/"
+aws s3 sync "${DASHBOARD_ROOT}/site/" "${destination}/" \
+  --delete \
+  --exclude "*.json" \
+  --cache-control "public,max-age=300"

--- a/.github/workflows/ci-test-dashboard.yml
+++ b/.github/workflows/ci-test-dashboard.yml
@@ -1,0 +1,155 @@
+name: CI Test Dashboard
+
+on:
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: "Number of recent UTC days to include"
+        required: false
+        type: number
+        default: 30
+      publish_bucket:
+        description: "Optional S3 bucket to publish the static dashboard to"
+        required: false
+        type: string
+      publish_prefix:
+        description: "Optional prefix within the publish bucket"
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.repository == 'dragonflydb/dragonfly'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      DASHBOARD_ROOT: tools/ci_test_dashboard
+      LOOKBACK_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.lookback_days || '30' }}
+      SOURCE_BUCKET: ${{ secrets.S3_REGTEST_BUCKET }}
+      PUBLISH_BUCKET: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_bucket || secrets.S3_CI_TEST_DASHBOARD_BUCKET }}
+      PUBLISH_PREFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_prefix || vars.CI_TEST_DASHBOARD_PREFIX }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Ensure AWS CLI is available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+          aws --version
+
+      - name: Download recent test results
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SOURCE_BUCKET}" ]]; then
+            echo "S3_REGTEST_BUCKET is empty"
+            exit 1
+          fi
+
+          if [[ ! "${LOOKBACK_DAYS}" =~ ^[0-9]+$ ]] || [[ "${LOOKBACK_DAYS}" -lt 1 ]]; then
+            echo "lookback_days must be a positive integer; got '${LOOKBACK_DAYS}'"
+            exit 2
+          fi
+
+          INPUT_DIR="${RUNNER_TEMP}/ci-test-dashboard/input"
+          JUNIT_DIR="${INPUT_DIR}/junit"
+          DASHBOARD_JSON_DIR="${INPUT_DIR}/dashboard"
+          mkdir -p "${JUNIT_DIR}" "${DASHBOARD_JSON_DIR}"
+          echo "INPUT_DIR=${INPUT_DIR}" >> "${GITHUB_ENV}"
+
+          for offset in $(seq 0 "$((LOOKBACK_DAYS - 1))"); do
+            year=$(date -u -d "${offset} days ago" +%Y)
+            month=$(date -u -d "${offset} days ago" +%m)
+            day=$(date -u -d "${offset} days ago" +%d)
+
+            cpp_junit_source="s3://${SOURCE_BUCKET}/test-results/junit/cpp/year=${year}/month=${month}/day=${day}/"
+            cpp_junit_target="${JUNIT_DIR}/cpp/year=${year}/month=${month}/day=${day}/"
+            echo "Downloading C++ CTest XML from ${cpp_junit_source}"
+            aws s3 sync "${cpp_junit_source}" "${cpp_junit_target}" \
+              --exclude "*" \
+              --include "*/ctest/*.xml"
+
+            regression_source="s3://${SOURCE_BUCKET}/test-results/junit/regression/year=${year}/month=${month}/day=${day}/"
+            regression_target="${JUNIT_DIR}/regression/year=${year}/month=${month}/day=${day}/"
+            echo "Downloading regression JUnit XML from ${regression_source}"
+            aws s3 sync "${regression_source}" "${regression_target}" \
+              --exclude "*" \
+              --include "*.xml"
+
+            dashboard_source="s3://${SOURCE_BUCKET}/test-results/dashboard/cpp/year=${year}/month=${month}/day=${day}/"
+            dashboard_target="${DASHBOARD_JSON_DIR}/cpp/year=${year}/month=${month}/day=${day}/"
+            echo "Downloading C++ GTest dashboard JSON from ${dashboard_source}"
+            aws s3 sync "${dashboard_source}" "${dashboard_target}" \
+              --exclude "*" \
+              --include "*/gtest-summary.json"
+          done
+
+          echo "Downloaded XML files: $(find "${JUNIT_DIR}" -type f -name "*.xml" | wc -l)"
+          echo "Downloaded dashboard JSON files: $(find "${DASHBOARD_JSON_DIR}" -type f -name "gtest-summary.json" | wc -l)"
+
+      - name: Build dashboard data
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "${DASHBOARD_ROOT}/build_dashboard.py" \
+            "${INPUT_DIR}" \
+            "${DASHBOARD_ROOT}/site/data/summary.json"
+
+      - name: Upload dashboard artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-test-dashboard
+          path: ${{ env.DASHBOARD_ROOT }}/site
+          if-no-files-found: error
+
+      - name: Publish dashboard site to S3
+        if: env.PUBLISH_BUCKET != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          destination="s3://${PUBLISH_BUCKET}"
+          if [[ -n "${PUBLISH_PREFIX}" ]]; then
+            destination="${destination}/${PUBLISH_PREFIX%/}"
+          fi
+
+          summary_file="${DASHBOARD_ROOT}/site/data/summary.json"
+          summary_gzip="${RUNNER_TEMP}/summary.json.gz"
+          gzip -9 -c "${summary_file}" > "${summary_gzip}"
+
+          echo "Publishing ${DASHBOARD_ROOT}/site to ${destination}/"
+          aws s3 sync "${DASHBOARD_ROOT}/site/" "${destination}/" \
+            --delete \
+            --exclude "data/summary.json" \
+            --cache-control "public,max-age=300"
+          aws s3 cp "${summary_gzip}" "${destination}/data/summary.json" \
+            --content-type "application/json" \
+            --content-encoding "gzip" \
+            --cache-control "public,max-age=3600"
+
+      - name: Skip S3 publish
+        if: env.PUBLISH_BUCKET == ''
+        run: echo "No publish bucket configured; dashboard is available as a workflow artifact."

--- a/.github/workflows/ci-test-dashboard.yml
+++ b/.github/workflows/ci-test-dashboard.yml
@@ -116,7 +116,7 @@ jobs:
           set -euo pipefail
           python3 "${DASHBOARD_ROOT}/build_dashboard.py" \
             "${INPUT_DIR}" \
-            "${DASHBOARD_ROOT}/site/data/summary.json"
+            "${DASHBOARD_ROOT}/site/data"
 
       - name: Upload dashboard artifact
         uses: actions/upload-artifact@v7
@@ -136,19 +136,44 @@ jobs:
             destination="${destination}/${PUBLISH_PREFIX%/}"
           fi
 
-          summary_file="${DASHBOARD_ROOT}/site/data/summary.json"
-          summary_gzip="${RUNNER_TEMP}/summary.json.gz"
-          gzip -9 -c "${summary_file}" > "${summary_gzip}"
+          gzip_dir="${RUNNER_TEMP}/ci-test-dashboard-gzip"
+          mkdir -p "${gzip_dir}"
 
-          echo "Publishing ${DASHBOARD_ROOT}/site to ${destination}/"
-          aws s3 sync "${DASHBOARD_ROOT}/site/" "${destination}/" \
-            --delete \
-            --exclude "data/summary.json" \
-            --cache-control "public,max-age=300"
-          aws s3 cp "${summary_gzip}" "${destination}/data/summary.json" \
+          while IFS= read -r -d '' json_file; do
+            relative_path="${json_file#${DASHBOARD_ROOT}/site/}"
+            gzip_file="${gzip_dir}/${relative_path}"
+            mkdir -p "$(dirname "${gzip_file}")"
+            gzip -9 -c "${json_file}" > "${gzip_file}"
+          done < <(find "${DASHBOARD_ROOT}/site/data" -type f -name "*.json" -print0)
+
+          manifest_file="${gzip_dir}/data/manifest.json"
+          if [[ ! -f "${manifest_file}" ]]; then
+            echo "Missing generated manifest: ${manifest_file}"
+            exit 1
+          fi
+
+          echo "Publishing dashboard JSON to ${destination}/"
+          while IFS= read -r -d '' gzip_file; do
+            relative_path="${gzip_file#${gzip_dir}/}"
+            if [[ "${relative_path}" == "data/manifest.json" ]]; then
+              continue
+            fi
+            aws s3 cp "${gzip_file}" "${destination}/${relative_path}" \
+              --content-type "application/json" \
+              --content-encoding "gzip" \
+              --cache-control "public,max-age=3600"
+          done < <(find "${gzip_dir}" -type f -name "*.json" -print0 | sort -z)
+
+          aws s3 cp "${manifest_file}" "${destination}/data/manifest.json" \
             --content-type "application/json" \
             --content-encoding "gzip" \
-            --cache-control "public,max-age=3600"
+            --cache-control "public,max-age=300"
+
+          echo "Publishing dashboard assets to ${destination}/"
+          aws s3 sync "${DASHBOARD_ROOT}/site/" "${destination}/" \
+            --delete \
+            --exclude "*.json" \
+            --cache-control "public,max-age=300"
 
       - name: Skip S3 publish
         if: env.PUBLISH_BUCKET == ''

--- a/.github/workflows/ci-test-dashboard.yml
+++ b/.github/workflows/ci-test-dashboard.yml
@@ -56,59 +56,13 @@ jobs:
           if ! command -v aws >/dev/null 2>&1; then
             python3 -m pip install --user awscli
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.local/bin:$PATH"
           fi
           aws --version
 
       - name: Download recent test results
         shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${SOURCE_BUCKET}" ]]; then
-            echo "S3_REGTEST_BUCKET is empty"
-            exit 1
-          fi
-
-          if [[ ! "${LOOKBACK_DAYS}" =~ ^[0-9]+$ ]] || [[ "${LOOKBACK_DAYS}" -lt 1 ]]; then
-            echo "lookback_days must be a positive integer; got '${LOOKBACK_DAYS}'"
-            exit 2
-          fi
-
-          INPUT_DIR="${RUNNER_TEMP}/ci-test-dashboard/input"
-          JUNIT_DIR="${INPUT_DIR}/junit"
-          DASHBOARD_JSON_DIR="${INPUT_DIR}/dashboard"
-          mkdir -p "${JUNIT_DIR}" "${DASHBOARD_JSON_DIR}"
-          echo "INPUT_DIR=${INPUT_DIR}" >> "${GITHUB_ENV}"
-
-          for offset in $(seq 0 "$((LOOKBACK_DAYS - 1))"); do
-            year=$(date -u -d "${offset} days ago" +%Y)
-            month=$(date -u -d "${offset} days ago" +%m)
-            day=$(date -u -d "${offset} days ago" +%d)
-
-            cpp_junit_source="s3://${SOURCE_BUCKET}/test-results/junit/cpp/year=${year}/month=${month}/day=${day}/"
-            cpp_junit_target="${JUNIT_DIR}/cpp/year=${year}/month=${month}/day=${day}/"
-            echo "Downloading C++ CTest XML from ${cpp_junit_source}"
-            aws s3 sync "${cpp_junit_source}" "${cpp_junit_target}" \
-              --exclude "*" \
-              --include "*/ctest/*.xml"
-
-            regression_source="s3://${SOURCE_BUCKET}/test-results/junit/regression/year=${year}/month=${month}/day=${day}/"
-            regression_target="${JUNIT_DIR}/regression/year=${year}/month=${month}/day=${day}/"
-            echo "Downloading regression JUnit XML from ${regression_source}"
-            aws s3 sync "${regression_source}" "${regression_target}" \
-              --exclude "*" \
-              --include "*.xml"
-
-            dashboard_source="s3://${SOURCE_BUCKET}/test-results/dashboard/cpp/year=${year}/month=${month}/day=${day}/"
-            dashboard_target="${DASHBOARD_JSON_DIR}/cpp/year=${year}/month=${month}/day=${day}/"
-            echo "Downloading C++ GTest dashboard JSON from ${dashboard_source}"
-            aws s3 sync "${dashboard_source}" "${dashboard_target}" \
-              --exclude "*" \
-              --include "*/gtest-summary.json"
-          done
-
-          echo "Downloaded XML files: $(find "${JUNIT_DIR}" -type f -name "*.xml" | wc -l)"
-          echo "Downloaded dashboard JSON files: $(find "${DASHBOARD_JSON_DIR}" -type f -name "gtest-summary.json" | wc -l)"
+        run: ${GITHUB_WORKSPACE}/.github/scripts/download-ci-dashboard-results.sh
 
       - name: Build dashboard data
         shell: bash
@@ -128,52 +82,7 @@ jobs:
       - name: Publish dashboard site to S3
         if: env.PUBLISH_BUCKET != ''
         shell: bash
-        run: |
-          set -euo pipefail
-
-          destination="s3://${PUBLISH_BUCKET}"
-          if [[ -n "${PUBLISH_PREFIX}" ]]; then
-            destination="${destination}/${PUBLISH_PREFIX%/}"
-          fi
-
-          gzip_dir="${RUNNER_TEMP}/ci-test-dashboard-gzip"
-          mkdir -p "${gzip_dir}"
-
-          while IFS= read -r -d '' json_file; do
-            relative_path="${json_file#${DASHBOARD_ROOT}/site/}"
-            gzip_file="${gzip_dir}/${relative_path}"
-            mkdir -p "$(dirname "${gzip_file}")"
-            gzip -9 -c "${json_file}" > "${gzip_file}"
-          done < <(find "${DASHBOARD_ROOT}/site/data" -type f -name "*.json" -print0)
-
-          manifest_file="${gzip_dir}/data/manifest.json"
-          if [[ ! -f "${manifest_file}" ]]; then
-            echo "Missing generated manifest: ${manifest_file}"
-            exit 1
-          fi
-
-          echo "Publishing dashboard JSON to ${destination}/"
-          while IFS= read -r -d '' gzip_file; do
-            relative_path="${gzip_file#${gzip_dir}/}"
-            if [[ "${relative_path}" == "data/manifest.json" ]]; then
-              continue
-            fi
-            aws s3 cp "${gzip_file}" "${destination}/${relative_path}" \
-              --content-type "application/json" \
-              --content-encoding "gzip" \
-              --cache-control "public,max-age=3600"
-          done < <(find "${gzip_dir}" -type f -name "*.json" -print0 | sort -z)
-
-          aws s3 cp "${manifest_file}" "${destination}/data/manifest.json" \
-            --content-type "application/json" \
-            --content-encoding "gzip" \
-            --cache-control "public,max-age=300"
-
-          echo "Publishing dashboard assets to ${destination}/"
-          aws s3 sync "${DASHBOARD_ROOT}/site/" "${destination}/" \
-            --delete \
-            --exclude "*.json" \
-            --cache-control "public,max-age=300"
+        run: ${GITHUB_WORKSPACE}/.github/scripts/publish-ci-dashboard-site-to-s3.sh
 
       - name: Skip S3 publish
         if: env.PUBLISH_BUCKET == ''

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tests/dragonfly/valkey_tcl/upstream/
 _codeql_build_dir/
 # CocoIndex Code (ccc)
 /.cocoindex_code/
+tools/ci_test_dashboard/site/data/*.json
+tools/ci_test_dashboard/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ tests/dragonfly/valkey_tcl/upstream/
 _codeql_build_dir/
 # CocoIndex Code (ccc)
 /.cocoindex_code/
-tools/ci_test_dashboard/site/data/*.json
+tools/ci_test_dashboard/site/data/**/*.json
 tools/ci_test_dashboard/tmp

--- a/tools/ci_test_dashboard/build_dashboard.py
+++ b/tools/ci_test_dashboard/build_dashboard.py
@@ -9,7 +9,7 @@ import math
 import sys
 import xml.etree.ElementTree as ET
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -250,7 +250,9 @@ def started_failing_in_sample(recent: list[dict[str, str]]) -> bool:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("input_dir", type=Path, help="Root containing downloaded JUnit XML")
+    parser.add_argument(
+        "input_dir", type=Path, help="Root containing downloaded JUnit XML and dashboard JSON"
+    )
     parser.add_argument("output_json", type=Path, help="Where to write summary JSON")
     parser.add_argument(
         "--limit",
@@ -270,7 +272,13 @@ def main() -> int:
         print(f"Input directory does not exist: {input_dir}", file=sys.stderr)
         return 2
 
-    xml_files = sorted(input_dir.rglob("*.xml"))
+    xml_root = input_dir / "junit" if (input_dir / "junit").is_dir() else input_dir
+    dashboard_root = input_dir / "dashboard"
+
+    xml_files = sorted(xml_root.rglob("*.xml"))
+    dashboard_json_files = (
+        sorted(dashboard_root.rglob("gtest-summary.json")) if dashboard_root.is_dir() else []
+    )
     if args.limit:
         xml_files = xml_files[: args.limit]
 
@@ -285,17 +293,14 @@ def main() -> int:
     run_keys: set[str] = set()
     dates: set[str] = set()
 
+    total_input_files = len(xml_files) + len(dashboard_json_files)
+
     for index, xml_file in enumerate(xml_files, 1):
         if index == 1 or index % 500 == 0:
-            print(f"Parsing {index}/{len(xml_files)}: {xml_file.relative_to(input_dir)}")
+            print(f"Parsing {index}/{total_input_files}: {xml_file.relative_to(xml_root)}")
 
-        meta = metadata_for(input_dir, xml_file)
-        run_keys.add("/".join([meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant]))
-        dates.add(meta.date)
-        by_suite[meta.suite] += 1
-        by_level[meta.level] += 1
-        by_workflow[meta.workflow] += 1
-        by_variant[meta.variant] += 1
+        meta = metadata_for(xml_root, xml_file)
+        add_report_metadata(meta, run_keys, dates, by_suite, by_level, by_workflow, by_variant)
 
         try:
             records = list(read_testcases(xml_file, meta))
@@ -306,30 +311,38 @@ def main() -> int:
 
         report_has_failure = False
         for record in records:
-            status = record["status"]
-            if status in FAIL_STATUSES:
+            if add_test_record(tests, tests_by_status, meta, record):
                 report_has_failure = True
-            tests_by_status[status] += 1
 
-            aggregate = tests.get(record["test_id"])
-            if aggregate is None:
-                aggregate = TestAggregate(
-                    test_id=record["test_id"],
-                    suite=meta.suite,
-                    level=meta.level,
-                    classname=record["classname"],
-                    name=record["name"],
-                    display_name=record["display_name"],
-                )
-                tests[record["test_id"]] = aggregate
+        reports_by_status["failed" if report_has_failure else "passed"] += 1
 
-            aggregate.add(
-                meta=meta,
-                status=status,
-                timestamp=record["timestamp"],
-                duration=record["duration"],
-                message=record["message"],
+    for index, json_file in enumerate(dashboard_json_files, len(xml_files) + 1):
+        if index == len(xml_files) + 1 or index % 500 == 0:
+            print(f"Parsing {index}/{total_input_files}: {json_file.relative_to(dashboard_root)}")
+
+        meta = metadata_for_dashboard_json(dashboard_root, json_file)
+        add_report_metadata(meta, run_keys, dates, by_suite, by_level, by_workflow, by_variant)
+
+        try:
+            records, embedded_parse_errors = read_dashboard_testcases(json_file, meta)
+        except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+            parse_errors.append({"file": meta.relative_path, "error": str(exc)})
+            reports_by_status["parse_error"] += 1
+            continue
+
+        for error in embedded_parse_errors:
+            parse_errors.append(
+                {
+                    "file": f"{meta.relative_path}:{error.get('file', 'unknown')}",
+                    "error": str(error.get("error", "unknown error")),
+                }
             )
+        reports_by_status["parse_error"] += len(embedded_parse_errors)
+
+        report_has_failure = False
+        for record_meta, record in records:
+            if add_test_record(tests, tests_by_status, record_meta, record):
+                report_has_failure = True
 
         reports_by_status["failed" if report_has_failure else "passed"] += 1
 
@@ -355,6 +368,7 @@ def main() -> int:
         },
         "totals": {
             "xml_files": len(xml_files),
+            "dashboard_json_files": len(dashboard_json_files),
             "runs": len(run_keys),
             "unique_tests": len(test_rows),
             "test_occurrences": sum(tests_by_status.values()),
@@ -392,10 +406,59 @@ def main() -> int:
     print(f"Wrote {output_json}")
     print(
         "Parsed "
-        f"{len(xml_files)} XML files, {summary['totals']['test_occurrences']} occurrences, "
+        f"{len(xml_files)} XML files and {len(dashboard_json_files)} dashboard JSON files, "
+        f"{summary['totals']['test_occurrences']} occurrences, "
         f"{summary['totals']['unique_tests']} unique tests."
     )
     return 0
+
+
+def add_report_metadata(
+    meta: Metadata,
+    run_keys: set[str],
+    dates: set[str],
+    by_suite: Counter[str],
+    by_level: Counter[str],
+    by_workflow: Counter[str],
+    by_variant: Counter[str],
+) -> None:
+    run_keys.add("/".join([meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant]))
+    dates.add(meta.date)
+    by_suite[meta.suite] += 1
+    by_level[meta.level] += 1
+    by_workflow[meta.workflow] += 1
+    by_variant[meta.variant] += 1
+
+
+def add_test_record(
+    tests: dict[str, TestAggregate],
+    tests_by_status: Counter[str],
+    meta: Metadata,
+    record: dict[str, Any],
+) -> bool:
+    status = record["status"]
+    tests_by_status[status] += 1
+
+    aggregate = tests.get(record["test_id"])
+    if aggregate is None:
+        aggregate = TestAggregate(
+            test_id=record["test_id"],
+            suite=meta.suite,
+            level=meta.level,
+            classname=record["classname"],
+            name=record["name"],
+            display_name=record["display_name"],
+        )
+        tests[record["test_id"]] = aggregate
+
+    aggregate.add(
+        meta=meta,
+        status=status,
+        timestamp=record["timestamp"],
+        duration=record["duration"],
+        message=record["message"],
+    )
+    return status in FAIL_STATUSES
 
 
 def metadata_for(root: Path, xml_file: Path) -> Metadata:
@@ -451,6 +514,36 @@ def metadata_for(root: Path, xml_file: Path) -> Metadata:
     )
 
 
+def metadata_for_dashboard_json(root: Path, json_file: Path) -> Metadata:
+    relative = json_file.relative_to(root)
+    parts = relative.parts
+
+    suite = parts[0] if len(parts) > 0 else "unknown"
+    year = value_part(parts, "year", "0000")
+    month = value_part(parts, "month", "00")
+    day = value_part(parts, "day", "00")
+    date = f"{year}-{month}-{day}"
+
+    try:
+        day_index = next(i for i, part in enumerate(parts) if part.startswith("day="))
+    except StopIteration:
+        day_index = 3
+
+    return Metadata(
+        suite=suite,
+        date=date,
+        workflow=get_part(parts, day_index + 1, "unknown-workflow"),
+        run_id=get_part(parts, day_index + 2, "unknown-run"),
+        attempt=get_part(parts, day_index + 3, "1"),
+        job=get_part(parts, day_index + 4, "unknown-job"),
+        variant=get_part(parts, day_index + 5, "unknown-variant"),
+        level="gtest",
+        group="gtest",
+        report_name=json_file.stem,
+        relative_path=relative.as_posix(),
+    )
+
+
 def value_part(parts: tuple[str, ...], key: str, default: str) -> str:
     prefix = f"{key}="
     for part in parts:
@@ -463,6 +556,83 @@ def get_part(parts: tuple[str, ...], index: int, default: str) -> str:
     if 0 <= index < len(parts):
         return parts[index]
     return default
+
+
+def read_dashboard_testcases(
+    json_file: Path, meta: Metadata
+) -> tuple[list[tuple[Metadata, dict[str, Any]]], list[dict[str, Any]]]:
+    payload = json.loads(json_file.read_text(encoding="utf-8"))
+    tests_payload = payload.get("tests", [])
+    if not isinstance(tests_payload, list):
+        raise ValueError("dashboard JSON 'tests' must be a list")
+
+    parse_errors = payload.get("parse_errors", [])
+    if not isinstance(parse_errors, list):
+        parse_errors = []
+
+    records = []
+    for item in tests_payload:
+        if not isinstance(item, dict):
+            continue
+
+        record_meta = metadata_for_dashboard_record(meta, item)
+        classname = str(
+            item.get("classname") or item.get("binary") or record_meta.group or "unknown"
+        )
+        name = str(item.get("name") or "unknown")
+        status = normalize_status(item.get("status"))
+        timestamp = normalize_timestamp(str(item.get("timestamp") or ""), record_meta.date)
+        duration = float_or_zero(item.get("time", item.get("duration", 0)))
+        message = normalize_message(item.get("message", ""))
+
+        records.append(
+            (
+                record_meta,
+                {
+                    "test_id": make_test_id(record_meta, classname, name),
+                    "classname": classname,
+                    "name": name,
+                    "display_name": display_name(record_meta, classname, name),
+                    "status": status,
+                    "timestamp": timestamp,
+                    "duration": duration,
+                    "message": message,
+                },
+            )
+        )
+
+    return records, parse_errors
+
+
+def metadata_for_dashboard_record(meta: Metadata, item: dict[str, Any]) -> Metadata:
+    source = str(item.get("source") or "")
+    relative_path = meta.relative_path if not source else f"{meta.relative_path}#{source}"
+    return replace(
+        meta,
+        suite=str(item.get("suite") or meta.suite),
+        level=str(item.get("level") or meta.level),
+        workflow=str(item.get("workflow") or meta.workflow),
+        run_id=str(item.get("run_id") or meta.run_id),
+        attempt=str(item.get("run_attempt") or meta.attempt),
+        job=str(item.get("job") or meta.job),
+        variant=str(item.get("variant") or meta.variant),
+        group=str(item.get("group") or item.get("binary") or meta.group),
+        report_name=source or meta.report_name,
+        relative_path=relative_path,
+    )
+
+
+def normalize_status(value: Any) -> str:
+    status = str(value or "unknown").lower()
+    if status == "errored":
+        return "error"
+    if status in {"passed", "failed", "error", "skipped"}:
+        return status
+    return "unknown"
+
+
+def normalize_message(value: Any) -> str:
+    return " ".join(str(value or "").split())[:500]
 
 
 def read_testcases(xml_file: Path, meta: Metadata) -> list[dict[str, Any]]:

--- a/tools/ci_test_dashboard/build_dashboard.py
+++ b/tools/ci_test_dashboard/build_dashboard.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Build compact dashboard JSON from downloaded JUnit XML."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+FAIL_STATUSES = {"failed", "error"}
+RECENT_LIMIT = 12
+EXAMPLE_LIMIT = 4
+SET_LIMIT = 8
+
+
+@dataclass
+class Metadata:
+    suite: str
+    date: str
+    workflow: str
+    run_id: str
+    attempt: str
+    job: str
+    variant: str
+    level: str
+    group: str
+    report_name: str
+    relative_path: str
+
+
+@dataclass
+class TestAggregate:
+    test_id: str
+    suite: str
+    level: str
+    classname: str
+    name: str
+    display_name: str
+    total: int = 0
+    passed: int = 0
+    failed: int = 0
+    errored: int = 0
+    skipped: int = 0
+    total_time: float = 0.0
+    first_seen: str | None = None
+    last_seen: str | None = None
+    last_failed: str | None = None
+    last_status: str = "unknown"
+    last_workflow: str = ""
+    last_run_id: str = ""
+    last_variant: str = ""
+    last_report: str = ""
+    workflows: set[str] = field(default_factory=set)
+    variants: set[str] = field(default_factory=set)
+    groups: set[str] = field(default_factory=set)
+    dates: set[str] = field(default_factory=set)
+    segments: dict[tuple[str, str, str], dict[str, Any]] = field(default_factory=dict)
+    recent: list[dict[str, str]] = field(default_factory=list)
+    failure_examples: list[dict[str, str]] = field(default_factory=list)
+
+    def add(
+        self, meta: Metadata, status: str, timestamp: str, duration: float, message: str
+    ) -> None:
+        self.total += 1
+        self.total_time += duration
+        if status == "passed":
+            self.passed += 1
+        elif status == "failed":
+            self.failed += 1
+        elif status == "error":
+            self.errored += 1
+        elif status == "skipped":
+            self.skipped += 1
+
+        if self.first_seen is None or timestamp < self.first_seen:
+            self.first_seen = timestamp
+        if self.last_seen is None or timestamp >= self.last_seen:
+            self.last_seen = timestamp
+            self.last_status = status
+            self.last_workflow = meta.workflow
+            self.last_run_id = meta.run_id
+            self.last_variant = meta.variant
+            self.last_report = meta.relative_path
+        if status in FAIL_STATUSES and (self.last_failed is None or timestamp >= self.last_failed):
+            self.last_failed = timestamp
+
+        self.workflows.add(meta.workflow)
+        self.variants.add(meta.variant)
+        self.groups.add(meta.group)
+        self.dates.add(meta.date)
+        self.add_segment(meta, status, timestamp, duration)
+        self.recent.append(
+            {
+                "status": status,
+                "time": timestamp,
+            }
+        )
+        self.recent.sort(key=lambda item: item["time"])
+        if len(self.recent) > RECENT_LIMIT:
+            self.recent = self.recent[-RECENT_LIMIT:]
+
+        if status in FAIL_STATUSES and message:
+            self.failure_examples.append(
+                {
+                    "status": status,
+                    "time": timestamp,
+                    "workflow": meta.workflow,
+                    "run_id": meta.run_id,
+                    "run_attempt": meta.attempt,
+                    "variant": meta.variant,
+                    "report": meta.relative_path,
+                    "message": message,
+                }
+            )
+            self.failure_examples.sort(key=lambda item: item["time"], reverse=True)
+            if len(self.failure_examples) > EXAMPLE_LIMIT:
+                self.failure_examples = self.failure_examples[:EXAMPLE_LIMIT]
+
+    def to_json(self) -> dict[str, Any]:
+        actionable = self.passed + self.failed + self.errored
+        failures = self.failed + self.errored
+        failure_rate = failures / actionable if actionable else 0.0
+        return {
+            "id": self.test_id,
+            "suite": self.suite,
+            "level": self.level,
+            "classname": self.classname,
+            "name": self.name,
+            "display_name": self.display_name,
+            "total": self.total,
+            "passed": self.passed,
+            "failed": self.failed,
+            "errored": self.errored,
+            "skipped": self.skipped,
+            "failures": failures,
+            "failure_rate": round(failure_rate, 4),
+            "avg_time": round(self.total_time / self.total, 4) if self.total else 0.0,
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "last_failed": self.last_failed,
+            "last_status": self.last_status,
+            "last_workflow": self.last_workflow,
+            "last_run_id": self.last_run_id,
+            "last_variant": self.last_variant,
+            "last_report": self.last_report,
+            "workflows": sorted_limited(self.workflows),
+            "variants": sorted_limited(self.variants),
+            "groups": sorted_limited(self.groups),
+            "filters": {
+                "dates": sorted(self.dates),
+                "workflows": sorted(self.workflows),
+                "variants": sorted(self.variants),
+            },
+            "segments": self.segments_json(),
+            "recent": self.recent,
+            "failure_examples": self.failure_examples,
+            "is_currently_failing": self.last_status in FAIL_STATUSES,
+            "is_flaky": failures > 0 and self.passed > 0,
+            "started_failing_in_sample": started_failing_in_sample(self.recent),
+        }
+
+    def add_segment(self, meta: Metadata, status: str, timestamp: str, duration: float) -> None:
+        key = (meta.date, meta.workflow, meta.variant)
+        segment = self.segments.get(key)
+        if segment is None:
+            segment = {
+                "date": meta.date,
+                "workflow": meta.workflow,
+                "variant": meta.variant,
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+                "errored": 0,
+                "skipped": 0,
+                "total_time": 0.0,
+                "first_seen": timestamp,
+                "last_seen": timestamp,
+                "last_failed": timestamp if status in FAIL_STATUSES else None,
+                "last_failed_run_id": meta.run_id if status in FAIL_STATUSES else "",
+                "last_failed_run_attempt": meta.attempt if status in FAIL_STATUSES else "",
+                "last_failed_report": meta.relative_path if status in FAIL_STATUSES else "",
+                "last_status": status,
+                "last_run_id": meta.run_id,
+                "last_report": meta.relative_path,
+            }
+            self.segments[key] = segment
+
+        segment["total"] += 1
+        segment["total_time"] += duration
+        if status == "passed":
+            segment["passed"] += 1
+        elif status == "failed":
+            segment["failed"] += 1
+        elif status == "error":
+            segment["errored"] += 1
+        elif status == "skipped":
+            segment["skipped"] += 1
+
+        if timestamp < segment["first_seen"]:
+            segment["first_seen"] = timestamp
+        if timestamp >= segment["last_seen"]:
+            segment["last_seen"] = timestamp
+            segment["last_status"] = status
+            segment["last_run_id"] = meta.run_id
+            segment["last_report"] = meta.relative_path
+        if status in FAIL_STATUSES and (
+            segment["last_failed"] is None or timestamp >= segment["last_failed"]
+        ):
+            segment["last_failed"] = timestamp
+            segment["last_failed_run_id"] = meta.run_id
+            segment["last_failed_run_attempt"] = meta.attempt
+            segment["last_failed_report"] = meta.relative_path
+
+    def segments_json(self) -> list[dict[str, Any]]:
+        rows = []
+        for segment in sorted(
+            self.segments.values(),
+            key=lambda item: (item["date"], item["workflow"], item["variant"]),
+        ):
+            row = dict(segment)
+            row["total_time"] = round(row["total_time"], 4)
+            rows.append(row)
+        return rows
+
+
+def sorted_limited(values: set[str]) -> list[str]:
+    clean = sorted(value for value in values if value)
+    if len(clean) <= SET_LIMIT:
+        return clean
+    return clean[:SET_LIMIT] + [f"+{len(clean) - SET_LIMIT} more"]
+
+
+def started_failing_in_sample(recent: list[dict[str, str]]) -> bool:
+    if len(recent) < 4:
+        return False
+    split = max(1, math.floor(len(recent) * 0.7))
+    earlier = recent[:split]
+    later = recent[split:]
+    return all(item["status"] not in FAIL_STATUSES for item in earlier) and any(
+        item["status"] in FAIL_STATUSES for item in later
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_dir", type=Path, help="Root containing downloaded JUnit XML")
+    parser.add_argument("output_json", type=Path, help="Where to write summary JSON")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Optional maximum XML files to parse, useful while iterating",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    input_dir = args.input_dir.resolve()
+    output_json = args.output_json.resolve()
+
+    if not input_dir.exists():
+        print(f"Input directory does not exist: {input_dir}", file=sys.stderr)
+        return 2
+
+    xml_files = sorted(input_dir.rglob("*.xml"))
+    if args.limit:
+        xml_files = xml_files[: args.limit]
+
+    tests: dict[str, TestAggregate] = {}
+    reports_by_status: Counter[str] = Counter()
+    tests_by_status: Counter[str] = Counter()
+    by_suite: Counter[str] = Counter()
+    by_level: Counter[str] = Counter()
+    by_workflow: Counter[str] = Counter()
+    by_variant: Counter[str] = Counter()
+    parse_errors: list[dict[str, str]] = []
+    run_keys: set[str] = set()
+    dates: set[str] = set()
+
+    for index, xml_file in enumerate(xml_files, 1):
+        if index == 1 or index % 500 == 0:
+            print(f"Parsing {index}/{len(xml_files)}: {xml_file.relative_to(input_dir)}")
+
+        meta = metadata_for(input_dir, xml_file)
+        run_keys.add("/".join([meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant]))
+        dates.add(meta.date)
+        by_suite[meta.suite] += 1
+        by_level[meta.level] += 1
+        by_workflow[meta.workflow] += 1
+        by_variant[meta.variant] += 1
+
+        try:
+            records = list(read_testcases(xml_file, meta))
+        except ET.ParseError as exc:
+            parse_errors.append({"file": meta.relative_path, "error": str(exc)})
+            reports_by_status["parse_error"] += 1
+            continue
+
+        report_has_failure = False
+        for record in records:
+            status = record["status"]
+            if status in FAIL_STATUSES:
+                report_has_failure = True
+            tests_by_status[status] += 1
+
+            aggregate = tests.get(record["test_id"])
+            if aggregate is None:
+                aggregate = TestAggregate(
+                    test_id=record["test_id"],
+                    suite=meta.suite,
+                    level=meta.level,
+                    classname=record["classname"],
+                    name=record["name"],
+                    display_name=record["display_name"],
+                )
+                tests[record["test_id"]] = aggregate
+
+            aggregate.add(
+                meta=meta,
+                status=status,
+                timestamp=record["timestamp"],
+                duration=record["duration"],
+                message=record["message"],
+            )
+
+        reports_by_status["failed" if report_has_failure else "passed"] += 1
+
+    test_rows = [aggregate.to_json() for aggregate in tests.values()]
+    test_rows.sort(
+        key=lambda item: (
+            item["failures"],
+            item["failure_rate"],
+            item["is_currently_failing"],
+            item["total"],
+        ),
+        reverse=True,
+    )
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    summary = {
+        "generated_at": generated_at,
+        "input_dir": str(input_dir),
+        "date_range": {
+            "first": min(dates) if dates else None,
+            "last": max(dates) if dates else None,
+            "days": sorted(dates),
+        },
+        "totals": {
+            "xml_files": len(xml_files),
+            "runs": len(run_keys),
+            "unique_tests": len(test_rows),
+            "test_occurrences": sum(tests_by_status.values()),
+            "reports_passed": reports_by_status["passed"],
+            "reports_failed": reports_by_status["failed"],
+            "parse_errors": len(parse_errors),
+            "passed": tests_by_status["passed"],
+            "failed": tests_by_status["failed"],
+            "errored": tests_by_status["error"],
+            "skipped": tests_by_status["skipped"],
+            "currently_failing": sum(1 for row in test_rows if row["is_currently_failing"]),
+            "flaky": sum(1 for row in test_rows if row["is_flaky"]),
+            "started_failing_in_sample": sum(
+                1 for row in test_rows if row["started_failing_in_sample"]
+            ),
+        },
+        "breakdowns": {
+            "by_suite": dict(sorted(by_suite.items())),
+            "by_level": dict(sorted(by_level.items())),
+            "by_workflow": dict(sorted(by_workflow.items())),
+            "by_variant": dict(sorted(by_variant.items())),
+            "tests_by_status": dict(sorted(tests_by_status.items())),
+        },
+        "facets": {
+            "dates": sorted(dates),
+            "workflows": sorted(by_workflow),
+            "variants": sorted(by_variant),
+        },
+        "tests": test_rows,
+        "parse_errors": parse_errors[:100],
+    }
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(summary, separators=(",", ":")), encoding="utf-8")
+    print(f"Wrote {output_json}")
+    print(
+        "Parsed "
+        f"{len(xml_files)} XML files, {summary['totals']['test_occurrences']} occurrences, "
+        f"{summary['totals']['unique_tests']} unique tests."
+    )
+    return 0
+
+
+def metadata_for(root: Path, xml_file: Path) -> Metadata:
+    relative = xml_file.relative_to(root)
+    parts = relative.parts
+
+    suite = parts[0] if len(parts) > 0 else "unknown"
+    year = value_part(parts, "year", "0000")
+    month = value_part(parts, "month", "00")
+    day = value_part(parts, "day", "00")
+    date = f"{year}-{month}-{day}"
+
+    try:
+        day_index = next(i for i, part in enumerate(parts) if part.startswith("day="))
+    except StopIteration:
+        day_index = 3
+
+    workflow = get_part(parts, day_index + 1, "unknown-workflow")
+    run_id = get_part(parts, day_index + 2, "unknown-run")
+    attempt = get_part(parts, day_index + 3, "1")
+    job = get_part(parts, day_index + 4, "unknown-job")
+    variant = get_part(parts, day_index + 5, "unknown-variant")
+    tail = parts[day_index + 6 :]
+
+    level = "junit"
+    group = ""
+    report_name = xml_file.stem
+
+    if suite == "cpp" and tail:
+        level = tail[0]
+        if level == "gtest" and len(tail) >= 3:
+            group = f"{tail[1]}/{Path(tail[2]).stem}"
+        elif level == "ctest":
+            group = xml_file.stem
+        else:
+            group = "/".join(tail[:-1])
+    elif suite == "regression":
+        level = "pytest"
+        group = xml_file.stem
+
+    return Metadata(
+        suite=suite,
+        date=date,
+        workflow=workflow,
+        run_id=run_id,
+        attempt=attempt,
+        job=job,
+        variant=variant,
+        level=level,
+        group=group,
+        report_name=report_name,
+        relative_path=relative.as_posix(),
+    )
+
+
+def value_part(parts: tuple[str, ...], key: str, default: str) -> str:
+    prefix = f"{key}="
+    for part in parts:
+        if part.startswith(prefix):
+            return part[len(prefix) :]
+    return default
+
+
+def get_part(parts: tuple[str, ...], index: int, default: str) -> str:
+    if 0 <= index < len(parts):
+        return parts[index]
+    return default
+
+
+def read_testcases(xml_file: Path, meta: Metadata) -> list[dict[str, Any]]:
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+    suites = [root] if strip_ns(root.tag) == "testsuite" else find_children(root, "testsuite")
+    records: list[dict[str, Any]] = []
+
+    for suite in suites:
+        suite_name = suite.attrib.get("name", "")
+        suite_timestamp = normalize_timestamp(suite.attrib.get("timestamp", ""), meta.date)
+        for testcase in find_direct_children(suite, "testcase"):
+            classname = testcase.attrib.get("classname") or suite_name or meta.group or "unknown"
+            name = testcase.attrib.get("name") or "unknown"
+            timestamp = normalize_timestamp(
+                testcase.attrib.get("timestamp", "") or suite_timestamp,
+                meta.date,
+            )
+            status, message = status_for(testcase)
+            duration = float_or_zero(testcase.attrib.get("time", "0"))
+
+            test_id = make_test_id(meta, classname, name)
+            records.append(
+                {
+                    "test_id": test_id,
+                    "classname": classname,
+                    "name": name,
+                    "display_name": display_name(meta, classname, name),
+                    "status": status,
+                    "timestamp": timestamp,
+                    "duration": duration,
+                    "message": message,
+                }
+            )
+
+    return records
+
+
+def find_children(element: ET.Element, wanted: str) -> list[ET.Element]:
+    return [child for child in element.iter() if strip_ns(child.tag) == wanted]
+
+
+def find_direct_children(element: ET.Element, wanted: str) -> list[ET.Element]:
+    return [child for child in list(element) if strip_ns(child.tag) == wanted]
+
+
+def strip_ns(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def status_for(testcase: ET.Element) -> tuple[str, str]:
+    failure = first_child(testcase, "failure")
+    if failure is not None:
+        return "failed", message_from(failure)
+
+    error = first_child(testcase, "error")
+    if error is not None:
+        return "error", message_from(error)
+
+    skipped = first_child(testcase, "skipped")
+    if skipped is not None:
+        return "skipped", message_from(skipped)
+
+    if testcase.attrib.get("status") == "notrun":
+        return "skipped", ""
+
+    return "passed", ""
+
+
+def first_child(element: ET.Element, wanted: str) -> ET.Element | None:
+    for child in list(element):
+        if strip_ns(child.tag) == wanted:
+            return child
+    return None
+
+
+def message_from(element: ET.Element) -> str:
+    message = element.attrib.get("message", "")
+    text = "".join(element.itertext()).strip()
+    combined = message or text
+    combined = " ".join(combined.split())
+    return combined[:500]
+
+
+def make_test_id(meta: Metadata, classname: str, name: str) -> str:
+    return f"{meta.suite}/{meta.level}/{classname}::{name}"
+
+
+def display_name(meta: Metadata, classname: str, name: str) -> str:
+    if meta.level == "ctest":
+        return name
+    return f"{classname}::{name}"
+
+
+def normalize_timestamp(value: str, fallback_date: str) -> str:
+    if not value:
+        return f"{fallback_date}T00:00:00Z"
+    normalized = value.strip()
+    if normalized.endswith("+00:00"):
+        normalized = normalized[:-6] + "Z"
+    if "T" not in normalized:
+        normalized = f"{fallback_date}T00:00:00Z"
+    if normalized.endswith("Z"):
+        return normalized
+    if "+" in normalized[10:] or "-" in normalized[10:]:
+        return normalized
+    return normalized + "Z"
+
+
+def float_or_zero(value: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci_test_dashboard/build_dashboard.py
+++ b/tools/ci_test_dashboard/build_dashboard.py
@@ -1,23 +1,30 @@
 #!/usr/bin/env python3
-"""Build compact dashboard JSON from downloaded JUnit XML."""
+"""Build static dashboard JSON from downloaded JUnit XML and compact test JSON."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
+import shutil
 import sys
 import xml.etree.ElementTree as ET
 from collections import Counter
 from dataclasses import dataclass, field, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 FAIL_STATUSES = {"failed", "error"}
 RECENT_LIMIT = 12
 EXAMPLE_LIMIT = 4
-SET_LIMIT = 8
+RANGE_OPTIONS = [
+    ("all", "All history", None),
+    ("7", "Last 7 days", 7),
+    ("14", "Last 14 days", 14),
+    ("30", "Last 30 days", 30),
+]
 
 
 @dataclass
@@ -43,68 +50,17 @@ class TestAggregate:
     classname: str
     name: str
     display_name: str
-    total: int = 0
-    passed: int = 0
-    failed: int = 0
-    errored: int = 0
-    skipped: int = 0
-    total_time: float = 0.0
-    first_seen: str | None = None
-    last_seen: str | None = None
-    last_failed: str | None = None
-    last_status: str = "unknown"
-    last_workflow: str = ""
-    last_run_id: str = ""
-    last_variant: str = ""
-    last_report: str = ""
-    workflows: set[str] = field(default_factory=set)
-    variants: set[str] = field(default_factory=set)
     groups: set[str] = field(default_factory=set)
-    dates: set[str] = field(default_factory=set)
-    segments: dict[tuple[str, str, str], dict[str, Any]] = field(default_factory=dict)
-    recent: list[dict[str, str]] = field(default_factory=list)
+    segments: dict[tuple[str, str, str, str, str, str], dict[str, Any]] = field(
+        default_factory=dict
+    )
     failure_examples: list[dict[str, str]] = field(default_factory=list)
 
     def add(
         self, meta: Metadata, status: str, timestamp: str, duration: float, message: str
     ) -> None:
-        self.total += 1
-        self.total_time += duration
-        if status == "passed":
-            self.passed += 1
-        elif status == "failed":
-            self.failed += 1
-        elif status == "error":
-            self.errored += 1
-        elif status == "skipped":
-            self.skipped += 1
-
-        if self.first_seen is None or timestamp < self.first_seen:
-            self.first_seen = timestamp
-        if self.last_seen is None or timestamp >= self.last_seen:
-            self.last_seen = timestamp
-            self.last_status = status
-            self.last_workflow = meta.workflow
-            self.last_run_id = meta.run_id
-            self.last_variant = meta.variant
-            self.last_report = meta.relative_path
-        if status in FAIL_STATUSES and (self.last_failed is None or timestamp >= self.last_failed):
-            self.last_failed = timestamp
-
-        self.workflows.add(meta.workflow)
-        self.variants.add(meta.variant)
         self.groups.add(meta.group)
-        self.dates.add(meta.date)
         self.add_segment(meta, status, timestamp, duration)
-        self.recent.append(
-            {
-                "status": status,
-                "time": timestamp,
-            }
-        )
-        self.recent.sort(key=lambda item: item["time"])
-        if len(self.recent) > RECENT_LIMIT:
-            self.recent = self.recent[-RECENT_LIMIT:]
 
         if status in FAIL_STATUSES and message:
             self.failure_examples.append(
@@ -124,9 +80,6 @@ class TestAggregate:
                 self.failure_examples = self.failure_examples[:EXAMPLE_LIMIT]
 
     def to_json(self) -> dict[str, Any]:
-        actionable = self.passed + self.failed + self.errored
-        failures = self.failed + self.errored
-        failure_rate = failures / actionable if actionable else 0.0
         return {
             "id": self.test_id,
             "suite": self.suite,
@@ -134,45 +87,21 @@ class TestAggregate:
             "classname": self.classname,
             "name": self.name,
             "display_name": self.display_name,
-            "total": self.total,
-            "passed": self.passed,
-            "failed": self.failed,
-            "errored": self.errored,
-            "skipped": self.skipped,
-            "failures": failures,
-            "failure_rate": round(failure_rate, 4),
-            "avg_time": round(self.total_time / self.total, 4) if self.total else 0.0,
-            "first_seen": self.first_seen,
-            "last_seen": self.last_seen,
-            "last_failed": self.last_failed,
-            "last_status": self.last_status,
-            "last_workflow": self.last_workflow,
-            "last_run_id": self.last_run_id,
-            "last_variant": self.last_variant,
-            "last_report": self.last_report,
-            "workflows": sorted_limited(self.workflows),
-            "variants": sorted_limited(self.variants),
-            "groups": sorted_limited(self.groups),
-            "filters": {
-                "dates": sorted(self.dates),
-                "workflows": sorted(self.workflows),
-                "variants": sorted(self.variants),
-            },
+            "groups": unique_sorted(self.groups),
             "segments": self.segments_json(),
-            "recent": self.recent,
             "failure_examples": self.failure_examples,
-            "is_currently_failing": self.last_status in FAIL_STATUSES,
-            "is_flaky": failures > 0 and self.passed > 0,
-            "started_failing_in_sample": started_failing_in_sample(self.recent),
         }
 
     def add_segment(self, meta: Metadata, status: str, timestamp: str, duration: float) -> None:
-        key = (meta.date, meta.workflow, meta.variant)
+        key = (meta.date, meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant)
         segment = self.segments.get(key)
         if segment is None:
             segment = {
                 "date": meta.date,
                 "workflow": meta.workflow,
+                "run_id": meta.run_id,
+                "run_attempt": meta.attempt,
+                "job": meta.job,
                 "variant": meta.variant,
                 "total": 0,
                 "passed": 0,
@@ -222,19 +151,19 @@ class TestAggregate:
         rows = []
         for segment in sorted(
             self.segments.values(),
-            key=lambda item: (item["date"], item["workflow"], item["variant"]),
+            key=lambda item: (
+                item["date"],
+                item["workflow"],
+                item["run_id"],
+                item["run_attempt"],
+                item["job"],
+                item["variant"],
+            ),
         ):
             row = dict(segment)
             row["total_time"] = round(row["total_time"], 4)
             rows.append(row)
         return rows
-
-
-def sorted_limited(values: set[str]) -> list[str]:
-    clean = sorted(value for value in values if value)
-    if len(clean) <= SET_LIMIT:
-        return clean
-    return clean[:SET_LIMIT] + [f"+{len(clean) - SET_LIMIT} more"]
 
 
 def started_failing_in_sample(recent: list[dict[str, str]]) -> bool:
@@ -253,7 +182,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "input_dir", type=Path, help="Root containing downloaded JUnit XML and dashboard JSON"
     )
-    parser.add_argument("output_json", type=Path, help="Where to write summary JSON")
+    parser.add_argument("output_json", type=Path, help="Where to write dashboard JSON files")
     parser.add_argument(
         "--limit",
         type=int,
@@ -285,10 +214,6 @@ def main() -> int:
     tests: dict[str, TestAggregate] = {}
     reports_by_status: Counter[str] = Counter()
     tests_by_status: Counter[str] = Counter()
-    by_suite: Counter[str] = Counter()
-    by_level: Counter[str] = Counter()
-    by_workflow: Counter[str] = Counter()
-    by_variant: Counter[str] = Counter()
     parse_errors: list[dict[str, str]] = []
     run_keys: set[str] = set()
     dates: set[str] = set()
@@ -300,7 +225,8 @@ def main() -> int:
             print(f"Parsing {index}/{total_input_files}: {xml_file.relative_to(xml_root)}")
 
         meta = metadata_for(xml_root, xml_file)
-        add_report_metadata(meta, run_keys, dates, by_suite, by_level, by_workflow, by_variant)
+        run_keys.add("/".join([meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant]))
+        dates.add(meta.date)
 
         try:
             records = list(read_testcases(xml_file, meta))
@@ -321,7 +247,8 @@ def main() -> int:
             print(f"Parsing {index}/{total_input_files}: {json_file.relative_to(dashboard_root)}")
 
         meta = metadata_for_dashboard_json(dashboard_root, json_file)
-        add_report_metadata(meta, run_keys, dates, by_suite, by_level, by_workflow, by_variant)
+        run_keys.add("/".join([meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant]))
+        dates.add(meta.date)
 
         try:
             records, embedded_parse_errors = read_dashboard_testcases(json_file, meta)
@@ -346,8 +273,263 @@ def main() -> int:
 
         reports_by_status["failed" if report_has_failure else "passed"] += 1
 
-    test_rows = [aggregate.to_json() for aggregate in tests.values()]
-    test_rows.sort(
+    test_rows = []
+    for aggregate in tests.values():
+        row = aggregate.to_json()
+        row["detail_file"] = detail_file_for(row["id"])
+        test_rows.append(row)
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    output_dir = prepare_output_dir(output_json)
+
+    for row in test_rows:
+        write_json(
+            output_dir / row["detail_file"],
+            {
+                "schema_version": 2,
+                "generated_at": generated_at,
+                "id": row["id"],
+                "segments": row["segments"],
+                "failure_examples": row["failure_examples"],
+            },
+        )
+
+    input_counts = {
+        "xml_files": len(xml_files),
+        "dashboard_json_files": len(dashboard_json_files),
+        "reports_passed": reports_by_status["passed"],
+        "reports_failed": reports_by_status["failed"],
+        "parse_errors": len(parse_errors),
+    }
+
+    ranges = []
+    for range_id, label, days in RANGE_OPTIONS:
+        range_summary = build_range_summary(
+            test_rows=test_rows,
+            range_id=range_id,
+            label=label,
+            days=days,
+            latest_day=max(dates) if dates else None,
+            generated_at=generated_at,
+        )
+        range_file = f"ranges/{range_id}.json"
+        write_json(output_dir / range_file, range_summary)
+        ranges.append(
+            {
+                "id": range_id,
+                "label": label,
+                "file": range_file,
+                "tests": len(range_summary["tests"]),
+                "date_range": range_summary["date_range"],
+            }
+        )
+
+    all_range = next(item for item in ranges if item["id"] == "all")
+    default_range = "30" if any(item["id"] == "30" for item in ranges) else all_range["id"]
+    manifest = {
+        "schema_version": 2,
+        "generated_at": generated_at,
+        "input_dir": str(input_dir),
+        "date_range": {
+            "first": min(dates) if dates else None,
+            "last": max(dates) if dates else None,
+            "days": sorted(dates),
+        },
+        "default_range": default_range,
+        "ranges": ranges,
+        "totals": {
+            **input_counts,
+            "runs": len(run_keys),
+            "unique_tests": len(test_rows),
+            "test_occurrences": sum(tests_by_status.values()),
+        },
+        "parse_errors": parse_errors[:100],
+    }
+    write_json(output_dir / "manifest.json", manifest)
+
+    print(f"Wrote dashboard data under {output_dir}")
+    print(
+        "Parsed "
+        f"{len(xml_files)} XML files and {len(dashboard_json_files)} dashboard JSON files, "
+        f"{sum(tests_by_status.values())} occurrences, "
+        f"{len(test_rows)} unique tests."
+    )
+    return 0
+
+
+def prepare_output_dir(output_path: Path) -> Path:
+    output_dir = output_path.parent if output_path.suffix else output_path
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in ("ranges", "tests"):
+        shutil.rmtree(output_dir / name, ignore_errors=True)
+        (output_dir / name).mkdir(parents=True, exist_ok=True)
+
+    return output_dir
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+
+
+def detail_file_for(test_id: str) -> str:
+    digest = hashlib.sha256(test_id.encode("utf-8")).hexdigest()[:20]
+    return f"tests/{digest}.json"
+
+
+def build_range_summary(
+    test_rows: list[dict[str, Any]],
+    range_id: str,
+    label: str,
+    days: int | None,
+    latest_day: str | None,
+    generated_at: str,
+) -> dict[str, Any]:
+    rows = []
+    for row in test_rows:
+        segments = segments_for_range(row["segments"], latest_day, days)
+        summary_row = summary_row_for_segments(row, segments)
+        if summary_row:
+            rows.append(summary_row)
+
+    sort_rows(rows)
+    active_dates = unique_sorted(date for row in rows for date in row.get("active_dates", []))
+
+    return {
+        "schema_version": 2,
+        "generated_at": generated_at,
+        "range": {
+            "id": range_id,
+            "label": label,
+            "days": days,
+        },
+        "date_range": {
+            "first": min(active_dates) if active_dates else None,
+            "last": max(active_dates) if active_dates else None,
+            "days": active_dates,
+        },
+        "tests": rows,
+    }
+
+
+def segments_for_range(
+    segments: list[dict[str, Any]], latest_day: str | None, days: int | None
+) -> list[dict[str, Any]]:
+    if days is None or latest_day is None:
+        return segments
+
+    try:
+        latest = datetime.strptime(latest_day, "%Y-%m-%d").date()
+    except ValueError:
+        return segments
+
+    cutoff = (latest - timedelta(days=days - 1)).isoformat()
+    return [segment for segment in segments if cutoff <= segment.get("date", "") <= latest_day]
+
+
+def summary_row_for_segments(
+    row: dict[str, Any], segments: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    if not segments:
+        return None
+
+    total = sum_int(segments, "total")
+    passed = sum_int(segments, "passed")
+    failed = sum_int(segments, "failed")
+    errored = sum_int(segments, "errored")
+    skipped = sum_int(segments, "skipped")
+    total_time = sum_float(segments, "total_time")
+    failures = failed + errored
+    actionable = passed + failed + errored
+    failure_rate = failures / actionable if actionable else 0.0
+    last_segment = max(segments, key=lambda item: item.get("last_seen") or "")
+    failed_segments = [segment for segment in segments if segment.get("last_failed")]
+    last_failed_segment = (
+        max(failed_segments, key=lambda item: item.get("last_failed") or "")
+        if failed_segments
+        else None
+    )
+    recent = recent_from_segments(segments)
+    active_dates = unique_sorted(segment.get("date") for segment in segments)
+    active_workflows = unique_sorted(segment.get("workflow") for segment in segments)
+    active_variants = unique_sorted(segment.get("variant") for segment in segments)
+
+    return {
+        "id": row["id"],
+        "detail_file": row["detail_file"],
+        "suite": row["suite"],
+        "level": row["level"],
+        "classname": row["classname"],
+        "name": row["name"],
+        "display_name": row["display_name"],
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "errored": errored,
+        "skipped": skipped,
+        "failures": failures,
+        "failure_rate": round(failure_rate, 4),
+        "avg_time": round(total_time / total, 4) if total else 0.0,
+        "first_seen": min_present(segment.get("first_seen") for segment in segments),
+        "last_seen": last_segment.get("last_seen"),
+        "last_failed": last_failed_segment.get("last_failed") if last_failed_segment else None,
+        "last_failed_run_id": (
+            last_failed_segment.get("last_failed_run_id", "") if last_failed_segment else ""
+        ),
+        "last_failed_run_attempt": (
+            last_failed_segment.get("last_failed_run_attempt", "") if last_failed_segment else ""
+        ),
+        "last_failed_report": (
+            last_failed_segment.get("last_failed_report", "") if last_failed_segment else ""
+        ),
+        "last_status": last_segment.get("last_status", "unknown"),
+        "last_workflow": last_segment.get("workflow", ""),
+        "last_run_id": last_segment.get("last_run_id", ""),
+        "last_variant": last_segment.get("variant", ""),
+        "last_report": last_segment.get("last_report", ""),
+        "groups": row.get("groups", []),
+        "active_dates": active_dates,
+        "active_workflows": active_workflows,
+        "active_variants": active_variants,
+        "is_currently_failing": last_segment.get("last_status") in FAIL_STATUSES,
+        "is_flaky": failures > 0 and passed > 0,
+        "started_failing_in_sample": started_failing_in_sample(recent),
+    }
+
+
+def sum_int(rows: list[dict[str, Any]], key: str) -> int:
+    return sum(int(row.get(key) or 0) for row in rows)
+
+
+def sum_float(rows: list[dict[str, Any]], key: str) -> float:
+    return sum(float(row.get(key) or 0) for row in rows)
+
+
+def min_present(values: Any) -> str | None:
+    present = [value for value in values if value]
+    return min(present) if present else None
+
+
+def recent_from_segments(segments: list[dict[str, Any]]) -> list[dict[str, str]]:
+    recent = [
+        {
+            "status": str(segment.get("last_status", "unknown")),
+            "time": str(segment.get("last_seen", "")),
+        }
+        for segment in segments
+        if segment.get("last_seen")
+    ]
+    recent.sort(key=lambda item: item["time"])
+    return recent[-RECENT_LIMIT:]
+
+
+def unique_sorted(values: Any) -> list[str]:
+    return sorted({str(value) for value in values if value})
+
+
+def sort_rows(rows: list[dict[str, Any]]) -> None:
+    rows.sort(
         key=lambda item: (
             item["failures"],
             item["failure_rate"],
@@ -356,78 +538,6 @@ def main() -> int:
         ),
         reverse=True,
     )
-
-    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-    summary = {
-        "generated_at": generated_at,
-        "input_dir": str(input_dir),
-        "date_range": {
-            "first": min(dates) if dates else None,
-            "last": max(dates) if dates else None,
-            "days": sorted(dates),
-        },
-        "totals": {
-            "xml_files": len(xml_files),
-            "dashboard_json_files": len(dashboard_json_files),
-            "runs": len(run_keys),
-            "unique_tests": len(test_rows),
-            "test_occurrences": sum(tests_by_status.values()),
-            "reports_passed": reports_by_status["passed"],
-            "reports_failed": reports_by_status["failed"],
-            "parse_errors": len(parse_errors),
-            "passed": tests_by_status["passed"],
-            "failed": tests_by_status["failed"],
-            "errored": tests_by_status["error"],
-            "skipped": tests_by_status["skipped"],
-            "currently_failing": sum(1 for row in test_rows if row["is_currently_failing"]),
-            "flaky": sum(1 for row in test_rows if row["is_flaky"]),
-            "started_failing_in_sample": sum(
-                1 for row in test_rows if row["started_failing_in_sample"]
-            ),
-        },
-        "breakdowns": {
-            "by_suite": dict(sorted(by_suite.items())),
-            "by_level": dict(sorted(by_level.items())),
-            "by_workflow": dict(sorted(by_workflow.items())),
-            "by_variant": dict(sorted(by_variant.items())),
-            "tests_by_status": dict(sorted(tests_by_status.items())),
-        },
-        "facets": {
-            "dates": sorted(dates),
-            "workflows": sorted(by_workflow),
-            "variants": sorted(by_variant),
-        },
-        "tests": test_rows,
-        "parse_errors": parse_errors[:100],
-    }
-
-    output_json.parent.mkdir(parents=True, exist_ok=True)
-    output_json.write_text(json.dumps(summary, separators=(",", ":")), encoding="utf-8")
-    print(f"Wrote {output_json}")
-    print(
-        "Parsed "
-        f"{len(xml_files)} XML files and {len(dashboard_json_files)} dashboard JSON files, "
-        f"{summary['totals']['test_occurrences']} occurrences, "
-        f"{summary['totals']['unique_tests']} unique tests."
-    )
-    return 0
-
-
-def add_report_metadata(
-    meta: Metadata,
-    run_keys: set[str],
-    dates: set[str],
-    by_suite: Counter[str],
-    by_level: Counter[str],
-    by_workflow: Counter[str],
-    by_variant: Counter[str],
-) -> None:
-    run_keys.add("/".join([meta.workflow, meta.run_id, meta.attempt, meta.job, meta.variant]))
-    dates.add(meta.date)
-    by_suite[meta.suite] += 1
-    by_level[meta.level] += 1
-    by_workflow[meta.workflow] += 1
-    by_variant[meta.variant] += 1
 
 
 def add_test_record(
@@ -616,10 +726,18 @@ def metadata_for_dashboard_record(meta: Metadata, item: dict[str, Any]) -> Metad
         attempt=str(item.get("run_attempt") or meta.attempt),
         job=str(item.get("job") or meta.job),
         variant=str(item.get("variant") or meta.variant),
-        group=str(item.get("group") or item.get("binary") or meta.group),
+        group=dashboard_record_group(meta, item),
         report_name=source or meta.report_name,
         relative_path=relative_path,
     )
+
+
+def dashboard_record_group(meta: Metadata, item: dict[str, Any]) -> str:
+    group = str(item.get("group") or "")
+    binary = str(item.get("binary") or "")
+    if group and binary:
+        return f"{group}/{binary}"
+    return group or binary or meta.group
 
 
 def normalize_status(value: Any) -> str:
@@ -718,6 +836,10 @@ def message_from(element: ET.Element) -> str:
 
 
 def make_test_id(meta: Metadata, classname: str, name: str) -> str:
+    if meta.level == "gtest":
+        source = meta.group or meta.report_name
+        if source:
+            return f"{meta.suite}/{meta.level}/{source}/{classname}::{name}"
     return f"{meta.suite}/{meta.level}/{classname}::{name}"
 
 

--- a/tools/ci_test_dashboard/site/app.js
+++ b/tools/ci_test_dashboard/site/app.js
@@ -1,0 +1,703 @@
+const state = {
+  data: null,
+  suite: 'all',
+  view: 'often',
+  range: 'all',
+  date: 'all',
+  workflow: 'all',
+  variant: 'all',
+  search: '',
+  selectedId: null,
+};
+
+const suiteOptions = [
+  ['all', 'All'],
+  ['cpp', 'C++'],
+  ['regression', 'Pytest'],
+];
+
+const viewOptions = [
+  ['failing', 'Failing'],
+  ['recent', 'Recent Failures'],
+  ['often', 'Often Failing'],
+  ['flaky', 'Flaky'],
+  ['started', 'Started Failing'],
+  ['all', 'All Tests'],
+];
+
+const rangeOptions = [
+  ['all', 'All history'],
+  ['7', 'Last 7 days'],
+  ['14', 'Last 14 days'],
+  ['30', 'Last 30 days'],
+];
+
+const statusRank = {
+  failed: 4,
+  error: 3,
+  skipped: 2,
+  passed: 1,
+  unknown: 0,
+};
+
+const failStatuses = new Set(['failed', 'error']);
+const recentFailureDays = 7;
+
+async function boot() {
+  try {
+    const response = await fetch('data/summary.json', {cache: 'no-store'});
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    state.data = await response.json();
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    render();
+  } catch (error) {
+    document.getElementById('dataStatus').textContent = 'No data';
+    document.getElementById('subtitle').textContent =
+        'Run python3 build_dashboard.py tmp/junit-results site/data/summary.json';
+    document.getElementById('detailsPane').textContent = String(error);
+  }
+}
+
+function render() {
+  renderHeader();
+  renderMetrics();
+  renderFilters();
+  renderTable();
+  renderDetails();
+}
+
+function renderHeader() {
+  const {generated_at: generatedAt, date_range: dateRange} = state.data;
+  document.getElementById('subtitle').textContent = `Data ${dateRange.first ?? 'unknown'} to ${
+      dateRange.last ?? 'unknown'}; generated ${formatDateTime(generatedAt)}`;
+  document.getElementById('dataStatus').textContent = 'Ready';
+}
+
+function renderMetrics() {
+  const totals = summarizeRows(baseFilteredRows());
+  const metrics = [
+    ['Tests in slice', totals.unique_tests],
+    ['Occurrences', totals.total],
+    ['Currently failing', totals.currently_failing],
+    ['Flaky', totals.flaky],
+    ['Failed occurrences', totals.failures],
+    ['Skipped', totals.skipped],
+  ];
+
+  document.getElementById('metrics').innerHTML = metrics
+                                                     .map(
+                                                         ([label, value]) => `
+        <article class="metric">
+          <div class="label">${escapeHtml(label)}</div>
+          <div class="value">${formatNumber(value)}</div>
+        </article>
+      `,
+                                                         )
+                                                     .join('');
+}
+
+function renderFilters() {
+  renderSegmented('suiteFilter', suiteOptions, state.suite, (value) => {
+    state.suite = value;
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    render();
+  });
+
+  renderSegmented('viewFilter', viewOptions, state.view, (value) => {
+    state.view = value;
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    render();
+  });
+
+  const searchInput = document.getElementById('searchInput');
+  if (searchInput.value !== state.search) {
+    searchInput.value = state.search;
+  }
+  searchInput.oninput = () => {
+    state.search = searchInput.value;
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    renderTable();
+    renderDetails();
+  };
+
+  renderSelect('rangeFilter', rangeOptions, state.range, (value) => {
+    state.range = value;
+    state.date = 'all';
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    render();
+  });
+
+  renderSelect('dateFilter', facetOptions('dates', 'All dates'), state.date, (value) => {
+    state.date = value;
+    if (value !== 'all') {
+      state.range = 'all';
+    }
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    render();
+  });
+
+  renderSelect(
+      'workflowFilter',
+      facetOptions('workflows', 'All workflows'),
+      state.workflow,
+      (value) => {
+        state.workflow = value;
+        state.selectedId = firstVisibleTest()?.id ?? null;
+        render();
+      },
+  );
+
+  renderSelect(
+      'variantFilter',
+      facetOptions('variants', 'All variants'),
+      state.variant,
+      (value) => {
+        state.variant = value;
+        state.selectedId = firstVisibleTest()?.id ?? null;
+        render();
+      },
+  );
+
+  document.getElementById('resetFilters').onclick = () => {
+    state.suite = 'all';
+    state.view = 'often';
+    state.range = 'all';
+    state.date = 'all';
+    state.workflow = 'all';
+    state.variant = 'all';
+    state.search = '';
+    state.selectedId = firstVisibleTest()?.id ?? null;
+    render();
+  };
+}
+
+function renderSegmented(elementId, options, value, onChange) {
+  const element = document.getElementById(elementId);
+  element.innerHTML = options
+                          .map(
+                              ([optionValue, label]) => `
+        <button class="${optionValue === value ? 'active' : ''}" data-value="${
+                                  escapeHtml(optionValue)}">
+          ${escapeHtml(label)}
+        </button>
+      `,
+                              )
+                          .join('');
+
+  for (const button of element.querySelectorAll('button')) {
+    button.onclick = () => onChange(button.dataset.value);
+  }
+}
+
+function renderSelect(elementId, options, value, onChange) {
+  const element = document.getElementById(elementId);
+  element.innerHTML =
+      options
+          .map(
+              ([optionValue, label]) =>
+                  `<option value="${escapeHtml(optionValue)}">${escapeHtml(label)}</option>`,
+              )
+          .join('');
+  element.value = value;
+  element.onchange = () => onChange(element.value);
+}
+
+function facetOptions(name, allLabel) {
+  const values = state.data.facets?.[name] ?? [];
+  return [['all', allLabel], ...values.map((value) => [value, value])];
+}
+
+function renderTable() {
+  const tests = visibleTests();
+  document.getElementById('tableTitle').textContent = titleForView(state.view);
+  document.getElementById('tableCount').textContent = `${formatNumber(tests.length)} tests`;
+
+  const rows = tests.slice(0, 500).map((test) => {
+    const selected = test.id === state.selectedId ? 'selected' : '';
+    const status = test.last_status;
+    return `
+      <tr class="${selected}" data-id="${escapeHtml(test.id)}">
+        <td>
+          <div class="test-name">
+            <strong>${escapeHtml(test.display_name)}</strong>
+            <span>${escapeHtml(test.classname)}</span>
+          </div>
+        </td>
+        <td><span class="badge ${escapeHtml(status)}">${escapeHtml(status)}</span></td>
+        <td>${formatNumber(test.failures)}</td>
+        <td>${escapeHtml(formatShortDateTime(test.last_failed, 'never'))}</td>
+        <td>${escapeHtml(formatShortDateTime(test.last_seen, 'unknown'))}</td>
+        <td>${escapeHtml(test.suite)} / ${escapeHtml(test.level)}</td>
+        <td>${formatPercent(test.failure_rate)}</td>
+        <td>${formatNumber(test.total)}</td>
+        <td>${formatDuration(test.avg_time)}</td>
+      </tr>
+    `;
+  });
+
+  document.getElementById('testRows').innerHTML = rows.join('');
+  for (const row of document.querySelectorAll('#testRows tr')) {
+    row.onclick = () => {
+      state.selectedId = row.dataset.id;
+      renderTable();
+      renderDetails();
+    };
+  }
+}
+
+function renderDetails() {
+  const pane = document.getElementById('detailsPane');
+  const source = state.data.tests.find((item) => item.id === state.selectedId);
+  const test = source ? deriveRow(source) : null;
+  if (!test) {
+    pane.className = 'empty-state';
+    pane.textContent = 'Select a test row.';
+    return;
+  }
+
+  pane.className = '';
+  pane.innerHTML = `
+    <div class="detail-title">
+      <strong>${escapeHtml(test.display_name)}</strong>
+      <span class="badge ${escapeHtml(test.last_status)}">${escapeHtml(test.last_status)}</span>
+    </div>
+
+    <div class="kv">
+      <span>Suite</span><span>${escapeHtml(test.suite)} / ${escapeHtml(test.level)}</span>
+      <span>Failures</span><span>${formatNumber(test.failures)} of ${formatNumber(test.total)} (${
+      formatPercent(test.failure_rate)})</span>
+      <span>Last failed</span><span>${escapeHtml(formatDateTime(test.last_failed, 'never'))}</span>
+      <span>Last seen</span><span>${escapeHtml(formatDateTime(test.last_seen))}</span>
+      <span>Workflow</span><span>${escapeHtml(test.last_workflow)}</span>
+      <span>Run</span><span>${runLink(test.last_run_id)}</span>
+      <span>Variant</span><span>${escapeHtml(test.last_variant)}</span>
+      <span>Report</span><span>${escapeHtml(test.last_report || 'unknown')}</span>
+    </div>
+
+    ${chips('Groups', test.groups)}
+    ${chips('Dates', test.active_dates)}
+    ${chips('Workflows', test.active_workflows)}
+    ${chips('Variants', test.active_variants)}
+    ${failureRuns(test.failure_runs)}
+    ${history(test.recent)}
+    ${failureExamples(test.failure_examples)}
+  `;
+}
+
+function chips(label, values) {
+  if (!values || values.length === 0) {
+    return '';
+  }
+  return `
+    <section>
+      <h2>${escapeHtml(label)}</h2>
+      <div class="chips">
+        ${values.map((value) => `<span class="chip">${escapeHtml(value)}</span>`).join('')}
+      </div>
+    </section>
+  `;
+}
+
+function history(recent) {
+  if (!recent || recent.length === 0) {
+    return '';
+  }
+  return `
+    <section>
+      <h2>Recent History</h2>
+      <div class="history">
+        ${
+      recent
+          .map(
+              (item) => `<span class="dot ${escapeHtml(item.status)}" title="${
+                  escapeHtml(item.label ?? item.status)} ${
+                  escapeHtml(formatDateTime(item.time))}"></span>`,
+              )
+          .join('')}
+      </div>
+    </section>
+  `;
+}
+
+function failureExamples(examples) {
+  if (!examples || examples.length === 0) {
+    return '';
+  }
+  return `
+    <section>
+      <h2>Failure Examples</h2>
+      ${
+      examples
+          .map(
+              (example) => `
+            <div class="failure-example">
+              <div class="failure-meta">
+                <strong>${escapeHtml(formatDateTime(example.time))}</strong>
+                ${runLink(example.run_id)}
+              </div>
+              <code>${escapeHtml(example.message)}</code>
+            </div>
+          `,
+              )
+          .join('')}
+    </section>
+  `;
+}
+
+function failureRuns(runs) {
+  if (!runs || runs.length === 0) {
+    return '';
+  }
+  return `
+    <section>
+      <h2>Failure Runs</h2>
+      <div class="failure-runs">
+        ${
+      runs.map(
+              (run) => `
+              <div class="failure-run">
+                ${runLink(run.run_id, `Run ${run.run_id}`)}
+                <span>${escapeHtml(formatShortDateTime(run.time))} · ${
+                  escapeHtml(run.workflow)}</span>
+                <span>${escapeHtml(run.variant)} · ${formatNumber(run.failures)} ${
+                  run.failures === 1 ? 'failure' : 'failures'}</span>
+              </div>
+            `,
+              )
+          .join('')}
+      </div>
+    </section>
+  `;
+}
+
+function visibleTests() {
+  const query = state.search.trim().toLowerCase();
+  return baseFilteredRows()
+      .filter((test) => viewPredicate(test, state.view))
+      .filter((test) => {
+        if (!query) {
+          return true;
+        }
+        return [
+          test.display_name,
+          test.classname,
+          test.name,
+          test.suite,
+          test.level,
+          test.last_workflow,
+          test.last_variant,
+          ...(test.filters?.workflows ?? []),
+          ...(test.filters?.variants ?? []),
+        ].join(' ')
+            .toLowerCase()
+            .includes(query);
+      })
+      .sort(sortForView(state.view));
+}
+
+function baseFilteredRows() {
+  return state.data.tests.filter((test) => state.suite === 'all' || test.suite === state.suite)
+      .map(deriveRow)
+      .filter(Boolean);
+}
+
+function deriveRow(test) {
+  const segments = (test.segments ?? []).filter(segmentMatches);
+  if (segments.length === 0) {
+    return null;
+  }
+
+  let total = 0;
+  let passed = 0;
+  let failed = 0;
+  let errored = 0;
+  let skipped = 0;
+  let totalTime = 0;
+  let firstSeen = null;
+  let lastFailed = null;
+  let lastFailedSegment = null;
+  let lastSegment = null;
+
+  for (const segment of segments) {
+    total += segment.total;
+    passed += segment.passed;
+    failed += segment.failed;
+    errored += segment.errored;
+    skipped += segment.skipped;
+    totalTime += segment.total_time;
+
+    if (!firstSeen || segment.first_seen < firstSeen) {
+      firstSeen = segment.first_seen;
+    }
+    if (segment.last_failed && (!lastFailed || segment.last_failed >= lastFailed)) {
+      lastFailed = segment.last_failed;
+      lastFailedSegment = segment;
+    }
+    if (!lastSegment || segment.last_seen >= lastSegment.last_seen) {
+      lastSegment = segment;
+    }
+  }
+
+  const failures = failed + errored;
+  const actionable = passed + failed + errored;
+  const failureRate = actionable ? failures / actionable : 0;
+  const recent = segments
+                     .map((segment) => ({
+                            status: segment.last_status,
+                            time: segment.last_seen,
+                            label: `${segment.last_status} ${segment.workflow} ${segment.variant}`,
+                          }))
+                     .sort((left, right) => left.time.localeCompare(right.time))
+                     .slice(-12);
+  const failureRuns = failureRunsFromSegments(segments);
+
+  return {
+    ...test,
+    total,
+    passed,
+    failed,
+    errored,
+    skipped,
+    failures,
+    failure_rate: failureRate,
+    avg_time: total ? totalTime / total : 0,
+    first_seen: firstSeen,
+    last_seen: lastSegment?.last_seen ?? null,
+    last_failed: lastFailed,
+    last_failed_run_id: lastFailedSegment?.last_failed_run_id ?? '',
+    last_failed_run_attempt: lastFailedSegment?.last_failed_run_attempt ?? '',
+    last_failed_report: lastFailedSegment?.last_failed_report ?? '',
+    last_status: lastSegment?.last_status ?? 'unknown',
+    last_workflow: lastSegment?.workflow ?? '',
+    last_run_id: lastSegment?.last_run_id ?? '',
+    last_variant: lastSegment?.variant ?? '',
+    last_report: lastSegment?.last_report ?? '',
+    is_currently_failing: failStatuses.has(lastSegment?.last_status),
+    is_flaky: failures > 0 && passed > 0,
+    started_failing_in_sample: startedFailingInHistory(recent),
+    recent,
+    failure_runs: failureRuns,
+    active_dates: uniqueSorted(segments.map((segment) => segment.date)),
+    active_workflows: uniqueSorted(segments.map((segment) => segment.workflow)),
+    active_variants: uniqueSorted(segments.map((segment) => segment.variant)),
+  };
+}
+
+function failureRunsFromSegments(segments) {
+  return segments.filter((segment) => segment.last_failed)
+      .map((segment) => ({
+             time: segment.last_failed,
+             workflow: segment.workflow,
+             run_id: segment.last_failed_run_id,
+             run_attempt: segment.last_failed_run_attempt,
+             variant: segment.variant,
+             report: segment.last_failed_report,
+             failures: (segment.failed ?? 0) + (segment.errored ?? 0),
+           }))
+      .sort((left, right) => compareNullableDates(right.time, left.time))
+      .slice(0, 20);
+}
+
+function segmentMatches(segment) {
+  return (
+      rangeMatches(segment.date) && (state.date === 'all' || segment.date === state.date) &&
+      (state.workflow === 'all' || segment.workflow === state.workflow) &&
+      (state.variant === 'all' || segment.variant === state.variant));
+}
+
+function rangeMatches(dateValue) {
+  if (state.range === 'all' || state.date !== 'all') {
+    return true;
+  }
+  const days = Number.parseInt(state.range, 10);
+  if (!Number.isFinite(days)) {
+    return true;
+  }
+  const latestDay = state.data.date_range?.last;
+  if (!latestDay) {
+    return true;
+  }
+  const latest = new Date(`${latestDay}T00:00:00Z`);
+  const cutoff = new Date(latest);
+  cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1));
+  const current = new Date(`${dateValue}T00:00:00Z`);
+  return current >= cutoff && current <= latest;
+}
+
+function summarizeRows(rows) {
+  return rows.reduce(
+      (totals, row) => {
+        totals.unique_tests += 1;
+        totals.total += row.total;
+        totals.failures += row.failures;
+        totals.skipped += row.skipped;
+        if (row.is_currently_failing) {
+          totals.currently_failing += 1;
+        }
+        if (row.is_flaky) {
+          totals.flaky += 1;
+        }
+        return totals;
+      },
+      {
+        unique_tests: 0,
+        total: 0,
+        failures: 0,
+        skipped: 0,
+        currently_failing: 0,
+        flaky: 0,
+      },
+  );
+}
+
+function startedFailingInHistory(recent) {
+  if (recent.length < 4) {
+    return false;
+  }
+  const split = Math.max(1, Math.floor(recent.length * 0.7));
+  const earlier = recent.slice(0, split);
+  const later = recent.slice(split);
+  return (
+      earlier.every((item) => !failStatuses.has(item.status)) &&
+      later.some((item) => failStatuses.has(item.status)));
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function firstVisibleTest() {
+  return visibleTests()[0] ?? null;
+}
+
+function viewPredicate(test, view) {
+  if (view === 'failing') {
+    return test.is_currently_failing;
+  }
+  if (view === 'often') {
+    return test.failures > 0;
+  }
+  if (view === 'recent') {
+    return test.failures > 0 && isRecentFailure(test.last_failed);
+  }
+  if (view === 'flaky') {
+    return test.is_flaky;
+  }
+  if (view === 'started') {
+    return test.started_failing_in_sample;
+  }
+  return true;
+}
+
+function sortForView(view) {
+  return (left, right) => {
+    if (view === 'recent') {
+      return (
+          compareNullableDates(right.last_failed, left.last_failed) ||
+          right.failures - left.failures || right.failure_rate - left.failure_rate ||
+          left.display_name.localeCompare(right.display_name));
+    }
+    if (view === 'all') {
+      return (
+          statusRank[right.last_status] - statusRank[left.last_status] ||
+          right.failures - left.failures || right.total - left.total ||
+          left.display_name.localeCompare(right.display_name));
+    }
+    return (
+        right.failures - left.failures || right.failure_rate - left.failure_rate ||
+        right.total - left.total || left.display_name.localeCompare(right.display_name));
+  };
+}
+
+function isRecentFailure(value) {
+  if (!value) {
+    return false;
+  }
+  const latestDay = state.data.date_range?.last;
+  if (!latestDay) {
+    return true;
+  }
+  const latest = new Date(`${latestDay}T23:59:59Z`);
+  const cutoff = new Date(latest);
+  cutoff.setUTCDate(cutoff.getUTCDate() - (recentFailureDays - 1));
+  return new Date(value) >= cutoff;
+}
+
+function compareNullableDates(left, right) {
+  if (!left && !right) {
+    return 0;
+  }
+  if (!left) {
+    return -1;
+  }
+  if (!right) {
+    return 1;
+  }
+  return left.localeCompare(right);
+}
+
+function runLink(runId, label = runId) {
+  if (!runId) {
+    return 'unknown';
+  }
+  const href = `https://github.com/dragonflydb/dragonfly/actions/runs/${encodeURIComponent(runId)}`;
+  return `<a href="${href}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+}
+
+function titleForView(view) {
+  const option = viewOptions.find(([value]) => value === view);
+  return option ? option[1] : 'Tests';
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat().format(value ?? 0);
+}
+
+function formatPercent(value) {
+  return `${Math.round((value ?? 0) * 1000) / 10}%`;
+}
+
+function formatDuration(seconds) {
+  if (!seconds) {
+    return '0s';
+  }
+  if (seconds < 1) {
+    return `${Math.round(seconds * 1000)}ms`;
+  }
+  return `${Math.round(seconds * 10) / 10}s`;
+}
+
+function formatDateTime(value, fallback = 'unknown') {
+  if (!value) {
+    return fallback;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toISOString().replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+}
+
+function formatShortDateTime(value, fallback = 'unknown') {
+  if (!value) {
+    return fallback;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toISOString().slice(0, 16).replace('T', ' ');
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll('\'', '&#039;');
+}
+
+boot();

--- a/tools/ci_test_dashboard/site/app.js
+++ b/tools/ci_test_dashboard/site/app.js
@@ -45,7 +45,7 @@ const recentFailureDays = 7;
 
 async function boot() {
   try {
-    const response = await fetch('data/summary.json', {cache: 'no-store'});
+    const response = await fetch('data/summary.json');
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }

--- a/tools/ci_test_dashboard/site/app.js
+++ b/tools/ci_test_dashboard/site/app.js
@@ -1,13 +1,13 @@
 const state = {
+  manifest: null,
   data: null,
   suite: 'all',
   view: 'often',
-  range: 'all',
-  date: 'all',
-  workflow: 'all',
-  variant: 'all',
+  range: '30',
   search: '',
   selectedId: null,
+  detailCache: new Map(),
+  detailErrors: new Map(),
 };
 
 const suiteOptions = [
@@ -25,7 +25,7 @@ const viewOptions = [
   ['all', 'All Tests'],
 ];
 
-const rangeOptions = [
+let rangeOptions = [
   ['all', 'All history'],
   ['7', 'Last 7 days'],
   ['14', 'Last 14 days'],
@@ -45,19 +45,60 @@ const recentFailureDays = 7;
 
 async function boot() {
   try {
-    const response = await fetch('data/summary.json');
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    state.data = await response.json();
-    state.selectedId = firstVisibleTest()?.id ?? null;
+    state.manifest = await fetchJson('data/manifest.json');
+    rangeOptions = rangesFromManifest(state.manifest);
+    state.range = state.manifest.default_range ?? rangeOptions[0]?.[0] ?? 'all';
+    await loadRange(state.range, false);
     render();
   } catch (error) {
     document.getElementById('dataStatus').textContent = 'No data';
     document.getElementById('subtitle').textContent =
-        'Run python3 build_dashboard.py tmp/junit-results site/data/summary.json';
+        'Run python3 build_dashboard.py tmp/junit-results site/data';
     document.getElementById('detailsPane').textContent = String(error);
   }
+}
+
+async function fetchJson(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`${path}: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function rangesFromManifest(manifest) {
+  const ranges = manifest.ranges ?? [];
+  if (ranges.length === 0) {
+    return rangeOptions;
+  }
+  return ranges.map((range) => [range.id, range.label]);
+}
+
+async function loadRange(rangeId, shouldRender = true) {
+  const range = rangeFile(rangeId);
+  document.getElementById('dataStatus').textContent = 'Loading';
+  state.data = await fetchJson(`data/${range.file}`);
+  state.range = range.id;
+  state.selectedId = currentSelectionInData() ? state.selectedId : firstVisibleTest()?.id ?? null;
+  if (shouldRender) {
+    render();
+  }
+}
+
+function rangeFile(rangeId) {
+  const ranges = state.manifest?.ranges ?? [];
+  return ranges.find((item) => item.id === rangeId) ?? ranges[0] ??
+      {id: 'all', file: 'ranges/all.json'};
+}
+
+function currentSelectionInData() {
+  return state.selectedId && state.data?.tests?.some((item) => item.id === state.selectedId);
+}
+
+function showDataError(error) {
+  document.getElementById('dataStatus').textContent = 'Error';
+  document.getElementById('detailsPane').className = 'empty-state';
+  document.getElementById('detailsPane').textContent = String(error);
 }
 
 function render() {
@@ -123,53 +164,14 @@ function renderFilters() {
   };
 
   renderSelect('rangeFilter', rangeOptions, state.range, (value) => {
-    state.range = value;
-    state.date = 'all';
-    state.selectedId = firstVisibleTest()?.id ?? null;
-    render();
+    loadRange(value).catch(showDataError);
   });
-
-  renderSelect('dateFilter', facetOptions('dates', 'All dates'), state.date, (value) => {
-    state.date = value;
-    if (value !== 'all') {
-      state.range = 'all';
-    }
-    state.selectedId = firstVisibleTest()?.id ?? null;
-    render();
-  });
-
-  renderSelect(
-      'workflowFilter',
-      facetOptions('workflows', 'All workflows'),
-      state.workflow,
-      (value) => {
-        state.workflow = value;
-        state.selectedId = firstVisibleTest()?.id ?? null;
-        render();
-      },
-  );
-
-  renderSelect(
-      'variantFilter',
-      facetOptions('variants', 'All variants'),
-      state.variant,
-      (value) => {
-        state.variant = value;
-        state.selectedId = firstVisibleTest()?.id ?? null;
-        render();
-      },
-  );
 
   document.getElementById('resetFilters').onclick = () => {
     state.suite = 'all';
     state.view = 'often';
-    state.range = 'all';
-    state.date = 'all';
-    state.workflow = 'all';
-    state.variant = 'all';
     state.search = '';
-    state.selectedId = firstVisibleTest()?.id ?? null;
-    render();
+    loadRange(state.manifest?.default_range ?? '30').catch(showDataError);
   };
 }
 
@@ -202,11 +204,6 @@ function renderSelect(elementId, options, value, onChange) {
           .join('');
   element.value = value;
   element.onchange = () => onChange(element.value);
-}
-
-function facetOptions(name, allLabel) {
-  const values = state.data.facets?.[name] ?? [];
-  return [['all', allLabel], ...values.map((value) => [value, value])];
 }
 
 function renderTable() {
@@ -250,7 +247,10 @@ function renderTable() {
 function renderDetails() {
   const pane = document.getElementById('detailsPane');
   const source = state.data.tests.find((item) => item.id === state.selectedId);
-  const test = source ? deriveRow(source) : null;
+  const detail = source ? state.detailCache.get(source.id) : null;
+  const detailError = source ? state.detailErrors.get(source.id) : null;
+  const needsDetail = Boolean(source?.detail_file && !detail && !detailError);
+  const test = source ? deriveRow(detailForSelectedRange(source, detail)) : null;
   if (!test) {
     pane.className = 'empty-state';
     pane.textContent = 'Select a test row.';
@@ -280,10 +280,85 @@ function renderDetails() {
     ${chips('Dates', test.active_dates)}
     ${chips('Workflows', test.active_workflows)}
     ${chips('Variants', test.active_variants)}
+    ${detailLoading(needsDetail)}
+    ${detailLoadError(detailError)}
     ${failureRuns(test.failure_runs)}
     ${history(test.recent)}
     ${failureExamples(test.failure_examples)}
   `;
+
+  if (needsDetail) {
+    loadTestDetail(source)
+        .then(() => {
+          if (state.selectedId === source.id) {
+            renderDetails();
+          }
+        })
+        .catch((error) => {
+          state.detailErrors.set(source.id, error);
+          if (state.selectedId === source.id) {
+            renderDetails();
+          }
+        });
+  }
+}
+
+function detailLoading(isLoading) {
+  if (!isLoading) {
+    return '';
+  }
+  return '<section class="empty-state">Loading details...</section>';
+}
+
+function detailLoadError(error) {
+  if (!error) {
+    return '';
+  }
+  return `<section class="empty-state">${escapeHtml(String(error))}</section>`;
+}
+
+async function loadTestDetail(test) {
+  if (!test.detail_file || state.detailCache.has(test.id)) {
+    return;
+  }
+  const detail = await fetchJson(`data/${test.detail_file}`);
+  state.detailCache.set(test.id, detail);
+}
+
+function detailForSelectedRange(source, detail) {
+  if (!detail) {
+    return source;
+  }
+
+  const activeDates = activeDateSet(source);
+  const segments = Array.isArray(detail.segments) ?
+      detail.segments.filter((segment) => inActiveDateSet(activeDates, segment.date)) :
+      [];
+  const failureExamples = Array.isArray(detail.failure_examples) ?
+      detail.failure_examples.filter(
+          (example) => inActiveDateSet(activeDates, datePart(example.time))) :
+      [];
+
+  return {
+    ...source,
+    ...detail,
+    segments,
+    failure_examples: failureExamples,
+  };
+}
+
+function activeDateSet(source) {
+  const dates = source.active_dates ?? state.data?.date_range?.days ?? [];
+  return new Set(dates.filter(Boolean));
+}
+
+function inActiveDateSet(activeDates, date) {
+  return activeDates.size === 0 || activeDates.has(date);
+}
+
+function datePart(value) {
+  const match = String(value ?? '').match(/^(\d{4}-\d{2}-\d{2})/);
+  return match ? match[1] : '';
 }
 
 function chips(label, values) {
@@ -388,8 +463,8 @@ function visibleTests() {
           test.level,
           test.last_workflow,
           test.last_variant,
-          ...(test.filters?.workflows ?? []),
-          ...(test.filters?.variants ?? []),
+          ...(test.active_workflows ?? []),
+          ...(test.active_variants ?? []),
         ].join(' ')
             .toLowerCase()
             .includes(query);
@@ -398,13 +473,18 @@ function visibleTests() {
 }
 
 function baseFilteredRows() {
-  return state.data.tests.filter((test) => state.suite === 'all' || test.suite === state.suite)
+  return (state.data?.tests ?? [])
+      .filter((test) => state.suite === 'all' || test.suite === state.suite)
       .map(deriveRow)
       .filter(Boolean);
 }
 
 function deriveRow(test) {
-  const segments = (test.segments ?? []).filter(segmentMatches);
+  if (!test.segments) {
+    return normalizedSummaryRow(test);
+  }
+
+  const segments = test.segments;
   if (segments.length === 0) {
     return null;
   }
@@ -485,6 +565,15 @@ function deriveRow(test) {
   };
 }
 
+function normalizedSummaryRow(test) {
+  return {
+    ...test,
+    active_dates: test.active_dates ?? [],
+    active_workflows: test.active_workflows ?? [],
+    active_variants: test.active_variants ?? [],
+  };
+}
+
 function failureRunsFromSegments(segments) {
   return segments.filter((segment) => segment.last_failed)
       .map((segment) => ({
@@ -498,32 +587,6 @@ function failureRunsFromSegments(segments) {
            }))
       .sort((left, right) => compareNullableDates(right.time, left.time))
       .slice(0, 20);
-}
-
-function segmentMatches(segment) {
-  return (
-      rangeMatches(segment.date) && (state.date === 'all' || segment.date === state.date) &&
-      (state.workflow === 'all' || segment.workflow === state.workflow) &&
-      (state.variant === 'all' || segment.variant === state.variant));
-}
-
-function rangeMatches(dateValue) {
-  if (state.range === 'all' || state.date !== 'all') {
-    return true;
-  }
-  const days = Number.parseInt(state.range, 10);
-  if (!Number.isFinite(days)) {
-    return true;
-  }
-  const latestDay = state.data.date_range?.last;
-  if (!latestDay) {
-    return true;
-  }
-  const latest = new Date(`${latestDay}T00:00:00Z`);
-  const cutoff = new Date(latest);
-  cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1));
-  const current = new Date(`${dateValue}T00:00:00Z`);
-  return current >= cutoff && current <= latest;
 }
 
 function summarizeRows(rows) {

--- a/tools/ci_test_dashboard/site/app.js
+++ b/tools/ci_test_dashboard/site/app.js
@@ -52,8 +52,6 @@ async function boot() {
     render();
   } catch (error) {
     document.getElementById('dataStatus').textContent = 'No data';
-    document.getElementById('subtitle').textContent =
-        'Run python3 build_dashboard.py tmp/junit-results site/data';
     document.getElementById('detailsPane').textContent = String(error);
   }
 }

--- a/tools/ci_test_dashboard/site/index.html
+++ b/tools/ci_test_dashboard/site/index.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dragonfly CI Test Dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <h1>Dragonfly CI Test Dashboard</h1>
+        <p id="subtitle">Loading test results...</p>
+      </div>
+      <div class="status-pill" id="dataStatus">Loading</div>
+    </header>
+
+    <main>
+      <section class="metrics" id="metrics"></section>
+
+      <section class="toolbar" aria-label="Filters">
+        <div class="search-box">
+          <label for="searchInput">Search</label>
+          <input id="searchInput" type="search" placeholder="test name, class, workflow" />
+        </div>
+
+        <div class="control-group">
+          <span>Suite</span>
+          <div class="segmented" id="suiteFilter"></div>
+        </div>
+
+        <div class="control-group">
+          <span>View</span>
+          <div class="segmented" id="viewFilter"></div>
+        </div>
+      </section>
+
+      <section class="toolbar filter-toolbar" aria-label="Run filters">
+        <div class="control-group">
+          <label for="rangeFilter">Range</label>
+          <select id="rangeFilter"></select>
+        </div>
+
+        <div class="control-group">
+          <label for="dateFilter">Date</label>
+          <select id="dateFilter"></select>
+        </div>
+
+        <div class="control-group">
+          <label for="workflowFilter">Workflow</label>
+          <select id="workflowFilter"></select>
+        </div>
+
+        <div class="control-group">
+          <label for="variantFilter">Variant</label>
+          <select id="variantFilter"></select>
+        </div>
+
+        <button class="secondary-button" id="resetFilters" type="button">Reset</button>
+      </section>
+
+      <section class="content-grid">
+        <section class="panel">
+          <div class="panel-header">
+            <h2 id="tableTitle">Tests</h2>
+            <span id="tableCount"></span>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Test</th>
+                  <th>Status</th>
+                  <th>Failures</th>
+                  <th>Last Failed</th>
+                  <th>Last Seen</th>
+                  <th>Suite</th>
+                  <th>Rate</th>
+                  <th>Runs</th>
+                  <th>Avg Time</th>
+                </tr>
+              </thead>
+              <tbody id="testRows"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <aside class="panel details">
+          <div class="panel-header">
+            <h2>Selected</h2>
+          </div>
+          <div id="detailsPane" class="empty-state">Select a test row.</div>
+        </aside>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tools/ci_test_dashboard/site/index.html
+++ b/tools/ci_test_dashboard/site/index.html
@@ -41,21 +41,6 @@
           <select id="rangeFilter"></select>
         </div>
 
-        <div class="control-group">
-          <label for="dateFilter">Date</label>
-          <select id="dateFilter"></select>
-        </div>
-
-        <div class="control-group">
-          <label for="workflowFilter">Workflow</label>
-          <select id="workflowFilter"></select>
-        </div>
-
-        <div class="control-group">
-          <label for="variantFilter">Variant</label>
-          <select id="variantFilter"></select>
-        </div>
-
         <button class="secondary-button" id="resetFilters" type="button">Reset</button>
       </section>
 

--- a/tools/ci_test_dashboard/site/styles.css
+++ b/tools/ci_test_dashboard/site/styles.css
@@ -1,0 +1,489 @@
+:root {
+  --bg: #f6f7f4;
+  --panel: #ffffff;
+  --ink: #202322;
+  --muted: #68706d;
+  --line: #d9ded9;
+  --accent: #136f63;
+  --accent-ink: #ffffff;
+  --warn: #a45112;
+  --bad: #b42318;
+  --bad-bg: #fff1ee;
+  --skip: #616b75;
+  --good: #177245;
+  --good-bg: #edf8f2;
+  --shadow: 0 1px 2px rgba(25, 31, 28, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.topbar {
+  align-items: center;
+  background: #20312f;
+  color: #f8fbf8;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  padding: 24px 32px;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 28px;
+  font-weight: 720;
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+#subtitle {
+  color: #c9d4d1;
+  margin-top: 8px;
+}
+
+.status-pill {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 999px;
+  color: #f8fbf8;
+  padding: 8px 12px;
+  white-space: nowrap;
+}
+
+main {
+  display: grid;
+  gap: 16px;
+  padding: 20px 32px 32px;
+}
+
+.metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(6, minmax(120px, 1fr));
+}
+
+.metric {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  min-height: 88px;
+  padding: 14px;
+}
+
+.metric .label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.metric .value {
+  font-size: 26px;
+  font-weight: 760;
+  margin-top: 10px;
+}
+
+.toolbar,
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.toolbar {
+  align-items: end;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(260px, 1fr) auto auto;
+  padding: 14px;
+}
+
+.search-box,
+.control-group {
+  display: grid;
+  gap: 8px;
+}
+
+label,
+.control-group > span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+input[type="search"] {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  min-height: 38px;
+  min-width: 0;
+  padding: 8px 10px;
+  width: 100%;
+}
+
+select {
+  background: #ffffff;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  min-height: 38px;
+  min-width: 180px;
+  padding: 8px 10px;
+  width: 100%;
+}
+
+.filter-toolbar {
+  grid-template-columns:
+    minmax(150px, 0.7fr) minmax(160px, 0.7fr) minmax(220px, 1fr)
+    minmax(260px, 1.4fr) auto;
+}
+
+.secondary-button {
+  background: #ffffff;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  cursor: pointer;
+  min-height: 38px;
+  padding: 8px 12px;
+}
+
+.secondary-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.segmented {
+  background: #eef1ed;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  display: flex;
+  padding: 3px;
+}
+
+.segmented button {
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  color: var(--muted);
+  cursor: pointer;
+  min-height: 30px;
+  padding: 5px 10px;
+  white-space: nowrap;
+}
+
+.segmented button.active {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.content-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(460px, 34vw);
+}
+
+.panel {
+  min-width: 0;
+}
+
+.panel-header {
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  min-height: 52px;
+  padding: 14px 16px;
+}
+
+#tableCount {
+  color: var(--muted);
+}
+
+.table-wrap {
+  max-height: calc(100vh - 318px);
+  min-height: 420px;
+  overflow: auto;
+}
+
+table {
+  border-collapse: collapse;
+  min-width: 1040px;
+  width: 100%;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--line);
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #f8faf7;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  position: sticky;
+  text-transform: uppercase;
+  top: 0;
+  z-index: 1;
+}
+
+tbody tr {
+  cursor: pointer;
+}
+
+tbody tr:hover,
+tbody tr.selected {
+  background: #f0f6f4;
+}
+
+.test-name {
+  display: grid;
+  gap: 4px;
+  min-width: 260px;
+}
+
+.test-name strong {
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.test-name span {
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.badge {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 8px;
+  white-space: nowrap;
+}
+
+.badge.passed {
+  background: var(--good-bg);
+  color: var(--good);
+}
+
+.badge.failed,
+.badge.error {
+  background: var(--bad-bg);
+  color: var(--bad);
+}
+
+.badge.skipped {
+  background: #eef0f2;
+  color: var(--skip);
+}
+
+.details {
+  align-self: start;
+  max-height: calc(100vh - 220px);
+  overflow: auto;
+}
+
+#detailsPane {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.empty-state {
+  color: var(--muted);
+}
+
+.detail-title {
+  display: grid;
+  gap: 6px;
+}
+
+.detail-title strong {
+  overflow-wrap: anywhere;
+}
+
+.kv {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 110px 1fr;
+}
+
+.kv span:nth-child(odd) {
+  color: var(--muted);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  background: #eef1ed;
+  border-radius: 999px;
+  color: #35413e;
+  padding: 4px 8px;
+}
+
+.history {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.dot {
+  border-radius: 3px;
+  height: 18px;
+  width: 18px;
+}
+
+.dot.passed {
+  background: var(--good);
+}
+
+.dot.failed,
+.dot.error {
+  background: var(--bad);
+}
+
+.dot.skipped {
+  background: #9aa3a9;
+}
+
+.failure-example {
+  background: #fff8f5;
+  border: 1px solid #f2d2c7;
+  border-radius: 8px;
+  color: #613124;
+  padding: 10px;
+}
+
+.failure-runs {
+  display: grid;
+  gap: 8px;
+}
+
+.failure-run {
+  background: #fbfcfa;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: grid;
+  gap: 5px;
+  padding: 10px;
+}
+
+.failure-run a,
+.failure-run span {
+  display: block;
+}
+
+.failure-run a {
+  font-weight: 700;
+}
+
+.failure-run span {
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.failure-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.failure-example code {
+  display: block;
+  margin-top: 6px;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 1100px) {
+  .metrics {
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .details {
+    max-height: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    align-items: start;
+    flex-direction: column;
+    padding: 20px;
+  }
+
+  main {
+    padding: 14px;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .segmented {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
- Add static CI test dashboard under tools/ci_test_dashboard.
- Add github job to rebuild the dashboard from CI test results (which are already uploaed by existing jobs). runs once per day
- Publish dashboard to S3 with generated JSON as db, as a static website
- Split json db into range summaries and lazy test detail JSON.

The main addition is the python script to build dashboard. It downloads and recursively reads test result dirs, and then creates JSON files which can be used by the javascript in the UI to render the table etc.

It is used in the workflow and then the static site data is copied to the S3 bucket from where the dashboard is served.

---

For reviewers: the UI part, single file html, css and js are AI generated frontend, they form the bulk of the LOC in PR. The main part is the workflow and the python script.

--- 

There are limitations due to static website, currently we are only showing the last 30 days of data. We do store the data itself forever, so this is just a UI limitation. When/if we require to see more historical data, we can make changes for that.