### PR TITLE
fix(server): journal partial lazy-field expiry for hash probes and FIELDEXPIRE

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -817,19 +817,37 @@ OpResult<vector<long>> OpFieldExpire(const OpArgs& op_args, string_view key, uin
   if (pv->IsExternal() && !pv->IsCool())
     return OpStatus::CANCELLED;  // can't mutate offloaded values synchronously
 
-  if (pv->ObjType() == OBJ_SET) {
-    auto result = SetFamily::SetFieldsExpireTime(op_args, ttl_sec, values, pv);
+  const bool is_set = pv->ObjType() == OBJ_SET;
+  // Only a TTL-carrying StringMap/StringSet can hold lazily expired members needing compensation.
+  const bool had_member_expiry = pv->Encoding() == kEncodingStrMap2 && pv->HasMemberExpiration();
+
+  vector<long> result;
+  bool key_deleted;
+  if (is_set) {
+    result = SetFamily::SetFieldsExpireTime(op_args, ttl_sec, values, pv);
     // Finalize memory accounting before potential deletion.
     auto_updater.Run();
-    SetFamily::DeleteSetIfEmpty(db_slice, op_args.db_cntx, key, *pv);
-    return result;
+    key_deleted = SetFamily::DeleteSetIfEmpty(db_slice, op_args.db_cntx, key, *pv);
   } else {
-    auto result = HSetFamily::SetFieldsExpireTime(op_args, ttl_sec, ExpireFlags::EXPIRE_ALWAYS, key,
-                                                  values, pv);
+    result = HSetFamily::SetFieldsExpireTime(op_args, ttl_sec, ExpireFlags::EXPIRE_ALWAYS, key,
+                                             values, pv);
     auto_updater.Run();
-    HSetFamily::DeleteIfEmpty(db_slice, op_args.db_cntx, key, *pv);
-    return result;
+    key_deleted = HSetFamily::DeleteIfEmpty(db_slice, op_args.db_cntx, key, *pv);
   }
+
+  // A member probed while lazily expired is still alive on a lagging replica and the replayed
+  // command would re-arm it there; delete it explicitly. Delete*IfEmpty journaled a DEL itself
+  // and may have yielded, so only locals are touched from here on.
+  if (!key_deleted && had_member_expiry && op_args.shard->journal()) {
+    absl::InlinedVector<std::string_view, 4> missing{key};
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (result[i] == -2)
+        missing.push_back(values[i]);
+    }
+    if (missing.size() > 1)
+      RecordJournal(op_args, is_set ? "SREM"sv : "HDEL"sv, missing);
+  }
+  return result;
 }
 
 // returns -2 if the key was not found, -3 if the field was not found,

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -670,19 +670,42 @@ OpResult<vector<long>> OpHExpire(const OpArgs& op_args, string_view key, uint32_
   if (pv->IsExternal() && !pv->IsCool())
     return OpStatus::CANCELLED;  // can't mutate offloaded hashes synchronously
 
+  // Only a TTL-carrying StringMap can hold lazily expired fields needing compensation.
+  const bool had_member_expiry = pv->Encoding() == kEncodingStrMap2 && pv->HasMemberExpiration();
+
   auto res = HSetFamily::SetFieldsExpireTime(op_args, ttl_sec, flags, key, values, pv);
 
   // If it is a hash which became empty after expiring fields, we must delete the key safely.
   // We use DelMutable which consumes the iterator/updater to prevent the crash.
+  bool key_deleted = false;
   if (pv->Encoding() == kEncodingStrMap2) {
     auto* sm = static_cast<StringMap*>(pv->RObjPtr());
     if (sm->UpperBoundSize() == 0) {
       db_slice.DelMutable(op_args.db_cntx, std::move(*op_res));
+      key_deleted = true;
+    }
+  }
+
+  // Journaling below may yield; disarm the updater so no dash iterator survives the yield
+  // (DelMutable already consumed it in the deleted case).
+  if (!key_deleted)
+    op_res->post_updater.Run();
+
+  if (op_args.shard->journal()) {
+    if (key_deleted) {
       // The replayed command re-applies a relative TTL against the replica clock and
       // cannot reproduce this deletion; journal it explicitly.
-      if (op_args.shard->journal()) {
-        RecordJournal(op_args, "DEL"sv, {key});
+      RecordJournal(op_args, "DEL"sv, {key});
+    } else if (had_member_expiry) {
+      // A field probed while lazily expired is still alive on a lagging replica and the
+      // replayed command would re-arm it there; delete it explicitly.
+      absl::InlinedVector<string_view, 4> missing{key};
+      for (size_t i = 0; i < values.size(); ++i) {
+        if (res[i] == -2)
+          missing.push_back(values[i]);
       }
+      if (missing.size() > 1)
+        RecordJournal(op_args, "HDEL"sv, missing);
     }
   }
 
@@ -707,17 +730,29 @@ OpResult<bool> CheckHSetExCondition(const OpArgs& op_args, string_view key,
   if (pv.IsExternal() && !pv.IsCool())
     return OpStatus::CANCELLED;  // can't inspect offloaded hashes synchronously
 
+  // Only a TTL-carrying StringMap can hold lazily expired fields needing compensation.
+  const bool had_member_expiry = pv.Encoding() == kEncodingStrMap2 && pv.HasMemberExpiration();
+
   HMapWrap hw{pv, op_args.db_cntx};
   bool holds = true;
+  absl::InlinedVector<string_view, 4> missing{key};
   for (size_t i = 0; i < fields.size(); i += 2) {
+    const bool found = bool(hw.Find(fields[i]));
+    if (had_member_expiry && !found)
+      missing.push_back(fields[i]);
     // FNX requires every field to be absent; FXX requires every field to be present.
-    if (fnx == bool(hw.Find(fields[i]))) {
+    if (fnx == found) {
       holds = false;
       break;
     }
   }
-  if (hw.Length() == 0)  // Find() may have lazily expired fields and emptied the hash.
+  if (hw.Length() == 0) {  // Find() may have lazily expired fields and emptied the hash.
     DeleteHw(hw, op_args, key);
+  } else if (missing.size() > 1 && op_args.shard->journal()) {
+    // A field probed while lazily expired is still alive on a lagging replica and the
+    // replayed condition would decide differently there; delete it explicitly first.
+    RecordJournal(op_args, "HDEL"sv, missing);
+  }
   return holds;
 }
 
@@ -998,6 +1033,9 @@ OpResult<vector<OptStr>> OpHGetEx(const OpArgs& op_args, string_view key, const 
   if (pv->IsExternal() && !pv->IsCool())
     return OpStatus::CANCELLED;  // offloaded hashes can't be read/mutated synchronously
 
+  // Only a TTL-carrying StringMap can hold lazily expired fields needing compensation.
+  const bool had_member_expiry = pv->Encoding() == kEncodingStrMap2 && pv->HasMemberExpiration();
+
   // Capture the current field values before mutating TTLs: a past/zero expiry deletes the field,
   // but its value must still be returned (Redis semantics).
   vector<OptStr> values;
@@ -1017,15 +1055,35 @@ OpResult<vector<OptStr>> OpHGetEx(const OpArgs& op_args, string_view key, const 
   }
 
   // Lazy field expiry during the read, or a 0-ttl deletion above, may have emptied the hash.
+  bool key_deleted = false;
   if (pv->Encoding() == kEncodingStrMap2) {
     auto* sm = static_cast<StringMap*>(pv->RObjPtr());
     if (sm->UpperBoundSize() == 0) {
       db_slice.DelMutable(op_args.db_cntx, std::move(*op_res));
+      key_deleted = true;
+    }
+  }
+
+  // Journaling below may yield; disarm the updater so no dash iterator survives the yield
+  // (DelMutable already consumed it in the deleted case).
+  if (!key_deleted)
+    op_res->post_updater.Run();
+
+  if (op_args.shard->journal()) {
+    if (key_deleted) {
       // The replayed command re-applies a relative TTL against the replica clock and
       // cannot reproduce this deletion; journal it explicitly.
-      if (op_args.shard->journal()) {
-        RecordJournal(op_args, "DEL"sv, {key});
+      RecordJournal(op_args, "DEL"sv, {key});
+    } else if (had_member_expiry) {
+      // A field probed while lazily expired is still alive on a lagging replica and the
+      // replayed command would re-arm or persist it there; delete it explicitly.
+      absl::InlinedVector<string_view, 4> missing{key};
+      for (size_t i = 0; i < fields.size(); ++i) {
+        if (!values[i].has_value())
+          missing.push_back(fields[i]);
       }
+      if (missing.size() > 1)
+        RecordJournal(op_args, "HDEL"sv, missing);
     }
   }
 

--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -1921,3 +1921,148 @@ async def test_shrink_emptied_key_replication_lag(df_factory: DflyInstanceFactor
         "deletion must be journaled explicitly: the replayed SHRINK finds the replayed "
         "member TTLs still alive and cannot reproduce it."
     )
+
+
+@pytest.mark.parametrize(
+    "trigger_cmd, expected_f1",
+    [
+        (["HEXPIRE", "myhash", "100", "FIELDS", "1", "f1"], None),
+        (["HGETEX", "myhash", "PERSIST", "FIELDS", "1", "f1"], None),
+        (["HGETEX", "myhash", "EX", "100", "FIELDS", "1", "f1"], None),
+        (["HSETEX", "myhash", "FXX", "FIELDS", "1", "f1", "vnew"], None),
+        (["HSETEX", "myhash", "FNX", "FIELDS", "1", "f1", "vnew"], "vnew"),
+        (["FIELDEXPIRE", "myhash", "100", "f1"], None),
+    ],
+    ids=["hexpire", "hgetex-persist", "hgetex-ex", "hsetex-fxx", "hsetex-fnx", "fieldexpire"],
+)
+async def test_hash_partial_field_expiry_replication_lag(
+    df_factory: DflyInstanceFactory, trigger_cmd, expected_f1
+):
+    """
+    Verify that hash commands probing a lazily expired field journal an explicit HDEL
+    when the hash does not become empty (a sibling field keeps the key alive).
+
+    Field TTLs replicate as relative values re-applied against the replica clock, so
+    under lag the replayed trigger finds the field still alive and takes a different
+    decision: HEXPIRE/FIELDEXPIRE re-arm it, HGETEX PERSIST makes it immortal, HSETEX
+    FXX overwrites it, HSETEX FNX refuses the write the master performed. The replica
+    is SIGSTOPped so the TTL-arming command and the trigger replay land back-to-back
+    on resume, before the replayed TTL elapses — only an explicit HDEL record can keep
+    the replica in sync.
+    """
+    if df_factory.params.gdb:
+        # Signals to a ptrace-traced server are intercepted by gdb: SIGSTOP on the
+        # wrapper pauses nothing, SIGSTOP on the child cannot be resumed with SIGCONT.
+        pytest.skip("SIGSTOP-based lag simulation cannot pause a gdb-traced server")
+
+    master = df_factory.create(proactor_threads=2)
+    replica = df_factory.create(proactor_threads=2)
+
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    # Set up replication before writing data so any later mismatch is real divergence
+    await start_replication(c_replica, master.port)
+
+    await c_master.execute_command("HSET", "myhash", "f1", "10", "keep", "x")
+    await check_all_replicas_finished([c_replica], c_master)
+    assert await c_replica.hlen("myhash") == 2
+
+    try:
+        # SIGSTOP is sent inside pause_process, so it must already be covered by finally.
+        await pause_process(replica.proc.pid)
+
+        # TTL 3 pairs with the elapsed guard below: a false pass (the replica lazily
+        # expiring the field itself during replay) needs a >2s stall between the two
+        # replayed records, which the guard rules out.
+        await c_master.execute_command("HEXPIRE", "myhash", "3", "FIELDS", "1", "f1")
+        await asyncio.sleep(3.2)
+
+        # Probes the lazily expired f1; the hash stays alive through 'keep'.
+        await c_master.execute_command(*trigger_cmd)
+        assert await c_master.hget("myhash", "f1") == expected_f1
+        assert await c_master.hget("myhash", "keep") == "x"
+    finally:
+        resume_time = time.monotonic()
+        resume_process(replica.proc.pid)
+
+    await check_all_replicas_finished([c_replica], c_master)
+
+    # A stall > 2s between the two replayed records lets the replica lazily expire the
+    # field itself, so neither verdict would be trustworthy — skip instead of failing.
+    elapsed = time.monotonic() - resume_time
+    if elapsed > 2:
+        pytest.skip(f"environment too slow to distinguish a missing HDEL ({elapsed:.1f}s)")
+
+    assert await c_replica.hget("myhash", "f1") == expected_f1, (
+        f"Replica diverged on 'f1' after {trigger_cmd[0]} probed it while lazily "
+        "expired on master. The probed-missing field must be journaled as an explicit "
+        "HDEL: the replayed command finds the replayed field TTL still alive and takes "
+        "a different decision."
+    )
+    assert await c_replica.hget("myhash", "keep") == "x"
+
+
+async def test_set_member_partial_expiry_replication_lag(df_factory: DflyInstanceFactory):
+    """
+    Verify that FIELDEXPIRE on a set journals an explicit SREM for a probed member
+    that was lazily expired, when the set does not become empty.
+
+    Same shape as the hash flavor: the replayed FIELDEXPIRE finds the replayed member
+    TTL still alive and re-arms the stale copy instead of reporting it missing.
+    """
+    if df_factory.params.gdb:
+        # Signals to a ptrace-traced server are intercepted by gdb: SIGSTOP on the
+        # wrapper pauses nothing, SIGSTOP on the child cannot be resumed with SIGCONT.
+        pytest.skip("SIGSTOP-based lag simulation cannot pause a gdb-traced server")
+
+    master = df_factory.create(proactor_threads=2)
+    replica = df_factory.create(proactor_threads=2)
+
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    # Set up replication before writing data so any later mismatch is real divergence
+    await start_replication(c_replica, master.port)
+
+    await c_master.sadd("myset", "m1", "keep")
+    await check_all_replicas_finished([c_replica], c_master)
+    assert await c_replica.scard("myset") == 2
+
+    try:
+        # SIGSTOP is sent inside pause_process, so it must already be covered by finally.
+        await pause_process(replica.proc.pid)
+
+        # TTL 3 pairs with the elapsed guard below: a false pass (the replica lazily
+        # expiring the member itself during replay) needs a >2s stall between the two
+        # replayed records, which the guard rules out.
+        await c_master.execute_command("FIELDEXPIRE", "myset", "3", "m1")
+        await asyncio.sleep(3.2)
+
+        # Probes the lazily expired m1; the set stays alive through 'keep'.
+        await c_master.execute_command("FIELDEXPIRE", "myset", "100", "m1")
+        assert await c_master.sismember("myset", "m1") == 0
+        assert await c_master.sismember("myset", "keep") == 1
+    finally:
+        resume_time = time.monotonic()
+        resume_process(replica.proc.pid)
+
+    await check_all_replicas_finished([c_replica], c_master)
+
+    # A stall > 2s between the two replayed records lets the replica lazily expire the
+    # member itself, so neither verdict would be trustworthy — skip instead of failing.
+    elapsed = time.monotonic() - resume_time
+    if elapsed > 2:
+        pytest.skip(f"environment too slow to distinguish a missing SREM ({elapsed:.1f}s)")
+
+    assert await c_replica.sismember("myset", "m1") == 0, (
+        "Replica still has member 'm1' after FIELDEXPIRE probed it while lazily "
+        "expired on master. The probed-missing member must be journaled as an explicit "
+        "SREM: the replayed command finds the replayed member TTL still alive and "
+        "re-arms the stale copy."
+    )
+    assert await c_replica.sismember("myset", "keep") == 1


### PR DESCRIPTION
HEXPIRE/HGETEX/HSETEX-FNX/FXX and FIELDEXPIRE journal an explicit HDEL/SREM for fields probed while lazily expired, so a lagging replica does not re-arm, persist, or overwrite the stale copy on replay.