### PR TITLE
fix: do not serve blocking XREAD from an emptied stream

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3942,9 +3942,11 @@ variant<bool, facade::ErrorReply> HasEntries2(const OpArgs& op_args, string_view
 
   stream* s = GetReadOnlyStream(*cobj);
 
-  // Fetch last id
+  // Fetch last id. s->last_id is only the last *generated* id: XDEL, XTRIM and XSETID leave it
+  // behind on an empty stream, so it must not be treated as a readable entry.
+  const bool stream_has_entries = s->length > 0;
   streamID last_id = s->last_id;
-  if (s->length)
+  if (stream_has_entries)
     StreamLastValidID(s, &last_id);
 
   // Check requested
@@ -3975,7 +3977,7 @@ variant<bool, facade::ErrorReply> HasEntries2(const OpArgs& op_args, string_view
     }
 
     // we know the requested last_id only when we already have it
-    if (streamCompareID(&last_id, &requested_sitem.group->last_id) > 0) {
+    if (stream_has_entries && streamCompareID(&last_id, &requested_sitem.group->last_id) > 0) {
       requested_sitem.id.val = requested_sitem.group->last_id;
       StreamIncrID(&requested_sitem.id.val);
     }
@@ -3989,7 +3991,7 @@ variant<bool, facade::ErrorReply> HasEntries2(const OpArgs& op_args, string_view
     }
   }
 
-  return streamCompareID(&last_id, &requested_sitem.id.val) >= 0;
+  return stream_has_entries && streamCompareID(&last_id, &requested_sitem.id.val) >= 0;
 }
 
 void CmdXRead(CmdArgParser parser, CommandContext* cmd_cntx) {

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -439,6 +439,24 @@ TEST_F(StreamFamilyTest, XReadGroupBlockDelconsumer) {
   EXPECT_THAT(resp_del_consumer, IntArg(0));
 }
 
+TEST_F(StreamFamilyTest, XReadBlockOnEmptiedStream) {
+  // XDEL leaves the last generated id behind, but the stream has nothing left to serve, so both
+  // reads must block instead of returning an empty reply.
+  Run({"xadd", "foo", "1-0", "k", "v"});
+  Run({"xdel", "foo", "1-0"});
+
+  EXPECT_THAT(Run({"xread", "block", "1", "streams", "foo", "0"}), ArgType(RespExpr::NIL_ARRAY));
+
+  Run({"xgroup", "create", "foo", "group", "0"});
+  EXPECT_THAT(Run({"xreadgroup", "group", "group", "alice", "block", "1", "streams", "foo", ">"}),
+              ArgType(RespExpr::NIL_ARRAY));
+
+  // A new entry is still served once it arrives.
+  Run({"xadd", "foo", "2-0", "k", "v"});
+  auto resp = Run({"xreadgroup", "group", "group", "alice", "block", "1", "streams", "foo", ">"});
+  EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockHonorsCount) {
   Run({"xgroup", "create", "foo", "group", "0", "MKSTREAM"});
 


### PR DESCRIPTION
related to: #7903
Summary: Fixes blocking XREAD/XREADGROUP on streams that were emptied (e.g., via XDEL/XTRIM/XSETID) but still had a stale last_id, which previously caused an immediate empty reply.

Changes:

- Teach HasEntries2 to treat s->last_id as non-readable when s->length == 0, ensuring BLOCK waits for the next entry
- Add a regression test covering blocking reads on an emptied stream and verifying delivery once a new entry arrives