### PR TITLE
fix(rdb): validate stream listpack field counts on load to prevent OOB walk

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -91,6 +91,12 @@ int64_t LpGetIntegerIfValid(unsigned char* ele, int* valid) {
 }
 
 // Returns 1 if the stream listpack entries structure is valid, 0 otherwise.
+// Beyond the structural listpack check, it verifies the stream master entry and every
+// record are internally consistent - in particular that the declared field and record
+// counts match the entries actually present - so that later stream iteration cannot walk
+// past the listpack end. Mirrors upstream streamValidateListpackIntegrity. The semantic
+// walk runs regardless of `deep`: on a no-auth deployment an attacker can point the server
+// at a hostile master via REPLICAOF, so the replication load path is not trusted either.
 int StreamValidateListpackIntegrity(unsigned char* lp, size_t size, int deep) {
   int valid_record;
   unsigned char *p, *next;
@@ -104,26 +110,121 @@ int StreamValidateListpackIntegrity(unsigned char* lp, size_t size, int deep) {
   if (!p)
     return 0;
 
-  LpGetIntegerIfValid(p, &valid_record);
+  // Master entry header: valid-count, deleted-count, num-master-fields.
+  int64_t entry_count = LpGetIntegerIfValid(p, &valid_record);
   if (!valid_record)
     return 0;
   p = next;
   if (!lpValidateNext(lp, &next, size))
     return 0;
 
-  LpGetIntegerIfValid(p, &valid_record);
+  int64_t deleted_count = LpGetIntegerIfValid(p, &valid_record);
   if (!valid_record)
     return 0;
   p = next;
   if (!lpValidateNext(lp, &next, size))
     return 0;
 
-  LpGetIntegerIfValid(p, &valid_record);
+  int64_t master_fields = LpGetIntegerIfValid(p, &valid_record);
   if (!valid_record)
     return 0;
   p = next;
   if (!lpValidateNext(lp, &next, size))
     return 0;
+
+  if (entry_count < 0 || deleted_count < 0 || master_fields < 0)
+    return 0;
+
+  // The master field names.
+  for (int64_t i = 0; i < master_fields; i++) {
+    p = next;
+    if (!lpValidateNext(lp, &next, size))
+      return 0;
+  }
+
+  // The zero terminator that closes the master entry.
+  int64_t zero = LpGetIntegerIfValid(p, &valid_record);
+  if (!valid_record || zero != 0)
+    return 0;
+  p = next;
+  if (!lpValidateNext(lp, &next, size))
+    return 0;
+
+  // Records. Their number is bounded by the declared valid + deleted counts, and each
+  // record's trailing lp-count must match the entries it spans. Both counts are already
+  // non-negative, so the total is summed in uint64_t: a signed sum could overflow to a
+  // negative value (undefined behavior) and skip the loop, bypassing validation.
+  uint64_t actual_deleted = 0;
+  uint64_t records = static_cast<uint64_t>(entry_count) + static_cast<uint64_t>(deleted_count);
+  while (records-- > 0) {
+    if (!p)
+      return 0;
+
+    int64_t fields = master_fields, extra_fields = 3;
+    int64_t flags = LpGetIntegerIfValid(p, &valid_record);
+    if (!valid_record)
+      return 0;
+    if (flags & STREAM_ITEM_FLAG_DELETED)
+      ++actual_deleted;
+    p = next;
+    if (!lpValidateNext(lp, &next, size))
+      return 0;
+
+    // The two entry-id deltas (ms, seq) relative to the master id.
+    LpGetIntegerIfValid(p, &valid_record);
+    if (!valid_record)
+      return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size))
+      return 0;
+    LpGetIntegerIfValid(p, &valid_record);
+    if (!valid_record)
+      return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size))
+      return 0;
+
+    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
+      fields = LpGetIntegerIfValid(p, &valid_record);
+      if (!valid_record || fields < 0)
+        return 0;
+      p = next;
+      if (!lpValidateNext(lp, &next, size))
+        return 0;
+
+      // Per-record field names.
+      for (int64_t i = 0; i < fields; i++) {
+        p = next;
+        if (!lpValidateNext(lp, &next, size))
+          return 0;
+      }
+      extra_fields += fields + 1;
+    }
+
+    // The field values.
+    for (int64_t i = 0; i < fields; i++) {
+      p = next;
+      if (!lpValidateNext(lp, &next, size))
+        return 0;
+    }
+
+    int64_t lp_count = LpGetIntegerIfValid(p, &valid_record);
+    if (!valid_record || lp_count != fields + extra_fields)
+      return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size))
+      return 0;
+  }
+
+  if (actual_deleted != static_cast<uint64_t>(deleted_count))
+    return 0;
+
+  // The walk must consume the whole listpack: p must be the final (EOF) byte. Rejects an
+  // early EOF with trailing bytes, which a non-deep load accepts and later reverse iteration
+  // (lpLast/lpPrev) would then read out of bounds.
+  if (next || p != lp + size - 1)
+    return 0;
+
   return 1;
 }
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -5,7 +5,9 @@
 
 extern "C" {
 #include "redis/crc64.h"
+#include "redis/listpack.h"
 #include "redis/redis_aux.h"
+#include "redis/stream.h"
 #include "redis/zmalloc.h"
 }
 
