### PR TITLE
fix(server): make per-slot memory_bytes track resident RAM and add tiered_bytes

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1394,8 +1394,7 @@ void CompactObj::GetString(char* dest) const {
   LOG(FATAL) << "Bad tag " << int(taglen_);
 }
 
-void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep, size_t mem_size) {
-  DCHECK_LE(mem_size, std::numeric_limits<uint32_t>::max());
+void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep) {
   uint16_t huff_header = 0;
   if (encoding_ == HUFFMAN_ENC) {
     CHECK(rep == ExternalRep::STRING);
@@ -1410,7 +1409,6 @@ void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep, size_t
   u_.ext_ptr.page_offset = offset % 4096;
   u_.ext_ptr.serialized_size = sz;
   u_.ext_ptr.offload.page_index = offset / 4096;
-  u_.ext_ptr.offload.mem_size = uint32_t(mem_size);
 }
 
 CompactObj::ExternalRep CompactObj::GetExternalRep() const {
@@ -1440,8 +1438,8 @@ auto CompactObj::GetCool() const -> CoolItem {
   return res;
 }
 
-void CompactObj::Freeze(size_t offset, size_t sz, size_t mem_size) {
-  SetExternal(offset, sz, GetExternalRep(), mem_size);
+void CompactObj::Freeze(size_t offset, size_t sz) {
+  SetExternal(offset, sz, GetExternalRep());
 }
 
 std::pair<size_t, size_t> CompactObj::GetExternalSlice() const {
@@ -1789,13 +1787,6 @@ size_t CompactObj::ResidentMallocUsed() const {
   if (taglen_ == EXTERNAL_TAG && u_.ext_ptr.is_cool)
     return u_.ext_ptr.cool_record->value.MallocUsed();
   return MallocUsed();
-}
-
-size_t CompactObj::LogicalMallocUsed() const {
-  if (taglen_ != EXTERNAL_TAG)
-    return MallocUsed();
-  return u_.ext_ptr.is_cool ? u_.ext_ptr.cool_record->value.MallocUsed()
-                            : u_.ext_ptr.offload.mem_size;
 }
 
 bool CompactObj::CmpNonInline(std::string_view sv) const {

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1394,7 +1394,7 @@ void CompactObj::GetString(char* dest) const {
   LOG(FATAL) << "Bad tag " << int(taglen_);
 }
 
-void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep) {
+void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep, uint32_t mem_size) {
   uint16_t huff_header = 0;
   if (encoding_ == HUFFMAN_ENC) {
     CHECK(rep == ExternalRep::STRING);
@@ -1409,6 +1409,7 @@ void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep) {
   u_.ext_ptr.page_offset = offset % 4096;
   u_.ext_ptr.serialized_size = sz;
   u_.ext_ptr.offload.page_index = offset / 4096;
+  u_.ext_ptr.offload.mem_size = mem_size;
 }
 
 CompactObj::ExternalRep CompactObj::GetExternalRep() const {
@@ -1438,8 +1439,8 @@ auto CompactObj::GetCool() const -> CoolItem {
   return res;
 }
 
-void CompactObj::Freeze(size_t offset, size_t sz) {
-  SetExternal(offset, sz, GetExternalRep());
+void CompactObj::Freeze(size_t offset, size_t sz, uint32_t mem_size) {
+  SetExternal(offset, sz, GetExternalRep(), mem_size);
 }
 
 std::pair<size_t, size_t> CompactObj::GetExternalSlice() const {
@@ -1781,6 +1782,19 @@ size_t CompactObj::MallocUsed(bool slow) const {
 
   LOG(DFATAL) << "should not reach";
   return 0;
+}
+
+size_t CompactObj::ResidentMallocUsed() const {
+  if (taglen_ == EXTERNAL_TAG && u_.ext_ptr.is_cool)
+    return u_.ext_ptr.cool_record->value.MallocUsed();
+  return MallocUsed();
+}
+
+size_t CompactObj::LogicalMallocUsed() const {
+  if (taglen_ != EXTERNAL_TAG)
+    return MallocUsed();
+  return u_.ext_ptr.is_cool ? u_.ext_ptr.cool_record->value.MallocUsed()
+                            : u_.ext_ptr.offload.mem_size;
 }
 
 bool CompactObj::CmpNonInline(std::string_view sv) const {

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1394,7 +1394,8 @@ void CompactObj::GetString(char* dest) const {
   LOG(FATAL) << "Bad tag " << int(taglen_);
 }
 
-void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep, uint32_t mem_size) {
+void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep, size_t mem_size) {
+  DCHECK_LE(mem_size, std::numeric_limits<uint32_t>::max());
   uint16_t huff_header = 0;
   if (encoding_ == HUFFMAN_ENC) {
     CHECK(rep == ExternalRep::STRING);
@@ -1409,7 +1410,7 @@ void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep, uint32
   u_.ext_ptr.page_offset = offset % 4096;
   u_.ext_ptr.serialized_size = sz;
   u_.ext_ptr.offload.page_index = offset / 4096;
-  u_.ext_ptr.offload.mem_size = mem_size;
+  u_.ext_ptr.offload.mem_size = uint32_t(mem_size);
 }
 
 CompactObj::ExternalRep CompactObj::GetExternalRep() const {
@@ -1439,7 +1440,7 @@ auto CompactObj::GetCool() const -> CoolItem {
   return res;
 }
 
-void CompactObj::Freeze(size_t offset, size_t sz, uint32_t mem_size) {
+void CompactObj::Freeze(size_t offset, size_t sz, size_t mem_size) {
   SetExternal(offset, sz, GetExternalRep(), mem_size);
 }
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -423,7 +423,7 @@ class CompactObj {
     return u_.ext_ptr.is_cool;
   }
 
-  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep, size_t mem_size);
+  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep);
   ExternalRep GetExternalRep() const;
 
   // Switches to empty, non-external string.
@@ -449,7 +449,7 @@ class CompactObj {
 
   // Prequisite: IsCool() is true.
   // Keeps cool record only as external value and discard in-memory part.
-  void Freeze(size_t offset, size_t sz, size_t mem_size);
+  void Freeze(size_t offset, size_t sz);
 
   std::pair<size_t, size_t> GetExternalSlice() const;
 
@@ -465,9 +465,6 @@ class CompactObj {
 
   // Bytes held in RAM: for a cool value that is the copy kept in its cool record.
   size_t ResidentMallocUsed() const;
-
-  // Bytes the object would occupy in RAM if it were not offloaded.
-  size_t LogicalMallocUsed() const;
 
   // Resets the object to empty state (string).
   void Reset();
@@ -581,8 +578,7 @@ class CompactObj {
     // cool_record pointer. Therefore, we moved this field into TieredCoolRecord itself.
     struct Offload {
       uint32_t page_index;
-      // Heap bytes the value had while resident. The serialized size differs in both directions.
-      uint32_t mem_size;
+      uint32_t reserved;
     };
 
     union {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -423,7 +423,7 @@ class CompactObj {
     return u_.ext_ptr.is_cool;
   }
 
-  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep);
+  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep, uint32_t mem_size);
   ExternalRep GetExternalRep() const;
 
   // Switches to empty, non-external string.
@@ -449,7 +449,7 @@ class CompactObj {
 
   // Prequisite: IsCool() is true.
   // Keeps cool record only as external value and discard in-memory part.
-  void Freeze(size_t offset, size_t sz);
+  void Freeze(size_t offset, size_t sz, uint32_t mem_size);
 
   std::pair<size_t, size_t> GetExternalSlice() const;
 
@@ -462,6 +462,12 @@ class CompactObj {
   // Returns the approximation of memory used by the object.
   // If slow is true, may use more expensive methods to calculate the precise size.
   size_t MallocUsed(bool slow = false) const;
+
+  // Bytes held in RAM: for a cool value that is the copy kept in its cool record.
+  size_t ResidentMallocUsed() const;
+
+  // Bytes the object would occupy in RAM if it were not offloaded.
+  size_t LogicalMallocUsed() const;
 
   // Resets the object to empty state (string).
   void Reset();
@@ -575,7 +581,8 @@ class CompactObj {
     // cool_record pointer. Therefore, we moved this field into TieredCoolRecord itself.
     struct Offload {
       uint32_t page_index;
-      uint32_t reserved;
+      // Heap bytes the value had while resident. The serialized size differs in both directions.
+      uint32_t mem_size;
     };
 
     union {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -423,7 +423,7 @@ class CompactObj {
     return u_.ext_ptr.is_cool;
   }
 
-  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep, uint32_t mem_size);
+  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep, size_t mem_size);
   ExternalRep GetExternalRep() const;
 
   // Switches to empty, non-external string.
@@ -449,7 +449,7 @@ class CompactObj {
 
   // Prequisite: IsCool() is true.
   // Keeps cool record only as external value and discard in-memory part.
-  void Freeze(size_t offset, size_t sz, uint32_t mem_size);
+  void Freeze(size_t offset, size_t sz, size_t mem_size);
 
   std::pair<size_t, size_t> GetExternalSlice() const;
 

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -878,12 +878,12 @@ TEST_F(CompactObjectTest, StrEncodingAndMaterialize) {
       EXPECT_EQ(test_str, enc.Decode(raw_str).Take());
 
       // Test Materialize
-      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING);  // dummy values
+      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING, 0);  // dummy values
       obj.Materialize(raw_str, true);
       EXPECT_EQ(test_str, obj.ToString());
 
       // Restore from external again, but not as a raw value
-      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING);
+      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING, 0);
       auto test_str2 = test_str + "updated";
       obj.Materialize(test_str2, false);
       EXPECT_EQ(obj.ToString(), test_str2);
@@ -930,14 +930,14 @@ TEST_F(CompactObjectTest, ExternalRepresentation) {
   {
     CompactValue obj;
     obj.SetString("test");
-    obj.SetExternal(0, 4, CompactObj::ExternalRep::STRING);
+    obj.SetExternal(0, 4, CompactObj::ExternalRep::STRING, 4);
     EXPECT_EQ(obj.ObjType(), OBJ_STRING);
   }
   {
     StringMap sm{};
     CompactValue obj;
     obj.SetRObjPtr(&sm);
-    obj.SetExternal(0, 4, CompactObj::ExternalRep::SERIALIZED_MAP);
+    obj.SetExternal(0, 4, CompactObj::ExternalRep::SERIALIZED_MAP, 4);
     EXPECT_EQ(obj.ObjType(), OBJ_HASH);
   }
 }

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -878,12 +878,12 @@ TEST_F(CompactObjectTest, StrEncodingAndMaterialize) {
       EXPECT_EQ(test_str, enc.Decode(raw_str).Take());
 
       // Test Materialize
-      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING, 0);  // dummy values
+      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING);  // dummy values
       obj.Materialize(raw_str, true);
       EXPECT_EQ(test_str, obj.ToString());
 
       // Restore from external again, but not as a raw value
-      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING, 0);
+      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING);
       auto test_str2 = test_str + "updated";
       obj.Materialize(test_str2, false);
       EXPECT_EQ(obj.ToString(), test_str2);
@@ -930,14 +930,14 @@ TEST_F(CompactObjectTest, ExternalRepresentation) {
   {
     CompactValue obj;
     obj.SetString("test");
-    obj.SetExternal(0, 4, CompactObj::ExternalRep::STRING, 4);
+    obj.SetExternal(0, 4, CompactObj::ExternalRep::STRING);
     EXPECT_EQ(obj.ObjType(), OBJ_STRING);
   }
   {
     StringMap sm{};
     CompactValue obj;
     obj.SetRObjPtr(&sm);
-    obj.SetExternal(0, 4, CompactObj::ExternalRep::SERIALIZED_MAP, 4);
+    obj.SetExternal(0, 4, CompactObj::ExternalRep::SERIALIZED_MAP);
     EXPECT_EQ(obj.ObjType(), OBJ_HASH);
   }
 }

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -321,9 +321,12 @@ OpStatus ElementAccess::Find(bool allow_wrong_type) {
 }
 
 OpResult<string> ElementAccess::Value() const {
-  return IsNewEntry()
-             ? OpResult<string>{string{}}
-             : ReadStringValue(context_.db_index, key_, updater_.it->second, EngineShard::tlocal());
+  if (IsNewEntry())
+    return OpResult<string>{string{}};
+
+  auto res = ReadStringValue(context_.db_index, key_, updater_.it->second, EngineShard::tlocal());
+  updater_.post_updater.ResyncBaseline();  // the read may have uploaded the value
+  return res;
 }
 
 bool ElementAccess::GetByteAtIndex(size_t idx, uint8_t* res) const {
@@ -351,9 +354,8 @@ void ElementAccess::Commit(string_view new_value) const {
     context_.ns->GetCurrentDbSlice().Del(context_, updater_.it);
   } else {
     const bool is_external = IsExternal();
-    // Overwriting a non-string type or an offloaded value: drop the old heap
-    // accounting once, and release the disk segment before storing in memory.
-    if (!IsNewEntry() && (updater_.it->second.ObjType() != OBJ_STRING || is_external)) {
+    // The value is replaced wholesale below, so drop the old heap accounting once.
+    if (!IsNewEntry()) {
       updater_.post_updater.ReduceHeapUsage();
     }
     if (is_external) {

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -359,7 +359,8 @@ void ElementAccess::Commit(string_view new_value) const {
       updater_.post_updater.ReduceHeapUsage();
     }
     if (is_external) {
-      EngineShard::tlocal()->tiered_storage()->Delete(context_.db_index, &updater_.it->second);
+      EngineShard::tlocal()->tiered_storage()->Delete(context_.db_index, key_,
+                                                      &updater_.it->second);
     }
     updater_.it->second.SetString(new_value);
     updater_.post_updater.Run();

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -713,7 +713,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgParser parser, CommandContext* 
   rb->StartArray(slots_stats.size());
 
   for (const auto& slot_data : slots_stats) {
-    rb->StartArray(9);
+    rb->StartArray(slot_data.second.tiered_bytes > 0 ? 11 : 9);
     rb->SendLong(slot_data.first);
     rb->SendBulkString("key_count");
     rb->SendLong(slot_data.second.key_count);
@@ -728,6 +728,11 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgParser parser, CommandContext* 
     rb->SendBulkString("memory_bytes");
     rb->SendLong(slot_data.second.memory_bytes +
                  slot_data.second.key_count * sizeof(CompactObj) * 2);
+
+    if (slot_data.second.tiered_bytes > 0) {
+      rb->SendBulkString("tiered_bytes");
+      rb->SendLong(slot_data.second.tiered_bytes);
+    }
   }
 }
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -13,11 +13,18 @@
 #include "absl/strings/substitute.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "core/compact_object.h"
 #include "core/detail/gen_utils.h"
+#include "core/page_usage/page_usage_stats.h"
 #include "facade/facade_test.h"
+#include "server/engine_shard_set.h"
 #include "server/test_utils.h"
+#include "server/tiered_storage.h"
+
+ABSL_DECLARE_FLAG(bool, force_epoll);
 
 namespace dfly::cluster {
 namespace {
@@ -633,6 +640,245 @@ TEST_F(ClusterFamilyTest, ClusterConfigDeleteSlots) {
                                 "total_writes", Not(IntArg(0)), "memory_bytes", IntArg(0))),
           RespArray(ElementsAre(IntArg(2), "key_count", IntArg(0), "total_reads", IntArg(0),
                                 "total_writes", Not(IntArg(0)), "memory_bytes", IntArg(0))))));
+}
+
+// SlotStats::memory_bytes is the logical key+value size, unchanged by offload or upload.
+class ClusterMemoryTest : public ClusterFamilyTest {
+ protected:
+  ClusterMemoryTest() {
+    num_threads_ = 1;
+  }
+
+  struct SlotInfo {
+    int64_t key_count = 0;
+    int64_t total_reads = 0;
+    int64_t total_writes = 0;
+    int64_t memory_bytes = 0;
+  };
+
+  SlotInfo GetSlotInfo(SlotId slot) {
+    auto resp = RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)});
+    const auto& row = resp.GetVec()[0].GetVec();
+    return SlotInfo{*row[2].GetInt(), *row[4].GetInt(), *row[6].GetInt(), *row[8].GetInt()};
+  }
+
+  // GETSLOTINFO adds a fixed per-key table-space term.
+  int64_t RawSlotMemory(SlotId slot) {
+    SlotInfo info = GetSlotInfo(slot);
+    return info.memory_bytes - info.key_count * int64_t(sizeof(CompactObj)) * 2;
+  }
+};
+
+#ifdef WITH_TIERING
+
+class ClusterTieredTest : public ClusterMemoryTest {
+ protected:
+  void SetUp() override {
+    if (absl::GetFlag(FLAGS_force_epoll)) {
+      GTEST_SKIP() << "Tiered storage requires io_uring";
+    }
+    flag_saver_.emplace();
+    SetTestFlag("tiered_prefix", "/tmp/cluster_tiered_test");
+    SetTestFlag("tiered_offload_threshold", "1.0");
+    SetTestFlag("tiered_min_value_size", "64");
+    SetTestFlag("tiered_experimental_cooling", "false");
+    ClusterMemoryTest::SetUp();
+    ConfigSingleNodeCluster(GetMyId());
+  }
+
+  void TearDown() override {
+    if (service_)
+      ClusterMemoryTest::TearDown();
+    flag_saver_.reset();
+  }
+
+  void WaitForOffload(size_t entries) {
+    ExpectConditionWithinTimeout(
+        [this, entries] { return GetMetrics().db_stats[0].tiered_entries == entries; });
+  }
+
+  std::optional<absl::FlagSaver> flag_saver_;
+};
+
+TEST_F(ClusterTieredTest, SlotMemoryReleasedOnExternalDelete) {
+  const string kKey = "tiered-del";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  ASSERT_GT(RawSlotMemory(slot), 0);
+
+  EXPECT_EQ(CheckedInt({"DEL", kKey}), 1);
+
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(info.key_count, 0);
+  EXPECT_EQ(info.memory_bytes, 0);
+}
+
+TEST_F(ClusterTieredTest, SlotMemoryStableOnExternalOverwrite) {
+  const string kKey = "tiered-set";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  const int64_t before = RawSlotMemory(slot);
+  ASSERT_GT(before, 0);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'y')}), "OK");
+  EXPECT_EQ(RawSlotMemory(slot), before);
+}
+
+TEST_F(ClusterTieredTest, SlotMemoryReleasedOnFlushSlots) {
+  const string kKey = "tiered-flush";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  ASSERT_GT(RawSlotMemory(slot), 0);
+
+  EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", absl::StrCat(slot), absl::StrCat(slot)}),
+            "OK");
+  ExpectConditionWithinTimeout([&]() { return GetSlotInfo(slot).key_count == 0; });
+
+  EXPECT_EQ(GetSlotInfo(slot).memory_bytes, 0);
+}
+
+TEST_F(ClusterTieredTest, SlotMemoryReleasedOnExpiry) {
+  const string kKey = "tiered-ttl";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  ASSERT_GT(RawSlotMemory(slot), 0);
+
+  EXPECT_EQ(CheckedInt({"PEXPIRE", kKey, "10"}), 1);
+  AdvanceTime(100);
+  EXPECT_THAT(Run({"GET", kKey}), ArgType(RespExpr::NIL));
+
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(info.key_count, 0);
+  EXPECT_EQ(info.memory_bytes, 0);
+}
+
+TEST_F(ClusterTieredTest, SlotMemoryNeverUnderflows) {
+  const string kKey = "tiered-append";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4000, 'x')}), "OK");
+  WaitForOffload(1);
+
+  for (int i = 0; i < 6; ++i)
+    Run({"APPEND", kKey, string(512, 'y')});
+
+  EXPECT_EQ(CheckedInt({"DEL", kKey}), 1);
+
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(info.key_count, 0);
+  EXPECT_EQ(info.memory_bytes, 0);
+}
+
+TEST_F(ClusterTieredTest, SlotMemoryReleasedOnConfigSlotRemoval) {
+  Run({"debug", "populate", "20", "key", "3000", "SLOTS", "1", "1"});
+  WaitForOffload(20);
+  ASSERT_GT(RawSlotMemory(1), 0);
+
+  ConfigSingleNodeCluster("abc");
+  ExpectConditionWithinTimeout([&]() { return CheckedInt({"dbsize"}) == 0; });
+
+  SlotInfo info = GetSlotInfo(1);
+  EXPECT_EQ(info.key_count, 0);
+  EXPECT_EQ(info.memory_bytes, 0);
+}
+
+class ClusterTieredCoolingTest : public ClusterTieredTest {
+ protected:
+  void SetUp() override {
+    ClusterTieredTest::SetUp();
+    if (!service_)  // skipped
+      return;
+    SetTestFlag("tiered_experimental_cooling", "true");
+    pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->UpdateFromFlags(); });
+  }
+};
+
+TEST_F(ClusterTieredCoolingTest, CoolSlotMemoryReleasedOnFlushSlots) {
+  const string kKey = "cool-flush";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  ASSERT_GT(RawSlotMemory(slot), 0);
+
+  EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", absl::StrCat(slot), absl::StrCat(slot)}),
+            "OK");
+  ExpectConditionWithinTimeout([&]() { return GetSlotInfo(slot).key_count == 0; });
+
+  EXPECT_EQ(GetSlotInfo(slot).memory_bytes, 0);
+  EXPECT_EQ(GetMetrics().db_stats[0].obj_memory_usage, 0u);
+}
+
+#endif  // WITH_TIERING
+
+TEST_F(ClusterMemoryTest, SlotMemoryFollowsDefrag) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  const SlotId slot = KeySlot("{tag}0");
+  const int kKeys = 120;
+
+  // Arrays grown element by element keep spare capacity that defrag drops, so the post-defrag
+  // delta is non-zero only for a non-power-of-two element count.
+  for (int i = 0; i < kKeys; ++i) {
+    Run({"JSON.SET", absl::StrCat("{tag}", i), "$", "[]"});
+    for (int j = 0; j < 40; ++j)
+      Run({"JSON.ARRAPPEND", absl::StrCat("{tag}", i), "$", absl::StrCat(j)});
+  }
+
+  shard_set->pool()->AwaitFiberOnAll([](unsigned, util::ProactorBase*) {
+    auto* shard = EngineShard::tlocal();
+    if (!shard)
+      return;
+    for (int i = 0; i < 100; ++i) {
+      PageUsage page_usage{CollectPageStats::NO, 0, CycleQuota::Unlimited()};
+      page_usage.SetForceReallocate(true);
+      shard->DoDefrag(&page_usage);
+      if (shard->GetDefragCursor() == 0)
+        break;
+    }
+  });
+
+  ASSERT_GT(GetMetrics().shard_stats.defrag_realloc_total, 0u);
+
+  // Every key shares one hashtag.
+  EXPECT_EQ(RawSlotMemory(slot), int64_t(GetMetrics().db_stats[0].obj_memory_usage));
+
+  for (int i = 0; i < kKeys; ++i)
+    Run({"DEL", absl::StrCat("{tag}", i)});
+
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(info.key_count, 0);
+  EXPECT_EQ(info.memory_bytes, 0);
+}
+
+TEST_F(ClusterMemoryTest, SlotTrafficCountersSurviveFlush) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  const string kKey = "traffic-key";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(1000, '#')}), "OK");
+  Run({"GET", kKey});
+
+  SlotInfo before = GetSlotInfo(slot);
+  ASSERT_GT(before.total_reads, 0);
+  ASSERT_GT(before.total_writes, 0);
+
+  Run({"FLUSHALL"});
+
+  SlotInfo after = GetSlotInfo(slot);
+  EXPECT_EQ(after.key_count, 0);
+  EXPECT_EQ(after.memory_bytes, 0);
+  EXPECT_EQ(after.total_reads, before.total_reads);
+  EXPECT_EQ(after.total_writes, before.total_writes);
 }
 
 // Test issue #1302

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -642,7 +642,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigDeleteSlots) {
                                 "total_writes", Not(IntArg(0)), "memory_bytes", IntArg(0))))));
 }
 
