### PR TITLE
refactor: small improvements with CmdArgParser

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -175,16 +175,20 @@ template <class T> struct VNum {
 // Validation rules for Next<Validated<T, Rules...>>(): free functions `RuleError rule(T)`. Reusable
 // ones take the message as a reference-to-constexpr NTTP.
 
-// Out of [min, max] -> generic type error (FInt is the idiomatic spelling).
-template <auto min, auto max>
-requires std::same_as<decltype(min), decltype(max)> RuleError InRange(decltype(min) v) {
-  return {v < min || v > max, {}};
+// Empty rule message: leaves the generic type error (INVALID_INT / INVALID_FLOAT) in place.
+inline constexpr char kNoRuleMsg[] = "";
+
+// v outside the closed [min, max] (ClosedRange) or open (min, max) (OpenRange) -> Msg; an empty Msg
+// keeps the generic type error. Integer endpoints are compared in v's type, so OpenRange<0, 1, ...>
+// also validates a floating-point probability (avoids float NTTPs, which need clang 18+).
+template <auto min, auto max, const auto& Msg = kNoRuleMsg, class V>
+requires std::same_as<decltype(min), decltype(max)> RuleError ClosedRange(V v) {
+  return {!(v >= min && v <= max), Msg};
 }
 
-// Out of [min, max] -> custom Msg. Integer bounds only (float NTTPs need clang 18+).
-template <auto min, auto max, const auto& Msg>
-requires std::same_as<decltype(min), decltype(max)> RuleError Bounded(decltype(min) v) {
-  return {!(v >= min && v <= max), Msg};
+template <auto min, auto max, const auto& Msg = kNoRuleMsg, class V>
+requires std::same_as<decltype(min), decltype(max)> RuleError OpenRange(V v) {
+  return {!(v > min && v < max), Msg};
 }
 
 // v < 0 -> custom Msg; NaN is accepted (matches a plain `v < 0` guard).
@@ -214,7 +218,7 @@ template <class T, RuleError (*... Rules)(T)> struct Validated : VNum<T> {
   }
 };
 
-template <auto min, auto max> using FInt = Validated<decltype(min), InRange<min, max>>;
+template <auto min, auto max> using FInt = Validated<decltype(min), ClosedRange<min, max>>;
 
 template <std::integral T> using Positive = FInt<T{1}, std::numeric_limits<T>::max()>;
 template <std::integral T> using NonNegativeInt = FInt<T{0}, std::numeric_limits<T>::max()>;

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -273,12 +273,12 @@ TEST_F(CmdArgParserTest, ValidatedRules) {
   }
 }
 
-TEST_F(CmdArgParserTest, BoundedRule) {
+TEST_F(CmdArgParserTest, RangeRules) {
   static constexpr char kMsg[] = "out of range";
 
-  // Integer range: in-range passes; below/above report the custom message; a non-integer stays
-  // generic INVALID_INT.
-  using Pct = Validated<int, Bounded<0, 100, kMsg>>;
+  // ClosedRange integer: in-range passes; below/above report the custom message; a non-integer
+  // stays generic INVALID_INT.
+  using Pct = Validated<int, ClosedRange<0, 100, kMsg>>;
   {
     auto parser = Make({"0", "100", "50"});
     EXPECT_EQ(static_cast<int>(parser.Next<Pct>()), 0);
@@ -295,6 +295,25 @@ TEST_F(CmdArgParserTest, BoundedRule) {
     auto parser = Make({"abc"});
     parser.Next<Pct>();
     EXPECT_EQ(parser.TakeError().type, CmdArgParser::INVALID_INT);
+  }
+
+  // Integer endpoints validate floating-point v: OpenRange<0, 1> excludes the endpoints, while
+  // ClosedRange<0, 1> includes them.
+  using OpenProb = Validated<double, OpenRange<0, 1, kMsg>>;
+  using ClosedProb = Validated<double, ClosedRange<0, 1, kMsg>>;
+  {
+    auto parser = Make({"0.5"});
+    EXPECT_DOUBLE_EQ(static_cast<double>(parser.Next<OpenProb>()), 0.5);
+    EXPECT_FALSE(parser.HasError());
+  }
+  for (std::string_view edge : {"0", "1"}) {
+    auto open = Make({edge});
+    open.Next<OpenProb>();
+    EXPECT_EQ(open.TakeError().MakeReply().ToSv(), "out of range");  // open excludes endpoints
+
+    auto closed = Make({edge});
+    closed.Next<ClosedProb>();
+    EXPECT_FALSE(closed.HasError());  // closed includes endpoints
   }
 }
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -560,7 +560,7 @@ void BitPos(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* builder = cmd_cntx->rb();
 
   auto key = parser.Next<string_view>();
-  int32_t value = parser.Next<Validated<int32_t, Bounded<int32_t{0}, int32_t{1}, kBitArgErr>>>();
+  int32_t value = parser.Next<Validated<int32_t, ClosedRange<0, 1, kBitArgErr>>>();
 
   int64_t start = parser.NextOrDefault<int64_t>();
   int64_t end = parser.NextOrDefault<int64_t>(std::numeric_limits<int64_t>::max());
@@ -584,20 +584,16 @@ void BitCount(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
   auto key = parser.Next<string_view>();
 
-  std::pair<int64_t, int64_t> start_end;
-  if (parser.HasNext()) {
-    auto tuple_result = parser.Next<int64_t, int64_t>();
-    start_end = std::make_pair(std::get<0>(tuple_result), std::get<1>(tuple_result));
-  } else {
-    start_end = std::make_pair(0, std::numeric_limits<int64_t>::max());
-  }
+  int64_t start = 0, end = std::numeric_limits<int64_t>::max();
+  if (parser.HasNext())
+    std::tie(start, end) = parser.Next<int64_t, int64_t>();
 
   bool as_bit = parser.HasNext() ? parser.MapNext("BYTE", false, "BIT", true) : false;
   if (!parser.Finalize()) {
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
-  auto cb = [&, start_end](Transaction* t, EngineShard* shard) {
-    return CountBitsForValue(t->GetOpArgs(shard), key, start_end.first, start_end.second, as_bit);
+  auto cb = [&, start, end](Transaction* t, EngineShard* shard) {
+    return CountBitsForValue(t->GetOpArgs(shard), key, start, end, as_bit);
   };
   OpResult<std::size_t> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   HandleOpValueResult(res, cmd_cntx->rb());

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -32,6 +32,8 @@ constexpr char kCmsWrongNumKeys[] = "CMS: wrong number of keys";
 constexpr char kCmsWrongNumKeysWeights[] = "CMS: wrong number of keys/weights";
 constexpr char kCmsCannotParseNumber[] = "CMS: Cannot parse number";
 constexpr char kCmsPositiveIncrement[] = "CMS: increment must be a positive integer";
+constexpr char kCmsErrRange[] = "CMS: error must be between 0 and 1 exclusive";
+constexpr char kCmsProbRange[] = "CMS: probability must be between 0 and 1 exclusive";
 
 constexpr uint32_t kMaxCmsWidth = 1'000'000;
 constexpr uint32_t kMaxCmsDepth = 100;
@@ -166,16 +168,10 @@ void CmdInitByProb(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   double error, probability;
 
-  tie(error, probability) = parser.Next<double, double>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  tie(error, probability) = parser.Next<Validated<double, OpenRange<0, 1, kCmsErrRange>>,
+                                        Validated<double, OpenRange<0, 1, kCmsProbRange>>>();
   RETURN_ON_PARSE_ERROR(parser, rb);
-
-  if (!(error > 0 && error < 1)) {
-    return rb->SendError("CMS: error must be between 0 and 1 exclusive");
-  }
-  if (!(probability > 0 && probability < 1)) {
-    return rb->SendError("CMS: probability must be between 0 and 1 exclusive");
-  }
 
   uint32_t width = 0, depth = 0;
   if (!ComputeCmsDimensions(error, probability, rb, &width, &depth))

--- a/src/server/cuckoo_filter_family.cc
+++ b/src/server/cuckoo_filter_family.cc
@@ -200,7 +200,7 @@ struct ReserveOpts {
       CuckooFilterOptions::kDefaultSlotsPerBucket};
   Validated<uint16_t, NotEq<uint16_t{0}, kMaxIterationsErr>> max_iterations{
       CuckooFilterOptions::kDefaultMaxIterations};
-  Validated<uint16_t, Bounded<uint16_t{0}, uint16_t{32767}, kExpansionErr>> expansion{
+  Validated<uint16_t, ClosedRange<0, 32767, kExpansionErr>> expansion{
       CuckooFilterOptions::kDefaultExpansion};
 };
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -658,11 +658,8 @@ ParseResult<AggregateParams::JoinParams> ParseAggregatorJoinParams(
     CmdArgParser* parser, absl::flat_hash_set<std::string>* known_indexes) {
   AggregateParams::JoinParams join_params;
   join_params.index = parser->Next<std::string>();
-  if (parser->Check("AS")) {
-    join_params.index_alias = parser->Next<std::string>();
-  } else {
+  if (!parser->Check("AS", &join_params.index_alias))
     join_params.index_alias = join_params.index;
-  }
 
   if (known_indexes->contains(join_params.index_alias)) {
     return CreateSyntaxError(

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -798,8 +798,8 @@ nonstd::expected<ReplicaOfArgs, ErrorReply> ReplicaOfArgs::FromCmdArgs(facade::P
     replicaof_args.port = 0;
   } else {
     replicaof_args.host = parser.Next<string>();
-    replicaof_args.port = parser.Next<uint16_t>();
-    if (auto err = parser.TakeError(); err || replicaof_args.port < 1) {
+    replicaof_args.port = parser.Next<Positive<uint16_t>>("port is out of range");
+    if (auto err = parser.TakeError(); err) {
       return nonstd::make_unexpected(ErrorReply("port is out of range"));
     }
     if (parser.HasNext()) {

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1382,11 +1382,8 @@ void CmdSRandMember(CmdArgParser parser, CommandContext* cmd_cntx) {
   bool is_count = parser.HasNext();
   int count = parser.NextOrDefault<int>(1);
 
-  if (parser.HasNext())
-    return cmd_cntx->SendError(WrongNumArgsError("SRANDMEMBER"));
-
-  if (auto err = parser.TakeError(); err)
-    return cmd_cntx->SendError(err.MakeReply());
+  if (!parser.Finalize())
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
 
   cmn::BackedArguments vals;
   auto cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -311,9 +311,9 @@ TEST_F(SetFamilyTest, SRandMember) {
   ASSERT_THAT(Run({"SRandMember", "unknown::set"}), ArgType(RespExpr::NIL));
   ASSERT_THAT(Run({"SRandMember", "unknown::set", "0"}), ArrLen(0));
 
-  // Test wrong arguments
+  // Test wrong arguments: Redis returns a syntax error for extra args (t_set.c srandmemberCommand).
   resp = Run({"SRandMember", "x", "5", "3"});
-  EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
 TEST_F(SetFamilyTest, SMIsMember) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1377,7 +1377,7 @@ cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   static constexpr char kGetExExpiryErr[] = "invalid expire time in 'getex' command";
-  using ExpiryValue = Validated<int64_t, Bounded<int64_t{1}, INT64_MAX, kGetExExpiryErr>>;
+  using ExpiryValue = Validated<int64_t, ClosedRange<int64_t{1}, INT64_MAX, kGetExExpiryErr>>;
   static constexpr auto kGrammar = Compile(Options(ExpiryOrPersist<ExpiryValue>()));
   auto opts = kGrammar.Apply(&parser);
 

--- a/src/server/topk_family.cc
+++ b/src/server/topk_family.cc
@@ -36,10 +36,6 @@ namespace {
 constexpr char kDecayRangeErr[] = "decay must be between 0 and 1";
 constexpr char kIncrRangeErr[] = "increment must be between 1 and 100000";
 
-RuleError DecayRange(double v) {
-  return {!(v >= 0 && v <= 1), kDecayRangeErr};
-}
-
 OpStatus OpReserve(const OpArgs& op_args, string_view key, uint32_t k, uint32_t width,
                    uint32_t depth, double decay) {
   auto& db_slice = op_args.GetDbSlice();
@@ -200,7 +196,7 @@ void TopkFamily::Reserve(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
   if (parser.HasNext()) {
     width = parser.Next<uint32_t>();
     depth = parser.Next<uint32_t>();
-    decay = parser.Next<Validated<double, DecayRange>>();
+    decay = parser.Next<Validated<double, ClosedRange<0, 1, kDecayRangeErr>>>();
     RETURN_ON_PARSE_ERROR(parser, rb);
 
     if ((width == 0) || (depth == 0)) {
@@ -268,8 +264,7 @@ void TopkFamily::IncrBy(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   items.reserve(parser.UnparsedArgs().size() / 2);
   while (parser.HasNext()) {
     auto [item, incr] =
-        parser.Next<string_view,
-                    Validated<uint32_t, Bounded<uint32_t{1}, uint32_t{100000}, kIncrRangeErr>>>();
+        parser.Next<string_view, Validated<uint32_t, ClosedRange<1, 100000, kIncrRangeErr>>>();
     items.emplace_back(item, incr);
   }
   RETURN_ON_PARSE_ERROR(parser, rb);

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -673,39 +673,34 @@ void IntervalVisitor::AddResult(const uint8_t* vstr, unsigned vlen, long long vl
   }
 }
 
-bool ParseBound(string_view src, ZSetFamily::Bound* bound) {
-  if (src.empty())
-    return false;
-
-  if (src[0] == '(') {
-    bound->is_open = true;
+// Token parsers for parser.Next(fn); also used directly by ZRangeInternal.
+ZSetFamily::Bound ParseScoreBound(string_view src, facade::RuleError& err) {
+  ZSetFamily::Bound bound;
+  if (!src.empty() && src[0] == '(') {
+    bound.is_open = true;
     src.remove_prefix(1);
   }
-
-  return ParseDouble(src, &bound->val);
+  if (src.empty() || !ParseDouble(src, &bound.val))
+    err = {true, kFloatRangeErr};
+  return bound;
 }
 
-bool ParseLexBound(string_view src, ZSetFamily::LexBound* bound) {
-  if (src.empty())
-    return false;
-
+ZSetFamily::LexBound ParseLexBound(string_view src, facade::RuleError& err) {
+  ZSetFamily::LexBound bound;
   if (src == "+") {
-    bound->type = ZSetFamily::LexBound::PLUS_INF;
+    bound.type = ZSetFamily::LexBound::PLUS_INF;
   } else if (src == "-") {
-    bound->type = ZSetFamily::LexBound::MINUS_INF;
-  } else if (src[0] == '(') {
-    bound->type = ZSetFamily::LexBound::OPEN;
-    src.remove_prefix(1);
-    bound->val = src;
-  } else if (src[0] == '[') {
-    bound->type = ZSetFamily::LexBound::CLOSED;
-    src.remove_prefix(1);
-    bound->val = src;
+    bound.type = ZSetFamily::LexBound::MINUS_INF;
+  } else if (!src.empty() && src[0] == '(') {
+    bound.type = ZSetFamily::LexBound::OPEN;
+    bound.val = src.substr(1);
+  } else if (!src.empty() && src[0] == '[') {
+    bound.type = ZSetFamily::LexBound::CLOSED;
+    bound.val = src.substr(1);
   } else {
-    return false;
+    err = {true, kLexRangeErr};
   }
-
-  return true;
+  return bound;
 }
 
 enum class AggType : uint8_t { SUM, MIN, MAX, NOOP };
@@ -1690,17 +1685,21 @@ void ZRangeInternal(const facade::ParsedArgs& args, ZSetFamily::RangeParams rang
   switch (range_params.interval_type) {
     case RP::IntervalType::SCORE: {
       ZSetFamily::ScoreInterval si;
-      if (!ParseBound(min_s, &si.first) || !ParseBound(max_s, &si.second)) {
+      RuleError err;
+      si.first = ParseScoreBound(min_s, err);
+      si.second = ParseScoreBound(max_s, err);
+      if (err.failed)
         return cmd_cntx->SendError(kFloatRangeErr);
-      }
       range_spec.interval = si;
       break;
     }
     case RP::IntervalType::LEX: {
       ZSetFamily::LexInterval li;
-      if (!ParseLexBound(min_s, &li.first) || !ParseLexBound(max_s, &li.second)) {
+      RuleError err;
+      li.first = ParseLexBound(min_s, err);
+      li.second = ParseLexBound(max_s, err);
+      if (err.failed)
         return cmd_cntx->SendError(kLexRangeErr);
-      }
       range_spec.interval = li;
       break;
     }
@@ -1820,12 +1819,7 @@ void ZRankGeneric(CmdArgParser parser, bool reverse, CommandContext* cmd_cntx) {
 
   string_view key = parser.Next();
   string_view member = parser.Next();
-  bool with_score = false;
-
-  if (parser.HasNext()) {
-    parser.ExpectTag("WITHSCORE");
-    with_score = true;
-  }
+  bool with_score = parser.Check("WITHSCORE");
 
   if (!parser.Finalize()) {
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
@@ -2189,14 +2183,10 @@ void CmdZCard(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdZCount(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-
-  string_view min_s = parser.Next();
-  string_view max_s = parser.Next();
-
   ZSetFamily::ScoreInterval si;
-  if (!ParseBound(min_s, &si.first) || !ParseBound(max_s, &si.second)) {
-    return cmd_cntx->SendError(kFloatRangeErr);
-  }
+  si.first = parser.Next(ParseScoreBound);
+  si.second = parser.Next(ParseScoreBound);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpCount(t->GetOpArgs(shard), key, si);
@@ -2563,14 +2553,10 @@ void CmdZPopMin(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdZLexCount(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-
-  string_view min_s = parser.Next();
-  string_view max_s = parser.Next();
-
   ZSetFamily::LexInterval li;
-  if (!ParseLexBound(min_s, &li.first) || !ParseLexBound(max_s, &li.second)) {
-    return cmd_cntx->SendError(kLexRangeErr);
-  }
+  li.first = parser.Next(ParseLexBound);
+  li.second = parser.Next(ParseLexBound);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpLexCount(t->GetOpArgs(shard), key, li);
@@ -2627,13 +2613,9 @@ void CmdZRevRangeByLex(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdZRemRangeByRank(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  string_view min_s = parser.Next();
-  string_view max_s = parser.Next();
-
   ZSetFamily::IndexInterval ii;
-  if (!SimpleAtoi(min_s, &ii.first) || !SimpleAtoi(max_s, &ii.second)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
-  }
+  std::tie(ii.first, ii.second) = parser.Next<int64_t, int64_t>();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   ZSetFamily::ZRangeSpec range_spec;
   range_spec.interval = ii;
@@ -2642,35 +2624,25 @@ void CmdZRemRangeByRank(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdZRemRangeByScore(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  string_view min_s = parser.Next();
-  string_view max_s = parser.Next();
-
   ZSetFamily::ScoreInterval si;
-  if (!ParseBound(min_s, &si.first) || !ParseBound(max_s, &si.second)) {
-    return cmd_cntx->SendError(kFloatRangeErr);
-  }
+  si.first = parser.Next(ParseScoreBound);
+  si.second = parser.Next(ParseScoreBound);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   ZSetFamily::ZRangeSpec range_spec;
-
   range_spec.interval = si;
-
   ZRemRangeGeneric(key, range_spec, cmd_cntx);
 }
 
 void CmdZRemRangeByLex(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  string_view min_s = parser.Next();
-  string_view max_s = parser.Next();
-
   ZSetFamily::LexInterval li;
-  if (!ParseLexBound(min_s, &li.first) || !ParseLexBound(max_s, &li.second)) {
-    return cmd_cntx->SendError(kLexRangeErr);
-  }
+  li.first = parser.Next(ParseLexBound);
+  li.second = parser.Next(ParseLexBound);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   ZSetFamily::ZRangeSpec range_spec;
-
   range_spec.interval = li;
-
   ZRemRangeGeneric(key, range_spec, cmd_cntx);
 }
 
@@ -2767,15 +2739,11 @@ void CmdZMScore(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdZScan(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-  string_view token = parser.Next();
-
-  uint64_t cursor = 0;
+  uint64_t cursor = parser.Next<uint64_t>("invalid cursor");
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  if (!absl::SimpleAtoi(token, &cursor)) {
-    return cmd_cntx->SendError("invalid cursor");
-  }
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   OpResult<ScanOpts> ops = ScanOpts::TryFrom(parser.UnparsedArgs());
   if (!ops) {

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -30,7 +30,7 @@ class ZSetFamily {
   using MScoreResponse = std::vector<std::optional<double>>;
 
   struct Bound {
-    double val;
+    double val = 0;
     bool is_open = false;
     Bound() = default;
     Bound(double v, bool open) : val(v), is_open(open) {


### PR DESCRIPTION
Summary: This PR refactors and slightly extends CmdArgParser range validation utilities, then applies them across several command families to simplify parsing and unify error handling.

Changes:

- Replaces the old InRange/Bounded rules with ClosedRange and OpenRange, including a default “no message” behavior to keep generic type errors.
- Updates FInt to use ClosedRange and adds tests covering closed/open behavior and float validation with integer endpoints.
- Refactors multiple command parsers to use the new rules (e.g. BITPOS, CMS INITBYPROB, Cuckoo reserve options, GETEX, TOPK reserve/incr).
- Simplifies argument parsing patterns using Finalize(), RemainingRange(), and Check() helpers.
- Adjusts SRANDMEMBER extra-arg handling/tests to return Redis-compatible syntax error.
- Refactors ZSET score/lex bound parsing into token-parser functions and plugs them into parser.Next(fn) call sites.

Technical Notes: The refactor centralizes range validation semantics and reduces per-command manual checks while keeping error reporting consistent via CmdArgParser’s latched-error model.