### PR TITLE
Fix tiered slot memory accounting

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -357,7 +357,8 @@ void ElementAccess::Commit(string_view new_value) const {
       updater_.post_updater.ReduceHeapUsage();
     }
     if (is_external) {
-      EngineShard::tlocal()->tiered_storage()->Delete(context_.db_index, &updater_.it->second);
+      EngineShard::tlocal()->tiered_storage()->Delete(context_.db_index, key_,
+                                                      &updater_.it->second);
     }
     updater_.it->second.SetString(new_value);
     updater_.post_updater.Run();

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -713,7 +713,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgParser parser, CommandContext* 
   rb->StartArray(slots_stats.size());
 
   for (const auto& slot_data : slots_stats) {
-    rb->StartArray(9);
+    rb->StartArray(slot_data.second.tiered_bytes > 0 ? 11 : 9);
     rb->SendLong(slot_data.first);
     rb->SendBulkString("key_count");
     rb->SendLong(slot_data.second.key_count);
@@ -728,6 +728,10 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgParser parser, CommandContext* 
     rb->SendBulkString("memory_bytes");
     rb->SendLong(slot_data.second.memory_bytes +
                  slot_data.second.key_count * sizeof(CompactObj) * 2);
+    if (slot_data.second.tiered_bytes > 0) {
+      rb->SendBulkString("tiered_bytes");
+      rb->SendLong(slot_data.second.tiered_bytes);
+    }
   }
 }
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -646,7 +646,7 @@ TEST_F(CoolingTieredClusterFamilyTest, ClusterGetSlotInfoRemovesTieredBytesOnWar
 
   const size_t tiered_bytes = GetMetrics().db_stats[0].tiered_used_bytes;
   EXPECT_EQ(Run({"GET", kKey}), value);
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 0; });
 
   EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
               RespElementsAre(RespArray(ElementsAre(

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -7,10 +7,12 @@
 #include <absl/flags/reflection.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-matchers.h>
+#include <unistd.h>
 
 #include <string>
 #include <string_view>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/substitute.h"
 #include "absl/time/clock.h"
@@ -33,6 +35,12 @@ namespace {
 
 using namespace std;
 using namespace testing;
+
+#ifdef WITH_TIERING
+string TieredTestPrefix() {
+  return absl::StrCat("/tmp/tiered_cluster_family_test_", getpid());
+}
+#endif
 
 class ClusterFamilyTest : public BaseFamilyTest {
  public:
@@ -93,7 +101,7 @@ class TieredClusterFamilyTest : public ClusterFamilyTest {
     if (absl::GetFlag(FLAGS_force_epoll)) {
       return;
     }
-    absl::SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_cluster_family_test");
+    absl::SetFlag(&FLAGS_tiered_prefix, TieredTestPrefix());
     absl::SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
     absl::SetFlag(&FLAGS_tiered_experimental_cooling, false);
   }
@@ -116,7 +124,7 @@ class CoolingTieredClusterFamilyTest : public ClusterFamilyTest {
     if (absl::GetFlag(FLAGS_force_epoll)) {
       return;
     }
-    absl::SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_cluster_family_test");
+    absl::SetFlag(&FLAGS_tiered_prefix, TieredTestPrefix());
     absl::SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
     absl::SetFlag(&FLAGS_tiered_experimental_cooling, true);
   }

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -646,7 +646,9 @@ TEST_F(CoolingTieredClusterFamilyTest, ClusterGetSlotInfoRemovesTieredBytesOnWar
 
   const size_t tiered_bytes = GetMetrics().db_stats[0].tiered_used_bytes;
   EXPECT_EQ(Run({"GET", kKey}), value);
-  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 0; });
+  if (GetMetrics().db_stats[0].tiered_entries != 0) {
+    GTEST_SKIP() << "Cooling cache entry was reclaimed before warmup";
+  }
 
   EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
               RespElementsAre(RespArray(ElementsAre(

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -2,6 +2,8 @@
 // See LICENSE for licensing terms.
 //
 
+#include <absl/flags/declare.h>
+#include <absl/flags/flag.h>
 #include <absl/flags/reflection.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-matchers.h>
@@ -18,6 +20,12 @@
 #include "core/detail/gen_utils.h"
 #include "facade/facade_test.h"
 #include "server/test_utils.h"
+
+#ifdef WITH_TIERING
+ABSL_DECLARE_FLAG(std::string, tiered_prefix);
+ABSL_DECLARE_FLAG(float, tiered_offload_threshold);
+ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
+#endif
 
 namespace dfly::cluster {
 namespace {
@@ -68,6 +76,34 @@ class ClusterFamilyTest : public BaseFamilyTest {
     EXPECT_EQ(RunPrivileged({"dflycluster", "config", config}), "OK");
   }
 };
+
+#ifdef WITH_TIERING
+class TieredClusterFamilyTest : public ClusterFamilyTest {
+ protected:
+  void ConfigureClusterFlags() override {
+    ClusterFamilyTest::ConfigureClusterFlags();
+    absl::SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_cluster_family_test");
+    absl::SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+    absl::SetFlag(&FLAGS_tiered_experimental_cooling, false);
+  }
+
+ private:
+  absl::FlagSaver flag_saver_;
+};
+
+class CoolingTieredClusterFamilyTest : public ClusterFamilyTest {
+ protected:
+  void ConfigureClusterFlags() override {
+    ClusterFamilyTest::ConfigureClusterFlags();
+    absl::SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_cluster_family_test");
+    absl::SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+    absl::SetFlag(&FLAGS_tiered_experimental_cooling, true);
+  }
+
+ private:
+  absl::FlagSaver flag_saver_;
+};
+#endif  // WITH_TIERING
 
 TEST_F(ClusterFamilyTest, ClusterConfigInvalidJSON) {
   EXPECT_THAT(RunPrivileged({"dflycluster", "config", "invalid JSON"}),
@@ -516,6 +552,95 @@ TEST_F(ClusterFamilyTest, ClusterGetSlotInfo) {
           RespArray(ElementsAre(IntArg(slot), "key_count", IntArg(1), "total_reads", IntArg(1),
                                 "total_writes", IntArg(2), "memory_bytes", IntArg(36))))));
 }
+
+#ifdef WITH_TIERING
+TEST_F(TieredClusterFamilyTest, ClusterGetSlotInfoReportsResidentAndTieredBytes) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  constexpr string_view kKey = "tiered-key";
+  const SlotId slot = KeySlot(kKey);
+  const string value(64 * 1024, '#');
+  ASSERT_EQ(Run({"SET", kKey, value}), "OK");
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes == 1; });
+
+  const size_t tiered_bytes = GetMetrics().db_stats[0].tiered_used_bytes;
+  EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
+              RespElementsAre(RespArray(ElementsAre(
+                  IntArg(slot), "key_count", IntArg(1), "total_reads", IntArg(0), "total_writes",
+                  IntArg(1), "memory_bytes", IntArg(36), "tiered_bytes", IntArg(tiered_bytes)))));
+}
+
+TEST_F(TieredClusterFamilyTest, ClusterGetSlotInfoRemovesTieredBytesOnDelete) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  constexpr string_view kKey = "tiered-key";
+  const SlotId slot = KeySlot(kKey);
+  ASSERT_EQ(Run({"SET", kKey, string(64 * 1024, '#')}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes == 1; });
+
+  EXPECT_THAT(Run({"DEL", kKey}), IntArg(1));
+  EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
+              RespElementsAre(RespArray(ElementsAre(IntArg(slot), "key_count", IntArg(0),
+                                                    "total_reads", IntArg(0), "total_writes",
+                                                    IntArg(2), "memory_bytes", IntArg(0)))));
+}
+
+TEST_F(TieredClusterFamilyTest, ClusterGetSlotInfoRestoresResidentBytesOnUpload) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  constexpr string_view kKey = "tiered-key";
+  const SlotId slot = KeySlot(kKey);
+  const string value(64 * 1024, '#');
+  ASSERT_EQ(Run({"SET", kKey, value}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes == 1; });
+
+  const size_t tiered_bytes = GetMetrics().db_stats[0].tiered_used_bytes;
+  EXPECT_EQ(Run({"GET", kKey}), value);
+  EXPECT_EQ(Run({"GET", kKey}), value);
+  ExpectConditionWithinTimeout([this] { return GetMetrics().db_stats[0].tiered_entries == 0; });
+
+  EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
+              RespElementsAre(RespArray(ElementsAre(
+                  IntArg(slot), "key_count", IntArg(1), "total_reads", IntArg(2), "total_writes",
+                  IntArg(1), "memory_bytes", IntArg(tiered_bytes + 36)))));
+}
+
+TEST_F(CoolingTieredClusterFamilyTest, ClusterGetSlotInfoRemovesTieredBytesOnWarmup) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  constexpr string_view kKey = "tiered-key";
+  const SlotId slot = KeySlot(kKey);
+  const string value(64 * 1024, '#');
+  ASSERT_EQ(Run({"SET", kKey, value}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes == 1; });
+
+  const size_t tiered_bytes = GetMetrics().db_stats[0].tiered_used_bytes;
+  EXPECT_EQ(Run({"GET", kKey}), value);
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
+
+  EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
+              RespElementsAre(RespArray(ElementsAre(
+                  IntArg(slot), "key_count", IntArg(1), "total_reads", IntArg(1), "total_writes",
+                  IntArg(1), "memory_bytes", IntArg(tiered_bytes + 36)))));
+}
+
+TEST_F(CoolingTieredClusterFamilyTest, ClusterGetSlotInfoRemovesResidentBytesOnDelete) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  constexpr string_view kKey = "tiered-key";
+  const SlotId slot = KeySlot(kKey);
+  ASSERT_EQ(Run({"SET", kKey, string(64 * 1024, '#')}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes == 1; });
+
+  EXPECT_THAT(Run({"DEL", kKey}), IntArg(1));
+  EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)}),
+              RespElementsAre(RespArray(ElementsAre(IntArg(slot), "key_count", IntArg(0),
+                                                    "total_reads", IntArg(0), "total_writes",
+                                                    IntArg(2), "memory_bytes", IntArg(0)))));
+}
+
+#endif  // WITH_TIERING
 
 TEST_F(ClusterFamilyTest, ClusterGetSlotInfoRanges) {
   ConfigSingleNodeCluster(GetMyId());

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -25,6 +25,7 @@
 ABSL_DECLARE_FLAG(std::string, tiered_prefix);
 ABSL_DECLARE_FLAG(float, tiered_offload_threshold);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
+ABSL_DECLARE_FLAG(bool, force_epoll);
 #endif
 
 namespace dfly::cluster {
@@ -80,8 +81,18 @@ class ClusterFamilyTest : public BaseFamilyTest {
 #ifdef WITH_TIERING
 class TieredClusterFamilyTest : public ClusterFamilyTest {
  protected:
+  void SetUp() override {
+    ClusterFamilyTest::SetUp();
+    if (absl::GetFlag(FLAGS_force_epoll)) {
+      GTEST_SKIP() << "Tiered storage requires io_uring";
+    }
+  }
+
   void ConfigureClusterFlags() override {
     ClusterFamilyTest::ConfigureClusterFlags();
+    if (absl::GetFlag(FLAGS_force_epoll)) {
+      return;
+    }
     absl::SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_cluster_family_test");
     absl::SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
     absl::SetFlag(&FLAGS_tiered_experimental_cooling, false);
@@ -93,8 +104,18 @@ class TieredClusterFamilyTest : public ClusterFamilyTest {
 
 class CoolingTieredClusterFamilyTest : public ClusterFamilyTest {
  protected:
+  void SetUp() override {
+    ClusterFamilyTest::SetUp();
+    if (absl::GetFlag(FLAGS_force_epoll)) {
+      GTEST_SKIP() << "Tiered storage requires io_uring";
+    }
+  }
+
   void ConfigureClusterFlags() override {
     ClusterFamilyTest::ConfigureClusterFlags();
+    if (absl::GetFlag(FLAGS_force_epoll)) {
+      return;
+    }
     absl::SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_cluster_family_test");
     absl::SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
     absl::SetFlag(&FLAGS_tiered_experimental_cooling, true);

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -492,6 +492,17 @@ SlotStats DbSlice::GetSlotStats(SlotId sid) const {
   return db_arr_[0]->slots_stats[sid];
 }
 
+void DbSlice::AdjustSlotStats(DbIndex dbid, std::string_view key, int64_t resident_delta,
+                              int64_t tiered_delta) {
+  auto* slots_stats = GetDBTable(dbid)->slots_stats.get();
+  if (slots_stats == nullptr)
+    return;
+
+  SlotStats& stats = slots_stats[KeySlot(key)];
+  stats.memory_bytes += resident_delta;
+  stats.tiered_bytes += tiered_delta;
+}
+
 DbSlice::AutoUpdater::AutoUpdater() {
 }
 
@@ -682,7 +693,7 @@ auto DbSlice::FindInternal(const Context& cntx, string_view key, optional<unsign
 
   // Fetch back cool items
   if (pv.IsExternal() && pv.IsCool()) {
-    pv = owner_->tiered_storage()->Warmup(cntx.db_index, pv.GetCool());
+    pv = owner_->tiered_storage()->Warmup(cntx.db_index, key, pv.GetCool());
   }
 
   // Mark this entry as being looked up. We use key (first) deliberately to preserve the hotness
@@ -1712,7 +1723,7 @@ void DbSlice::RemoveOffloadedEntriesFromTieredStorage(absl::Span<const DbIndex> 
     do {
       cursor = db_ptr->prime.Traverse(cursor, [&](PrimeIterator it) {
         if (it->second.IsExternal()) {
-          tiered_storage->Delete(index, &it->second);
+          tiered_storage->Delete(index, it->first.GetSlice(&scratch), &it->second);
         } else if (it->second.HasStashPending()) {
           tiered_storage->CancelStash(std::make_pair(index, it->first.GetSlice(&scratch)),
                                       &it->second);
@@ -1932,7 +1943,7 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
     string_view key = del_it->first.GetSlice(&scratch);
     shard_owner()->tiered_storage()->CancelStash(std::make_pair(table->index, key), &pv);
   } else if (pv.IsExternal()) {
-    shard_owner()->tiered_storage()->Delete(table->index, &del_it->second);
+    shard_owner()->tiered_storage()->Delete(table->index, del_it.key(), &del_it->second);
   }
 
   ssize_t value_heap_size = pv.MallocUsed(), key_size_used = del_it->first.MallocUsed();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -499,8 +499,24 @@ void DbSlice::AdjustSlotStats(DbIndex dbid, std::string_view key, int64_t reside
     return;
 
   SlotStats& stats = slots_stats[KeySlot(key)];
-  stats.memory_bytes += resident_delta;
-  stats.tiered_bytes += tiered_delta;
+  auto adjust_bytes = [](uint64_t* bytes, int64_t delta) {
+    if (delta >= 0) {
+      *bytes += static_cast<uint64_t>(delta);
+      return;
+    }
+
+    // Avoid negating INT64_MIN while converting the negative delta to its magnitude.
+    uint64_t decrement = static_cast<uint64_t>(-(delta + 1)) + 1;
+    if (*bytes < decrement) {
+      LOG(DFATAL) << "Slot memory accounting underflow: " << *bytes << " - " << decrement;
+      *bytes = 0;
+      return;
+    }
+    *bytes -= decrement;
+  };
+
+  adjust_bytes(&stats.memory_bytes, resident_delta);
+  adjust_bytes(&stats.tiered_bytes, tiered_delta);
 }
 
 DbSlice::AutoUpdater::AutoUpdater() {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -253,6 +253,10 @@ class DbSlice {
   // Returns slot statistics for db 0.
   SlotStats GetSlotStats(SlotId sid) const;
 
+  // Updates resident and tiered value bytes for a slot.
+  void AdjustSlotStats(DbIndex dbid, std::string_view key, int64_t resident_delta,
+                       int64_t tiered_delta);
+
   void UpdateMemoryParams(int64_t budget, size_t bytes_per_object) {
     memory_budget_ = budget;
     bytes_per_object_ = bytes_per_object;

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -149,7 +149,7 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   // ReadHll may have warmed the value back into memory; re-check before Delete.
   if (res.it->second.IsExternal()) {
     res.post_updater.ReduceHeapUsage();
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
   }
   res.it->second.SetString(hll);
   return std::min(updated, 1);
@@ -325,7 +325,7 @@ OpResult<int> PFMergeInternal(string_view key, Transaction* tx, SinkReplyBuilder
     auto& res = *op_res;
     if (!res.is_new && res.it->second.IsExternal()) {
       res.post_updater.ReduceHeapUsage();
-      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
     }
     res.it->second.SetString(hll);
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -285,7 +285,7 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
     // The read may have warmed the value back into memory; re-check before Delete.
     if (res.it->second.IsExternal()) {
       res.post_updater.ReduceHeapUsage();
-      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
     }
     res.it->second.SetString(new_val);
     return true;
@@ -346,7 +346,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
   // only runs while it is still external.
   if (add_res.it->second.IsExternal()) {
     add_res.post_updater.ReduceHeapUsage();
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &add_res.it->second);
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &add_res.it->second);
   }
   add_res.it->second.SetString(str);
 
@@ -983,7 +983,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
 
   // If value is external, mark it as deleted
   if (prime_value.IsExternal()) {
-    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, &prime_value);
+    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, it_upd->it.key(), &prime_value);
   }
 
   // overwrite existing entry.

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -65,12 +65,13 @@ DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
 }
 
 SlotStats& SlotStats::operator+=(const SlotStats& o) {
-  static_assert(sizeof(SlotStats) == 32);
+  static_assert(sizeof(SlotStats) == 40);
 
   ADD(key_count);
   ADD(total_reads);
   ADD(total_writes);
   ADD(memory_bytes);
+  ADD(tiered_bytes);
   return *this;
 }
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -47,6 +47,7 @@ struct SlotStats {
   uint64_t total_reads = 0;
   uint64_t total_writes = 0;
   uint64_t memory_bytes = 0;
+  uint64_t tiered_bytes = 0;
   SlotStats& operator+=(const SlotStats& o);
 };
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -234,7 +234,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   void RetireColdEntries(size_t additional_memory);
 
   // Set value to be an in-memory type again. Update memory stats.
-  void Upload(DbIndex dbid, string_view value, PrimeValue* pv) {
+  void Upload(DbIndex dbid, string_view key, string_view value, PrimeValue* pv) {
     DCHECK(!value.empty());
     switch (pv->GetExternalRep()) {
       case CompactObj::ExternalRep::STRING: {
@@ -253,6 +253,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       }
     };
 
+    db_slice_.AdjustSlotStats(dbid, key, pv->MallocUsed(), -static_cast<int64_t>(value.size()));
     RecordDeleted(*pv, value.size(), GetDbTableStats(dbid));
   }
 
@@ -269,6 +270,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       stats_.total_stashes++;
 
       StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
+      const int64_t resident_delta =
+          ts_->config_.experimental_cooling ? 0 : -static_cast<int64_t>(pv->MallocUsed());
+      db_slice_.AdjustSlotStats(key.first, key.second, resident_delta, segment.length);
       if (ts_->config_.experimental_cooling) {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
@@ -349,13 +353,17 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
 
       // We remove it from both cool storage and the offline storage.
       pv = ts_->DeleteCool(item.record);
+      string key;
+      db_slice_.AdjustSlotStats(dbid, it->first.GetSlice(&key), 0,
+                                -static_cast<int64_t>(segment.length));
       auto* stats = GetDbTableStats(dbid);
       stats->tiered_entries--;
       stats->tiered_used_bytes -= segment.length;
     } else {
       // Cut out relevant part of value and restore it to memory
       string_view value = page.substr(item_segment.offset - segment.offset, item_segment.length);
-      Upload(dbid, value, &pv);
+      string key;
+      Upload(dbid, it->first.GetSlice(&key), value, &pv);
     }
   }
 }
@@ -405,6 +413,8 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
       if (metrics.modified || pv->WasTouched()) {
         ++stats_.total_uploads;
         decoder->Upload(pv);
+        db_slice_.AdjustSlotStats(key->first, key->second, pv->MallocUsed(),
+                                  -static_cast<int64_t>(segment.length));
         RecordDeleted(*pv, segment.length, GetDbTableStats(key->first));
         return true;
       }
@@ -565,6 +575,12 @@ void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
   }
   fragment_ref.ClearOffloaded();
   op_manager_->DeleteOffloaded(dbid, segment);
+}
+
+void TieredStorage::Delete(DbIndex dbid, std::string_view key, FragmentRef fragment_ref) {
+  tiering::DiskSegment segment = fragment_ref.GetExternalSlice();
+  op_manager_->db_slice_.AdjustSlotStats(dbid, key, 0, -static_cast<int64_t>(segment.length));
+  Delete(dbid, fragment_ref);
 }
 
 void TieredStorage::CancelStash(tiering::PendingId id, tiering::FragmentRef fragment_ref) {
@@ -754,6 +770,9 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
 
     // Now the item is only in storage.
     tiering::DiskSegment segment = FromCoolItem(pv.GetCool());
+    string key;
+    op_manager_->db_slice_.AdjustSlotStats(record->db_index, it->first.GetSlice(&key),
+                                           -static_cast<int64_t>(record->value.MallocUsed()), 0);
     pv.Freeze(segment.offset, segment.length);
 
     auto* stats = op_manager_->GetDbTableStats(record->db_index);
@@ -827,11 +846,12 @@ void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
   pv->SetCool(segment.offset, segment.length, rep, record);
 }
 
-PrimeValue TieredStorage::Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
+PrimeValue TieredStorage::Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item) {
   tiering::DiskSegment segment = FromCoolItem(item);
 
   // We remove it from both cool storage and the offline storage.
   PrimeValue hot = DeleteCool(item.record);
+  op_manager_->db_slice_.AdjustSlotStats(dbid, key, 0, -static_cast<int64_t>(segment.length));
   op_manager_->DeleteOffloaded(dbid, segment);
   return hot;
 }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -579,7 +579,13 @@ void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
 
 void TieredStorage::Delete(DbIndex dbid, std::string_view key, FragmentRef fragment_ref) {
   tiering::DiskSegment segment = fragment_ref.GetExternalSlice();
-  op_manager_->db_slice_.AdjustSlotStats(dbid, key, 0, -static_cast<int64_t>(segment.length));
+  int64_t resident_delta = 0;
+  if (auto* cool = fragment_ref.GetCoolRecord(); cool) {
+    resident_delta = -static_cast<int64_t>(cool->value.MallocUsed());
+    op_manager_->GetDbTableStats(dbid)->AddTypeMemoryUsage(cool->value.ObjType(), resident_delta);
+  }
+  op_manager_->db_slice_.AdjustSlotStats(dbid, key, resident_delta,
+                                         -static_cast<int64_t>(segment.length));
   Delete(dbid, fragment_ref);
 }
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -91,8 +91,9 @@ class TieredStorage : public TieredStorageBase {
   void StashPartialValue(tiering::PendingId id, const StashDescriptor& blobs,
                          BackPressureFuture* backpressure);
 
-  // Delete value, must be offloaded (external type)
+  // Delete value, must be offloaded (external type).
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
+  void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
 
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(tiering::DiskSegment segment) const;
@@ -110,7 +111,7 @@ class TieredStorage : public TieredStorageBase {
   size_t ReclaimMemory(size_t goal);
 
   // Returns the primary value, and deletes the cool item as well as its offloaded storage.
-  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item);
+  PrimeValue Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item);
 
   TieredStats GetStats() const;
 
@@ -274,6 +275,9 @@ class TieredStorage : public TieredStorageBase {
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {
   }
 
+  void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref) {
+  }
+
   bool HasModificationPending(tiering::DiskSegment segment) const {
     return false;
   }
@@ -318,7 +322,7 @@ class TieredStorage : public TieredStorageBase {
     return 0;
   }
 
-  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
+  PrimeValue Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item) {
     return PrimeValue{};
   }
 


### PR DESCRIPTION
## Summary
- Make `DFLYCLUSTER GETSLOTINFO` report resident memory in `memory_bytes` when tiering offloads values.
- Add an optional `tiered_bytes` field for slots with offloaded bytes.
- Cover offload, delete, upload, cooling warmup, and no-tier builds.

Fixes #7955

## Validation
- `cluster_family_test` (tiering enabled): 37/37 passed
- `cluster_family_test` (WITH_TIERING=OFF): 32/32 passed
- `pre-commit run --files ...` passed