### PR TITLE
chore: improve debug compact-table docs and return type

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -211,15 +211,24 @@ class DashTable : public detail::DashTableBase {
     return buddy_idx;
   }
 
+  // Result of Merge(): `merged` is true iff the two segments were merged. When `merged` is
+  // false, `declined_depth_guard` tells apart the two ways it can fail: true means Merge
+  // refused to run because it would violate the initial_depth invariant (no items were
+  // touched); false means a real rollback happened (items were moved into `keep` then moved
+  // back after a failed insertion).
+  struct MergeResult {
+    bool merged = false;
+    bool declined_depth_guard = false;
+  };
+
   // - Moves all items from `buddy_id` to `keep_id` (merges the two segments).
   //   After merge completes, `buddy_id` segment is deleted.
-  // - Return true if the two segments merged successfully.
-  // - If an insertion fails we rollback and abort the merge (return false).
+  // - If an insertion fails we rollback and abort the merge.
   // - Merge can run only if there are no active snapshots.
   // - Prefer calling this function only when the combined size of both segments
   //   than x * segment_capacity. With x: 0 < x < 0.25 as statistically this won't
   //   trigger rollbacks.
-  bool Merge(unsigned keep_id, unsigned buddy_id) {
+  MergeResult Merge(unsigned keep_id, unsigned buddy_id) {
     auto* keep = GetSegment(keep_id);
     auto* buddy = GetSegment(buddy_id);
 
@@ -233,7 +242,7 @@ class DashTable : public detail::DashTableBase {
     // After merge, keep will have depth-1, which determines unique_segments
     uint8_t depth_after_merge = keep->local_depth() - 1;
     if (depth_after_merge < initial_depth_) {
-      return false;
+      return {.merged = false, .declined_depth_guard = true};
     }
 
     bool should_rollback = false;
@@ -267,7 +276,7 @@ class DashTable : public detail::DashTableBase {
       auto hash_fn = [this](const auto& k) { return policy_.HashFn(k); };
       keep->Split(hash_fn, buddy, [](auto&&...) {});
 
-      return false;
+      return {.merged = false, .declined_depth_guard = false};
     }
 
     // Same as Split()
@@ -287,7 +296,7 @@ class DashTable : public detail::DashTableBase {
     --unique_segments_;
     bucket_count_ -= keep->num_buckets();
 
-    return true;
+    return {.merged = true, .declined_depth_guard = false};
   }
 
   size_t GetSegmentCount() const {

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -484,7 +484,7 @@ TEST_F(DashTest, MergeFailureRollback) {
 
   size_t total_size_before = dt_.size();
 
-  bool merge_succeeded = dt_.Merge(sid, buddy_id);
+  bool merge_succeeded = dt_.Merge(sid, buddy_id).merged;
 
   EXPECT_EQ(dt_.size(), total_size_before);
 
@@ -561,7 +561,7 @@ TEST_F(DashTest, MergePreservesSize) {
     auto* buddy = dt_.GetSegment(buddy_id);
     size_t combined_size = seg->SlowSize() + buddy->SlowSize();
     if (combined_size <= static_cast<size_t>(0.25 * seg->capacity())) {
-      bool merged = dt_.Merge(seg_id, buddy_id);
+      bool merged = dt_.Merge(seg_id, buddy_id).merged;
       if (merged) {
         // Size must be unchanged after each merge
         EXPECT_EQ(dt_.size(), size_before)
@@ -608,7 +608,7 @@ TEST_F(DashTest, MergeKeyLookupConsistency) {
       auto* buddy = dt_.GetSegment(buddy_id);
       size_t combined_size = seg->SlowSize() + buddy->SlowSize();
       if (combined_size <= static_cast<size_t>(0.25 * seg->capacity())) {
-        if (dt_.Merge(seg_id, buddy_id)) {
+        if (dt_.Merge(seg_id, buddy_id).merged) {
           merged_any = true;
         }
       }
@@ -717,7 +717,7 @@ TEST_F(DashTest, MergeDirectoryConsistency) {
       size_t combined = keep->SlowSize() + buddy->SlowSize();
 
       if (combined <= static_cast<size_t>(0.25 * keep->capacity())) {
-        bool merged = dt_.Merge(keep_id, buddy_id);
+        bool merged = dt_.Merge(keep_id, buddy_id).merged;
         ASSERT_TRUE(merged);
 
         // After merge, all dir entries that covered buddy must now point to keep
@@ -760,7 +760,7 @@ TEST_F(DashTest, MergeWithAliasedEntries) {
     size_t threshold = static_cast<size_t>(0.25 * seg0->capacity());
 
     if (combined <= threshold) {
-      bool ok = dt_.Merge(0, 1);
+      bool ok = dt_.Merge(0, 1).merged;
       ASSERT_TRUE(ok);
 
       // Now segment at entries 0 and 1 is the same depth-2 object
@@ -790,7 +790,7 @@ TEST_F(DashTest, MergeWithAliasedEntries) {
       if (seg2 != seg3) {
         size_t combined23 = seg2->SlowSize() + seg3->SlowSize();
         if (combined23 <= static_cast<size_t>(0.25 * seg2->capacity())) {
-          bool ok23 = dt_.Merge(2, 3);
+          bool ok23 = dt_.Merge(2, 3).merged;
           if (ok23) {
             // Now both {0,1} and {2,3} are depth-2 segments — they ARE buddies
             // FindBuddyId(0): bit_pos=1, buddy_idx=0^2=2, GetSegment(2)->local_depth()=2 == 2 -> 2
@@ -886,8 +886,8 @@ TEST_F(DashTest, FindBuddyIdCanonicalForStripe) {
   }
 
   ASSERT_NE(keep_a, UINT_MAX);
-  ASSERT_TRUE(dt_.Merge(keep_a, bud_a));
-  ASSERT_TRUE(dt_.Merge(keep_b, bud_b));
+  ASSERT_TRUE(dt_.Merge(keep_a, bud_a).merged);
+  ASSERT_TRUE(dt_.Merge(keep_b, bud_b).merged);
 
   // After both merges:
   //   - segment at keep_a has local_depth = d-1, aliased by stripe {keep_a, keep_a+1}
@@ -968,7 +968,7 @@ TEST_F(DashTest, NextSegCanonicalBehavior) {
     auto* buddy = dt_.GetSegment(next);
     if (buddy->local_depth() == seg->local_depth() &&
         seg->SlowSize() + buddy->SlowSize() <= static_cast<size_t>(0.25 * seg->capacity())) {
-      bool ok = dt_.Merge(static_cast<unsigned>(i), static_cast<unsigned>(next));
+      bool ok = dt_.Merge(static_cast<unsigned>(i), static_cast<unsigned>(next)).merged;
       if (ok)
         break;
     }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -737,10 +737,9 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "COMPACT-TABLE [threshold]",
         "    Merge underutilized buddy-segment pairs in the dash table to reclaim memory.",
         "    Two buddy segments are merged when their combined size is <= threshold *",
-        "    segment_capacity (i.e. against ONE segment's capacity, not the sum of both),",
-        "    so on average each buddy must be under roughly threshold/2 full. <threshold>",
-        "    is in (0, 1] and defaults to 0.25. Returns a map with 'merged', 'attempted',",
-        "    'rolled_back', 'skipped_min_depth' counts and 'exited_on_snapshot' (1 if the",
+        "    segment_capacity, so on average each buddy must be under roughly threshold/2",
+        "    full. <threshold> is in (0, 1] and defaults to 0.25. Returns a stats map with",
+        "    'merged', 'attempted', 'rolled_back' counts and 'exited_on_snapshot' (1 if the",
         "    scan exited early due to an in-progress snapshot).",
         "UNIQ-STRS",
         "    Prints per-object unique string stats and estimated dedup savings across shards.",
@@ -1817,15 +1816,13 @@ void DebugCmd::CompactTable(facade::CmdArgParser parser, CommandContext* cmd_cnt
     total += r;
   }
 
-  rb->StartCollection(5, CollectionType::MAP);
+  rb->StartCollection(4, CollectionType::MAP);
   rb->SendSimpleString("merged");
   rb->SendLong(total.merged);
   rb->SendSimpleString("attempted");
   rb->SendLong(total.attempted);
   rb->SendSimpleString("rolled_back");
   rb->SendLong(total.rolled_back);
-  rb->SendSimpleString("skipped_min_depth");
-  rb->SendLong(total.skipped_min_depth);
   rb->SendSimpleString("exited_on_snapshot");
   rb->SendLong(total.exited_on_snapshot ? 1 : 0);
 }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -740,8 +740,8 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "    segment_capacity (i.e. against ONE segment's capacity, not the sum of both),",
         "    so on average each buddy must be under roughly threshold/2 full. <threshold>",
         "    is in (0, 1] and defaults to 0.25. Returns a map with 'merged', 'attempted',",
-        "    'rolled_back' counts and 'exited_on_snapshot' (1 if the scan exited early due",
-        "    to an in-progress snapshot).",
+        "    'rolled_back', 'skipped_min_depth' counts and 'exited_on_snapshot' (1 if the",
+        "    scan exited early due to an in-progress snapshot).",
         "UNIQ-STRS",
         "    Prints per-object unique string stats and estimated dedup savings across shards.",
         "HELP",
@@ -1817,13 +1817,15 @@ void DebugCmd::CompactTable(facade::CmdArgParser parser, CommandContext* cmd_cnt
     total += r;
   }
 
-  rb->StartCollection(4, CollectionType::MAP);
+  rb->StartCollection(5, CollectionType::MAP);
   rb->SendSimpleString("merged");
   rb->SendLong(total.merged);
   rb->SendSimpleString("attempted");
   rb->SendLong(total.attempted);
   rb->SendSimpleString("rolled_back");
   rb->SendLong(total.rolled_back);
+  rb->SendSimpleString("skipped_min_depth");
+  rb->SendLong(total.skipped_min_depth);
   rb->SendSimpleString("exited_on_snapshot");
   rb->SendLong(total.exited_on_snapshot ? 1 : 0);
 }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -736,8 +736,12 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "    Prints segment info for the current database.",
         "COMPACT-TABLE [threshold]",
         "    Merge underutilized buddy-segment pairs in the dash table to reclaim memory.",
-        "    <threshold> is the maximum combined fill ratio (0, 1] below which two buddy",
-        "    segments are merged; defaults to 0.25. Returns the number of segments merged.",
+        "    Two buddy segments are merged when their combined size is <= threshold *",
+        "    segment_capacity (i.e. against ONE segment's capacity, not the sum of both),",
+        "    so on average each buddy must be under roughly threshold/2 full. <threshold>",
+        "    is in (0, 1] and defaults to 0.25. Returns a map with 'merged', 'attempted',",
+        "    'rolled_back' counts and 'exited_on_snapshot' (1 if the scan exited early due",
+        "    to an in-progress snapshot).",
         "UNIQ-STRS",
         "    Prints per-object unique string stats and estimated dedup savings across shards.",
         "HELP",
@@ -1803,12 +1807,25 @@ void DebugCmd::CompactTable(facade::CmdArgParser parser, CommandContext* cmd_cnt
   }
 
   const DbIndex db_idx = cmd_cntx->server_conn_cntx()->db_index();
-  std::vector<size_t> results(shard_set->size());
+  std::vector<EngineShard::CompactTableStats> results(shard_set->size());
   shard_set->RunBlockingInParallel([&](EngineShard* shard) {
     results[shard->shard_id()] = shard->CompactTable(threshold, db_idx);
   });
 
-  rb->SendLong(std::accumulate(results.begin(), results.end(), 0ul));
+  EngineShard::CompactTableStats total;
+  for (const auto& r : results) {
+    total += r;
+  }
+
+  rb->StartCollection(4, CollectionType::MAP);
+  rb->SendSimpleString("merged");
+  rb->SendLong(total.merged);
+  rb->SendSimpleString("attempted");
+  rb->SendLong(total.attempted);
+  rb->SendSimpleString("rolled_back");
+  rb->SendLong(total.rolled_back);
+  rb->SendSimpleString("exited_on_snapshot");
+  rb->SendLong(total.exited_on_snapshot ? 1 : 0);
 }
 
 void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1230,9 +1230,7 @@ EngineShard::CompactTableStats EngineShard::CompactTable(double threshold, DbInd
       if (seg_merged) {
         ++stats.merged;
         merged_any = true;
-      } else if (declined_depth_guard) {
-        ++stats.skipped_min_depth;
-      } else {
+      } else if (!declined_depth_guard) {
         ++stats.rolled_back;
       }
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1226,9 +1226,12 @@ EngineShard::CompactTableStats EngineShard::CompactTable(double threshold, DbInd
         continue;
 
       ++stats.attempted;
-      if (prime.Merge(seg_id, buddy_id)) {
+      auto [seg_merged, declined_depth_guard] = prime.Merge(seg_id, buddy_id);
+      if (seg_merged) {
         ++stats.merged;
         merged_any = true;
+      } else if (declined_depth_guard) {
+        ++stats.skipped_min_depth;
       } else {
         ++stats.rolled_back;
       }

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1192,17 +1192,18 @@ EngineShard::TxQueueInfo EngineShard::AnalyzeTxQueue() const {
   return info;
 }
 
-size_t EngineShard::CompactTable(double threshold, DbIndex db_idx) {
+EngineShard::CompactTableStats EngineShard::CompactTable(double threshold, DbIndex db_idx) {
   DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
   auto& prime = db_slice.GetDBTable(db_idx)->prime;
-  size_t total_seg_merged = 0;
+  CompactTableStats stats;
 
   while (true) {
     bool merged_any = false;
     // Prompt GetSegmentCount() each iteration to handle directory resizes across preemptions
     for (size_t seg_id = 0; seg_id < prime.GetSegmentCount(); seg_id = prime.NextSeg(seg_id)) {
       if (SliceSnapshot::IsSnaphotInProgress()) {
-        return total_seg_merged;
+        stats.exited_on_snapshot = true;
+        return stats;
       }
       // Fetch segment pointer fresh each iteration
       auto* seg = prime.GetSegment(seg_id);
@@ -1216,15 +1217,20 @@ size_t EngineShard::CompactTable(double threshold, DbIndex db_idx) {
 
       auto* buddy = prime.GetSegment(buddy_id);
 
+      // max_size is threshold * ONE segment's capacity, but combined is the SUM of both
+      // buddies, so each buddy must average under roughly threshold/2 full to qualify.
       const size_t combined = seg->SlowSize() + buddy->SlowSize();
       const size_t max_size = threshold * seg->capacity();
 
       if (combined > max_size)
         continue;
 
+      ++stats.attempted;
       if (prime.Merge(seg_id, buddy_id)) {
-        ++total_seg_merged;
+        ++stats.merged;
         merged_any = true;
+      } else {
+        ++stats.rolled_back;
       }
 
       // Yield after merge (don't hold pointers across yield)
@@ -1235,7 +1241,7 @@ size_t EngineShard::CompactTable(double threshold, DbIndex db_idx) {
       break;
   }
 
-  return total_seg_merged;
+  return stats;
 }
 
 }  // namespace dfly

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -221,8 +221,23 @@ class EngineShard {
     return defrag_state_.cursor;
   }
 
-  // Return total segments merged.
-  size_t CompactTable(double threshold, DbIndex db_idx);
+  struct CompactTableStats {
+    size_t merged = 0;                // segments successfully merged
+    size_t attempted = 0;             // buddy pairs that passed the size gate and were tried
+    size_t rolled_back = 0;           // attempted merges that failed and were rolled back
+    bool exited_on_snapshot = false;  // true if we bailed out early due to a snapshot in progress
+
+    CompactTableStats& operator+=(const CompactTableStats& o) {
+      merged += o.merged;
+      attempted += o.attempted;
+      rolled_back += o.rolled_back;
+      exited_on_snapshot = exited_on_snapshot || o.exited_on_snapshot;
+      return *this;
+    }
+  };
+
+  // Merge underutilized buddy-segment pairs in the dash table.
+  CompactTableStats CompactTable(double threshold, DbIndex db_idx);
 
  private:
   struct DefragTaskState {

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -222,15 +222,25 @@ class EngineShard {
   }
 
   struct CompactTableStats {
-    size_t merged = 0;                // segments successfully merged
-    size_t attempted = 0;             // buddy pairs that passed the size gate and were tried
-    size_t rolled_back = 0;           // attempted merges that failed and were rolled back
-    bool exited_on_snapshot = false;  // true if we bailed out early due to a snapshot in progress
+    // Segments successfully merged.
+    size_t merged = 0;
+    // Buddy pairs that passed the size gate and were handed to Merge (includes pairs
+    // that Merge then declined via the depth guard, see skipped_min_depth below).
+    size_t attempted = 0;
+    // Attempted merges that moved items into the buddy and then had to roll back
+    // after a failed insertion.
+    size_t rolled_back = 0;
+    // Buddy pairs declined before any items were touched, because merging would
+    // violate the initial_depth invariant.
+    size_t skipped_min_depth = 0;
+    // True if we bailed out early due to a snapshot in progress.
+    bool exited_on_snapshot = false;
 
     CompactTableStats& operator+=(const CompactTableStats& o) {
       merged += o.merged;
       attempted += o.attempted;
       rolled_back += o.rolled_back;
+      skipped_min_depth += o.skipped_min_depth;
       exited_on_snapshot = exited_on_snapshot || o.exited_on_snapshot;
       return *this;
     }

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -224,15 +224,11 @@ class EngineShard {
   struct CompactTableStats {
     // Segments successfully merged.
     size_t merged = 0;
-    // Buddy pairs that passed the size gate and were handed to Merge (includes pairs
-    // that Merge then declined via the depth guard, see skipped_min_depth below).
+    // Buddy pairs that passed the size gate and were handed to Merge.
     size_t attempted = 0;
     // Attempted merges that moved items into the buddy and then had to roll back
     // after a failed insertion.
     size_t rolled_back = 0;
-    // Buddy pairs declined before any items were touched, because merging would
-    // violate the initial_depth invariant.
-    size_t skipped_min_depth = 0;
     // True if we bailed out early due to a snapshot in progress.
     bool exited_on_snapshot = false;
 
@@ -240,7 +236,6 @@ class EngineShard {
       merged += o.merged;
       attempted += o.attempted;
       rolled_back += o.rolled_back;
-      skipped_min_depth += o.skipped_min_depth;
       exited_on_snapshot = exited_on_snapshot || o.exited_on_snapshot;
       return *this;
     }

--- a/tests/dragonfly/test_dash_gc.py
+++ b/tests/dragonfly/test_dash_gc.py
@@ -5,6 +5,12 @@ from .seeder import Seeder
 import logging
 
 
+def _compact_table_stats(flat_reply):
+    """DEBUG COMPACT-TABLE replies with a RESP map, which arrives as a flat
+    [k1, v1, k2, v2, ...] list over RESP2."""
+    return dict(zip(flat_reply[::2], flat_reply[1::2]))
+
+
 @dfly_args({"proactor_threads": 2, "maxmemory": "1G"})
 async def test_gc_merges_segments_and_shrinks_capacity(async_client: aioredis.Redis):
     value_size = 50
@@ -31,10 +37,12 @@ async def test_gc_merges_segments_and_shrinks_capacity(async_client: aioredis.Re
         await async_client.delete(*keys_to_delete[batch_start : batch_start + 1000])
 
     # Run GC with aggressive threshold to trigger merges
-    segments_merged = await async_client.execute_command("DEBUG", "COMPACT-TABLE", "0.5")
+    compact_stats = _compact_table_stats(
+        await async_client.execute_command("DEBUG", "COMPACT-TABLE", "0.5")
+    )
 
     stats_after = await async_client.info("MEMORY")
-    assert segments_merged > 0
+    assert compact_stats["merged"] > 0
     # Fewer segments means fewer buckets, so the table's total capacity must shrink
     assert stats_after["prime_capacity"] < stats_before["prime_capacity"], (
         f"Table capacity should shrink after GC: before={stats_before['prime_capacity']}, "
@@ -42,7 +50,7 @@ async def test_gc_merges_segments_and_shrinks_capacity(async_client: aioredis.Re
     )
 
     logging.info(
-        f"COMPACT-TABLE merged {segments_merged} segments, "
+        f"COMPACT-TABLE stats: {compact_stats}, "
         f"capacity {stats_before['prime_capacity']} -> {stats_after['prime_capacity']}"
     )
 


### PR DESCRIPTION
* add stats in return type {merged, attempted, rolled_back, exited_on_snapshotn skipped_min_depth}
* add docs on what threshold really is