### PR TITLE
fix(server): Partial cascaded replication - fix chain splits

### DIFF
--- a/src/common/thread_safe_value.h
+++ b/src/common/thread_safe_value.h
@@ -1,0 +1,38 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <utility>
+
+#include "util/fibers/synchronization.h"
+
+namespace cmn {
+
+// A minimal mutex-guarded value. Assignment (last-wins) and dereference are the only operations,
+// each taking the (fiber-aware) mutex, so it is meant for cold paths where a full custom holder
+// would be overkill. Dereference returns a copy to avoid handing out a reference outside the lock.
+template <typename T> class ThreadSafeValue {
+ public:
+  ThreadSafeValue() = default;
+  explicit ThreadSafeValue(T val) : val_(std::move(val)) {
+  }
+
+  ThreadSafeValue& operator=(T val) {
+    util::fb2::LockGuard lk(mu_);
+    val_ = std::move(val);
+    return *this;
+  }
+
+  T operator*() const {
+    util::fb2::LockGuard lk(mu_);
+    return val_;
+  }
+
+ private:
+  mutable util::fb2::Mutex mu_;
+  T val_{};
+};
+
+}  // namespace cmn

--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -57,7 +57,8 @@ void JournalWriter::Write(const journal::Entry::Payload& payload) {
 void JournalWriter::Write(const journal::Entry& entry) {
   // Check if entry has a new db index and we need to emit a SELECT entry.
   if (entry.opcode != journal::Op::SELECT && entry.opcode != journal::Op::LSN &&
-      entry.opcode != journal::Op::PING && (!cur_dbid_ || entry.dbid != *cur_dbid_)) {
+      entry.opcode != journal::Op::PING && entry.opcode != journal::Op::LINEAGE &&
+      (!cur_dbid_ || entry.dbid != *cur_dbid_)) {
     Write(journal::Entry{journal::Op::SELECT, entry.dbid, entry.slot});
     cur_dbid_ = entry.dbid;
   }
@@ -73,6 +74,8 @@ void JournalWriter::Write(const journal::Entry& entry) {
       return Write(entry.lsn);
     case journal::Op::PING:
       return;
+    case journal::Op::LINEAGE:
+      return Write(entry.payload);  // lineage_id is encoded in payload
     case journal::Op::COMMAND:
       Write(entry.txid);
       Write(1u);  // deprecated field, kept for backward compatibility.
@@ -215,8 +218,13 @@ std::error_code JournalReader::ReadEntry(journal::ParsedEntry* dest) {
   dest->dbid = dbid_;
   dest->opcode = opcode;
   dest->cmd.clear();
+
   if (opcode == journal::Op::PING) {
     return {};
+  }
+
+  if (opcode == journal::Op::LINEAGE) {
+    return ReadCommand(&dest->cmd);  // we store lineage id in payload
   }
 
   if (opcode == journal::Op::LSN) {

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -64,6 +64,9 @@ void TransactionData::AddEntry(journal::ParsedEntry&& entry) {
       return;
     case journal::Op::PING:
       return;
+    case journal::Op::LINEAGE:
+      command = std::move(entry.cmd);  // lineage id is stored in command
+      return;
     case journal::Op::EXPIRED:
     case journal::Op::COMMAND:
       command = std::move(entry.cmd);

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -14,7 +14,16 @@
 namespace dfly {
 namespace journal {
 
-enum class Op : uint8_t { SELECT = 6, EXPIRED = 9 /* sunset*/, COMMAND = 10, PING = 13, LSN = 15 };
+enum class Op : uint8_t {
+  SELECT = 6,
+  EXPIRED = 9 /* sunset*/,
+  COMMAND = 10,
+  PING = 13,
+  LSN = 15,
+
+  // Signals change of lineage id. Must be passed further to reach whole replica subtree
+  LINEAGE = 16,
+};
 
 struct EntryBase {
   TxId txid;

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -564,7 +564,8 @@ error_code Replica::InitiateDflySync(std::optional<LastMasterSyncData> last_mast
       partial_sync_lsn = shard_flows_[i]->JournalExecutedCount();
     }
     shard_flows_[i].reset(new DflyShardReplica(server(), master_context_, i, &service_,
-                                               multi_shard_exe_, load_context.get()));
+                                               multi_shard_exe_, load_context.get(),
+                                               &forked_lineage_));
     if (partial_sync_lsn > 0) {
       shard_flows_[i]->SetRecordsExecuted(partial_sync_lsn);
     }
@@ -1131,6 +1132,15 @@ void DflyShardReplica::StableSyncDflyReadFb(ExecutionState* cntx) {
         // if journal is active.
         journal::RecordEntry(0, journal::Op::PING, 0, nullopt, {});
       }
+    } else if (tx_data.opcode == journal::Op::LINEAGE) {
+      // One of our ancestors forked the lineage and updated us with the new roots master id
+      string_view new_lineage_id = tx_data.command.Front();
+      *forked_lineage_ = string(new_lineage_id);
+      journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);
+
+      if (EngineShard::tlocal() && EngineShard::tlocal()->journal()) {  // pass further
+        journal::RecordEntry(0, journal::Op::LINEAGE, 0, nullopt, {new_lineage_id, ArgSlice{}});
+      }
     } else {
       const bool is_successful = ExecuteTx(std::move(tx_data), cntx);
       if (is_successful) {
@@ -1219,10 +1229,12 @@ void DflyShardReplica::StableSyncDflyAcksFb(ExecutionState* cntx) {
 DflyShardReplica::DflyShardReplica(ServerContext server_context, MasterContext master_context,
                                    uint32_t flow_id, Service* service,
                                    std::shared_ptr<MultiShardExecution> multi_shard_exe,
-                                   RdbLoadContext* load_context)
+                                   RdbLoadContext* load_context,
+                                   cmn::ThreadSafeValue<std::string>* forked_lineage)
     : ProtocolClient(server_context),
       service_(*service),
       master_context_(master_context),
+      forked_lineage_(forked_lineage),
       multi_shard_exe_(multi_shard_exe),
       flow_id_(flow_id) {
   executor_ = std::make_unique<JournalExecutor>(service);

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -10,6 +10,7 @@
 #include <queue>
 #include <variant>
 
+#include "common/thread_safe_value.h"
 #include "facade/facade_types.h"
 #include "facade/redis_parser.h"
 #include "io/io_buf.h"
@@ -128,7 +129,11 @@ class Replica : ProtocolClient {
   // The replication id of the lineage root master. Equals the direct master's id, unless the
   // direct master advertised an ancestor id (cascaded replication), in which case it is the
   // ancestor's id. Used to negotiate partial sync when reconnecting up the chain.
+  // After a lineage fork (a promoted ancestor sent a LINEAGE marker), we adopt the new lineage
+  // root's id carried by the marker instead of the old ancestor's id.
   std::string GetLineageId() const {
+    if (std::string forked = *forked_lineage_; !forked.empty())
+      return forked;
     return master_context_.lineage_id;
   }
 
@@ -171,6 +176,9 @@ class Replica : ProtocolClient {
   util::fb2::Fiber sync_fb_;
   util::fb2::Fiber acks_fb_;
   util::fb2::EventCount replica_waker_;
+
+  // Lineage id adopted from a LINEAGE marker after a promoted ancestor forked; last-wins.
+  cmn::ThreadSafeValue<std::string> forked_lineage_;
 
   std::vector<std::unique_ptr<DflyShardReplica>> shard_flows_;
   std::vector<std::vector<unsigned>> thread_flow_map_;  // a map from proactor id to flow list.
@@ -221,7 +229,8 @@ class DflyShardReplica : public ProtocolClient {
  public:
   DflyShardReplica(ServerContext server_context, MasterContext master_context, uint32_t flow_id,
                    Service* service, std::shared_ptr<MultiShardExecution> multi_shard_exe,
-                   class RdbLoadContext* load_context);
+                   class RdbLoadContext* load_context,
+                   cmn::ThreadSafeValue<std::string>* forked_lineage);
   ~DflyShardReplica();
 
   void Cancel();
@@ -265,6 +274,9 @@ class DflyShardReplica : public ProtocolClient {
  private:
   Service& service_;
   MasterContext master_context_;
+
+  // Points at the owning Replica's forked lineage holder; assigned when a LINEAGE marker arrives.
+  cmn::ThreadSafeValue<std::string>* forked_lineage_;
 
   std::optional<base::IoBuf> leftover_buf_;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3346,6 +3346,18 @@ void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
     if (absl::GetFlag(FLAGS_replicaof_no_one_start_journal)) {
       // Start journal and keep offsets.
       repl_ptr->StartJournalAtOwnLSN();
+
+      if (absl::GetFlag(FLAGS_experimental_cascaded_partial_sync)) {
+        // We are being promoted while possibly serving sub-replicas that share our master's
+        // lineage. Emit a LINEAGE marker carrying our own replication id (the new lineage root) so
+        // downstream replicas adopt it: they can still partial-sync within our new lineage, but
+        // will full-sync if they reconnect to the old ancestor (split-brain safety).
+        std::string_view new_lineage_id = master_replid_;
+        shard_set->RunBriefInParallel([new_lineage_id](EngineShard* shard) {
+          if (shard->journal())
+            journal::RecordEntry(0, journal::Op::LINEAGE, 0, nullopt, {new_lineage_id, ArgSlice{}});
+        });
+      }
     }
     // flip flag before clearing replica_
     SetMasterFlagOnAllThreads(true);

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -1171,20 +1171,21 @@ async def test_cascaded_partial_sync(df_factory, reconnect_to):
     assert len(lines) == 0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Master rotation not implemented yet",
-)
 async def test_cascaded_partial_sync_split_brain(df_factory):
-    """Split-brain safety: master -> r1 -> r2, then r1 is promoted to standalone and
-    BOTH master and r1 take independent writes to the same key. r2 (following r1) then reconnects
-    directly to master.
+    """Split-brain safety + deep-chain lineage propagation. Chain master -> r1 -> r2 -> r3. r1 is
+    promoted, forming a new lineage r1 -> r2 -> r3, and both master and r1 take divergent writes to
+    the same key in the shared LSN space.
+      * r3 (a grandchild of r1) reconnects to the new root r1 and PARTIAL syncs: the LINEAGE marker
+        carries r1's id all the way down, so r3 - not just r1's direct child - adopts it. Without
+        propagating the id, r3 would present r2's id and be forced into a full sync.
+      * r3 then reconnects up to the old master and must FULL sync, converging to master's
+        authoritative value instead of silently keeping r1's divergent data (split-brain safety).
     """
     flag = {"proactor_threads": 4, "experimental_cascaded_partial_sync": None}
-    master, r1, r2 = (df_factory.create(**flag) for _ in range(3))
-    df_factory.start_all([master, r1, r2])
+    master, r1, r2, r3 = (df_factory.create(**flag) for _ in range(4))
+    df_factory.start_all([master, r1, r2, r3])
 
-    c_master, c_r1, c_r2 = master.client(), r1.client(), r2.client()
+    c_master, c_r1, c_r2, c_r3 = master.client(), r1.client(), r2.client(), r3.client()
 
     # Base data + a shared key that both branches will later diverge on.
     # NOTE: append (not set) because SET is omit-optimized which disables partial sync.
@@ -1192,13 +1193,13 @@ async def test_cascaded_partial_sync_split_brain(df_factory):
         await c_master.append(f"k{i}", "val")
     await c_master.append("diverge", "base")
 
-    # Build chain master -> r1 -> r2.
-    await c_r1.execute_command(f"REPLICAOF localhost {master.port}")
-    await wait_for_replicas_state(c_r1)
-    await c_r2.execute_command(f"REPLICAOF localhost {r1.port}")
-    await wait_for_replicas_state(c_r2)
+    # Build chain master -> r1 -> r2 -> r3.
+    for c, upstream in [(c_r1, master), (c_r2, r1), (c_r3, r2)]:
+        await c.execute_command(f"REPLICAOF localhost {upstream.port}")
+        await wait_for_replicas_state(c)
     await check_all_replicas_finished([c_r1], c_master)
     await check_all_replicas_finished([c_r2], c_r1)
+    await check_all_replicas_finished([c_r3], c_r2)
 
     # r1 splits from master and both sides write divergent values to the same key in the shared
     # LSN space.
@@ -1206,16 +1207,28 @@ async def test_cascaded_partial_sync_split_brain(df_factory):
     await c_master.append("diverge", "_MASTER")
     await c_r1.append("diverge", "_R1")
     await check_all_replicas_finished([c_r2], c_r1)
+    await check_all_replicas_finished([c_r3], c_r2)
 
     assert (await c_master.get("diverge")) == "base_MASTER"
-    assert (await c_r2.get("diverge")) == "base_R1"
+    assert (await c_r3.get("diverge")) == "base_R1"
 
-    # r2 reconnects directly to master. It must converge to master's authoritative value.
-    await c_r2.execute_command(f"REPLICAOF localhost {master.port}")
-    await check_all_replicas_finished([c_r2], c_master)
+    # The grandchild reconnects directly to the new root r1, skipping r2: partial sync within the
+    # new lineage.
+    await c_r3.execute_command(f"REPLICAOF localhost {r1.port}")
+    await check_all_replicas_finished([c_r3], c_r1)
+    assert (await c_r3.get("diverge")) == "base_R1"
+    assert (await c_r3.info("replication"))["psync_successes"] == 1
 
-    master_val, r2_val = await asyncio.gather(c_master.get("diverge"), c_r2.get("diverge"))
-    assert r2_val == master_val, f"split-brain divergence: master={master_val!r} r2={r2_val!r}"
+    # r3 reconnects up to the old master: it must full sync and converge to master's value.
+    await c_r3.execute_command(f"REPLICAOF localhost {master.port}")
+    await check_all_replicas_finished([c_r3], c_master)
+    master_val, r3_val = await asyncio.gather(c_master.get("diverge"), c_r3.get("diverge"))
+    assert r3_val == master_val, f"split-brain divergence: master={master_val!r} r3={r3_val!r}"
+
+    r3.stop()
+    assert len(r3.find_in_logs(f"Started partial sync with localhost:{r1.port}")) == 1
+    assert len(r3.find_in_logs(f"Started full sync with localhost:{r1.port}")) == 0
+    assert len(r3.find_in_logs(f"Started full sync with localhost:{master.port}")) == 1
 
 
 @pytest.mark.parametrize("proactors", [1, 4, 6])


### PR DESCRIPTION
No full review: Please just validate my design

Currently a replication change shares the same LSN numbering and "lineage" master id - all of that is passed on with the replication handshake protocol (CAPA/FLOW). Splitting a chain would result with two halves having the same root id and numbering, but possibly having totally different data. WE need to handle those split events

Whenever a node becomes standalone now, it issues a `LINEAGE` opcode through the journal to notify all its replicas that the lineage id was updated. The replicas pass it on.  Most importantly: this LINEAGE update happens before the new master runs any standalone command

This is a **simplification**: Redis remembers the full replication history with LSN timestamps. In a way - instead of replacing the last lineage id with the new id, it keeps a list of previous ids. The practical difference is the following - if we got lineage but no new commands we can still sync to an old master, but with DF as we've made it over the binary cut, we can't anymore