-// SlotStats::memory_bytes is the logical key+value size, unchanged by offload or upload.
+// SlotStats::memory_bytes tracks resident RAM; SlotStats::tiered_bytes tracks disk bytes.
 class ClusterMemoryTest : public ClusterFamilyTest {
  protected:
   ClusterMemoryTest() {
@@ -654,12 +654,18 @@ class ClusterMemoryTest : public ClusterFamilyTest {
     int64_t total_reads = 0;
     int64_t total_writes = 0;
     int64_t memory_bytes = 0;
+    int64_t tiered_bytes = 0;  // reported only when non-zero
   };
 
   SlotInfo GetSlotInfo(SlotId slot) {
     auto resp = RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)});
     const auto& row = resp.GetVec()[0].GetVec();
-    return SlotInfo{*row[2].GetInt(), *row[4].GetInt(), *row[6].GetInt(), *row[8].GetInt()};
+    SlotInfo info{*row[2].GetInt(), *row[4].GetInt(), *row[6].GetInt(), *row[8].GetInt()};
+    if (row.size() > 9) {
+      EXPECT_EQ(row[9], "tiered_bytes");
+      info.tiered_bytes = *row[10].GetInt();
+    }
+    return info;
   }
 
   // GETSLOTINFO adds a fixed per-key table-space term.