@@ -2127,6 +2129,113 @@ TEST_F(RdbTest, RestoreStreamConsumerGroupCorruption) {
   EXPECT_THAT(Run({"EXISTS", "ok1"}), IntArg(1));
   EXPECT_EQ(Run({"RESTORE", "ok2", "0", build({x, y}, {{"c1", {x}}, {"c2", {y}}})}), "OK");
   EXPECT_THAT(Run({"EXISTS", "ok2"}), IntArg(1));
+}
+
+// A master entry declaring more fields than the listpack holds makes stream iteration walk
+// lpNext past the end and crash; RESTORE must reject the inconsistent stream.
+TEST_F(RdbTest, RestoreStreamListpackMasterFieldsOverflow) {
+  auto u64le = [](std::string* out, uint64_t v) {
+    uint8_t b[8];
+    absl::little_endian::Store64(b, v);
+    out->append(reinterpret_cast<const char*>(b), sizeof(b));
+  };
+
+  // A one-node stream DUMP whose master entry declares the given counts. An optional record with
+  // no fields can be added to test consistency between deleted_count and the record flags.
+  auto build = [&](int64_t count, int64_t deleted, int64_t num_master_fields,
+                   std::optional<int64_t> record_flags = std::nullopt) {
+    uint8_t* lp = lpNew(0);
+    lp = lpAppendInteger(lp, count);              // valid entry count
+    lp = lpAppendInteger(lp, deleted);            // deleted count
+    lp = lpAppendInteger(lp, num_master_fields);  // master fields (untrusted)
+    lp = lpAppendInteger(lp, 0);                  // terminator
+    if (record_flags) {
+      CHECK_EQ(num_master_fields, 0);
+      lp = lpAppendInteger(lp, *record_flags);
+      lp = lpAppendInteger(lp, 0);  // entry ID milliseconds delta
+      lp = lpAppendInteger(lp, 0);  // entry ID sequence delta
+      lp = lpAppendInteger(lp, 3);  // flags + two ID deltas
+    }
+    std::string lp_blob(reinterpret_cast<const char*>(lp), lpBytes(lp));
+    lpFree(lp);
+
+    std::string p;
+    p.push_back(RDB_TYPE_STREAM_LISTPACKS);
+    AppendLen(&p, 1);                           // one listpack node
+    AppendString(&p, std::string(16, '\x01'));  // 16-byte master ID (sizeof(streamID))
+    AppendString(&p, lp_blob);                  // the crafted master-entry listpack
+    AppendLen(&p, 0);                           // stream_len
+    AppendLen(&p, 0);                           // last_id.ms
+    AppendLen(&p, 0);                           // last_id.seq
+    AppendLen(&p, 0);                           // consumer-group count
+
+    uint8_t ver[2];
+    absl::little_endian::Store16(ver, RDB_SER_VERSION);
+    p.append(reinterpret_cast<const char*>(ver), sizeof(ver));
+    u64le(&p, crc64(0, reinterpret_cast<const uint8_t*>(p.data()), p.size()));
+    return p;
+  };
+
+  // Control: truthful counts must still load.
+  EXPECT_EQ(Run({"RESTORE", "safe", "0", build(0, 0, 0)}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "safe"}), IntArg(1));
+
+  // Inflated master-fields count: crashes a vulnerable loader in streamGetEdgeID, rejected here.
+  EXPECT_THAT(Run({"RESTORE", "overflow", "0", build(0, 0, 1000)}), ErrArg("Bad data format"));
+  EXPECT_THAT(Run({"EXISTS", "overflow"}), IntArg(0));
+
+  // valid + deleted counts whose signed sum overflows; must not wrap negative and skip the walk.
+  EXPECT_THAT(Run({"RESTORE", "sumovf", "0", build(INT64_MAX, 1, 0)}), ErrArg("Bad data format"));
+  EXPECT_THAT(Run({"EXISTS", "sumovf"}), IntArg(0));
+
+  // The number of records carrying the DELETED flag must match deleted_count in the master entry.
+  EXPECT_THAT(Run({"RESTORE", "deleted-mismatch", "0",
+                   build(1, 0, 0, STREAM_ITEM_FLAG_SAMEFIELDS | STREAM_ITEM_FLAG_DELETED)}),
+              ErrArg("Bad data format"));
+  EXPECT_THAT(Run({"EXISTS", "deleted-mismatch"}), IntArg(0));
+
+  // Real streams must still round-trip, exercising both SAMEFIELDS and full records.
+  Run({"XADD", "s", "1-1", "a", "1", "b", "2"});  // master fields {a, b}
+  Run({"XADD", "s", "2-1", "a", "3", "b", "4"});  // same fields -> SAMEFIELDS
+  Run({"XADD", "s", "3-1", "c", "5"});            // different fields -> full record
+  auto dump = Run({"DUMP", "s"});
+  Run({"DEL", "s"});
+  EXPECT_EQ(Run({"RESTORE", "s", "0", dump.GetString()}), "OK");
+  EXPECT_THAT(Run({"XLEN", "s"}), IntArg(3));
+}
+
+// An early EOF with trailing bytes passes the non-deep lpValidateIntegrity but must be
+// rejected by the walk; otherwise reverse iteration (lpLast/lpPrev) reads the trailing bytes
+// out of bounds. Exercised via the non-deep full-RDB load path.
+TEST_F(RdbTest, LoadStreamListpackEarlyEof) {
+  uint8_t* lp = lpNew(0);
+  lp = lpAppendInteger(lp, 0);  // count
+  lp = lpAppendInteger(lp, 0);  // deleted
+  lp = lpAppendInteger(lp, 0);  // num master fields
+  lp = lpAppendInteger(lp, 0);  // terminator
+  std::string blob(reinterpret_cast<const char*>(lp), lpBytes(lp));
+  lpFree(lp);
+
+  // The trailing LP_EOF becomes an early EOF once junk and a new final EOF follow it; patch
+  // the header total-bytes to the enlarged size so lpValidateIntegrity still accepts it.
+  blob.append(4, '\x7f');
+  blob.push_back('\xff');
+  absl::little_endian::Store32(reinterpret_cast<uint8_t*>(blob.data()), blob.size());
+
+  std::string body;
+  body.push_back(RDB_TYPE_STREAM_LISTPACKS);
+  AppendString(&body, "earlyeof");               // key
+  AppendLen(&body, 1);                           // one listpack node
+  AppendString(&body, std::string(16, '\x01'));  // 16-byte master ID
+  AppendString(&body, blob);                     // the early-EOF listpack
+  AppendLen(&body, 0);                           // stream_len
+  AppendLen(&body, 0);                           // last_id.ms
+  AppendLen(&body, 0);                           // last_id.seq
+  AppendLen(&body, 0);                           // consumer-group count
+
+  // Skipping the corrupt key is non-fatal; the point is that it is never stored.
+  std::ignore = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body)); });
+  EXPECT_THAT(Run({"EXISTS", "earlyeof"}), IntArg(0));
 }
 
 // Integration test for snapshot egress throttling (--snapshot_egress_limit_bytes).


### PR DESCRIPTION
Follow-up #7929.
The stream RDB loader accepted a listpack whose master entry declared more fields than the listpack actually contained. Stream iteration then walked lpNext past the listpack end (lpNext(lp, NULL)), crashing the server. A single RESTORE triggers it during load; it is reachable pre-auth on the default (no-auth) configuration, and also via a hostile master through REPLICAOF.

Changes:
- Replace the shallow StreamValidateListpackIntegrity (which only checked the three header integers) with the full semantic walk from upstream: validate the master field count, the zero terminator, and every record including lp-count == fields + extra_fields, requiring the walk to end exactly at EOF.
- Run the walk on every load path, not only deep/RESTORE. deep_integrity is false for replication and RDB-file loads, and REPLICAOF is reachable pre-auth on a no-auth deployment, so the replication load path is not trusted either.