### PR TITLE
build: disable AWS support by default

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -35,7 +35,7 @@ inputs:
   with-aws:
     description: "Build with AWS support"
     required: false
-    default: 'ON'
+    default: 'OFF'
     type: string
   targets:
     description: "Build targets to compile"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ if (HAS_SPLIT_DWARF_C)
 endif()
 
 set(LEGACY_GLOG OFF CACHE BOOL "Use legacy glog instead of absl")
+set(WITH_AWS OFF CACHE BOOL "Build with helio native AWS support")
 
 include(third_party)
 include(internal)


### PR DESCRIPTION
Disables native AWS support by default in CMake and the reusable builder action.

This avoids enabling the optional AWS dependency unless explicitly requested.

Helio AWS implementation becomes the only option.