@@ -697,59 +703,84 @@ class ClusterTieredTest : public ClusterMemoryTest {
         [this, entries] { return GetMetrics().db_stats[0].tiered_entries == entries; });
   }
 
+  // The background offloader keeps moving bytes between the counters; park it and drain
+  // in-flight stashes so that multi-command assertions see a stable state.
+  void StopOffloading() {
+    SetTestFlag("tiered_offload_threshold", "0.0");
+    pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->UpdateFromFlags(); });
+    ExpectConditionWithinTimeout(
+        [this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0u; });
+  }
+
   std::optional<absl::FlagSaver> flag_saver_;
 };
 
-TEST_F(ClusterTieredTest, SlotMemoryReleasedOnExternalDelete) {
+// memory_bytes tracks resident RAM only: offloading moves the value's bytes from memory_bytes
+// to tiered_bytes, and both must return to zero once the slot is empty.
+TEST_F(ClusterTieredTest, SlotCountersFollowOffloadAndDelete) {
   const string kKey = "tiered-del";
   const SlotId slot = KeySlot(kKey);
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
-  ASSERT_GT(RawSlotMemory(slot), 0);
+
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(RawSlotMemory(slot), 0);
+  EXPECT_GT(info.tiered_bytes, 0);
 
   EXPECT_EQ(CheckedInt({"DEL", kKey}), 1);
 
-  SlotInfo info = GetSlotInfo(slot);
+  info = GetSlotInfo(slot);
   EXPECT_EQ(info.key_count, 0);
   EXPECT_EQ(info.memory_bytes, 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
 }
 
-TEST_F(ClusterTieredTest, SlotMemoryStableOnExternalOverwrite) {
+// The single key lives in one slot, so the slot counters must mirror the db-wide ones exactly.
+TEST_F(ClusterTieredTest, SlotCountersFollowExternalOverwrite) {
   const string kKey = "tiered-set";
   const SlotId slot = KeySlot(kKey);
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
-  const int64_t before = RawSlotMemory(slot);
-  ASSERT_GT(before, 0);
 
+  // Overwriting an offloaded value releases its disk extent; the new value may get offloaded
+  // again right away, so compare against the db-wide counters instead of fixed values.
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'y')}), "OK");
-  EXPECT_EQ(RawSlotMemory(slot), before);
+  StopOffloading();
+
+  auto db_stats = GetMetrics().db_stats[0];
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(RawSlotMemory(slot), int64_t(db_stats.obj_memory_usage));
+  EXPECT_EQ(info.tiered_bytes, int64_t(db_stats.tiered_used_bytes));
+  // The old extent was released: at most one value's worth of disk is held.
+  EXPECT_LE(db_stats.tiered_used_bytes, 3584u);
 }
 
