### PR TITLE
server: Change pytest to unit test for mem. accounting

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -1078,6 +1078,25 @@ TEST_F(DflyEngineTest, ExpireInlineKeyAccounting) {
   EXPECT_EQ(stats.memory_usage_by_type[OBJ_KEY], 0);
 }
 
+TEST_F(DflyEngineTest, ShortKeyAllocationGap) {
+  // Populates a large number of small keys with TTL. Then check that gap between used memory and
+  // per object reported sum should not be too large. The test fails if the keys report actual
+  // string length, and passes if they report block size.
+  EXPECT_EQ(Run({"DEBUG", "POPULATE", "250000", "abcdefgh", "10", "EXPIRE", "1000", "100000"}),
+            "OK");
+  const auto metrics = GetMetrics();
+
+  const ssize_t total_usage =
+      metrics.db_stats[0].obj_memory_usage + metrics.db_stats[0].table_mem_usage;
+  const ssize_t used_mem = metrics.heap_used_bytes;
+
+  const ssize_t delta = used_mem - total_usage;
+  const double threshold = used_mem * 0.1;
+
+  EXPECT_LE(std::abs(delta), threshold)
+      << " gap: " << std::abs(delta) / 1024 << " threshold: " << threshold / 1024;
+}
+
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -503,32 +503,3 @@ async def test_bitops_denyoom(df_factory: DflyInstanceFactory):
         with pytest.raises(redis.exceptions.ResponseError, match="[Oo]ut of memory"):
             await client.execute_command(*cmd)
     assert await client.ping()
-
-
-@pytest.mark.asyncio
-async def test_short_key_allocation_gap(df_factory: DflyInstanceFactory):
-    """
-    Creates many small sized keys with ttl. Then checks that the object used memory is close to used memory.
-    The test accompanies a change where such keys now report the total block size instead of string length.
-    The older case resulted in a gap between the used memory vs reported memory by object size.
-    """
-    from celery.utils.debug import humanbytes as h
-
-    df_server = df_factory.create(proactor_threads=1)
-    df_server.start()
-
-    client = df_server.client()
-    await client.execute_command(
-        "DEBUG", "POPULATE", 500000, "abcdefgh", 10, "EXPIRE", 1000, 100000
-    )
-    await asyncio.sleep(1)
-    memory = await client.info("memory")
-    used_memory = memory["used_memory"]
-    object_used = memory["object_used_memory"]
-    table_used = memory["table_used_memory"]
-    threshold = used_memory * 0.1
-    total_used = object_used + table_used
-    logging.info(
-        f"used={h(used_memory)} object_used={h(object_used)} table_used={h(table_used)} total_used={h(total_used)} threshold={h(threshold)}"
-    )
-    assert abs(used_memory - total_used) <= used_memory * 0.1


### PR DESCRIPTION
Converts `test_short_key_allocation_gap` to unit test `DflyEngineTest::ShortKeyAllocationGap`

test size further cut back to bare minimum that fails on old size accounting