### PR TITLE
ci: cache 3rd-party dependencies

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -62,6 +62,11 @@ inputs:
     required: false
     default: 'default'
     type: string
+  enable-deps-cache:
+    description: "Cache the built third-party deps (third_party/_deps) and their build artifacts, skipping both download and compilation on a hit. 'false' (default) skips it."
+    required: false
+    default: 'false'
+    type: string
 
 runs:
   using: "composite"
@@ -77,19 +82,79 @@ runs:
           exit 1
         fi
 
-    - name: Setup ccache
+    - name: Restore/save cache (ccache)
       if: ${{ inputs.enable-ccache == 'true' }}
-      # Persist compiled objects across ephemeral runners so unchanged files aren't recompiled.
+      # - Reuse compiled objects across runners so unchanged files are not recompiled.
+      # - The action restores here and saves in its GitHub Actions post-step (auto-generated): "Post Restore/save cache (ccache)".
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        # ATTENTION: this is the ccache key template. Changing it (or any input that feeds it:
-        # cache-key-suffix / build-type / c-compiler / cxx-compiler / sanitizers etc) changes the key
-        # for EVERY caller. Keep whatever warms refs/heads/main in sync with this key, or PR
-        # builds stop matching the warm cache and go cold.
+        # - This is the ccache key template used by every caller.
+        # - Changing it or one of its inputs creates a new cache. Keep main's cache producer aligned with this key so
+        #   pull requests can restore the cache warmed on main.
         key: dfly-ccache-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.c-compiler }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}
         max-size: ${{ inputs.ccache-max-size }}
         save: ${{ inputs.ccache-save }}
         verbose: 1
