### PR TITLE
fix(facade): split read buffer accounting

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -191,17 +191,39 @@ bool MatchHttp11Line(string_view line) {
          absl::EndsWith(line, "HTTP/1.1");
 }
 
+// ReadBufTracker should be the only one to update ConnectionStats::read_buf_capacity
+// To use it as RAII object, call the ctor, or if the update should be immediate, call
+// ReadBufTracker::Update() directly.
 struct ReadBufTracker {
   explicit ReadBufTracker(const io::IoBuf& io_buf, uint32_t conn_id)
       : io_buf_(io_buf), last_capacity_(io_buf.Capacity()), id_(conn_id) {
   }
 
   ~ReadBufTracker() {
-    size_t capacity = io_buf_.Capacity();
-    if (last_capacity_ != capacity) {
-      VLOG(2) << CONN_ID << "Grown io_buf to " << capacity;
-      tl_facade_stats->conn_stats.read_buf_capacity += capacity - last_capacity_;
+    Update(last_capacity_, io_buf_.Capacity(), id_);
+  }
+
+  // Make it static so we may also call it directly without constructing a ReadBufTracker object.
+  static void Update(size_t previous_capacity, size_t new_capacity, uint32_t conn_id) {
+    if (previous_capacity == new_capacity)
+      return;
+    DCHECK(tl_facade_stats);
+
+    size_t& read_buf_capacity = tl_facade_stats->conn_stats.read_buf_capacity;
+    if (new_capacity > previous_capacity) {
+      read_buf_capacity += new_capacity - previous_capacity;
+    } else {
+      const size_t delta = previous_capacity - new_capacity;
+      DCHECK_GE(read_buf_capacity, delta);
+      if (ABSL_PREDICT_FALSE(read_buf_capacity < delta)) {
+        LOG(DFATAL) << "Read-buffer capacity accounting underflow: total=" << read_buf_capacity
+                    << " delta=" << delta;
+        read_buf_capacity = 0;
+      } else
+        read_buf_capacity -= delta;
     }
+    VLOG(2) << "[" << conn_id << "] io_buf capacity changed from " << previous_capacity << " to "
+            << new_capacity << " (read_buf_capacity = " << read_buf_capacity << ")";
   }
 
  private:
@@ -909,6 +931,7 @@ void Connection::OnPreMigrateThread() {
   socket_->CancelOnErrorCb();
   DCHECK(!async_fb_.IsJoinable()) << GetClientId();
 
+  UnregisterReadBufCapacity();
   DecreaseConnStats();
 }
 
@@ -943,6 +966,7 @@ void Connection::OnPostMigrateThread() {
     LaunchAsyncFiberIfNeeded();
   }
 
+  RegisterReadBufCapacity();
   IncreaseConnStats();
 }
 
@@ -973,6 +997,12 @@ void Connection::HandleRequests() {
   VLOG(1) << CONN_ID << "HandleRequests";
   DCHECK(tl_facade_stats);
   auto& conn_stats = tl_facade_stats->conn_stats;
+
+  // Read-buffer capacity is registered before TLS and protocol detection, so it must be removed on
+  // every exit, including HTTP and early-failure paths. Normal connection stats are owned by
+  // ConnectionFlow and transferred separately during migration.
+  RegisterReadBufCapacity();
+  absl::Cleanup read_buf_guard = [this] { UnregisterReadBufCapacity(); };
 
   auto remote_ep = RemoteEndpointStr();
 
@@ -1347,10 +1377,11 @@ void Connection::ConnectionFlow() {
   DCHECK(reply_builder_);
   auto& conn_stats = tl_facade_stats->conn_stats;
 
-  // Register the new connection with the thread-local statistics.
-  // At this point (connection birth), local queue stats/luggage are 0,
-  // so only connection counts and buffer capacities are incremented.
+  // Register client statistics for this protocol flow. Read-buffer capacity was registered before
+  // protocol detection. Migration transfers these normal statistics between proactors.
   IncreaseConnStats();
+  absl::Cleanup conn_stats_guard = [this] { DecreaseConnStats(); };
+
   ++conn_stats.conn_received_cnt;
 
   ++local_stats_.read_cnt;
@@ -1405,12 +1436,6 @@ void Connection::ConnectionFlow() {
   DCHECK(!HasPendingMessages());
 
   service_->OnConnectionClose(cc_.get());
-
-  // We have already cleared the queues above (DrainConnectionQueues), so local queue stats
-  // (dispatch_q_bytes_, etc.) represent 0 usage. DecreaseConnStats will safely subtract 0 for those
-  // stats, while correctly removing this connection from the global connection counts and buffer
-  // capacity tracking.
-  DecreaseConnStats();
 
   if (ioloop_v2_) {
     socket_->ResetOnRecvHook();
@@ -2792,8 +2817,6 @@ void Connection::IncreaseConnStats() {
     ++conn_stats.num_conns_main;
   else
     ++conn_stats.num_conns_other;
-  conn_stats.read_buf_capacity += io_buf_.Capacity();
-
   conn_stats.dispatch_queue_entries += dispatch_q_.size();
   conn_stats.dispatch_queue_bytes += dispatch_q_bytes_;
   conn_stats.pipeline_queue_entries += parsed_cmd_q_len_;
@@ -2832,9 +2855,6 @@ void Connection::DecreaseConnStats() {
     DCHECK_GT(conn_stats.num_conns_other, 0u);
     --conn_stats.num_conns_other;
   }
-  DCHECK_GE(conn_stats.read_buf_capacity, io_buf_.Capacity());
-  conn_stats.read_buf_capacity -= io_buf_.Capacity();
-
   DCHECK_GE(conn_stats.dispatch_queue_entries, dispatch_q_.size());
   conn_stats.dispatch_queue_entries -= dispatch_q_.size();
   DCHECK_GE(conn_stats.dispatch_queue_bytes, dispatch_q_bytes_);
@@ -2850,6 +2870,22 @@ void Connection::DecreaseConnStats() {
   conn_stats.pipeline_queue_entries -= parsed_cmd_q_len_;
   DCHECK_GE(conn_stats.pipeline_queue_bytes, parsed_cmd_q_bytes_);
   conn_stats.pipeline_queue_bytes -= parsed_cmd_q_bytes_;
+}
+
+void Connection::RegisterReadBufCapacity() {
+  DCHECK(tl_facade_stats);
+  DCHECK(!read_buf_capacity_registered_);
+  // Registration includes setting the flag and adding the current buffer capacity.
+  ReadBufTracker::Update(0, io_buf_.Capacity(), id_);
+  read_buf_capacity_registered_ = true;
+}
+
+void Connection::UnregisterReadBufCapacity() {
+  DCHECK(tl_facade_stats);
+  DCHECK(read_buf_capacity_registered_);
+  // Unregistration includes clearing the flag and subtracting the current buffer capacity.
+  ReadBufTracker::Update(io_buf_.Capacity(), 0, id_);
+  read_buf_capacity_registered_ = false;
 }
 
 void Connection::BreakOnce(uint32_t ev_mask) {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -476,6 +476,8 @@ class Connection : public util::Connection {
 
   void IncreaseConnStats();
   void DecreaseConnStats();
+  void RegisterReadBufCapacity();
+  void UnregisterReadBufCapacity();
   void BreakOnce(uint32_t ev_mask);
 
   // The read buffer with read data that needs to be parsed and processed.
@@ -701,6 +703,10 @@ class Connection : public util::Connection {
   // True after IncreaseConnStats registers this connection in the current thread's stats.
   // False before registration and after DecreaseConnStats unregisters it during close/migration.
   bool conn_stats_registered_ = false;
+
+  // Used for DEBUG assertions. true when this connection's io_buf_ capacity contributes to the
+  // current thread's total.
+  bool read_buf_capacity_registered_ = false;
 
   // True while this connection contributes to connection_memory_bytes. Set false for
   // replication-flow connections, whose direct memory is excluded from the client connection

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -1,5 +1,5 @@
 import json
-
+import asyncio
 import aiohttp
 
 from . import dfly_args
@@ -33,6 +33,43 @@ async def test_skip_metrics(df_server: DflyInstance):
     async with get_http_session("whoops", "whoops") as session:
         resp = await session.get(f"http://localhost:{df_server.admin_port}/metrics")
         assert resp.status == 200
+
+
+@dfly_args({"proactor_threads": "1"})
+async def test_metrics_does_not_count_http_connection(df_server: DflyInstance):
+    """Verify that a metrics request does not count its HTTP connection as a client."""
+    async with get_http_session() as session:
+        async with session.get(f"http://localhost:{df_server.port}/metrics") as resp:
+            assert resp.status == 200
+            metrics = await resp.text()
+
+    assert 'dragonfly_connected_clients{listener="main"} 0' in metrics
+
+
+@dfly_args({"proactor_threads": "1"})
+async def test_http_metrics_does_not_leak_read_buffer_capacity(df_server: DflyInstance):
+    """Verify pre-registration HTTP reads do not leak read-buffer capacity."""
+    observer = df_server.client()  # ordinary RESP client
+    baseline_read_buffer_bytes = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    reader, writer = await asyncio.open_connection(
+        "localhost", df_server.port
+    )  # Raw asyncio TCP stream (Manually constructed HTTP)
+    writer.write(b"GET /" + (b"a" * 200))
+    await writer.drain()
+    await asyncio.sleep(0.1)
+    writer.write(b" HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+    await writer.drain()
+    response = await reader.readuntil(b"\r\n\r\n")
+    assert response.startswith(b"HTTP/1.1 ")
+
+    writer.close()
+    await writer.wait_closed()
+
+    current_read_buffer_bytes = int((await observer.info("clients"))["client_read_buffer_bytes"])
+    assert current_read_buffer_bytes == baseline_read_buffer_bytes
+
+    await observer.aclose()
 
 
 async def test_no_password_main_port(df_server: DflyInstance):


### PR DESCRIPTION
Separate read-buffer capacity registration from ConnectionFlow's normal
connection statistics with RegisterReadBufCapacity and
UnregisterReadBufCapacity.

Make ReadBufTracker::Update the sole read-buffer capacity updater, so
buffer resizing and connection migration update the owning proactor's
statistics exactly once. Register capacity before TLS and HTTP detection
and unregister it on every exit path.

Add HTTP regression tests verifying that:
- test_metrics_does_not_count_http_connection excludes HTTP requests from
  connected-client metrics.
- test_http_metrics_does_not_leak_read_buffer_capacity releases capacity
  grown while detecting a fragmented HTTP request.