-TEST_F(ClusterTieredTest, SlotMemoryReleasedOnFlushSlots) {
+TEST_F(ClusterTieredTest, SlotCountersReleasedOnFlushSlots) {
   const string kKey = "tiered-flush";
   const SlotId slot = KeySlot(kKey);
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
-  ASSERT_GT(RawSlotMemory(slot), 0);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
 
   EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", absl::StrCat(slot), absl::StrCat(slot)}),
             "OK");
   ExpectConditionWithinTimeout([&]() { return GetSlotInfo(slot).key_count == 0; });
 
-  EXPECT_EQ(GetSlotInfo(slot).memory_bytes, 0);
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(info.memory_bytes, 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
 }
 
-TEST_F(ClusterTieredTest, SlotMemoryReleasedOnExpiry) {
+TEST_F(ClusterTieredTest, SlotCountersReleasedOnExpiry) {
   const string kKey = "tiered-ttl";
   const SlotId slot = KeySlot(kKey);
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
-  ASSERT_GT(RawSlotMemory(slot), 0);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
 
   EXPECT_EQ(CheckedInt({"PEXPIRE", kKey, "10"}), 1);
   AdvanceTime(100);
@@ -758,9 +789,12 @@ TEST_F(ClusterTieredTest, SlotMemoryReleasedOnExpiry) {
   SlotInfo info = GetSlotInfo(slot);
   EXPECT_EQ(info.key_count, 0);
   EXPECT_EQ(info.memory_bytes, 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
 }
 
-TEST_F(ClusterTieredTest, SlotMemoryNeverUnderflows) {
+// Uploads and re-offloads move bytes between the two counters; they must mirror the db-wide
+// ones at every step and never wrap around zero.
+TEST_F(ClusterTieredTest, SlotCountersFollowUploadAndAppend) {
   const string kKey = "tiered-append";
   const SlotId slot = KeySlot(kKey);
 
@@ -769,18 +803,24 @@ TEST_F(ClusterTieredTest, SlotMemoryNeverUnderflows) {
 
   for (int i = 0; i < 6; ++i)
     Run({"APPEND", kKey, string(512, 'y')});
+  StopOffloading();
+
+  auto db_stats = GetMetrics().db_stats[0];
+  EXPECT_EQ(RawSlotMemory(slot), int64_t(db_stats.obj_memory_usage));
+  EXPECT_EQ(GetSlotInfo(slot).tiered_bytes, int64_t(db_stats.tiered_used_bytes));
 
   EXPECT_EQ(CheckedInt({"DEL", kKey}), 1);
 
   SlotInfo info = GetSlotInfo(slot);
   EXPECT_EQ(info.key_count, 0);
   EXPECT_EQ(info.memory_bytes, 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
 }
 
-TEST_F(ClusterTieredTest, SlotMemoryReleasedOnConfigSlotRemoval) {
+TEST_F(ClusterTieredTest, SlotCountersReleasedOnConfigSlotRemoval) {
   Run({"debug", "populate", "20", "key", "3000", "SLOTS", "1", "1"});
   WaitForOffload(20);
-  ASSERT_GT(RawSlotMemory(1), 0);
+  ASSERT_GT(GetSlotInfo(1).tiered_bytes, 0);
 
   ConfigSingleNodeCluster("abc");
   ExpectConditionWithinTimeout([&]() { return CheckedInt({"dbsize"}) == 0; });
@@ -788,6 +828,27 @@ TEST_F(ClusterTieredTest, SlotMemoryReleasedOnConfigSlotRemoval) {
   SlotInfo info = GetSlotInfo(1);
   EXPECT_EQ(info.key_count, 0);
   EXPECT_EQ(info.memory_bytes, 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
+}
+
+// MOVE transfers the disk bytes to the target db's slot ledger; the later deletion there must
+// not underflow. Tolerates MOVE being rejected in cluster mode by a future change.
+TEST_F(ClusterTieredTest, SlotTieredBytesFollowMove) {
+  const string kKey = "tiered-move";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
+
+  auto resp = Run({"MOVE", kKey, "1"});
+  if (resp.type == RespExpr::ERROR)
+    return;
+  EXPECT_THAT(resp, IntArg(1));
+
+  EXPECT_EQ(GetSlotInfo(slot).tiered_bytes, 0);
+  Run({"FLUSHALL"});
+  EXPECT_EQ(Run({"PING"}), "PONG");
 }
 
 class ClusterTieredCoolingTest : public ClusterTieredTest {
@@ -801,20 +862,46 @@ class ClusterTieredCoolingTest : public ClusterTieredTest {
   }
 };
 
-TEST_F(ClusterTieredCoolingTest, CoolSlotMemoryReleasedOnFlushSlots) {
+// A cool value is both on disk and in RAM, so it counts in both metrics until either copy goes.
+TEST_F(ClusterTieredCoolingTest, CoolSlotCountersReleasedOnFlushSlots) {
   const string kKey = "cool-flush";
   const SlotId slot = KeySlot(kKey);
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
-  ASSERT_GT(RawSlotMemory(slot), 0);
+
+  // The cool value's RAM copy stays in the slot's memory_bytes.
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(RawSlotMemory(slot), int64_t(GetMetrics().db_stats[0].obj_memory_usage));
+  EXPECT_GT(RawSlotMemory(slot), 0);
+  EXPECT_GT(info.tiered_bytes, 0);
 
   EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", absl::StrCat(slot), absl::StrCat(slot)}),
             "OK");
   ExpectConditionWithinTimeout([&]() { return GetSlotInfo(slot).key_count == 0; });
 
-  EXPECT_EQ(GetSlotInfo(slot).memory_bytes, 0);
+  info = GetSlotInfo(slot);
+  EXPECT_EQ(info.memory_bytes, 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
   EXPECT_EQ(GetMetrics().db_stats[0].obj_memory_usage, 0u);
+}
+
+// Warming a cool value up on read releases its disk copy.
+TEST_F(ClusterTieredCoolingTest, CoolSlotCountersReleasedOnWarmup) {
+  const string kKey = "cool-warm";
+  const SlotId slot = KeySlot(kKey);
+
+  EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
+  WaitForOffload(1);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
+  StopOffloading();
+
+  EXPECT_EQ(Run({"GET", kKey}), string(4096, 'x'));
+
+  SlotInfo info = GetSlotInfo(slot);
+  EXPECT_EQ(RawSlotMemory(slot), int64_t(GetMetrics().db_stats[0].obj_memory_usage));
+  EXPECT_GT(RawSlotMemory(slot), 0);
+  EXPECT_EQ(info.tiered_bytes, 0);
 }
 
 #endif  // WITH_TIERING

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -368,6 +368,21 @@ template <typename F> struct CallbackConsumer : public DbSlice::ChangeConsumerIn
   F f_;
 };
 
+void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotStats::*stat,
+                    string_view name) {
+  if (delta == 0 || !db->slots_stats)
+    return;
+
+  const SlotId sid = KeySlot(key);
+  uint64_t& value = db->slots_stats[sid].*stat;
+  if (delta < 0 && value < uint64_t(-delta)) {
+    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot " << name << ": " << value << " + "
+                           << delta << ", slot: " << sid;
+    delta = -int64_t(value);
+  }
+  value += delta;
+}
+
 }  // namespace
 
 void AccountObjectMemory(string_view key, unsigned type, int64_t delta, DbTable* db) {
@@ -376,33 +391,12 @@ void AccountObjectMemory(string_view key, unsigned type, int64_t delta, DbTable*
     return;
 
   db->stats.AddTypeMemoryUsage(type, delta);
-
-  if (!db->slots_stats)
-    return;
-
-  const SlotId sid = KeySlot(key);
-  uint64_t& slot_memory = db->slots_stats[sid].memory_bytes;
-  if (delta < 0 && slot_memory < uint64_t(-delta)) {
-    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot memory usage: " << slot_memory
-                           << " + " << delta << ", slot: " << sid;
-    delta = -int64_t(slot_memory);
-  }
-  slot_memory += delta;
+  UpdateSlotStat(key, delta, db, &SlotStats::memory_bytes, "memory usage");
 }
 
 void AccountSlotTieredBytes(string_view key, int64_t delta, DbTable* db) {
   DCHECK_NE(db, nullptr);
-  if (delta == 0 || !db->slots_stats)
-    return;
-
-  const SlotId sid = KeySlot(key);
-  uint64_t& tiered_bytes = db->slots_stats[sid].tiered_bytes;
-  if (delta < 0 && tiered_bytes < uint64_t(-delta)) {
-    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot tiered usage: " << tiered_bytes
-                           << " + " << delta << ", slot: " << sid;
-    delta = -int64_t(tiered_bytes);
-  }
-  tiered_bytes += delta;
+  UpdateSlotStat(key, delta, db, &SlotStats::tiered_bytes, "tiered usage");
 }
 
 #define ADD(x) (x) += o.x

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -370,28 +370,39 @@ template <typename F> struct CallbackConsumer : public DbSlice::ChangeConsumerIn
 
 }  // namespace
 
-void AccountObjectMemory(string_view key, unsigned type, int64_t resident_delta,
-                         int64_t logical_delta, DbTable* db) {
+void AccountObjectMemory(string_view key, unsigned type, int64_t delta, DbTable* db) {
   DCHECK_NE(db, nullptr);
+  if (delta == 0)
+    return;
 
-  if (resident_delta != 0)
-    db->stats.AddTypeMemoryUsage(type, resident_delta);
+  db->stats.AddTypeMemoryUsage(type, delta);
 
-  if (logical_delta == 0 || !db->slots_stats)
+  if (!db->slots_stats)
     return;
 
   const SlotId sid = KeySlot(key);
   uint64_t& slot_memory = db->slots_stats[sid].memory_bytes;
-  if (logical_delta < 0 && slot_memory < uint64_t(-logical_delta)) {
+  if (delta < 0 && slot_memory < uint64_t(-delta)) {
     LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot memory usage: " << slot_memory
-                           << " + " << logical_delta << ", slot: " << sid;
-    logical_delta = -int64_t(slot_memory);
+                           << " + " << delta << ", slot: " << sid;
+    delta = -int64_t(slot_memory);
   }
-  slot_memory += logical_delta;
+  slot_memory += delta;
 }
 
-void AccountObjectMemory(string_view key, unsigned type, int64_t delta, DbTable* db) {
-  AccountObjectMemory(key, type, delta, delta, db);
+void AccountSlotTieredBytes(string_view key, int64_t delta, DbTable* db) {
+  DCHECK_NE(db, nullptr);
+  if (delta == 0 || !db->slots_stats)
+    return;
+
+  const SlotId sid = KeySlot(key);
+  uint64_t& tiered_bytes = db->slots_stats[sid].tiered_bytes;
+  if (delta < 0 && tiered_bytes < uint64_t(-delta)) {
+    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot tiered usage: " << tiered_bytes
+                           << " + " << delta << ", slot: " << sid;
+    delta = -int64_t(tiered_bytes);
+  }
+  tiered_bytes += delta;
 }
 
 #define ADD(x) (x) += o.x
@@ -525,15 +536,13 @@ void DbSlice::AutoUpdater::ReduceHeapUsage() {
     return;
   }
 
-  // The baselines are up to date even if a blocking tiered read uploaded the value mid-scope:
-  // such reads are followed by ResyncBaseline(). Subtracting them keeps this call idempotent.
+  // The baseline is up to date even if a blocking tiered read uploaded the value mid-scope:
+  // such reads are followed by ResyncBaseline(). Subtracting it keeps this call idempotent.
   AccountObjectMemory(fields_.key, fields_.orig_obj_type, -int64_t(fields_.orig_value_heap_size),
-                      -int64_t(fields_.orig_logical_size),
                       fields_.db_slice->GetDBTable(fields_.db_ind));
 
   // Reset to avoid double accounting, and sync the type after accounting.
   fields_.orig_value_heap_size = 0;
-  fields_.orig_logical_size = 0;
   fields_.orig_obj_type = fields_.it->second.ObjType();
 }
 
@@ -544,7 +553,6 @@ void DbSlice::AutoUpdater::ResyncBaseline() {
 
   const PrimeValue& pv = fields_.it->second;
   fields_.orig_value_heap_size = pv.ResidentMallocUsed();
-  fields_.orig_logical_size = pv.LogicalMallocUsed();
   fields_.orig_obj_type = pv.ObjType();
 }
 
@@ -562,8 +570,7 @@ void DbSlice::AutoUpdater::Run() {
 
   const PrimeValue& pv = fields_.it->second;
   CompactObjType current_type = pv.ObjType();
-  int64_t current_resident = static_cast<int64_t>(pv.ResidentMallocUsed());
-  int64_t current_logical = static_cast<int64_t>(pv.LogicalMallocUsed());
+  int64_t current_size = static_cast<int64_t>(pv.ResidentMallocUsed());
   DbTable* table = fields_.db_slice->GetDBTable(fields_.db_ind);
 
   if (current_type != fields_.orig_obj_type) {
@@ -571,13 +578,11 @@ void DbSlice::AutoUpdater::Run() {
     // Applying (current_size - orig_size) to the new type would incorrectly subtract
     // from a counter that never had the original bytes added to it.
     AccountObjectMemory(fields_.key, fields_.orig_obj_type,
-                        -static_cast<int64_t>(fields_.orig_value_heap_size),
-                        -static_cast<int64_t>(fields_.orig_logical_size), table);
-    AccountObjectMemory(fields_.key, current_type, current_resident, current_logical, table);
+                        -static_cast<int64_t>(fields_.orig_value_heap_size), table);
+    AccountObjectMemory(fields_.key, current_type, current_size, table);
   } else {
     AccountObjectMemory(fields_.key, current_type,
-                        current_resident - static_cast<int64_t>(fields_.orig_value_heap_size),
-                        current_logical - static_cast<int64_t>(fields_.orig_logical_size), table);
+                        current_size - static_cast<int64_t>(fields_.orig_value_heap_size), table);
   }
 
   fields_.db_slice->PostUpdate(fields_.db_ind, fields_.key);
@@ -595,7 +600,6 @@ DbSlice::AutoUpdater::AutoUpdater(DbIndex db_ind, std::string_view key, const It
               .it = it,
               .key = key,
               .orig_value_heap_size = it->second.ResidentMallocUsed(),
-              .orig_logical_size = it->second.LogicalMallocUsed(),
               .orig_obj_type = it->second.ObjType()} {
   DCHECK(IsValid(it));
 }
@@ -718,7 +722,7 @@ auto DbSlice::FindInternal(const Context& cntx, string_view key, optional<unsign
 
   // Fetch back cool items
   if (pv.IsExternal() && pv.IsCool()) {
-    pv = owner_->tiered_storage()->Warmup(cntx.db_index, pv.GetCool());
+    pv = owner_->tiered_storage()->Warmup(cntx.db_index, key, pv.GetCool());
   }
 
   // Mark this entry as being looked up. We use key (first) deliberately to preserve the hotness
@@ -1758,7 +1762,7 @@ void DbSlice::RemoveOffloadedEntriesFromTieredStorage(absl::Span<const DbIndex> 
     do {
       cursor = db_ptr->prime.Traverse(cursor, [&](PrimeIterator it) {
         if (it->second.IsExternal()) {
-          tiered_storage->Delete(index, &it->second);
+          tiered_storage->Delete(index, it->first.GetSlice(&scratch), &it->second);
         } else if (it->second.HasStashPending()) {
           tiered_storage->CancelStash(std::make_pair(index, it->first.GetSlice(&scratch)),
                                       &it->second);
@@ -1976,14 +1980,13 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
   // The tiered delete blanks the external metadata, zeroing the reported size and type.
   const CompactObjType val_type = pv.ObjType();
   const ssize_t value_heap_size = pv.ResidentMallocUsed();
-  const ssize_t value_logical_size = pv.LogicalMallocUsed();
 
   if (pv.HasStashPending()) {
     string scratch;
     string_view key = del_it->first.GetSlice(&scratch);
     shard_owner()->tiered_storage()->CancelStash(std::make_pair(table->index, key), &pv);
   } else if (pv.IsExternal()) {
-    shard_owner()->tiered_storage()->Delete(table->index, &del_it->second);
+    shard_owner()->tiered_storage()->Delete(table->index, del_it.key(), &del_it->second);
   }
 
   ssize_t key_size_used = del_it->first.MallocUsed();
@@ -1992,8 +1995,7 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
   } else {
     AccountObjectMemory(del_it.key(), OBJ_KEY, -key_size_used, table);  // Key
   }
-  AccountObjectMemory(del_it.key(), val_type, -value_heap_size, -value_logical_size,
-                      table);  // Value
+  AccountObjectMemory(del_it.key(), val_type, -value_heap_size, table);  // Value
 
   if (async && MayDeleteAsynchronously(pv)) {
     auto schedule = [](auto* ds) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -72,20 +72,6 @@ constexpr auto kPrimeSegmentSize = PrimeTable::kSegBytes;
 // mi_malloc good size is 32768. i.e. we have malloc waste of 1.5%.
 static_assert(kPrimeSegmentSize <= 32304);
 
-void AccountObjectMemory(string_view key, unsigned type, int64_t size, DbTable* db) {
-  DCHECK_NE(db, nullptr);
-  if (size == 0)
-    return;
-
-  DbTableStats& stats = db->stats;
-
-  stats.AddTypeMemoryUsage(type, size);
-
-  if (db->slots_stats) {
-    db->slots_stats[KeySlot(key)].memory_bytes += size;
-  }
-}
-
 class PrimeEvictionPolicy {
  public:
   static constexpr bool can_evict = true;  // we implement eviction functionality.
@@ -384,6 +370,30 @@ template <typename F> struct CallbackConsumer : public DbSlice::ChangeConsumerIn
 
 }  // namespace
 
+void AccountObjectMemory(string_view key, unsigned type, int64_t resident_delta,
+                         int64_t logical_delta, DbTable* db) {
+  DCHECK_NE(db, nullptr);
+
+  if (resident_delta != 0)
+    db->stats.AddTypeMemoryUsage(type, resident_delta);
+
+  if (logical_delta == 0 || !db->slots_stats)
+    return;
+
+  const SlotId sid = KeySlot(key);
+  uint64_t& slot_memory = db->slots_stats[sid].memory_bytes;
+  if (logical_delta < 0 && slot_memory < uint64_t(-logical_delta)) {
+    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot memory usage: " << slot_memory
+                           << " + " << logical_delta << ", slot: " << sid;
+    logical_delta = -int64_t(slot_memory);
+  }
+  slot_memory += logical_delta;
+}
+
+void AccountObjectMemory(string_view key, unsigned type, int64_t delta, DbTable* db) {
+  AccountObjectMemory(key, type, delta, delta, db);
+}
+
 #define ADD(x) (x) += o.x
 
 DbStats& DbStats::operator+=(const DbStats& o) {
@@ -511,10 +521,32 @@ DbSlice::AutoUpdater::~AutoUpdater() {
 }
 
 void DbSlice::AutoUpdater::ReduceHeapUsage() {
-  AccountObjectMemory(fields_.key, fields_.orig_obj_type, -fields_.orig_value_heap_size,
+  if (fields_.db_slice == nullptr) {
+    return;
+  }
+
+  // Use the current sizes, not the ones captured at construction: a tiered read may have
+  // uploaded the value back to memory in the meantime.
+  const PrimeValue& pv = fields_.it->second;
+  AccountObjectMemory(fields_.key, fields_.orig_obj_type, -int64_t(pv.ResidentMallocUsed()),
+                      -int64_t(pv.LogicalMallocUsed()),
                       fields_.db_slice->GetDBTable(fields_.db_ind));
-  fields_.orig_value_heap_size = 0;                      // Reset to avoid double accounting.
-  fields_.orig_obj_type = fields_.it->second.ObjType();  // Sync type after accounting.
+
+  // Reset to avoid double accounting, and sync the type after accounting.
+  fields_.orig_value_heap_size = 0;
+  fields_.orig_logical_size = 0;
+  fields_.orig_obj_type = pv.ObjType();
+}
+
+void DbSlice::AutoUpdater::ResyncBaseline() {
+  if (fields_.db_slice == nullptr) {
+    return;
+  }
+
+  const PrimeValue& pv = fields_.it->second;
+  fields_.orig_value_heap_size = pv.ResidentMallocUsed();
+  fields_.orig_logical_size = pv.LogicalMallocUsed();
+  fields_.orig_obj_type = pv.ObjType();
 }
 
 void DbSlice::AutoUpdater::Run() {
@@ -529,8 +561,10 @@ void DbSlice::AutoUpdater::Run() {
 
   CHECK_NE(fields_.db_slice, nullptr);
 
-  CompactObjType current_type = fields_.it->second.ObjType();
-  int64_t current_size = static_cast<int64_t>(fields_.it->second.MallocUsed());
+  const PrimeValue& pv = fields_.it->second;
+  CompactObjType current_type = pv.ObjType();
+  int64_t current_resident = static_cast<int64_t>(pv.ResidentMallocUsed());
+  int64_t current_logical = static_cast<int64_t>(pv.LogicalMallocUsed());
   DbTable* table = fields_.db_slice->GetDBTable(fields_.db_ind);
 
   if (current_type != fields_.orig_obj_type) {
@@ -538,11 +572,13 @@ void DbSlice::AutoUpdater::Run() {
     // Applying (current_size - orig_size) to the new type would incorrectly subtract
     // from a counter that never had the original bytes added to it.
     AccountObjectMemory(fields_.key, fields_.orig_obj_type,
-                        -static_cast<int64_t>(fields_.orig_value_heap_size), table);
-    AccountObjectMemory(fields_.key, current_type, current_size, table);
+                        -static_cast<int64_t>(fields_.orig_value_heap_size),
+                        -static_cast<int64_t>(fields_.orig_logical_size), table);
+    AccountObjectMemory(fields_.key, current_type, current_resident, current_logical, table);
   } else {
-    ssize_t delta = current_size - static_cast<int64_t>(fields_.orig_value_heap_size);
-    AccountObjectMemory(fields_.key, current_type, delta, table);
+    AccountObjectMemory(fields_.key, current_type,
+                        current_resident - static_cast<int64_t>(fields_.orig_value_heap_size),
+                        current_logical - static_cast<int64_t>(fields_.orig_logical_size), table);
   }
 
   fields_.db_slice->PostUpdate(fields_.db_ind, fields_.key);
@@ -559,7 +595,8 @@ DbSlice::AutoUpdater::AutoUpdater(DbIndex db_ind, std::string_view key, const It
               .db_ind = db_ind,
               .it = it,
               .key = key,
-              .orig_value_heap_size = it->second.MallocUsed(),
+              .orig_value_heap_size = it->second.ResidentMallocUsed(),
+              .orig_logical_size = it->second.LogicalMallocUsed(),
               .orig_obj_type = it->second.ObjType()} {
   DCHECK(IsValid(it));
 }
@@ -1013,6 +1050,16 @@ util::fb2::Fiber DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
 
     CreateDb(index);
     std::swap(db_arr_[index]->trans_locks, flush_db_arr[index]->trans_locks);
+
+    // Unlike the key_count/memory_bytes gauges, traffic counters are cumulative history.
+    const auto& old_slots = flush_db_arr[index]->slots_stats;
+    auto& new_slots = db_arr_[index]->slots_stats;
+    if (old_slots && new_slots) {
+      for (SlotId sid = 0; sid <= kMaxSlotNum; ++sid) {
+        new_slots[sid].total_reads = old_slots[sid].total_reads;
+        new_slots[sid].total_writes = old_slots[sid].total_writes;
+      }
+    }
   }
 
   LOG_IF(DFATAL, !fetched_items_.empty())
@@ -1927,6 +1974,11 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
 
   PrimeValue& pv = del_it->second;
 
+  // The tiered delete blanks the external metadata, zeroing the reported size and type.
+  const CompactObjType val_type = pv.ObjType();
+  const ssize_t value_heap_size = pv.ResidentMallocUsed();
+  const ssize_t value_logical_size = pv.LogicalMallocUsed();
+
   if (pv.HasStashPending()) {
     string scratch;
     string_view key = del_it->first.GetSlice(&scratch);
@@ -1935,13 +1987,14 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
     shard_owner()->tiered_storage()->Delete(table->index, &del_it->second);
   }
 
-  ssize_t value_heap_size = pv.MallocUsed(), key_size_used = del_it->first.MallocUsed();
+  ssize_t key_size_used = del_it->first.MallocUsed();
   if (del_it->first.IsInline()) {
     --stats.inline_keys;
   } else {
     AccountObjectMemory(del_it.key(), OBJ_KEY, -key_size_used, table);  // Key
   }
-  AccountObjectMemory(del_it.key(), pv.ObjType(), -value_heap_size, table);  // Value
+  AccountObjectMemory(del_it.key(), val_type, -value_heap_size, -value_logical_size,
+                      table);  // Value
 
   if (async && MayDeleteAsynchronously(pv)) {
     auto schedule = [](auto* ds) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -525,17 +525,16 @@ void DbSlice::AutoUpdater::ReduceHeapUsage() {
     return;
   }
 
-  // Use the current sizes, not the ones captured at construction: a tiered read may have
-  // uploaded the value back to memory in the meantime.
-  const PrimeValue& pv = fields_.it->second;
-  AccountObjectMemory(fields_.key, fields_.orig_obj_type, -int64_t(pv.ResidentMallocUsed()),
-                      -int64_t(pv.LogicalMallocUsed()),
+  // The baselines are up to date even if a blocking tiered read uploaded the value mid-scope:
+  // such reads are followed by ResyncBaseline(). Subtracting them keeps this call idempotent.
+  AccountObjectMemory(fields_.key, fields_.orig_obj_type, -int64_t(fields_.orig_value_heap_size),
+                      -int64_t(fields_.orig_logical_size),
                       fields_.db_slice->GetDBTable(fields_.db_ind));
 
   // Reset to avoid double accounting, and sync the type after accounting.
   fields_.orig_value_heap_size = 0;
   fields_.orig_logical_size = 0;
-  fields_.orig_obj_type = pv.ObjType();
+  fields_.orig_obj_type = fields_.it->second.ObjType();
 }
 
 void DbSlice::AutoUpdater::ResyncBaseline() {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -31,6 +31,13 @@ class SlotSet;
 
 using facade::OpResult;
 
+// `resident_delta` goes to the per-db/per-type counters (bytes held in RAM), `logical_delta` to
+// the per-slot counter (size as if resident, so offloading must not move it).
+void AccountObjectMemory(std::string_view key, unsigned type, int64_t resident_delta,
+                         int64_t logical_delta, DbTable* db);
+
+void AccountObjectMemory(std::string_view key, unsigned type, int64_t delta, DbTable* db);
+
 struct DbStats : public DbTableStats {
   // number of active keys.
   size_t key_count = 0;
@@ -182,6 +189,10 @@ class DbSlice {
     // Used when the existing object is overridden by a new one.
     void ReduceHeapUsage();
 
+    // Re-reads the entry's current sizes into the baseline. Call it after a blocking tiered
+    // read, which may upload the value back into memory and account for it behind our back.
+    void ResyncBaseline();
+
     void Run();
     void Cancel();
 
@@ -197,6 +208,7 @@ class DbSlice {
 
       // The following fields are calculated at init time
       size_t orig_value_heap_size = 0;
+      size_t orig_logical_size = 0;
       CompactObjType orig_obj_type = 0;
     };
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -31,12 +31,12 @@ class SlotSet;
 
 using facade::OpResult;
 
-// `resident_delta` goes to the per-db/per-type counters (bytes held in RAM), `logical_delta` to
-// the per-slot counter (size as if resident, so offloading must not move it).
-void AccountObjectMemory(std::string_view key, unsigned type, int64_t resident_delta,
-                         int64_t logical_delta, DbTable* db);
-
+// Applies a delta to the per-db/per-type counters and to the owning slot's memory_bytes.
+// All of them track resident RAM.
 void AccountObjectMemory(std::string_view key, unsigned type, int64_t delta, DbTable* db);
+
+// Applies a delta to the owning slot's tiered_bytes - disk bytes held by the slot's entries.
+void AccountSlotTieredBytes(std::string_view key, int64_t delta, DbTable* db);
 
 struct DbStats : public DbTableStats {
   // number of active keys.
@@ -208,7 +208,6 @@ class DbSlice {
 
       // The following fields are calculated at init time
       size_t orig_value_heap_size = 0;
-      size_t orig_logical_size = 0;
       CompactObjType orig_obj_type = 0;
     };
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -744,6 +744,28 @@ TEST_F(DflyEngineTest, Bug496) {
   });
 }
 
+// A second call before the value is replaced must not subtract the same bytes again.
+TEST_F(DflyEngineTest, ReduceHeapUsageIdempotent) {
+  shard_set->RunBlockingInParallel([](EngineShard* shard) {
+    auto& db = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
+
+    {
+      auto res = *db.AddOrFind({}, "key", std::nullopt);
+      res.it->second.SetString(string(1000, 'x'));
+    }
+
+    size_t before = db.GetStats().db_stats[0].obj_memory_usage;
+    EXPECT_GT(before, 0u);
+
+    auto res = db.FindMutable({}, "key");
+    res.post_updater.ReduceHeapUsage();
+    res.post_updater.ReduceHeapUsage();
+    res.post_updater.Run();
+
+    EXPECT_EQ(db.GetStats().db_stats[0].obj_memory_usage, before);
+  });
+}
+
 TEST_F(DflyEngineTest, Issue607) {
   // https://github.com/dragonflydb/dragonfly/issues/607
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -366,6 +366,7 @@ std::optional<CollectedPageStats> EngineShard::DoDefrag(PageUsage* page_usage) {
   uint64_t attempts = 0;
 
   DbTable* db_table = slice.GetDBTable(defrag_state_.dbid);
+  std::string scratch;
   do {
     cur = prime_table->Traverse(cur, [&](PrimeIterator it) {
       // for each value check whether we should move it because it
@@ -376,7 +377,7 @@ std::optional<CollectedPageStats> EngineShard::DoDefrag(PageUsage* page_usage) {
       if (did) {
         reallocations++;
         if (const ssize_t delta = it->second.MallocUsed() - original_size; delta != 0) {
-          db_table->stats.AddTypeMemoryUsage(it->second.ObjType(), delta);
+          AccountObjectMemory(it->first.GetSlice(&scratch), it->second.ObjType(), delta, db_table);
         }
       }
     });

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -943,6 +943,20 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   uint64_t exp_ts = from_res.it->first.GetExpireTime();
   RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, from_res.it->second, op_args.shard);
   from_res.post_updater.ReduceHeapUsage();
+
+  // FindMutable warms cool values up, so only a fully-external value still holds disk bytes;
+  // move its tiered accounting to the target db together with the value.
+  if (from_res.it->second.IsExternal()) {
+    const int64_t tiered_len = from_res.it->second.GetExternalSlice().second;
+    DbTable* src_table = db_slice.GetDBTable(op_args.db_cntx.db_index);
+    DbTable* dst_table = db_slice.GetDBTable(target_db);
+    AccountSlotTieredBytes(key, -tiered_len, src_table);
+    AccountSlotTieredBytes(key, tiered_len, dst_table);
+    src_table->stats.tiered_entries--;
+    src_table->stats.tiered_used_bytes -= tiered_len;
+    dst_table->stats.tiered_entries++;
+    dst_table->stats.tiered_used_bytes += tiered_len;
+  }
   PrimeValue from_obj = std::move(from_res.it->second);
 
   db_slice.DelMutable(op_args.db_cntx, std::move(from_res));
@@ -1296,6 +1310,9 @@ void GenericFamily::Delex(facade::CmdArgParser parser, CommandContext* cmd_cntx)
           es->tiered_storage());
 
       auto result = fut.Get();
+      // The read may have uploaded the value back into memory and accounted for it right away,
+      // which leaves the updater's baseline behind. Resync before any return.
+      it_res->post_updater.ResyncBaseline();
       if (!result)
         // Tiered storage read failed - return generic I/O error
         return OpStatus::IO_ERROR;

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -149,7 +149,7 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   }
   res.post_updater.ReduceHeapUsage();
   if (res.it->second.IsExternal()) {
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
   }
   res.it->second.SetString(hll);
   return std::min(updated, 1);
@@ -325,7 +325,7 @@ OpResult<int> PFMergeInternal(string_view key, Transaction* tx, SinkReplyBuilder
     auto& res = *op_res;
     if (!res.is_new && res.it->second.IsExternal()) {
       res.post_updater.ReduceHeapUsage();
-      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
     }
     res.it->second.SetString(hll);
 

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -105,6 +105,7 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
     initSparseHll(StringToHllPtr(hll));
   } else {
     auto val = ReadHll(op_args, key, res.it->second);
+    res.post_updater.ResyncBaseline();  // the read may have uploaded the value
     RETURN_ON_BAD_STATUS(val);
     hll = std::move(val).value();
   }
@@ -146,9 +147,8 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
     hll = string{hll_sds, sdslen(hll_sds)};
     sdsfree(hll_sds);
   }
-  // ReadHll may have warmed the value back into memory; re-check before Delete.
+  res.post_updater.ReduceHeapUsage();
   if (res.it->second.IsExternal()) {
-    res.post_updater.ReduceHeapUsage();
     op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
   }
   res.it->second.SetString(hll);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -278,13 +278,13 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
     auto tier = ReadTieredString(op_args.db_cntx.db_index, key, res.it->second,
                                  op_args.shard->tiered_storage())
                     .Get();
+    res.post_updater.ResyncBaseline();  // the read may have uploaded the value
     if (!tier)
       return OpStatus::IO_ERROR;
     string slice = std::move(tier).value();
     string new_val = prepend ? absl::StrCat(val, slice) : absl::StrCat(slice, val);
-    // The read may have warmed the value back into memory; re-check before Delete.
+    res.post_updater.ReduceHeapUsage();
     if (res.it->second.IsExternal()) {
-      res.post_updater.ReduceHeapUsage();
       op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
     }
     res.it->second.SetString(new_val);
@@ -321,6 +321,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
     auto res = ReadTieredString(op_args.db_cntx.db_index, key, add_res.it->second,
                                 op_args.shard->tiered_storage())
                    .Get();
+    add_res.post_updater.ResyncBaseline();  // the read may have uploaded the value
     if (!res)
       return OpStatus::IO_ERROR;
     tmp = std::move(res).value();
@@ -342,10 +343,8 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
 
   char* str = RedisReplyBuilder::FormatDouble(base, buf, sizeof(buf));
 
-  // The tiered read may have warmed the value back into memory; re-check so Delete
-  // only runs while it is still external.
+  add_res.post_updater.ReduceHeapUsage();
   if (add_res.it->second.IsExternal()) {
-    add_res.post_updater.ReduceHeapUsage();
     op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &add_res.it->second);
   }
   add_res.it->second.SetString(str);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -285,7 +285,7 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
     string new_val = prepend ? absl::StrCat(val, slice) : absl::StrCat(slice, val);
     res.post_updater.ReduceHeapUsage();
     if (res.it->second.IsExternal()) {
-      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
     }
     res.it->second.SetString(new_val);
     return true;
@@ -345,7 +345,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
 
   add_res.post_updater.ReduceHeapUsage();
   if (add_res.it->second.IsExternal()) {
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &add_res.it->second);
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &add_res.it->second);
   }
   add_res.it->second.SetString(str);
 
@@ -982,7 +982,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
 
   // If value is external, mark it as deleted
   if (prime_value.IsExternal()) {
-    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, &prime_value);
+    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, it_upd->it.key(), &prime_value);
   }
 
   // overwrite existing entry.

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -65,12 +65,13 @@ DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
 }
 
 SlotStats& SlotStats::operator+=(const SlotStats& o) {
-  static_assert(sizeof(SlotStats) == 32);
+  static_assert(sizeof(SlotStats) == 40);
 
   ADD(key_count);
   ADD(total_reads);
   ADD(total_writes);
   ADD(memory_bytes);
+  ADD(tiered_bytes);
   return *this;
 }
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -47,6 +47,7 @@ struct SlotStats {
   uint64_t total_reads = 0;
   uint64_t total_writes = 0;
   uint64_t memory_bytes = 0;
+  uint64_t tiered_bytes = 0;
   SlotStats& operator+=(const SlotStats& o);
 };
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -88,11 +88,14 @@ constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
 // so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
 constexpr uint32_t kMaxPendingDefrags = 100;
 
-// Called after setting new value in place of previous segment
-void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, DbTableStats* stats) {
-  stats->AddTypeMemoryUsage(fragment_ref.ObjType(), fragment_ref.MallocUsed());
-  stats->tiered_entries--;
-  stats->tiered_used_bytes -= tiered_len;
+// Called after setting new value in place of previous segment.
+// The per-slot ledger already carried the pre-offload size, so it only takes the difference.
+void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, int64_t logical_delta,
+                   string_view key, DbTable* db) {
+  AccountObjectMemory(key, fragment_ref.ObjType(), int64_t(fragment_ref.MallocUsed()),
+                      logical_delta, db);
+  db->stats.tiered_entries--;
+  db->stats.tiered_used_bytes -= tiered_len;
 }
 
 tiering::DiskSegment FromCoolItem(const PrimeValue::CoolItem& item) {
@@ -234,8 +237,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   void RetireColdEntries(size_t additional_memory);
 
   // Set value to be an in-memory type again. Update memory stats.
-  void Upload(DbIndex dbid, string_view value, PrimeValue* pv) {
+  void Upload(DbIndex dbid, string_view key, string_view value, PrimeValue* pv) {
     DCHECK(!value.empty());
+    const size_t logical_before = pv->LogicalMallocUsed();
     switch (pv->GetExternalRep()) {
       case CompactObj::ExternalRep::STRING: {
         pv->Materialize(value, true);
@@ -253,7 +257,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       }
     };
 
-    RecordDeleted(*pv, value.size(), GetDbTableStats(dbid));
+    RecordDeleted(*pv, value.size(), int64_t(pv->MallocUsed()) - int64_t(logical_before), key,
+                  db_slice_.GetDBTable(dbid));
   }
 
   // Find entry by key in db_slice and store external segment in place of original value.
@@ -273,8 +278,10 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
       } else {
-        stats->AddTypeMemoryUsage(pv->ObjType(), -pv->MallocUsed());
-        pv->SetExternal(segment.offset, segment.length, blobs.rep);
+        // Only the RAM ledger changes: SetExternal preserves the logical size in the value.
+        const size_t mem_size = pv->MallocUsed();
+        stats->AddTypeMemoryUsage(pv->ObjType(), -int64_t(mem_size));
+        pv->SetExternal(segment.offset, segment.length, blobs.rep, mem_size);
       }
     } else {
       LOG(DFATAL) << "Should not reach here";
@@ -355,7 +362,8 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
     } else {
       // Cut out relevant part of value and restore it to memory
       string_view value = page.substr(item_segment.offset - segment.offset, item_segment.length);
-      Upload(dbid, value, &pv);
+      string scratch;
+      Upload(dbid, it->first.GetSlice(&scratch), value, &pv);
     }
   }
 }
@@ -391,11 +399,14 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
     return false;
 
   if (const auto* key = std::get_if<tiering::ListNodeId>(&id); key) {
-    DbIndex db_id = std::get<0>(*key);
+    QList* ql = reinterpret_cast<QList*>(std::get<1>(*key));
+    // The list may have been moved to another db since the node was stashed.
+    DbIndex db_id = ql->GetDbIndex();
     QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(*key));
     ++stats_.total_uploads;
     decoder->Upload(node);
-    RecordDeleted(node, segment.length, GetDbTableStats(db_id));
+    // A node upload does not change the list's logical size.
+    RecordDeleted(node, segment.length, 0, {}, db_slice_.GetDBTable(db_id));
     return true;
   }
 
@@ -404,8 +415,10 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
     if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
       if (metrics.modified || pv->WasTouched()) {
         ++stats_.total_uploads;
+        const size_t logical_before = pv->LogicalMallocUsed();
         decoder->Upload(pv);
-        RecordDeleted(*pv, segment.length, GetDbTableStats(key->first));
+        RecordDeleted(*pv, segment.length, int64_t(pv->MallocUsed()) - int64_t(logical_before),
+                      key->second, db_slice_.GetDBTable(key->first));
         return true;
       }
       pv->SetTouched(true);
@@ -560,8 +573,8 @@ void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
 
   tiering::DiskSegment segment = fragment_ref.GetExternalSlice();
   if (auto* cool = fragment_ref.GetCoolRecord(); cool) {
-    auto hot = DeleteCool(cool);
-    DCHECK_EQ(hot.ObjType(), OBJ_STRING);
+    // Cooling is type agnostic, so the recovered value may be of any offloadable type.
+    DeleteCool(cool);
   }
   fragment_ref.ClearOffloaded();
   op_manager_->DeleteOffloaded(dbid, segment);
@@ -614,6 +627,7 @@ TieredStats TieredStorage::GetStats() const {
   }
 
   {  // Own stats
+    stats.total_deletes = stats_.total_deletes;
     stats.total_stash_overflows = stats_.stash_overflow_cnt;
     stats.cold_storage_bytes = stats_.cool_memory_used;
     stats.total_offloading_steps = stats_.offloading_steps;
@@ -754,10 +768,11 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
 
     // Now the item is only in storage.
     tiering::DiskSegment segment = FromCoolItem(pv.GetCool());
-    pv.Freeze(segment.offset, segment.length);
+    const size_t mem_size = record->value.MallocUsed();
+    pv.Freeze(segment.offset, segment.length, mem_size);
 
     auto* stats = op_manager_->GetDbTableStats(record->db_index);
-    stats->AddTypeMemoryUsage(record->value.ObjType(), -record->value.MallocUsed());
+    stats->AddTypeMemoryUsage(record->value.ObjType(), -int64_t(mem_size));
     CompactObj::DeleteMR<TieredCoolRecord>(record);
   } while (gained < goal);
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -88,12 +88,11 @@ constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
 // so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
 constexpr uint32_t kMaxPendingDefrags = 100;
 
-// Called after setting new value in place of previous segment.
-// The per-slot ledger already carried the pre-offload size, so it only takes the difference.
-void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, int64_t logical_delta,
-                   string_view key, DbTable* db) {
-  AccountObjectMemory(key, fragment_ref.ObjType(), int64_t(fragment_ref.MallocUsed()),
-                      logical_delta, db);
+// Called after setting new value in place of previous segment
+void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, string_view key,
+                   DbTable* db) {
+  AccountObjectMemory(key, fragment_ref.ObjType(), fragment_ref.MallocUsed(), db);
+  AccountSlotTieredBytes(key, -int64_t(tiered_len), db);
   db->stats.tiered_entries--;
   db->stats.tiered_used_bytes -= tiered_len;
 }
@@ -239,7 +238,6 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   // Set value to be an in-memory type again. Update memory stats.
   void Upload(DbIndex dbid, string_view key, string_view value, PrimeValue* pv) {
     DCHECK(!value.empty());
-    const size_t logical_before = pv->LogicalMallocUsed();
     switch (pv->GetExternalRep()) {
       case CompactObj::ExternalRep::STRING: {
         pv->Materialize(value, true);
@@ -257,8 +255,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       }
     };
 
-    RecordDeleted(*pv, value.size(), int64_t(pv->MallocUsed()) - int64_t(logical_before), key,
-                  db_slice_.GetDBTable(dbid));
+    RecordDeleted(*pv, value.size(), key, db_slice_.GetDBTable(dbid));
   }
 
   // Find entry by key in db_slice and store external segment in place of original value.
@@ -266,11 +263,12 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment) {
     UnblockBackpressure(key, true);
     if (auto* pv = Find(key.first, key.second); pv) {
-      auto* stats = GetDbTableStats(key.first);
+      DbTable* table = db_slice_.GetDBTable(key.first);
 
       pv->SetStashPending(false);
-      stats->tiered_entries++;
-      stats->tiered_used_bytes += segment.length;
+      table->stats.tiered_entries++;
+      table->stats.tiered_used_bytes += segment.length;
+      AccountSlotTieredBytes(key.second, segment.length, table);
       stats_.total_stashes++;
 
       StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
@@ -278,10 +276,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
       } else {
-        // Only the RAM ledger changes: SetExternal preserves the logical size in the value.
-        const size_t mem_size = pv->MallocUsed();
-        stats->AddTypeMemoryUsage(pv->ObjType(), -int64_t(mem_size));
-        pv->SetExternal(segment.offset, segment.length, blobs.rep, mem_size);
+        AccountObjectMemory(key.second, pv->ObjType(), -int64_t(pv->MallocUsed()), table);
+        pv->SetExternal(segment.offset, segment.length, blobs.rep);
       }
     } else {
       LOG(DFATAL) << "Should not reach here";
@@ -349,6 +345,8 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
     // TODO: Handle upload and cooling via type dependent decoders
 
     stats_.total_defrags++;
+    string scratch;
+    string_view item_key = it->first.GetSlice(&scratch);
     PrimeValue& pv = it->second;
     if (pv.IsCool()) {
       PrimeValue::CoolItem item = pv.GetCool();
@@ -356,14 +354,14 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
 
       // We remove it from both cool storage and the offline storage.
       pv = ts_->DeleteCool(item.record);
-      auto* stats = GetDbTableStats(dbid);
-      stats->tiered_entries--;
-      stats->tiered_used_bytes -= segment.length;
+      DbTable* table = db_slice_.GetDBTable(dbid);
+      table->stats.tiered_entries--;
+      table->stats.tiered_used_bytes -= segment.length;
+      AccountSlotTieredBytes(item_key, -int64_t(segment.length), table);
     } else {
       // Cut out relevant part of value and restore it to memory
       string_view value = page.substr(item_segment.offset - segment.offset, item_segment.length);
-      string scratch;
-      Upload(dbid, it->first.GetSlice(&scratch), value, &pv);
+      Upload(dbid, item_key, value, &pv);
     }
   }
 }
@@ -405,8 +403,11 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
     QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(*key));
     ++stats_.total_uploads;
     decoder->Upload(node);
-    // A node upload does not change the list's logical size.
-    RecordDeleted(node, segment.length, 0, {}, db_slice_.GetDBTable(db_id));
+    // Node ids carry no key, so per-slot counters cannot follow them.
+    auto* stats = GetDbTableStats(db_id);
+    stats->AddTypeMemoryUsage(OBJ_LIST, node->sz);
+    stats->tiered_entries--;
+    stats->tiered_used_bytes -= segment.length;
     return true;
   }
 
@@ -415,10 +416,8 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
     if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
       if (metrics.modified || pv->WasTouched()) {
         ++stats_.total_uploads;
-        const size_t logical_before = pv->LogicalMallocUsed();
         decoder->Upload(pv);
-        RecordDeleted(*pv, segment.length, int64_t(pv->MallocUsed()) - int64_t(logical_before),
-                      key->second, db_slice_.GetDBTable(key->first));
+        RecordDeleted(*pv, segment.length, key->second, db_slice_.GetDBTable(key->first));
         return true;
       }
       pv->SetTouched(true);
@@ -564,6 +563,12 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
     stats_.total_clients_throttled++;
     *backpressure = stash_backpressure_[{dbid, string{key}}];
   }
+}
+
+void TieredStorage::Delete(DbIndex dbid, std::string_view key, FragmentRef fragment_ref) {
+  AccountSlotTieredBytes(key, -int64_t(fragment_ref.GetExternalSlice().second),
+                         op_manager_->db_slice_.GetDBTable(dbid));
+  Delete(dbid, fragment_ref);
 }
 
 void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
@@ -768,11 +773,12 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
 
     // Now the item is only in storage.
     tiering::DiskSegment segment = FromCoolItem(pv.GetCool());
-    const size_t mem_size = record->value.MallocUsed();
-    pv.Freeze(segment.offset, segment.length, mem_size);
+    pv.Freeze(segment.offset, segment.length);
 
-    auto* stats = op_manager_->GetDbTableStats(record->db_index);
-    stats->AddTypeMemoryUsage(record->value.ObjType(), -int64_t(mem_size));
+    string scratch;
+    AccountObjectMemory(it->first.GetSlice(&scratch), record->value.ObjType(),
+                        -int64_t(record->value.MallocUsed()),
+                        op_manager_->db_slice_.GetDBTable(record->db_index));
     CompactObj::DeleteMR<TieredCoolRecord>(record);
   } while (gained < goal);
 
@@ -842,8 +848,9 @@ void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
   pv->SetCool(segment.offset, segment.length, rep, record);
 }
 
-PrimeValue TieredStorage::Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
+PrimeValue TieredStorage::Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item) {
   tiering::DiskSegment segment = FromCoolItem(item);
+  AccountSlotTieredBytes(key, -int64_t(segment.length), op_manager_->db_slice_.GetDBTable(dbid));
 
   // We remove it from both cool storage and the offline storage.
   PrimeValue hot = DeleteCool(item.record);

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -92,6 +92,8 @@ class TieredStorage : public TieredStorageBase {
                          BackPressureFuture* backpressure);
 
   // Delete value, must be offloaded (external type)
+  void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
+  // List node fragments carry no key, so per-slot counters cannot follow them.
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
 
   // Returns true if there is a pending modification for the given segment.
@@ -110,7 +112,7 @@ class TieredStorage : public TieredStorageBase {
   size_t ReclaimMemory(size_t goal);
 
   // Returns the primary value, and deletes the cool item as well as its offloaded storage.
-  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item);
+  PrimeValue Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item);
 
   TieredStats GetStats() const;
 
@@ -271,6 +273,9 @@ class TieredStorage : public TieredStorageBase {
              BackPressureFuture* backpressure) {
   }
 
+  void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref) {
+  }
+
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {
   }
 
@@ -318,7 +323,7 @@ class TieredStorage : public TieredStorageBase {
     return 0;
   }
 
-  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
+  PrimeValue Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item) {
     return PrimeValue{};
   }
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1642,6 +1642,20 @@ TEST_F(PureDiskTSTest, IncrByFloatParseErrorAfterUploadReleasesObjectMemory) {
   EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
 }
 
