### PR TITLE
Fix borrowed Lua GET replies

### DIFF
--- a/src/common/borrowed_string.h
+++ b/src/common/borrowed_string.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -139,6 +140,21 @@ class BorrowedStringOps {
 inline void BorrowedString::Unpin() noexcept {
   if (pin_)
     BorrowedStringOps::Get()->Release(std::move(*this));
+}
+
+// Materialize a borrowed string into a single contiguous std::string. Raw
+// (unencoded) borrows copy their user-visible bytes; packed encodings are
+// decoded once via the registered ops. Consumers that need a contiguous buffer
+// (script interpreter, HTTP/JSON) use this. iovec sinks should prefer chunked
+// decoding (RedisReplyBuilder::SendBulkStringBorrowed) to avoid the extra copy.
+inline std::string DecodeToString(const BorrowedString& bs) {
+  if (!bs.IsEncoded())
+    return std::string{bs.view()};
+
+  auto* ops = BorrowedStringOps::Get();
+  std::string out(ops->DecodedSize(bs), '\0');
+  ops->DecodeChunk(bs, bs.view().size(), 0, std::span<char>{out.data(), out.size()});
+  return out;
 }
 
 }  // namespace cmn

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -352,27 +352,6 @@ void RedisReplyBuilderBase::SendBulkString(T&& str) {
 }
 template void RedisReplyBuilderBase::SendBulkString(std::string&&);
 
