### PR TITLE
tests: Fix linter errors

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -6,6 +6,7 @@ import time
 
 import async_timeout
 import pytest
+
 import redis
 from redis import asyncio as aioredis
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -686,7 +686,7 @@ async def test_acl_revoke_pub_sub_while_subscribed(df_factory):
 
     async def publish_worker(client):
         logging.debug("Starting publish_worker")
-        for i in range(0, 10):
+        for i in range(10):
             logging.debug(f"publisher iteration: {i}")
             await client.publish("channel", f"message{i}")
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -1,9 +1,15 @@
+import asyncio
+import logging
+import os
 import tempfile
+import time
 
 import async_timeout
+import pytest
+import redis
+from redis import asyncio as aioredis
 
 from . import dfly_args
-from .utility import *
 
 
 @pytest.mark.asyncio
@@ -169,7 +175,7 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
     assert res == "OK"
 
     with pytest.raises(redis.exceptions.NoPermissionError):
-        await client.execute_command(f"SET x bar")
+        await client.execute_command("SET x bar")
     await client.aclose()
 
     # NOPERM between multi and exec
@@ -205,7 +211,7 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
 
     await client.execute_command("AUTH myuser kk")
     assert "OK" == await client.execute_command("MULTI")
-    await client.execute_command(f"SET x bar")
+    await client.execute_command("SET x bar")
     await client.execute_command("EXEC")
 
     # NOPERM between multi and exec
@@ -221,7 +227,7 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
     denied = False
     while not denied and time.time() - start < 10:
         try:
-            await client.execute_command(f"SET x bar")
+            await client.execute_command("SET x bar")
             await asyncio.sleep(0.1)
         except redis.exceptions.NoPermissionError:
             denied = True
@@ -523,12 +529,12 @@ async def test_set_len_acl_log(async_client):
     res = await async_client.execute_command("ACL LOG")
     assert 7 == len(res)
 
-    await async_client.execute_command(f"CONFIG SET acllog_max_len 3")
+    await async_client.execute_command("CONFIG SET acllog_max_len 3")
 
     res = await async_client.execute_command("ACL LOG")
     assert 3 == len(res)
 
-    await async_client.execute_command(f"CONFIG SET acllog_max_len 10")
+    await async_client.execute_command("CONFIG SET acllog_max_len 10")
 
     for x in range(7):
         with pytest.raises(redis.exceptions.AuthenticationError):

--- a/tests/dragonfly/celery_test.py
+++ b/tests/dragonfly/celery_test.py
@@ -68,7 +68,7 @@ async def test_celery_push_jobs(async_client: aioredis.Redis, celery_app):
     process_job = celery_app.tasks["process_job"]
 
     results = []
-    for i in range(0, 200):
+    for i in range(200):
         results.append(process_job.delay(f"job{i}"))
 
     queue_len = await async_client.llen("my_queue")
@@ -78,7 +78,6 @@ async def test_celery_push_jobs(async_client: aioredis.Redis, celery_app):
 
 
 def test_celery_inspect(celery_app, celery_worker):
-    process_job = celery_app.tasks["process_job"]
     inspector = celery_app.control.inspect()
 
     # Worker should be alive

--- a/tests/dragonfly/celery_test.py
+++ b/tests/dragonfly/celery_test.py
@@ -1,14 +1,15 @@
 import logging
 import threading
-from redis import asyncio as aioredis
 
 import pytest
 from celery import Celery
 from celery.contrib.testing.worker import (
-    setup_app_for_worker,
     TestWorkController,
     _set_task_join_will_block,
+    setup_app_for_worker,
 )
+
+from redis import asyncio as aioredis
 
 
 def _process_job(job_id):

--- a/tests/dragonfly/cluster_mgr_test.py
+++ b/tests/dragonfly/cluster_mgr_test.py
@@ -2,6 +2,7 @@ import logging
 import subprocess
 
 import pytest
+
 import redis
 from redis import asyncio as aioredis
 

--- a/tests/dragonfly/cluster_mgr_test.py
+++ b/tests/dragonfly/cluster_mgr_test.py
@@ -1,8 +1,10 @@
+import logging
 import subprocess
+
 import pytest
 import redis
 from redis import asyncio as aioredis
-from .utility import *
+
 from . import dfly_args
 
 BASE_PORT = 30001
@@ -37,7 +39,7 @@ async def test_cluster_mgr(df_factory):
     assert run_cluster_mgr(["--action=config_single_remote", f"--target_port={BASE_PORT}"])
     for i in range(1, NODES):
         assert run_cluster_mgr(
-            ["--action=attach", f"--target_port={BASE_PORT}", f"--attach_port={BASE_PORT+i}"]
+            ["--action=attach", f"--target_port={BASE_PORT}", f"--attach_port={BASE_PORT + i}"]
         )
 
     # Feed the cluster with data and test that it works correctly
@@ -48,10 +50,10 @@ async def test_cluster_mgr(df_factory):
     # Migrate ~half of the slots to node 1
     assert run_cluster_mgr(
         [
-            f"--action=migrate",
+            "--action=migrate",
             f"--target_port={BASE_PORT + 1}",
-            f"--slot_start=8000",
-            f"--slot_end=16383",
+            "--slot_start=8000",
+            "--slot_end=16383",
         ]
     )
     await check_cluster_data(client)