+// The no-delete outcome returns with the value still in place after the conditional read.
+TEST_F(PureDiskTSTest, DelExNoMatchAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  EXPECT_EQ(CheckedInt({"DELEX", "k", "IFEQ", "nomatch"}), 0);
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
 TEST_F(PureDiskTSTest, PfAddInvalidHllAfterUploadReleasesObjectMemory) {
   Run({"SET", "k", BuildString(4000, 'z')});  // not a valid HLL
   ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1536,4 +1536,159 @@ TEST_F(PureDiskTSMTTest, SquashedVerifyFailConcurrent) {
   EXPECT_EQ(Run({"PING"}), "PONG");
 }
 
+// Expiry removes the entry without the lookup that would have warmed a cool value up.
+TEST_F(TieredStorageTest, CoolExpiryReleasesObjectMemory) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  UpdateFromFlags();
+
+  const int kNum = 20;
+  for (int i = 0; i < kNum; ++i)
+    Run({"SET", absl::StrCat("k", i), BuildString(4000), "PX", "20000"});
+
+  ExpectConditionWithinTimeout(
+      [this] { return GetMetrics().db_stats[0].tiered_entries == unsigned(kNum); });
+
+  EXPECT_GT(GetMetrics().db_stats[0].obj_memory_usage, 0u);
+
+  AdvanceTime(30000);
+  for (int i = 0; i < kNum; ++i)
+    EXPECT_THAT(Run({"GET", absl::StrCat("k", i)}), ArgType(RespExpr::NIL));
+
+  EXPECT_EQ(CheckedInt({"DBSIZE"}), 0);
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, McAppendAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  // The first read only marks the entry as touched; the next one uploads it.
+  Run({"GET", "k"});
+  RunMC(MemcacheParser::APPEND, "k", MCArgs{"suffix", 0});
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, IncrByFloatAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", absl::StrCat("1.", string(4000, '0'), "5")});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  Run({"INCRBYFLOAT", "k", "1.5"});
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, BitfieldAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  Run({"BITFIELD", "k", "SET", "u8", "0", "255"});
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, SetBitAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  Run({"SETBIT", "k", "40000", "1"});
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, ReadOnlyBitfieldAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000)});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  Run({"BITFIELD", "k", "GET", "u8", "0"});
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+// The error path returns before the value is replaced.
+TEST_F(PureDiskTSTest, IncrByFloatParseErrorAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000, 'z')});  // not a number
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  EXPECT_THAT(Run({"INCRBYFLOAT", "k", "1.5"}), ErrArg("not a valid float"));
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, PfAddInvalidHllAfterUploadReleasesObjectMemory) {
+  Run({"SET", "k", BuildString(4000, 'z')});  // not a valid HLL
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 1u; });
+
+  Run({"GET", "k"});
+  Run({"PFADD", "k", "elem"});
+
+  Run({"DEL", "k"});
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(metrics.db_stats[0].obj_memory_usage, 0u);
+}
+
+TEST_F(PureDiskTSTest, TotalDeletesReported) {
+  const int kNum = 5;
+  for (int i = 0; i < kNum; ++i)
+    Run({"SET", absl::StrCat("k", i), BuildString(4000)});
+
+  ExpectConditionWithinTimeout(
+      [this] { return GetMetrics().db_stats[0].tiered_entries == unsigned(kNum); });
+
+  EXPECT_EQ(GetMetrics().tiered_stats.total_deletes, 0u);
+
+  for (int i = 0; i < kNum; ++i)
+    Run({"DEL", absl::StrCat("k", i)});
+
+  EXPECT_EQ(GetMetrics().tiered_stats.total_deletes, unsigned(kNum));
+}
+
+// Cooling is type agnostic, so a hash can reach the tiered delete path holding a cool record.
+TEST_F(TieredStorageTest, CoolHashDeleteDoesNotAbort) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+  SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  SetFlag(&FLAGS_tiered_experimental_hash_support, true);
+  UpdateFromFlags();
+
+  // Listpack hashes go through small bins, which only flush at 4KB - one hash never stashes.
+  const int kNum = 60;
+  for (int i = 0; i < kNum; ++i)
+    Run({"HSET", absl::StrCat("h", i), "f", BuildString(200)});
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries > 0u; });
+
+  Run({"FLUSHALL"});
+  EXPECT_EQ(Run({"PING"}), "PONG");
+  EXPECT_EQ(GetMetrics().db_stats[0].obj_memory_usage, 0u);
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Implements #7955: `DFLYCLUSTER GETSLOTINFO` `memory_bytes` now reports resident RAM only - decremented when a value is offloaded to tiered storage and incremented when it is brought back - and a new optional `tiered_bytes` field reports the disk bytes held by the slot's entries (present only when non-zero). Previously every tiered transition bypassed slot accounting entirely, so the counter leaked on DEL/expiry/FLUSHSLOTS of offloaded values and could wrap negative; `object_used_memory` also leaked on several tiered paths.