-void RedisReplyBuilderBase::SendBulkStringBorrowed(const cmn::BorrowedString& bs) {
-  ReplyScope scope(this);
-  tl_facade_stats->reply_stats.borrowed_string_sent_cnt++;
-
-  auto* ops = cmn::BorrowedStringOps::Get();
-  size_t total = ops->DecodedSize(bs);
-
-  DVLOG(1) << "SendBulkBorrowed " << total << " enc=" << unsigned(bs.encoding());
-  WritePieces(kLengthPrefix, total, kCRLF);
-  if (bs.IsEncoded()) {
-    WriteDecodedAscii(bs);
-  } else {
-    WriteRef(bs.view());
-  }
-  WritePieces(kCRLF);
-}
-
-void RedisReplyBuilderBase::SendBulkStringBorrowed(cmn::BorrowedString&& bs) {
-  SendBulkStringBorrowed(static_cast<const cmn::BorrowedString&>(bs));
-}
-
 void RedisReplyBuilderBase::SendLong(long val) {
   ReplyScope scope(this);
   WritePieces(kLongPref, val, kCRLF);
@@ -457,6 +436,27 @@ void RedisReplyBuilderBase::SendVerbatimString(std::string_view str, VerbatimFor
 
 std::string RedisReplyBuilderBase::SerializeCommand(std::string_view command) {
   return string{command} + kCRLF;
+}
+
+void RedisReplyBuilder::SendBulkStringBorrowed(const cmn::BorrowedString& bs) {
+  ReplyScope scope(this);
+  tl_facade_stats->reply_stats.borrowed_string_sent_cnt++;
+
+  auto* ops = cmn::BorrowedStringOps::Get();
+  size_t total = ops->DecodedSize(bs);
+
+  DVLOG(1) << "SendBulkBorrowed " << total << " enc=" << unsigned(bs.encoding());
+  WritePieces(kLengthPrefix, total, kCRLF);
+  if (bs.IsEncoded()) {
+    WriteDecodedAscii(bs);
+  } else {
+    WriteRef(bs.view());
+  }
+  WritePieces(kCRLF);
+}
+
+void RedisReplyBuilder::SendBulkStringBorrowed(cmn::BorrowedString&& bs) {
+  SendBulkStringBorrowed(static_cast<const cmn::BorrowedString&>(bs));
 }
 
 void RedisReplyBuilder::SendSimpleStrArr(const facade::ArgRange& strs) {

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -233,11 +233,11 @@ class RedisReplyBuilderBase : public SinkReplyBuilder {
   requires std::is_same_v<T, std::string>
   void SendBulkString(T&& str);
 
-  void SendBulkStringBorrowed(const cmn::BorrowedString& bs);
-
-  // The interface exposes only the rvalue function to allow squashing to "steal" the value,
-  // the real builder implementation forwards it to the constref version
-  virtual void SendBulkStringBorrowed(cmn::BorrowedString&& bs);
+  // Send a borrowed bulk string. Abstract: every concrete builder decides how
+  // (RedisReplyBuilder streams via iovec, the interpreter decodes to a string,
+  // squashing steals the value). The rvalue-only interface lets squashing
+  // "steal" the borrow.
+  virtual void SendBulkStringBorrowed(cmn::BorrowedString&& bs) = 0;
 
   void SendLong(long val) override;
   virtual void SendDouble(double val);  // RESP: Number
@@ -286,6 +286,14 @@ class RedisReplyBuilder : public RedisReplyBuilderBase {
       rb->StartArray(len);
     }
   };
+
+  // Optimized borrowed-string send: chunk-decode directly into the sink scratch
+  // (encoded) or reference the raw bytes (unencoded), avoiding a materialized
+  // copy. The const-ref overload is non-consuming, so capture replay can call
+  // it while the borrow stays owned by the payload; the rvalue override just
+  // forwards to it.
+  void SendBulkStringBorrowed(const cmn::BorrowedString& bs);
+  void SendBulkStringBorrowed(cmn::BorrowedString&& bs) override;
 
   void SendSimpleStrArr(const facade::ArgRange& strs);
   void SendBulkStrArr(const facade::ArgRange& strs, CollectionType ct = CollectionType::ARRAY);

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -142,6 +142,23 @@ TEST_F(DflyEngineTest, EvalResp) {
                                    ElementsAre("b", IntArg(2), "a", IntArg(1))));
 }
 
+TEST_F(DflyEngineTest, EvalGetLargeBorrowedStrings) {
+  std::string raw(32 * 1024, '\x81');
+  std::string ascii(32 * 1024, 'a');
+
+  EXPECT_THAT(Run({"set", "ascii", ascii}), "OK");
+  EXPECT_THAT(Run({"set", "raw", raw}), "OK");
+  optional<int64_t> ascii_usage = Run({"memory", "usage", "ascii"}).GetInt();
+  optional<int64_t> raw_usage = Run({"memory", "usage", "raw"}).GetInt();
+  ASSERT_TRUE(ascii_usage);
+  ASSERT_TRUE(raw_usage);
+  EXPECT_GT(*raw_usage, *ascii_usage);
+
+  EXPECT_THAT(Run({"eval", "return {redis.call('get', KEYS[1]), redis.call('get', KEYS[2])}", "2",
+                   "ascii", "raw"}),
+              RespElementsAre(ascii, raw));
+}
+
 TEST_F(DflyEngineTest, EvalPublish) {
   auto resp = pp_->at(1)->Await([&] { return Run({"subscribe", "foo"}); });
   EXPECT_THAT(resp, ArrLen(3));

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -129,22 +129,16 @@ struct CaptureVisitor {
     absl::StrAppend(&str, JsonEscape(vs->str));
   }
 
-  void operator()(cmn::BorrowedString bs) {
-    // HTTP visitor wants a single contiguous string to JSON-escape. For raw
-    // encodings the bytes are already user-visible; for packed encodings we
-    // materialize once via the registered decode op (chunked decoding only
-    // matters for iovec sinks).
+  void operator()(const cmn::BorrowedString& bs) {
+    // HTTP visitor wants a single contiguous string to JSON-escape. Raw bytes
+    // are already user-visible (avoid a copy); packed encodings are decoded
+    // once via the shared helper (chunked decoding only matters for iovec
+    // sinks).
     if (!bs.IsEncoded()) {
       absl::StrAppend(&str, JsonEscape(bs.view()));
       return;
     }
-    auto* ops = cmn::BorrowedStringOps::Get();
-    const size_t dec_size = ops->DecodedSize(bs);
-    // Default-initialized buffer — skips the value-init zero-fill that
-    // std::string(n, '\0') would do, since DecodeChunk overwrites every byte.
-    auto buf = std::make_unique_for_overwrite<char[]>(dec_size);
-    ops->DecodeChunk(bs, bs.view().size(), 0, std::span<char>(buf.get(), dec_size));
-    absl::StrAppend(&str, JsonEscape(std::string_view(buf.get(), dec_size)));
+    absl::StrAppend(&str, JsonEscape(cmn::DecodeToString(bs)));
   }
 
   void operator()(payload::Null) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -512,15 +512,14 @@ void InterpreterReplier::SendBulkString(string_view str) {
 }
 
 void InterpreterReplier::SendBulkStringBorrowed(cmn::BorrowedString&& bs) {
+  // No streaming sink here: decode into a contiguous string and route through
+  // SendBulkString (-> explr_->OnString), rather than RedisReplyBuilder's
+  // iovec-based chunked path.
   if (!bs.IsEncoded())
     return SendBulkString(bs.view());
 
-  auto* ops = cmn::BorrowedStringOps::Get();
-  string decoded(ops->DecodedSize(bs), '\0');
-  auto result = ops->DecodeChunk(bs, bs.view().size(), 0, std::span<char>{decoded});
-  DCHECK_EQ(result.src_consumed, bs.view().size());
-  DCHECK_EQ(result.dec_written, decoded.size());
-  SendBulkString(decoded);
+  string decoded = cmn::DecodeToString(bs);
+  SendBulkString(string_view{decoded});
 }
 
 void InterpreterReplier::StartCollection(unsigned len, CollectionType type) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -347,6 +347,7 @@ class InterpreterReplier : public RedisReplyBuilder {
   void SendError(std::string_view str, std::string_view type) final;
 
   void SendBulkString(std::string_view str) final;
+  void SendBulkStringBorrowed(cmn::BorrowedString&& bs) final;
   void SendSimpleString(std::string_view str) final;
 
   void SendNullArray() final;
@@ -508,6 +509,18 @@ void InterpreterReplier::SendDouble(double val) {
 void InterpreterReplier::SendBulkString(string_view str) {
   explr_->OnString(str);
   PostItem();
+}
+
+void InterpreterReplier::SendBulkStringBorrowed(cmn::BorrowedString&& bs) {
+  if (!bs.IsEncoded())
+    return SendBulkString(bs.view());
+
+  auto* ops = cmn::BorrowedStringOps::Get();
+  string decoded(ops->DecodedSize(bs), '\0');
+  auto result = ops->DecodeChunk(bs, bs.view().size(), 0, std::span<char>{decoded});
+  DCHECK_EQ(result.src_consumed, bs.view().size());
+  DCHECK_EQ(result.dec_written, decoded.size());
+  SendBulkString(decoded);
 }
 
 void InterpreterReplier::StartCollection(unsigned len, CollectionType type) {


### PR DESCRIPTION
Fixes Lua `redis.call('GET', ...)` for large zero-copy values by translating borrowed replies in `InterpreterReplier`, rather than forwarding them to its null network sink.

Adds raw and ASCII-packed large-value coverage, and asserts their `MEMORY USAGE` differs before executing Lua.

Original crash stack reference:
```
dfly::Interpreter::RedisGenericCommand
dfly::Service::CallFromScript
dfly::(anonymous namespace)::CmdGet
facade::RedisReplyBuilderBase::SendBulkStringBorrowed
facade::SinkReplyBuilder::WriteDecodedAscii
facade::SinkReplyBuilder::Flush
facade::SinkReplyBuilder::Send
io::Sink::Write
```

Tests:
- `build-dbg/dragonfly_test --gtest_filter='DflyEngineTest.EvalGetLargeBorrowedStrings'`