@@ -65,26 +67,26 @@ async def test_cluster_mgr(df_factory):
     # Can't attach non-replica as replica
     assert not run_cluster_mgr(
         [
-            f"--action=attach",
+            "--action=attach",
             f"--target_port={BASE_PORT}",
-            f"--attach_port={BASE_PORT+2}",
-            f"--attach_as_replica=True",
+            f"--attach_port={BASE_PORT + 2}",
+            "--attach_as_replica=True",
         ]
     )
 
     # Reattach node 2 and migrate some slots to it
     assert run_cluster_mgr(
-        ["--action=attach", f"--target_port={BASE_PORT}", f"--attach_port={BASE_PORT+2}"]
+        ["--action=attach", f"--target_port={BASE_PORT}", f"--attach_port={BASE_PORT + 2}"]
     )
     await check_cluster_data(client)
     # Slots 7000-8000 belong to node0, while 8001-9000 belong to node1. cluster_mgr doesn't support
     # such a migration in a single command.
     assert not run_cluster_mgr(
         [
-            f"--action=migrate",
+            "--action=migrate",
             f"--target_port={BASE_PORT + 1}",
-            f"--slot_start=7000",
-            f"--slot_end=9000",
+            "--slot_start=7000",
+            "--slot_end=9000",
         ]
     )
     assert run_cluster_mgr(
@@ -93,10 +95,10 @@ async def test_cluster_mgr(df_factory):
     await check_cluster_data(client)
     assert run_cluster_mgr(
         [
-            f"--action=migrate",
+            "--action=migrate",
             f"--target_port={BASE_PORT + 2}",
-            f"--slot_start=8000",
-            f"--slot_end=10000",
+            "--slot_start=8000",
+            "--slot_end=10000",
         ]
     )
     await check_cluster_data(client)
@@ -104,8 +106,8 @@ async def test_cluster_mgr(df_factory):
     # Can't attach replica before running REPLICAOF
     assert not run_cluster_mgr(
         [
-            f"--action=attach",
-            f"--attach_as_replica=True",
+            "--action=attach",
+            "--attach_as_replica=True",
             f"--target_port={BASE_PORT}",
             f"--attach_port={replicas[0].port}",
         ]
@@ -117,8 +119,8 @@ async def test_cluster_mgr(df_factory):
         await replica_clients[i].execute_command(f"replicaof 127.0.0.1 {masters[i].port}")
         assert run_cluster_mgr(
             [
-                f"--action=attach",
-                f"--attach_as_replica=True",
+                "--action=attach",
+                "--attach_as_replica=True",
                 f"--target_port={masters[i].port}",
                 f"--attach_port={replicas[i].port}",
             ]
@@ -137,19 +139,19 @@ async def test_cluster_mgr(df_factory):
     await c_master0.execute_command(f"replicaof 127.0.0.1 {replicas[0].port}")
     assert run_cluster_mgr(
         [
-            f"--action=attach",
-            f"--attach_as_replica=True",
+            "--action=attach",
+            "--attach_as_replica=True",
             f"--target_port={replicas[0].port}",
             f"--attach_port={masters[0].port}",
         ]
     )
     assert run_cluster_mgr(["--action=takeover", f"--target_port={masters[0].port}"])
-    await c_master0.execute_command(f"replicaof no one")
+    await c_master0.execute_command("replicaof no one")
     await replica_clients[0].execute_command(f"replicaof 127.0.0.1 {masters[0].port}")
     assert run_cluster_mgr(
         [
-            f"--action=attach",
-            f"--attach_as_replica=True",
+            "--action=attach",
+            "--attach_as_replica=True",
             f"--target_port={masters[0].port}",
             f"--attach_port={replicas[0].port}",
         ]

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -12,13 +12,13 @@ from binascii import crc_hqx
 from dataclasses import dataclass
 
 import pytest
-from redis import asyncio as aioredis
-from redis.cluster import ClusterNode
-from redis.cluster import RedisCluster
+from redis.cluster import ClusterNode, RedisCluster
 from redis.exceptions import MovedError
 
+from redis import asyncio as aioredis
+
 from . import dfly_args
-from .instance import DflyInstanceFactory, DflyInstance
+from .instance import DflyInstance, DflyInstanceFactory
 from .seeder import DebugPopulateSeeder
 from .utility import (
     DflySeederFactory,

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2669,7 +2669,7 @@ async def test_cluster_memory_consumption_migration(df_factory: DflyInstanceFact
     migration_nodes = len(instances) - 1
     slot_step = 16384 // migration_nodes
     ranges = []
-    for i in range(0, migration_nodes):
+    for i in range(migration_nodes):
         ranges.append(i * slot_step)
     ranges.append(16384)
 
@@ -3434,7 +3434,7 @@ async def test_SearchRequestDistribution(df_factory: DflyInstanceFactory):
     cclient = instances[0].cluster_client()
 
     docs_num = 100
-    for i in range(0, docs_num):
+    for i in range(docs_num):
         assert await cclient.execute_command("HSET", f"s{i}", "title", f"test {i}") == 1
 
     async def search_test():
@@ -3442,7 +3442,7 @@ async def test_SearchRequestDistribution(df_factory: DflyInstanceFactory):
             "FT.SEARCH", "idx", "@title:test", "text", "LIMIT", "0", "1000"
         )
         assert res[0] == docs_num
-        for i in range(0, docs_num):
+        for i in range(docs_num):
             assert f"s{i}" in res
 
     await asyncio.gather(*(search_test() for _ in range(docs_num)))
@@ -3477,7 +3477,7 @@ async def test_SortedSearchRequest(df_factory: DflyInstanceFactory):
     cclient = instances[0].cluster_client()
 
     docs_num = 100
-    for i in range(0, docs_num):
+    for i in range(docs_num):
         assert (
             await cclient.execute_command("HSET", f"s{i}", "title", f"test {i}", "size", f"{i}")
             == 2
@@ -3502,7 +3502,7 @@ async def test_SortedSearchRequest(df_factory: DflyInstanceFactory):
         for i in range(offset, offset + limit_size):
             assert f"s{i}" in res, f"offset: {offset}, limit_size: {limit_size}, res: {res}"
 
-        for i in range(0, offset):
+        for i in range(offset):
             assert f"s{i}" not in res
 
         for i in range(offset + limit_size, docs_num):
@@ -3540,7 +3540,7 @@ async def test_remove_docs_on_cluster_migration(df_factory):
 
     # Populate node 0
     keys = 100
-    for i in range(0, keys):
+    for i in range(keys):
         random_string = "".join(random.choices(string.ascii_letters + string.digits, k=1_000))
         await nodes[0].client.execute_command("HSET", f"doc:{i}", "v", random_string)
 

--- a/tests/dragonfly/config_test.py
+++ b/tests/dragonfly/config_test.py
@@ -1,8 +1,6 @@
 import pytest
 import redis
 from redis.asyncio import Redis as RedisClient
-from .utility import *
-from .instance import DflyStartException
 
 
 async def test_maxclients(df_factory):

--- a/tests/dragonfly/config_test.py
+++ b/tests/dragonfly/config_test.py
@@ -1,6 +1,7 @@
 import pytest
-import redis
 from redis.asyncio import Redis as RedisClient
+
+import redis
 
 
 async def test_maxclients(df_factory):

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -16,7 +16,6 @@ from copy import deepcopy
 from pathlib import Path
 from tempfile import gettempdir, mkdtemp
 from time import sleep
-from typing import Dict, List, Union
 
 import pymemcache
 import pytest
@@ -259,7 +258,7 @@ async def proxy_factory():
         yield create_proxy
 
 
-def parse_args(args: List[str]) -> Dict[str, Union[str, None]]:
+def parse_args(args: list[str]) -> dict[str, str | None]:
     args_dict = {}
     for arg in args:
         if "=" in arg:

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -20,18 +20,19 @@ from time import sleep
 import pymemcache
 import pytest
 import pytest_asyncio
+
 import redis
 from redis import asyncio as aioredis
 
 from . import PortPicker
-from .instance import DflyInstance, DflyParams, DflyInstanceFactory, RedisServer
+from .instance import DflyInstance, DflyInstanceFactory, DflyParams, RedisServer
 from .proxy import Proxy
 from .utility import (
     DflySeederFactory,
+    download_with_retries,
     gen_ca_cert,
     gen_certificate,
     skip_if_not_in_github,
-    download_with_retries,
 )
 
 logging.getLogger("asyncio").setLevel(logging.WARNING)
@@ -70,8 +71,9 @@ def _download_minio_binary(dest: Path):
 
 def _start_minio_server(endpoint):
     """Start MinIO subprocess and configure env vars for S3 tests."""
-    import boto3
     from urllib.parse import urlparse
+
+    import boto3
 
     cache_dir = Path.home() / ".cache" / "dragonfly-tests"
     cache_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -10,8 +10,6 @@ from threading import Thread
 
 import async_timeout
 import pytest
-import redis as base_redis
-from redis import asyncio as aioredis
 from redis.backoff import NoBackoff
 from redis.cache import CacheConfig
 from redis.exceptions import (
@@ -22,9 +20,12 @@ from redis.exceptions import (
 )
 from redis.retry import Retry
 
+import redis as base_redis
+from redis import asyncio as aioredis
+
 from . import dfly_args, dfly_multi_test_args
 from .instance import DflyInstance, DflyInstanceFactory
-from .utility import tick_timer, assert_eventually, parse_client_list
+from .utility import assert_eventually, parse_client_list, tick_timer
 
 BASE_PORT = 1111
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1063,7 +1063,7 @@ async def test_send_delay_metric(df_server: DflyInstance):
 async def test_match_http(df_server: DflyInstance):
     reader, writer = await asyncio.open_connection("localhost", df_server.port)
     for i in range(2000):
-        writer.write("foo bar ".encode())
+        writer.write(b"foo bar ")
         await writer.drain()
 
 
@@ -1148,7 +1148,7 @@ async def test_pipeline_batching_while_migrating(
     writer.write((f"EVALSHA {sha} 1 a\r\n" + incrs).encode())
     await writer.drain()
     # We migrate only when the socket wakes up, so send another batch to trigger migration
-    writer.write("INCR a\r\n".encode())
+    writer.write(b"INCR a\r\n")
     await writer.drain()
 
     # The data doesn't necessarily arrive in a single batch
@@ -1956,7 +1956,7 @@ async def test_timeout(df_server: DflyInstance, async_client: aioredis.Redis):
 @dfly_args({"send_timeout": 3})
 async def test_send_timeout(df_server, async_client: aioredis.Redis):
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
-    writer.write("client setname writer_test\n".encode())
+    writer.write(b"client setname writer_test\n")
     await writer.drain()
     assert "OK" in (await reader.readline()).decode()
     clients = await async_client.client_list()
@@ -1967,7 +1967,7 @@ async def test_send_timeout(df_server, async_client: aioredis.Redis):
 
     async def get_task():
         while True:
-            writer.write("GET a\n".encode())
+            writer.write(b"GET a\n")
             await writer.drain()
             await asyncio.sleep(0.1)
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -605,12 +605,12 @@ async def test_subscribers_with_active_publisher(df_server: DflyInstance, max_co
 
     async def publish_worker():
         client = aioredis.Redis(connection_pool=async_pool)
-        for i in range(0, 2000):
+        for i in range(2000):
             await client.publish("channel", f"message-{i}")
         await client.aclose()
 
     async def channel_reader(channel: aioredis.client.PubSub):
-        for i in range(0, 150):
+        for i in range(150):
             try:
                 async with async_timeout.timeout(1):
                     await channel.get_message(ignore_subscribe_messages=True)
@@ -1185,7 +1185,7 @@ async def test_parser_memory_stats(df_server, async_client: aioredis.Redis):
     writer.write(b"*1000\r\n")
     writer.write(b"$4\r\nmget\r\n")
     val = (b"a" * 100) + b"\r\n"
-    for i in range(0, 900):
+    for i in range(900):
         writer.write(b"$100\r\n" + val)
     await writer.drain()  # writer is pending because the request is not finished.
 
@@ -2027,7 +2027,7 @@ async def test_pipeline_cache_only_async_squashed_dispatches(df_factory):
     # them only after execution, so while `INFO` runs the cache is empty.
     # high max_busy_read_usec ensures that the connection fiber has enough time to push
     # all the commands to reach the squashing limit.
-    for i in range(0, 10):
+    for i in range(10):
         # 10 INFO commands exceed pipeline_squash=9, so the whole pipeline is squashed and
         # INFO should report pipeline_cache_bytes == 0 for every command in it.
         res = await push_pipeline(10)

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -122,9 +122,7 @@ async def test_django_cacheops_script(async_client, num_keys=500):
         assert await async_client.exists(k)
         for table, fields in DJANGO_CACHEOPS_SCHEMA(vs).items():
             for sub_schema in fields:
-                conj_key = f"conj:{table}:" + "&".join(
-                    "{}={}".format(f, v) for f, v in sub_schema.items()
-                )
+                conj_key = f"conj:{table}:" + "&".join(f"{f}={v}" for f, v in sub_schema.items())
                 assert await async_client.sismember(conj_key, k)
 
 

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -236,7 +236,7 @@ async def test_eval_error_propagation(async_client):
             await async_client.eval(template.format(cmd), 1, "l")
             if does_abort:
                 assert False, "Eval must have thrown an error: " + cmd
-        except aioredis.RedisError as e:
+        except aioredis.RedisError:
             if not does_abort:
                 assert False, "Error should have been ignored: " + cmd
 
@@ -373,7 +373,7 @@ async def test_gc_force_flag(async_client: aioredis.Redis):
           end
         end
     """
-    for i in range(0, 1000):
+    for i in range(1000):
         await asyncio.gather(*(async_client.eval(SCRIPT, 0) for _ in range(5)))
 
     info = await async_client.info("memory")
@@ -392,7 +392,7 @@ async def test_gc_force_flag(async_client: aioredis.Redis):
 
     await async_client.execute_command("CONFIG", "SET", "lua_mem_gc_threshold", "1000")
 
-    for i in range(0, 1000):
+    for i in range(1000):
         await asyncio.gather(*(async_client.eval(SCRIPT, 0) for _ in range(5)))
 
     info = await async_client.info("memory")

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -7,6 +7,7 @@ import time
 
 import async_timeout
 import pytest
+
 from redis import asyncio as aioredis
 
 from . import dfly_args, dfly_multi_test_args

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -1,13 +1,15 @@
-import logging
-import pytest
-import redis
 import asyncio
+import logging
+
+import pytest
+
+import redis
 from redis import asyncio as aioredis
 
-from . import dfly_multi_test_args, dfly_args
+from . import dfly_args, dfly_multi_test_args
 from .instance import DflyInstance, DflyStartException
-from .utility import batch_fill_data, gen_test_data, EnvironCntx
 from .seeder import DebugPopulateSeeder
+from .utility import EnvironCntx, batch_fill_data, gen_test_data
 
 
 @dfly_multi_test_args({"keys_output_limit": 512}, {"keys_output_limit": 1024})

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -168,22 +168,20 @@ async def test_blocking_multiple_dbs(async_client: aioredis.Redis, df_server: Df
 
 
 async def test_arg_from_environ_overwritten_by_cli(df_factory):
-    with EnvironCntx(DFLY_port="6378"):
-        with df_factory.create(port=6377):
-            client = aioredis.Redis(port=6377)
-            await client.ping()
+    with EnvironCntx(DFLY_port="6378"), df_factory.create(port=6377):
+        client = aioredis.Redis(port=6377)
+        await client.ping()
 
 
 async def test_arg_from_environ(df_factory):
-    with EnvironCntx(DFLY_requirepass="pass"):
-        with df_factory.create() as dfly:
-            # Expect password from environment variable
-            with pytest.raises(redis.exceptions.AuthenticationError):
-                client = aioredis.Redis(port=dfly.port)
-                await client.ping()
-
-            client = aioredis.Redis(password="pass", port=dfly.port)
+    with EnvironCntx(DFLY_requirepass="pass"), df_factory.create() as dfly:
+        # Expect password from environment variable
+        with pytest.raises(redis.exceptions.AuthenticationError):
+            client = aioredis.Redis(port=dfly.port)
             await client.ping()
+
+        client = aioredis.Redis(password="pass", port=dfly.port)
+        await client.ping()
 
 
 async def test_unknown_dfly_env(df_factory, export_dfly_password):

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -140,7 +140,6 @@ def get_json_object(json_str):
 
 @dfly_args({"proactor_threads": "1", "expose_http_api": "true", "slowlog_log_slower_than": 0})
 async def test_http_api_json_response(df_server: DflyInstance):
-    client = df_server.client()
     async with get_http_session() as session:
         body = '["set", "foo","bar"]'
         async with session.post(f"http://localhost:{df_server.port}/api", data=body) as resp:

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -1,5 +1,7 @@
-import aiohttp
 import json
+
+import aiohttp
+
 from . import dfly_args
 from .instance import DflyInstance
 

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -9,7 +9,7 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass
-from typing import Dict, Optional, List, Union
+from typing import Dict, List, Union
 
 import aiohttp
 import psutil
@@ -93,14 +93,14 @@ class DflyInstance:
         self.args = args
         self.args.update(params.args)
         self.params = params
-        self.proc: Optional[subprocess.Popen] = None
-        self._client: Optional[RedisClient] = None
+        self.proc: subprocess.Popen | None = None
+        self._client: RedisClient | None = None
         self.log_files: List[str] = []
         self.dynamic_port = False
         self.sed_proc = None
         self.clients = []
         # Optional hard RLIMIT_AS cap (mirrors `ulimit -v`) for OOM tests.
-        self.vmem_limit_bytes: Optional[int] = None
+        self.vmem_limit_bytes: int | None = None
 
         if self.params.existing_port:
             self._port = self.params.existing_port
@@ -318,7 +318,7 @@ class DflyInstance:
         return self._port
 
     @property
-    def admin_port(self) -> Optional[int]:
+    def admin_port(self) -> int | None:
         if self.params.existing_admin_port:
             return self.params.existing_admin_port
         if "admin_port" in self.args:
@@ -326,7 +326,7 @@ class DflyInstance:
         return None
 
     @property
-    def mc_port(self) -> Optional[int]:
+    def mc_port(self) -> int | None:
         if self.params.existing_mc_port:
             return self.params.existing_mc_port
         if "memcached_port" in self.args:

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -9,7 +9,6 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Union
 
 import aiohttp
 import psutil
@@ -28,7 +27,7 @@ class DflyParams:
     gdb: bool
     direct_output: bool
     buffered_out: bool
-    args: Dict[str, Union[str, None]]
+    args: dict[str, str | None]
     existing_port: int
     existing_admin_port: int
     existing_mc_port: int
@@ -95,7 +94,7 @@ class DflyInstance:
         self.params = params
         self.proc: subprocess.Popen | None = None
         self._client: RedisClient | None = None
-        self.log_files: List[str] = []
+        self.log_files: list[str] = []
         self.dynamic_port = False
         self.sed_proc = None
         self.clients = []
@@ -357,7 +356,7 @@ class DflyInstance:
             return ports.pop()
         raise RuntimeError("Couldn't parse port")
 
-    def get_logs_from_psutil(self) -> List[str]:
+    def get_logs_from_psutil(self) -> list[str]:
         p = psutil.Process(self.proc.pid)
         rv = []
         for file in p.open_files():
@@ -507,7 +506,7 @@ class DflyInstanceFactory:
         self.instances.append(instance)
         return instance
 
-    def start_all(self, instances: List[DflyInstance]):
+    def start_all(self, instances: list[DflyInstance]):
         """Start multiple instances in parallel"""
         for instance in instances:
             instance._start()

--- a/tests/dragonfly/json_test.py
+++ b/tests/dragonfly/json_test.py
@@ -1,6 +1,7 @@
 from json import JSONDecoder, JSONEncoder, dumps
 
 import pytest
+
 import redis
 from redis import asyncio as aioredis
 

--- a/tests/dragonfly/json_test.py
+++ b/tests/dragonfly/json_test.py
@@ -1,8 +1,8 @@
+from json import JSONDecoder, JSONEncoder, dumps
+
 import pytest
 import redis
 from redis import asyncio as aioredis
-from .utility import *
-from json import JSONDecoder, JSONEncoder, dumps
 
 jane = {"name": "Jane", "Age": 33, "Location": "Chawton"}
 
@@ -37,7 +37,7 @@ async def test_access_json_value_as_string(async_client: aioredis.Redis):
     assert the_type == "ReJSON-RL"
     # you cannot access this key as string
     with pytest.raises(redis.exceptions.ResponseError) as e:
-        result = await async_client.get(key_name)
+        await async_client.get(key_name)
 
     assert e.value.args[0] == "WRONGTYPE Operation against a key holding the wrong kind of value"
 
@@ -104,7 +104,7 @@ async def test_arrappend(async_client: aioredis.Redis, description, expected_val
 
     # make sure the value is as expected
     first_element = await async_client.execute_command("json.get", key_name, "$[0]")
-    assert first_element == "[{}]".format(expected_value)
+    assert first_element == f"[{expected_value}]"
 
     # make sure the type is as expected
     actual_type = await async_client.execute_command("json.type", key_name, "$[0]")

--- a/tests/dragonfly/list_family_test.py
+++ b/tests/dragonfly/list_family_test.py
@@ -1,7 +1,8 @@
 import asyncio
-from redis import asyncio as aioredis
 
 import pytest
+
+from redis import asyncio as aioredis
 
 
 @pytest.mark.parametrize("index", range(50))

--- a/tests/dragonfly/management_test.py
+++ b/tests/dragonfly/management_test.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 from redis import asyncio as aioredis
 from redis.exceptions import ResponseError
 

--- a/tests/dragonfly/management_test.py
+++ b/tests/dragonfly/management_test.py
@@ -1,6 +1,7 @@
 import pytest
-from redis import asyncio as aioredis
 from redis.exceptions import ResponseError
+
+from redis import asyncio as aioredis
 
 
 @pytest.mark.asyncio

--- a/tests/dragonfly/memcache_meta.py
+++ b/tests/dragonfly/memcache_meta.py
@@ -1,13 +1,14 @@
 import pytest
-from .instance import DflyInstance
-from . import dfly_args
 from meta_memcache import (
+    CacheClient,
     Key,
     ServerAddress,
-    CacheClient,
     connection_pool_factory_builder,
 )
 from meta_memcache.protocol import RequestFlags, Success
+
+from . import dfly_args
+from .instance import DflyInstance
 
 DEFAULT_ARGS = {"memcached_port": 11211, "proactor_threads": 4}
 

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -297,7 +297,7 @@ async def test_no_rss_eviction_overflow_on_expired_keys(df_factory: DflyInstance
     val_size = 1024 * 50  # 50 kb for key
     num_keys = data_fill_size // val_size
 
-    for i in range(0, 5):
+    for i in range(5):
         pipe = client.pipeline(transaction=False)
         step_keys = num_keys + i * 10
         await pipe.execute_command("DEBUG", "POPULATE", step_keys, "key_1", val_size)

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -254,8 +254,8 @@ async def test_eviction_on_rss_treshold(df_factory: DflyInstanceFactory, heartbe
             await client.execute_command(f"LPUSH {name} {rand_str}")
 
     # Make them STICK so we don't evict them
-    await client.execute_command(f"STICK list_1")
-    await client.execute_command(f"STICK list_2")
+    await client.execute_command("STICK list_1")
+    await client.execute_command("STICK list_2")
 
     await client.execute_command("CONFIG SET enable_heartbeat_eviction true")
 
@@ -390,7 +390,7 @@ async def test_remove_docs_on_eviction(df_factory):
     await asyncio.sleep(1)
 
     # Get number of docs in index
-    index_info = await client.execute_command(f"FT.INFO idx")
+    index_info = await client.execute_command("FT.INFO idx")
     index_info_num_docs = index_info[9]
 
     # Get number of keys in database

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -5,6 +5,7 @@ import string
 import time
 
 import pytest
+
 import redis
 
 from . import dfly_args

--- a/tests/dragonfly/proactor_threads_test.py
+++ b/tests/dragonfly/proactor_threads_test.py
@@ -8,6 +8,7 @@ ignores FLAGS_proactor_threads entirely. The fix resets pool_size to 0 when
 """
 
 import pytest
+
 from .instance import DflyInstanceFactory
 
 

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -7,7 +7,7 @@ import pytest
 import redis.asyncio as aioredis
 
 from .instance import DflyInstanceFactory
-from .utility import ValueType, wait_available_async, assert_eventually
+from .utility import ValueType, assert_eventually, wait_available_async
 
 
 async def _bounded(awaitable, timeout=5):

--- a/tests/dragonfly/replication_config_test.py
+++ b/tests/dragonfly/replication_config_test.py
@@ -9,6 +9,7 @@ import tarfile
 import async_timeout
 import pymemcache
 import pytest
+
 import redis
 
 from . import dfly_args

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -1292,7 +1292,7 @@ async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
     df_factory.start_all([replica, master])
 
     async def stream(client, total):
-        for i in range(0, total):
+        for i in range(total):
             prefix = "{prefix}"
             # Seed to one shard only. This will eventually cause one of the flows to become stale.
             await client.execute_command(f"SET {prefix}foo{i} bar{i}")

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -8,13 +8,12 @@ from itertools import chain, repeat
 
 import async_timeout
 import pytest
+
 import redis
 from redis import asyncio as aioredis
 
 from . import dfly_args
-from .instance import DflyInstanceFactory, DflyInstance
-from .seeder import DebugPopulateSeeder
-from .seeder import Seeder as SeederV2
+from .instance import DflyInstance, DflyInstanceFactory
 from .replication_utils import (
     ADMIN_PORT,
     get_metric_value,
@@ -23,11 +22,13 @@ from .replication_utils import (
     start_replication,
     wait_for_replica_status,
 )
+from .seeder import DebugPopulateSeeder
+from .seeder import Seeder as SeederV2
 from .utility import (
-    assert_eventually,
-    check_all_replicas_finished,
     DflySeederFactory,
     ExpirySeeder,
+    assert_eventually,
+    check_all_replicas_finished,
     info_tick_timer,
     tmp_file_name,
     wait_available_async,
@@ -688,8 +689,8 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     # redis-py >= 7 retries on ConnectionError by default, and BusyLoadingError
     # inherits from ConnectionError, causing the REPLICAOF to be silently
     # retried until loading finishes.
-    from redis.retry import Retry
     from redis.backoff import NoBackoff
+    from redis.retry import Retry
 
     c_replica = replica.client(retry=Retry(NoBackoff(), 0))
 

--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -47,13 +47,13 @@ async def test_search(df_factory):
 
     # First, create an index on replica
     await c_replica.execute_command("FT.CREATE", "idx-r", "SCHEMA", "f1", "numeric")
-    for i in range(0, 10):
+    for i in range(10):
         await c_replica.hset(f"k{i}", mapping={"f1": i})
     assert (await c_replica.ft("idx-r").search("@f1:[5 9]")).total == 5
 
     # Second, create an index on master
     await c_master.execute_command("FT.CREATE", "idx-m", "SCHEMA", "f2", "numeric")
-    for i in range(0, 10):
+    for i in range(10):
         await c_master.hset(f"k{i}", mapping={"f2": i * 2})
     assert (await c_master.ft("idx-m").search("@f2:[6 10]")).total == 3
 

--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -9,16 +9,17 @@ import async_timeout
 import psutil
 import pymemcache
 import pytest
+
 from redis import asyncio as aioredis
 
 from . import dfly_args
 from .instance import DflyInstanceFactory
-from .seeder import DebugPopulateSeeder, HnswSearchSeeder
-from .seeder import Seeder as SeederV2
 from .replication_utils import (
     setup_replication,
     start_replication,
 )
+from .seeder import DebugPopulateSeeder, HnswSearchSeeder
+from .seeder import Seeder as SeederV2
 from .utility import (
     assert_eventually,
     check_all_replicas_finished,

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -6,13 +6,12 @@ import time
 
 import async_timeout
 import pytest
+
 import redis
 from redis import asyncio as aioredis
 
 from . import dfly_args
 from .instance import DflyInstanceFactory
-from .seeder import DebugPopulateSeeder
-from .seeder import Seeder as SeederV2
 from .replication_utils import (
     ADMIN_PORT,
     assert_replica_data_matches,
@@ -22,6 +21,8 @@ from .replication_utils import (
     setup_replication,
     start_replication,
 )
+from .seeder import DebugPopulateSeeder
+from .seeder import Seeder as SeederV2
 from .utility import (
     assert_eventually,
     batch_fill_data,

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -765,7 +765,7 @@ async def test_script_transfer(df_factory):
 
     # Load some scripts into master ahead
     scripts = []
-    for i in range(0, 10):
+    for i in range(10):
         sha = await c_master.script_load(SCRIPT_TEMPLATE.format(i))
         scripts.append(sha)
 

--- a/tests/dragonfly/replication_utils.py
+++ b/tests/dragonfly/replication_utils.py
@@ -25,7 +25,6 @@ import asyncio
 import dataclasses
 import logging
 import time
-from typing import List, Union
 
 from redis import asyncio as aioredis
 
@@ -190,9 +189,9 @@ class ReplicationSetup:
     """
 
     master: DflyInstance
-    replicas: List[DflyInstance]
+    replicas: list[DflyInstance]
     c_master: "object"
-    c_replicas: List["object"]
+    c_replicas: list["object"]
 
     def __iter__(self):
         return iter((self.master, self.replicas, self.c_master, self.c_replicas))
@@ -211,7 +210,7 @@ async def setup_replication(
     *,
     master_args: dict | None = None,
     replica_args: dict | None = None,
-    replicas: Union[int, List[dict]] = 1,
+    replicas: int | list[dict] = 1,
     connect: bool = True,
     wait: bool = True,
 ) -> ReplicationSetup:

--- a/tests/dragonfly/replication_utils.py
+++ b/tests/dragonfly/replication_utils.py
@@ -25,7 +25,7 @@ import asyncio
 import dataclasses
 import logging
 import time
-from typing import List, Optional, Union
+from typing import List, Union
 
 from redis import asyncio as aioredis
 
@@ -209,8 +209,8 @@ class ReplicationSetup:
 async def setup_replication(
     df_factory: DflyInstanceFactory,
     *,
-    master_args: Optional[dict] = None,
-    replica_args: Optional[dict] = None,
+    master_args: dict | None = None,
+    replica_args: dict | None = None,
     replicas: Union[int, List[dict]] = 1,
     connect: bool = True,
     wait: bool = True,

--- a/tests/dragonfly/search_benchmark_test.py
+++ b/tests/dragonfly/search_benchmark_test.py
@@ -1,17 +1,18 @@
 import logging
 import time
+
 import pytest
 
 from . import dfly_args
 from .instance import DflyInstance
 from .search_benchmark_utils import (
-    generate_document_columns,
+    DOCUMENT_KEY,
+    INDEX_KEY,
     create_search_index,
+    generate_document_columns,
     generate_document_data,
     run_query_load_test,
     set_random_seed,
-    INDEX_KEY,
-    DOCUMENT_KEY,
 )
 
 

--- a/tests/dragonfly/search_benchmark_utils.py
+++ b/tests/dragonfly/search_benchmark_utils.py
@@ -4,7 +4,6 @@ import random
 import string
 import uuid
 import math
-from typing import List, Tuple
 from redis import asyncio as aioredis
 from redis.commands.search.query import Query
 
@@ -60,10 +59,10 @@ def _initialize_pre_generated_data(size: int):
 
 async def generate_document_data(
     client: aioredis.Redis,
-    columns: List[Tuple[str, str]],
+    columns: list[tuple[str, str]],
     num_documents: int,
     chunk_size: int = 1000,
-) -> List[str]:
+) -> list[str]:
     # Initialize pre-generated data
     _initialize_pre_generated_data(num_documents)
 
@@ -87,7 +86,7 @@ async def generate_document_data(
 
 
 async def _generate_documents_chunk(
-    client: aioredis.Redis, document_ids: List[str], columns: List[Tuple[str, str]]
+    client: aioredis.Redis, document_ids: list[str], columns: list[tuple[str, str]]
 ):
     pipeline = client.pipeline()
 
@@ -109,7 +108,7 @@ async def _generate_documents_chunk(
     await pipeline.execute()
 
 
-def generate_search_query(columns: List[Tuple[str, str]], document_ids: List[str]) -> Query:
+def generate_search_query(columns: list[tuple[str, str]], document_ids: list[str]) -> Query:
     column_names = [name for name, _ in columns]
     num_columns = random.randint(int(len(column_names) / 3.5), int(len(column_names) / 2))
     selected_columns = random.sample(column_names, num_columns)
@@ -147,8 +146,8 @@ def create_simple_numeric_filter(property_name: str, property_type: str) -> str:
 async def run_query_client(
     client_id: int,
     df_server,
-    columns: List[Tuple[str, str]],
-    document_ids: List[str],
+    columns: list[tuple[str, str]],
+    document_ids: list[str],
     num_queries: int,
 ) -> int:
     client = df_server.client()
@@ -181,8 +180,8 @@ async def run_query_client(
 
 async def run_query_load_test(
     df_server,
-    columns: List[Tuple[str, str]],
-    document_ids: List[str],
+    columns: list[tuple[str, str]],
+    document_ids: list[str],
     total_queries: int,
     num_concurrent_clients: int,
 ) -> int:
@@ -200,7 +199,7 @@ async def run_query_load_test(
     return total_completed
 
 
-def generate_document_columns(num_columns: int = 700) -> List[Tuple[str, str]]:
+def generate_document_columns(num_columns: int = 700) -> list[tuple[str, str]]:
     max_text_fields = 128
 
     # Available types for generation
@@ -252,7 +251,7 @@ def generate_document_columns(num_columns: int = 700) -> List[Tuple[str, str]]:
     return columns
 
 
-async def create_search_index(client: aioredis.Redis, columns: List[Tuple[str, str]]) -> None:
+async def create_search_index(client: aioredis.Redis, columns: list[tuple[str, str]]) -> None:
     text_field_count = sum(1 for _, col_type in columns if col_type == "TEXT")
 
     if text_field_count > 128:

--- a/tests/dragonfly/search_benchmark_utils.py
+++ b/tests/dragonfly/search_benchmark_utils.py
@@ -1,11 +1,13 @@
 import asyncio
 import logging
+import math
 import random
 import string
 import uuid
-import math
-from redis import asyncio as aioredis
+
 from redis.commands.search.query import Query
+
+from redis import asyncio as aioredis
 
 
 def set_random_seed(seed: int):

--- a/tests/dragonfly/search_benchmark_utils.py
+++ b/tests/dragonfly/search_benchmark_utils.py
@@ -43,8 +43,6 @@ PRE_GENERATED_UIDS = []
 
 
 def _initialize_pre_generated_data(size: int):
-    global PRE_GENERATED_STRINGS, PRE_GENERATED_UIDS
-
     # Clear previous data and generate new
     PRE_GENERATED_STRINGS.clear()
     PRE_GENERATED_UIDS.clear()
@@ -162,7 +160,7 @@ async def run_query_client(
         for i in range(num_queries):
             try:
                 query = generate_search_query(columns, document_ids)
-                results = await client.ft(INDEX_KEY).search(query)
+                await client.ft(INDEX_KEY).search(query)
                 success_count += 1
 
             except Exception as e:

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -10,9 +10,16 @@ import time
 
 import numpy as np
 import pytest
+from redis.commands.search.field import (
+    GeoField,
+    NumericField,
+    TagField,
+    TextField,
+    VectorField,
+)
+
 import redis
 from redis import asyncio as aioredis
-from redis.commands.search.field import TextField, NumericField, TagField, VectorField, GeoField
 
 try:
     from redis.commands.search.indexDefinition import IndexDefinition, IndexType

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -9,8 +9,9 @@ import time
 from dataclasses import dataclass
 
 import numpy as np
-import redis
 import redis.asyncio as aioredis
+
+import redis
 
 try:
     from importlib import resources as impresources

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -401,7 +401,7 @@ class HnswSearchSeeder:
         r = await client.execute_command(
             "FT.SEARCH",
             self.index_name,
-            "*=>[KNN {k} @embedding $vec]".format(k=k),
+            f"*=>[KNN {k} @embedding $vec]",
             "NOCONTENT",
             "PARAMS",
             "2",
@@ -425,7 +425,7 @@ class HnswSearchSeeder:
         r = await client.execute_command(
             "FT.SEARCH",
             self.index_name,
-            "@doc_id:{{{id}}}=>[KNN {k} @embedding $vec]".format(id=doc_num, k=k),
+            f"@doc_id:{{{doc_num}}}=>[KNN {k} @embedding $vec]",
             "NOCONTENT",
             "PARAMS",
             "2",

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -1,17 +1,16 @@
 import asyncio
 import json as json_mod
-import random
 import logging
-import re
-import typing
 import math
-import redis
-import redis.asyncio as aioredis
-from dataclasses import dataclass
-import time
+import random
+import re
 import sys
+import time
+from dataclasses import dataclass
 
 import numpy as np
+import redis
+import redis.asyncio as aioredis
 
 try:
     from importlib import resources as impresources
@@ -25,7 +24,7 @@ class SeederBase:
     CACHED_SCRIPTS = {}
     DEFAULT_TYPES = ["STRING", "LIST", "SET", "HASH", "ZSET", "JSON", "STREAM"]
 
-    def __init__(self, types: typing.List[str] | None = None, seed=None):
+    def __init__(self, types: list[str] | None = None, seed=None):
         self.uid = SeederBase.UID_COUNTER
         SeederBase.UID_COUNTER += 1
         self.types = types if types is not None else type(self).DEFAULT_TYPES
@@ -38,9 +37,7 @@ class SeederBase:
         logging.debug(f"Random seed: {self.seed}, check: {random.randrange(100)}")
 
     @classmethod
-    async def capture(
-        clz, client: aioredis.Redis, types: typing.List[str] | None = None
-    ) -> typing.Tuple[int]:
+    async def capture(clz, client: aioredis.Redis, types: list[str] | None = None) -> tuple[int]:
         """Generate hash capture for all data stored in instance pointed by client"""
 
         sha = await client.script_load(clz._load_script("hash"))
@@ -92,7 +89,7 @@ class DebugPopulateSeeder(SeederBase):
         variance=5,
         samples=10,
         collection_size=None,
-        types: typing.List[str] | None = None,
+        types: list[str] | None = None,
         seed=None,
     ):
         SeederBase.__init__(self, types, seed)
@@ -147,7 +144,7 @@ class Seeder(SeederBase):
         counter: int
         stop_key: str
 
-    units: typing.List[Unit]
+    units: list[Unit]
 
     def __init__(
         self,
@@ -155,7 +152,7 @@ class Seeder(SeederBase):
         key_target=10_000,
         data_size=100,
         collection_size=None,
-        types: typing.List[str] | None = None,
+        types: list[str] | None = None,
         huge_value_target=5,
         huge_value_size=100000,
         seed=None,
@@ -234,7 +231,7 @@ class Seeder(SeederBase):
         unit.counter = int(result[0])
         huge_entries = int(result[1])
 
-        msg = f"running unit {unit.prefix}/{unit.type} took {time.time() - s}, target {args[4+0]}"
+        msg = f"running unit {unit.prefix}/{unit.type} took {time.time() - s}, target {args[4 + 0]}"
         if huge_entries > 0:
             msg = f"{msg}. Total huge entries {huge_entries} added."
 

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -419,7 +419,7 @@ class HnswSearchSeeder:
         checks presence in the index, making this a reliable existence check.
         """
         doc_key = doc_id if isinstance(doc_id, str) else doc_id.decode()
-        doc_num = doc_key[len(self.prefix) :] if doc_key.startswith(self.prefix) else doc_key
+        doc_num = doc_key.removeprefix(self.prefix)
         r = await client.execute_command(
             "FT.SEARCH",
             self.index_name,

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -25,7 +25,7 @@ class SeederBase:
     CACHED_SCRIPTS = {}
     DEFAULT_TYPES = ["STRING", "LIST", "SET", "HASH", "ZSET", "JSON", "STREAM"]
 
-    def __init__(self, types: typing.Optional[typing.List[str]] = None, seed=None):
+    def __init__(self, types: typing.List[str] | None = None, seed=None):
         self.uid = SeederBase.UID_COUNTER
         SeederBase.UID_COUNTER += 1
         self.types = types if types is not None else type(self).DEFAULT_TYPES
@@ -39,7 +39,7 @@ class SeederBase:
 
     @classmethod
     async def capture(
-        clz, client: aioredis.Redis, types: typing.Optional[typing.List[str]] = None
+        clz, client: aioredis.Redis, types: typing.List[str] | None = None
     ) -> typing.Tuple[int]:
         """Generate hash capture for all data stored in instance pointed by client"""
 
@@ -92,7 +92,7 @@ class DebugPopulateSeeder(SeederBase):
         variance=5,
         samples=10,
         collection_size=None,
-        types: typing.Optional[typing.List[str]] = None,
+        types: typing.List[str] | None = None,
         seed=None,
     ):
         SeederBase.__init__(self, types, seed)
@@ -155,7 +155,7 @@ class Seeder(SeederBase):
         key_target=10_000,
         data_size=100,
         collection_size=None,
-        types: typing.Optional[typing.List[str]] = None,
+        types: typing.List[str] | None = None,
         huge_value_target=5,
         huge_value_size=100000,
         seed=None,

--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -1,11 +1,14 @@
 import asyncio
-import async_timeout
 import string
+
+import async_timeout
+import pytest
 from redis import asyncio as aioredis
+
 from . import dfly_args
+from .instance import DflyInstanceFactory
 from .seeder import Seeder, DebugPopulateSeeder
-from .instance import DflyInstanceFactory, DflyInstance
-from .utility import *
+from .utility import DflySeederFactory, ValueType
 
 
 @dfly_args({"proactor_threads": 4})

--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -3,11 +3,12 @@ import string
 
 import async_timeout
 import pytest
+
 from redis import asyncio as aioredis
 
 from . import dfly_args
 from .instance import DflyInstanceFactory
-from .seeder import Seeder, DebugPopulateSeeder
+from .seeder import DebugPopulateSeeder, Seeder
 from .utility import DflySeederFactory, ValueType
 
 

--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 import subprocess
 import time
-from typing import Awaitable
+from collections.abc import Awaitable
 
 import pytest
 

--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -5,8 +5,6 @@ from redis import asyncio as aioredis
 import pytest
 import time
 import asyncio
-from datetime import datetime
-from sys import stderr
 import logging
 
 from .utility import assert_eventually, wait_available_async
@@ -74,7 +72,7 @@ class Sentinel:
             f"port {self.port}",
             f"sentinel monitor {self.default_deployment} 127.0.0.1 {self.initial_master_port} 1",
             f"sentinel down-after-milliseconds {self.default_deployment} 3000",
-            f"slave-priority 100",
+            "slave-priority 100",
         ]
         self.config_file.write_text("\n".join(config))
 

--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -1,16 +1,17 @@
-import pathlib
-import subprocess
-from typing import Awaitable
-from redis import asyncio as aioredis
-import pytest
-import time
 import asyncio
 import logging
+import pathlib
+import subprocess
+import time
+from typing import Awaitable
 
-from .utility import assert_eventually, wait_available_async
+import pytest
 
-from .instance import DflyInstanceFactory
+from redis import asyncio as aioredis
+
 from . import dfly_args
+from .instance import DflyInstanceFactory
+from .utility import assert_eventually, wait_available_async
 
 
 # Helper function to parse some sentinel cli commands output as key value dictionaries.

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -4,11 +4,12 @@ import subprocess
 
 import aiohttp
 import pytest
-import redis
 from prometheus_client.samples import Sample
 from pymemcache import Client
-from redis import asyncio as aioredis
 from redis.exceptions import ResponseError
+
+import redis
+from redis import asyncio as aioredis
 
 from . import dfly_args
 from .instance import DflyInstance
@@ -86,8 +87,8 @@ async def test_get_databases(async_client: aioredis.Redis):
 async def test_client_kill(df_factory):
     with df_factory.create(port=1111, admin_port=1112) as instance:
         instance: DflyInstance
-        from redis.backoff import NoBackoff
         from redis.asyncio.retry import Retry
+        from redis.backoff import NoBackoff
 
         client = instance.client(retry=Retry(NoBackoff(), 0))
         admin_client = instance.admin_client()

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -244,7 +244,7 @@ async def test_latency_stats(async_client: aioredis.Redis):
         await async_client.hgetall("missing")
 
     latency_stats = await async_client.info("LATENCYSTATS")
-    for expected in {"hgetall", "set", "get"}:
+    for expected in ("hgetall", "set", "get"):
         key = f"latency_percentiles_usec_{expected}"
         assert key in latency_stats
         assert latency_stats[key].keys() == {"p50", "p99", "p99.9"}

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -1,14 +1,18 @@
+import logging
 import platform
+import subprocess
 
 import aiohttp
+import pytest
+import redis
 from prometheus_client.samples import Sample
 from pymemcache import Client
-
+from redis import asyncio as aioredis
 from redis.exceptions import ResponseError
 
 from . import dfly_args
 from .instance import DflyInstance
-from .utility import *
+from .utility import assert_eventually
 
 
 @pytest.fixture(scope="class")
@@ -21,7 +25,7 @@ class TestServer:
         connection.send_command("QUIT")
         assert connection.read_response() == b"OK"
 
-        with pytest.raises(redis.exceptions.ConnectionError) as e:
+        with pytest.raises(redis.exceptions.ConnectionError):
             connection.read_response()
 
     def test_quit_after_sub(self, connection):
@@ -31,7 +35,7 @@ class TestServer:
         connection.send_command("QUIT")
         assert connection.read_response() == b"OK"
 
-        with pytest.raises(redis.exceptions.ConnectionError) as e:
+        with pytest.raises(redis.exceptions.ConnectionError):
             connection.read_response()
 
     async def test_multi_exec(self, async_client: aioredis.Redis):
@@ -95,13 +99,13 @@ async def test_client_kill(df_factory):
             assert len(await admin_client.execute_command("CLIENT LIST")) == 2
 
             # Can't kill admin from regular connection
-            with pytest.raises(ResponseError) as e_info:
+            with pytest.raises(ResponseError):
                 await client_conn.execute_command("CLIENT KILL LADDR 127.0.0.1:1112")
 
             assert len(await admin_client.execute_command("CLIENT LIST")) == 2
             await admin_client.execute_command("CLIENT KILL LADDR 127.0.0.1:1111")
             assert len(await admin_client.execute_command("CLIENT LIST")) == 1
-            with pytest.raises(redis.exceptions.ConnectionError) as e_info:
+            with pytest.raises(redis.exceptions.ConnectionError):
                 await client_conn.ping()
 
 

--- a/tests/dragonfly/set_test.py
+++ b/tests/dragonfly/set_test.py
@@ -33,7 +33,7 @@ async def test_spop_with_null_byte_members(df_factory: DflyInstanceFactory):
     num_members = 10
 
     for i in range(num_members):
-        await client.sadd("set", "b'MEMBER\x01\x02\x00_KEY{i}'".format(i=i))
+        await client.sadd("set", f"b'MEMBER\x01\x02\x00_KEY{i}'")
 
     assert await client.scard("set") == num_members
 

--- a/tests/dragonfly/set_test.py
+++ b/tests/dragonfly/set_test.py
@@ -1,8 +1,6 @@
 import pytest
-from redis import asyncio as aioredis
-from .instance import DflyInstance, DflyInstanceFactory
-import logging
-import asyncio
+
+from .instance import DflyInstanceFactory
 
 
 @pytest.mark.asyncio
@@ -14,12 +12,11 @@ async def test_sscan_regression(df_factory: DflyInstanceFactory):
 
     client = df.client()
 
-    await client.execute_command(f"SADD key el1 el2")
+    await client.execute_command("SADD key el1 el2")
 
     element = "a*" * 3
 
-    cursor = await client.execute_command(f"SSCAN key 0 match {element}.pt")
-    length = len(cursor[1])
+    await client.execute_command(f"SSCAN key 0 match {element}.pt")
     # Takes 3 seconds
     res = await client.execute_command("SLOWLOG GET 100")
     assert res == []

--- a/tests/dragonfly/shutdown_test.py
+++ b/tests/dragonfly/shutdown_test.py
@@ -2,7 +2,6 @@ import pytest
 import asyncio
 import redis
 from redis import asyncio as aioredis
-from pathlib import Path
 
 from . import dfly_args
 from .instance import DflyInstanceFactory
@@ -35,7 +34,7 @@ class TestDflyAutoLoadSnapshot:
             while True:
                 try:
                     value = await client.execute_command(f"INCR {key}")
-                except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError) as e:
+                except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
                     break
             return key, value
 
@@ -103,7 +102,6 @@ class TestShutdownOptions:
         except Exception as e:
             print(e)
             # Connection may be dropped as part of shutdown; this is acceptable
-            pass
 
         await client.connection_pool.disconnect()
 

--- a/tests/dragonfly/shutdown_test.py
+++ b/tests/dragonfly/shutdown_test.py
@@ -1,5 +1,7 @@
-import pytest
 import asyncio
+
+import pytest
+
 import redis
 from redis import asyncio as aioredis
 

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -2,20 +2,21 @@ import asyncio
 import glob
 import logging
 import os
-from pathlib import Path
+import random
 import shutil
 import signal
 import socket
 import subprocess
 import time
 import uuid
+from pathlib import Path
 
-from async_timeout import timeout
 import boto3
 import pytest
-import redis
-import random
+from async_timeout import timeout
 from pymemcache.client.base import Client as MCClient
+
+import redis
 from redis import asyncio as aioredis
 
 from . import dfly_args
@@ -24,11 +25,11 @@ from .replication_utils import compare_datasets
 from .seeder import DebugPopulateSeeder, Seeder
 from .utility import (
     assert_eventually,
-    wait_available_async,
+    check_all_replicas_finished,
     is_saving,
     tmp_file_name,
+    wait_available_async,
     wait_for_replicas_state,
-    check_all_replicas_finished,
 )
 
 BASIC_ARGS = {"dir": "{DRAGONFLY_TMP}/", "proactor_threads": 4}

--- a/tests/dragonfly/test_dash_gc.py
+++ b/tests/dragonfly/test_dash_gc.py
@@ -1,8 +1,10 @@
 import asyncio
+import logging
+
 from redis import asyncio as aioredis
+
 from . import dfly_args
 from .seeder import Seeder
-import logging
 
 
 @dfly_args({"proactor_threads": 2, "maxmemory": "1G"})

--- a/tests/dragonfly/tiering_test.py
+++ b/tests/dragonfly/tiering_test.py
@@ -1,21 +1,23 @@
-import async_timeout
 import asyncio
 import itertools
 import logging
-import pytest
 import random
+
+import async_timeout
+import pytest
 import redis.asyncio as aioredis
 
 from . import dfly_args
-from .seeder import DebugPopulateSeeder, Seeder as SeederV2
+from .instance import DflyInstance, DflyInstanceFactory
+from .seeder import DebugPopulateSeeder
+from .seeder import Seeder as SeederV2
 from .utility import (
+    LogMonitor,
+    check_all_replicas_finished,
+    compare_master_replica_keys,
     info_tick_timer,
     wait_for_replicas_state,
-    check_all_replicas_finished,
-    LogMonitor,
-    compare_master_replica_keys,
 )
-from .instance import DflyInstance, DflyInstanceFactory
 
 BASIC_ARGS = {
     "proactor_threads": 4,

--- a/tests/dragonfly/tls_conf_test.py
+++ b/tests/dragonfly/tls_conf_test.py
@@ -1,7 +1,10 @@
+import os
+
 import pytest
 import redis
-from .utility import *
+
 from .instance import DflyStartException
+from .utility import gen_ca_cert, gen_certificate
 
 
 async def test_tls_no_auth(df_factory, with_tls_server_args):

--- a/tests/dragonfly/tls_conf_test.py
+++ b/tests/dragonfly/tls_conf_test.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 import redis
 
 from .instance import DflyStartException

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -13,7 +13,7 @@ import sys
 import time
 from enum import Enum
 from shutil import copyfileobj
-from typing import Iterable
+from collections.abc import Iterable
 
 import fakeredis
 import pytest

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -884,7 +884,7 @@ class ExpirySeeder:
         while not self.stop_flag:
             try:
                 pipeline = client.pipeline(transaction=False)
-                for i in range(0, self.batch_size):
+                for i in range(self.batch_size):
                     pipeline.execute_command(f"SET tmp{self.i} bar{self.i} EX {self.timeout}")
                     self.i = self.i + 1
                 await pipeline.execute()

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -1,27 +1,29 @@
 import asyncio
+import difflib
 import functools
 import itertools
-import logging
-import sys
-import wrapt
-from redis import asyncio as aioredis
-import redis
-import random
-import string
-import time
-import difflib
 import json
-import subprocess
-import pytest
+import logging
 import os
-import fakeredis
-from typing import Iterable
-from enum import Enum
+import random
 import re
+import string
+import subprocess
+import sys
+import time
+from enum import Enum
 from shutil import copyfileobj
+from typing import Iterable
+
+import fakeredis
+import pytest
+import wrapt
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+import redis
+from redis import asyncio as aioredis
 
 
 def tmp_file_name():

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -11,9 +11,9 @@ import string
 import subprocess
 import sys
 import time
+from collections.abc import Iterable
 from enum import Enum
 from shutil import copyfileobj
-from collections.abc import Iterable
 
 import fakeredis
 import pytest

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -15,7 +15,7 @@ import subprocess
 import pytest
 import os
 import fakeredis
-from typing import Iterable, Union
+from typing import Iterable
 from enum import Enum
 import re
 from shutil import copyfileobj
@@ -146,9 +146,7 @@ async def info_tick_timer(client: aioredis.Redis, section=None, **kwargs):
 # wait for a process becomes "responsive":
 # for a master - waits that it finishes loading a snapshot if it's budy doing so,
 # and for replica it waits until it finishes its full sync stage and reaches the stable sync state.
-async def wait_available_async(
-    clients: Union[aioredis.Redis, Iterable[aioredis.Redis]], timeout=120
-):
+async def wait_available_async(clients: aioredis.Redis | Iterable[aioredis.Redis], timeout=120):
     if not isinstance(clients, aioredis.Redis):
         # Syntactic sugar to seamlessly handle an array of clients.
         return await asyncio.gather(*(wait_available_async(c, timeout=timeout) for c in clients))

--- a/tests/dragonfly/valkey_search/valkey_search_test_case_dragonfly.py
+++ b/tests/dragonfly/valkey_search/valkey_search_test_case_dragonfly.py
@@ -132,25 +132,18 @@ class ReplicationGroup:
     def cleanup(rg):
         """Cleanup Dragonfly instances"""
         # Cleanup is handled by Dragonfly fixtures
-        pass
 
 
 class ValkeySearchTestCaseCommon:
     """Common base class for tests"""
 
-    pass
-
 
 class ValkeyTestCase(ValkeySearchTestCaseCommon):
     """Base test case class"""
 
-    pass
-
 
 class ReplicationTestCase(ValkeyTestCase):
     """Replication test case"""
-
-    pass
 
 
 class ValkeySearchTestCaseBase(ValkeySearchTestCaseCommon):
@@ -267,8 +260,6 @@ class ValkeySearchTestCaseBase(ValkeySearchTestCaseCommon):
 class ValkeySearchTestCaseDebugMode(ValkeySearchTestCaseBase):
     """Debug mode variant"""
 
-    pass
-
 
 class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
     """Cluster test case - simplified for single Dragonfly instance"""
@@ -352,5 +343,3 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
 
 class ValkeySearchClusterTestCaseDebugMode(ValkeySearchClusterTestCase):
     """Debug mode cluster variant"""
-
-    pass


### PR DESCRIPTION
pytest linter errors block PRs which touch test files, because we have a pyflakes hook now. 

These errors throughout the tree are fixed with ruff in this PR in one batch by running it manually with `--select` and then `--fix` (not using AI)

where `--fix` is not available either code is fixed by hand, or those modules are skipped.

`tests/dragonfly/valkey_search` is excluded because it relies on some types which are not directly visible, so any changes there are blocked by pre-commit hook.

in addition to errors which block commits, some code cleanliness fixes are also applied, such as

- unnecessary encodes
- less verbose type annotations
- sort import blocks

after all the fixes:

```
ruff check tests/dragonfly/ --exclude tests/dragonfly/valkey_search

...
Found 448 errors.
No fixes available (85 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

all the auto-fixes are applied, the unsafe-fixes can be done later.