+
+    - name: Compute third-party deps cache key
+      # - Generate one key for restore, save, and failure cleanup so those steps always use the same cache entry.
+      # - hashFiles() includes dependency definitions, dependency build settings, and patches. Add any new file that
+      #   changes a dependency's fetched source or build output, or an old cache could be restored incorrectly.
+      # - internal.cmake, sanitizers, and cxx-flags affect the compiler settings inherited by dependencies, so each
+      #   setting combination needs its own cache entry.
+      # - This cache restores complete third_party and _deps directories before the build. An exact hit skips fetching
+      #   and building dependencies. ccache is separate: it caches individual object files and also covers src/.
+      if: inputs.enable-deps-cache == 'true'
+      id: deps-cache-key
+      shell: bash
+      run: |
+        HASH="${{ hashFiles('src/external_libs.cmake', 'CMakeLists.txt', 'src/CMakeLists.txt', 'helio/cmake/third_party.cmake', 'helio/cmake/internal.cmake', 'patches/**', 'helio/patches/**') }}"
+        PREFIX="dfly-deps-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}-${{ inputs.cxx-flags }}-"
+        if [ -z "${HASH}" ]; then
+          echo "::error title=deps-cache::hashFiles() matched no files - refusing to cache under a degenerate key. Check the file list in this step."
+          exit 1
+        fi
+        {
+          echo "key=${PREFIX}${HASH}"
+          echo "prefix=${PREFIX}"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Restore cache (deps)
+      # - actions/cache/restore only downloads a cache; unlike the combined cache action, it never saves automatically.
+      # - The separate Save step can therefore require a successful build, while the failure step can delete this key.
+      # - Cache both directories: third_party contains ExternalProject builds; _deps contains FetchContent builds.
+      # - Paths are workspace-relative because actions/cache runs inside the job's container, where host paths do not
+      #   exist.
+      if: inputs.enable-deps-cache == 'true'
+      id: deps-cache-restore
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ${{ inputs.build-dir }}/third_party
+          ${{ inputs.build-dir }}/_deps
+        key: ${{ steps.deps-cache-key.outputs.key }}
+        restore-keys: |
+          ${{ steps.deps-cache-key.outputs.prefix }}
+
+    - name: Report cache status (deps)
+      # - Print the exact, fallback, or miss result in the log and Job Summary.
+      if: always() && inputs.enable-deps-cache == 'true'
+      shell: bash
+      run: |
+        if [ "${{ steps.deps-cache-restore.outputs.cache-hit }}" = "true" ]; then
+          STATUS="FULL HIT (exact key match) - third_party/_deps fully restored, no rebuild expected"
+        elif [ -n "${{ steps.deps-cache-restore.outputs.cache-matched-key }}" ]; then
+          STATUS="PARTIAL HIT (restore-keys fallback: '${{ steps.deps-cache-restore.outputs.cache-matched-key }}') - the build will rebuild whatever changed since that key"
+        else
+          STATUS="MISS - no matching cache found, full cold third-party build expected (~140s)"
+        fi
+        echo "Third-party deps cache: ${STATUS}"
+        echo "  primary key: ${{ steps.deps-cache-key.outputs.key }}"
+        {
+          echo "### Third-party deps cache"
+          echo "- **${STATUS}**"
+          echo "- primary key: \`${{ steps.deps-cache-key.outputs.key }}\`"
+        } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Configure CMake
       shell: bash
@@ -148,7 +213,8 @@ runs:
     - name: Build
       shell: bash
       run: |
-        cd ${GITHUB_WORKSPACE}/${{ inputs.build-dir }}
+        # - Use $GITHUB_WORKSPACE: it is the workspace path inside the container. github.workspace is the host path.
+        cd "${GITHUB_WORKSPACE}/${{ inputs.build-dir }}"
         echo "Building target: ${{ inputs.targets }}"
         if [ "${{ inputs.enable-ccache }}" = "true" ]; then
           ccache -z || true   # zero stats so the summary below reflects only this build
@@ -157,4 +223,34 @@ runs:
         if [ "${{ inputs.enable-ccache }}" = "true" ]; then
           echo "===== ccache stats (this build) ====="
           ccache -s || true
+        fi
+
+    - name: Save cache (deps)
+      # - Save only after configuration and build succeed. Later test failures must not discard a valid deps cache.
+      # - Never save a failed or cancelled build: it may contain incomplete artifacts.
+      # - Do not save when this step already restored the requested cache. There is nothing new to upload, and saving
+      #   it again would create an unnecessary copy for this run's branch or pull request.
+      if: success() && inputs.enable-deps-cache == 'true' && steps.deps-cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          ${{ inputs.build-dir }}/third_party
+          ${{ inputs.build-dir }}/_deps
+        key: ${{ steps.deps-cache-key.outputs.key }}
+
+    - name: Clear cache on build failure (deps)
+      # - On failure, remove this run's cache key so a partial dependency build is never reused.
+      # - Do not delete an exact restore hit: this run cannot overwrite it because Save skips exact hits.
+      # - --ref limits deletion to this run's ref. Without it, a matching pull-request key could delete main's cache.
+      if: failure() && inputs.enable-deps-cache == 'true' && steps.deps-cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "Build failed - clearing third-party deps cache key so the next run doesn't reuse it:"
+        echo "  ${{ steps.deps-cache-key.outputs.key }} (ref: ${{ github.ref }})"
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "::warning::'gh' CLI not found - skipping cache cleanup. Clear manually: gh cache delete '${{ steps.deps-cache-key.outputs.key }}' --ref '${{ github.ref }}'"
+        elif ! gh cache delete "${{ steps.deps-cache-key.outputs.key }}" --repo "${{ github.repository }}" --ref "${{ github.ref }}"; then
+          echo "::warning::Could not delete deps cache (missing 'actions: write' permission on forked PRs, or nothing saved under this key yet). Clear manually: gh cache delete '${{ steps.deps-cache-key.outputs.key }}' --ref '${{ github.ref }}'"
         fi

--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -98,31 +98,38 @@ runs:
 
     - name: Compute third-party deps cache key
       # - Generate one key for restore, save, and failure cleanup so those steps always use the same cache entry.
+      # - Require a caller-specific suffix: third-party artifacts are incompatible across container environments.
       # - hashFiles() includes dependency definitions, dependency build settings, and patches. Add any new file that
       #   changes a dependency's fetched source or build output, or an old cache could be restored incorrectly.
       # - internal.cmake, sanitizers, and cxx-flags affect the compiler settings inherited by dependencies, so each
       #   setting combination needs its own cache entry.
-      # - This cache restores complete third_party and _deps directories before the build. An exact hit skips fetching
-      #   and building dependencies. ccache is separate: it caches individual object files and also covers src/.
+      # - ccache is separate: it caches individual object files and also covers src/.
       if: inputs.enable-deps-cache == 'true'
       id: deps-cache-key
       shell: bash
       run: |
+        suffix="${{ inputs.cache-key-suffix }}"
+        if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
+          echo "::error title=deps-cache::enable-deps-cache is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so deps caches don't collide across configs."
+          exit 1
+        fi
         HASH="${{ hashFiles('src/external_libs.cmake', 'CMakeLists.txt', 'src/CMakeLists.txt', 'helio/cmake/third_party.cmake', 'helio/cmake/internal.cmake', 'patches/**', 'helio/patches/**') }}"
-        PREFIX="dfly-deps-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}-${{ inputs.cxx-flags }}-"
         if [ -z "${HASH}" ]; then
           echo "::error title=deps-cache::hashFiles() matched no files - refusing to cache under a degenerate key. Check the file list in this step."
           exit 1
         fi
-        {
-          echo "key=${PREFIX}${HASH}"
-          echo "prefix=${PREFIX}"
-        } >> "${GITHUB_OUTPUT}"
+        echo "key=dfly-deps-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}-${{ inputs.cxx-flags }}-${{ inputs.with-aws }}-${HASH}" >> "${GITHUB_OUTPUT}"
 
     - name: Restore cache (deps)
       # - actions/cache/restore only downloads a cache; unlike the combined cache action, it never saves automatically.
       # - The separate Save step can therefore require a successful build, while the failure step can delete this key.
-      # - Cache both directories: third_party contains ExternalProject builds; _deps contains FetchContent builds.
+      # - third_party contains the ExternalProject sources, per-step stamps and installed libs; _deps contains the
+      #   FetchContent builds (e.g. abseil).
+      # - .ninja_log is REQUIRED for a usable hit. Ninja only trusts a previously-built output if its build log records
+      #   that Ninja built it. On a fresh (or tar-restored) tree without the log, Ninja re-runs every ExternalProject
+      #   step regardless of file mtimes - and re-running the non-idempotent AWS 'patch -p1' against already-patched
+      #   sources fails the build. Restoring .ninja_log makes Ninja treat the cached third_party/_deps work as done.
+      # - CMakeFiles/*_project-complete are the final ExternalProject markers; caching them keeps the hit fully clean.
       # - Paths are workspace-relative because actions/cache runs inside the job's container, where host paths do not
       #   exist.
       if: inputs.enable-deps-cache == 'true'
@@ -132,21 +139,19 @@ runs:
         path: |
           ${{ inputs.build-dir }}/third_party
           ${{ inputs.build-dir }}/_deps
+          ${{ inputs.build-dir }}/.ninja_log
+          ${{ inputs.build-dir }}/CMakeFiles/*_project-complete
         key: ${{ steps.deps-cache-key.outputs.key }}
-        restore-keys: |
-          ${{ steps.deps-cache-key.outputs.prefix }}
 
     - name: Report cache status (deps)
-      # - Print the exact, fallback, or miss result in the log and Job Summary.
+      # - Only exact cache keys are used (no restore-keys), so a hit means the config matches the saved artifacts.
       if: always() && inputs.enable-deps-cache == 'true'
       shell: bash
       run: |
         if [ "${{ steps.deps-cache-restore.outputs.cache-hit }}" = "true" ]; then
-          STATUS="FULL HIT (exact key match) - third_party/_deps fully restored, no rebuild expected"
-        elif [ -n "${{ steps.deps-cache-restore.outputs.cache-matched-key }}" ]; then
-          STATUS="PARTIAL HIT (restore-keys fallback: '${{ steps.deps-cache-restore.outputs.cache-matched-key }}') - the build will rebuild whatever changed since that key"
+          STATUS="FULL HIT (exact key match) - third_party/_deps and Ninja build log restored"
         else
-          STATUS="MISS - no matching cache found, full cold third-party build expected (~140s)"
+          STATUS="MISS - no matching cache found, full cold third-party build expected"
         fi
         echo "Third-party deps cache: ${STATUS}"
         echo "  primary key: ${{ steps.deps-cache-key.outputs.key }}"
@@ -236,13 +241,16 @@ runs:
         path: |
           ${{ inputs.build-dir }}/third_party
           ${{ inputs.build-dir }}/_deps
+          ${{ inputs.build-dir }}/.ninja_log
+          ${{ inputs.build-dir }}/CMakeFiles/*_project-complete
         key: ${{ steps.deps-cache-key.outputs.key }}
 
     - name: Clear cache on build failure (deps)
-      # - On failure, remove this run's cache key so a partial dependency build is never reused.
-      # - Do not delete an exact restore hit: this run cannot overwrite it because Save skips exact hits.
+      # - On failure of a cold build, clear the cache record so the next run rebuilds instead of reusing partial work.
+      # - Leave an exact hit in place: it was a valid, previously-saved cache and this run's failure is unrelated to it.
       # - --ref limits deletion to this run's ref. Without it, a matching pull-request key could delete main's cache.
-      if: failure() && inputs.enable-deps-cache == 'true' && steps.deps-cache-restore.outputs.cache-hit != 'true'
+      # - Skip cleanup when key computation failed before producing a key.
+      if: failure() && inputs.enable-deps-cache == 'true' && steps.deps-cache-key.outputs.key != '' && steps.deps-cache-restore.outputs.cache-hit != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -1,8 +1,7 @@
-# Cache reaper - keeps the repo's 10 GB Actions cache budget tight. Two triggers:
-#   - closed pull_request:   delete ALL ccache entries for that PR (refs/pull/<N>/merge).
-#   - schedule / manual:     remove duplications (dedup) - keep the newest cache per (ref, config), delete older copies.
-#                            This trims refs/heads/main duplicates left by the 3-hourly regression/
-#                            epoll runs, whose append-timestamp saves a new entry every run.
+# - Keep the repository's Actions cache quota under control.
+# - On closed pull requests, delete all ccache and dependency caches for refs/pull/<N>/merge.
+# - On scheduled or manual runs, keep only the newest cache for each ref and configuration.
+# - This removes timestamped ccache duplicates and old dependency keys that remain eligible for prefix fallback.
 name: Cache reaper
 
 on:
@@ -12,14 +11,14 @@ on:
     - cron: "0 */3 * * *"
   workflow_dispatch:
 
-# One reap per PR; scheduled/manual reaps share a single group. A newer run supersedes an in-flight one.
+# One reap per PR - scheduled/manual reaps share a single group. A newer run supersedes an in-flight one.
 concurrency:
   group: cache-reaper-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: true
 
 jobs:
   reap:
-    # Make sure that: 1) per-PR cleanups are parallel and isolated 2) scheduled dedups are serialized to one at a time.
+    # - Run independent pull-request cleanups in parallel; serialize scheduled and manual cleanup runs.
     if: github.repository == 'dragonflydb/dragonfly' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
@@ -34,27 +33,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Repo-wide cache usage (10 GB limit), printed before/after so the log shows what was reclaimed.
-          # NOTE: deliberately NOT using `gh api .../actions/cache/usage` here - that aggregate
-          # endpoint is an async, separately-refreshed rollup and can still report pre-deletion
-          # totals for a while after a delete. `gh cache list` hits the live cache-metadata store
-          # directly (confirmed consistent immediately after deletes), so we sum sizeInBytes
-          # ourselves instead of trusting the lagging aggregate.
+          # - Print live repository-wide cache usage before and after cleanup.
+          # - Sum `gh cache list` results instead of the asynchronous cache-usage API, which can lag after deletions.
+          # - Group usage into ccache, third-party dependencies cache, and other caches.
+          # - ccache-action automatically prefixes each persisted ccache key with "ccache-".
           print_repo_cache_usage() {
-            gh cache list --limit 1000 --json sizeInBytes --jq \
-              '(map(.sizeInBytes) | add // 0) as $bytes
-               | "Repo cache: \($bytes/1048576|floor) MB used, "
-                 + "\(length) caches "
-                 + "(limit 10240 MB, \((10737418240 - $bytes)/1048576|floor) MB free)"'
+            gh cache list --limit 1000 --json sizeInBytes,key --jq '
+              def cat:
+                if (.key | test("^ccache-dfly-ccache-")) then "ccache"
+                elif (.key | test("^dfly-deps-")) then "3rd-party deps"
+                else "other" end;
+              (map(.sizeInBytes) | add // 0) as $total
+              | (group_by(cat) | map({cat: (.[0] | cat), count: length, mb: ((map(.sizeInBytes) | add) / 1048576 | floor)})
+                 | sort_by(-.mb)) as $groups
+              | "Repo cache: \($total/1048576|floor) MB used, \(length) caches",
+                ($groups[] | "  \(.cat): \(.count) caches, \(.mb) MB")
+            '
           }
 
           echo "== Before cleanup =="
           print_repo_cache_usage || true
 
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            # PR closed/merged: delete every cache scoped to this PR ref in one non-interactive call.
-            # Best-effort count for the log only; unlike `gh cache delete --all` below, it doesn't
-            # need to be exact, so a transient failure here must not abort the actual cleanup.
+            # - Delete every cache scoped to the closed pull request's ref.
+            # - The count is informational - failure to read it must not prevent cleanup.
             before_count=$(gh cache list --ref "$PR_REF" --limit 1000 --json id --jq 'length' || echo '?')
             echo "PR closed - deleting all caches for $PR_REF ($before_count found)"
             if ! gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches; then
@@ -62,11 +64,13 @@ jobs:
             fi
             echo "Deleted $before_count cache(s) for $PR_REF"
           else
-            # Scheduled/manual: keep the newest cache per (ref, config), delete the older duplicate copies.
+            # - Keep the newest cache for each ref and configuration; delete older duplicates.
+            # - ccache keys add a timestamp on every save, so remove that timestamp before grouping.
+            # - Dependency keys end in a content hash; remove it too because older hashes remain prefix-restorable.
             echo "Scheduled dedup - keeping newest per (ref, config), deleting older copies"
             stale=$(gh cache list --limit 1000 --json id,key,ref,createdAt \
-              --jq '[ .[] | select(.key|test("dfly-ccache")) ]
-                    | group_by(.ref + "|" + (.key | sub("-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$";"")))
+              --jq '[ .[] | select(.key|test("^ccache-dfly-ccache-|^dfly-deps-")) ]
+                    | group_by(.ref + "|" + (.key | sub("-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$|-[0-9a-f]{64}$";"")))
                     | map(sort_by(.createdAt) | .[:-1]) | flatten
                     | .[] | "\(.id)\t\(.ref)\t\(.key)"')
             if [ -z "$stale" ]; then

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -1,7 +1,7 @@
 # - Keep the repository's Actions cache quota under control.
 # - On closed pull requests, delete all ccache and dependency caches for refs/pull/<N>/merge.
 # - On scheduled or manual runs, keep only the newest cache for each ref and configuration.
-# - This removes timestamped ccache duplicates and old dependency keys that remain eligible for prefix fallback.
+# - This removes timestamped ccache duplicates and obsolete dependency-definition keys.
 name: Cache reaper
 
 on:
@@ -66,7 +66,7 @@ jobs:
           else
             # - Keep the newest cache for each ref and configuration; delete older duplicates.
             # - ccache keys add a timestamp on every save, so remove that timestamp before grouping.
-            # - Dependency keys end in a content hash; remove it too because older hashes remain prefix-restorable.
+            # - Dependency keys end in a content hash; remove it to group obsolete definitions by configuration.
             echo "Scheduled dedup - keeping newest per (ref, config), deleting older copies"
             stale=$(gh cache list --limit 1000 --json id,key,ref,createdAt \
               --jq '[ .[] | select(.key|test("^ccache-dfly-ccache-|^dfly-deps-")) ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       contents: read
       id-token: write
       packages: read
+      actions: write # To allow deleting cache
 
     env:
       CPP_JUNIT_DIR: ${{ github.workspace }}/test-results/junit/cpp
@@ -121,6 +122,7 @@ jobs:
         with:
           enable-ccache: 'true'
           ccache-save: 'true'
+          enable-deps-cache: 'true'
           build-type: ${{matrix.build-type}}
           cache-key-suffix: ${{ matrix.container }}
           ccache-max-size: ${{ matrix.ccache-max-size || '1G' }}
@@ -432,6 +434,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # To allow deleting cache
 
     container:
       image: ghcr.io/romange/ubuntu-dev:24
@@ -458,6 +461,7 @@ jobs:
         with:
           enable-ccache: 'true'
           ccache-save: 'true'
+          enable-deps-cache: 'true'
           build-type: Release
           cache-key-suffix: 'df_common_bin'
           c-compiler: gcc

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # To allow deleting cache
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}
@@ -45,6 +46,7 @@ jobs:
         with:
           enable-ccache: 'true'
           ccache-save: 'true'
+          enable-deps-cache: 'true'
           build-type: ${{matrix.build-type}}
           cache-key-suffix: 'df_common_bin'
           c-compiler: gcc

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # To allow deleting cache
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}
@@ -45,6 +46,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           enable-ccache: 'true'
+          enable-deps-cache: 'true'
           cache-key-suffix: 'df_common_bin'
           c-compiler: gcc
           cxx-compiler: g++

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # To allow deleting cache
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}
@@ -47,6 +48,7 @@ jobs:
         with:
           enable-ccache: 'true'
           ccache-save: 'true'
+          enable-deps-cache: 'true'
           build-type: ${{matrix.build-type}}
           cache-key-suffix: 'df_common_bin'
           c-compiler: gcc

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -73,6 +73,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write # To allow deleting cache
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -73,7 +73,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      actions: write # To allow deleting cache
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}


### PR DESCRIPTION
Restore and save third_party/_deps with dependency-definition hashes.
Failed builds clear partial entries, preventing invalid cache restores.
Enable the cache in shared CI jobs and reap stale entries on a schedule.

**This reduces up to ~2:20 minutes** from the total job time - a hit allowed
to completely skip the download and the build of third-party
dependencies.