Changes:

- Route tiered transitions through slot accounting: offload and freeze debit `memory_bytes`, uploads credit it; new `AccountSlotTieredBytes` maintains per-slot `tiered_bytes` at stash completion, delete, upload, cool warmup and bin defragmentation. A cool value counts in both (RAM copy + disk copy), mirroring the db-wide `tiered_entries_bytes` semantics
- `TieredStorage::Delete`/`Warmup` gain key-aware overloads; list-node fragments carry no key and keep the unkeyed path
- `CompactObj::ResidentMallocUsed()`: like `MallocUsed()`, but a cool value reports its in-memory copy; used for deletion snapshots and `AutoUpdater` baselines
- `PerformDeletionAtomic` snapshots type and size before the tiered delete blanks the metadata
- `AutoUpdater::ResyncBaseline()` after blocking tiered reads that upload the value mid-scope (INCRBYFLOAT, memcached APPEND, PFADD, BITFIELD, DELEX - incl. error paths); `ReduceHeapUsage()` is idempotent again
- `MOVE` of an offloaded value migrates its tiered accounting to the target db (previously stranded counters caused a `CHECK` failure on the next FLUSHALL)
- Underflow guards on both per-slot counters; defrag deltas routed through slot accounting; cumulative `total_reads`/`total_writes` survive FLUSHALL; `tiered_total_deletes` reported; `TieredStorage::Delete` accepts cool non-string values

Fixes #7955