### PR TITLE
fix: check the requested id when waking a blocked XREAD

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3034,15 +3034,8 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
                                                      : KeyReadyResult::kKeyNotFound;
 
     StreamIDsItem& sitem = opts->stream_ids.at(key);
-    if (sitem.id.val.ms != UINT64_MAX && sitem.id.val.seq != UINT64_MAX)
-      return KeyReadyResult::kReady;
-
     const CompactObj& cobj = (*res_it)->second;
     stream* s = GetReadOnlyStream(cobj);
-    streamID last_id = s->last_id;
-    if (s->length) {
-      StreamLastValidID(s, &last_id);
-    }
 
     // Update group pointer and check it's validity
     if (opts->read_group) {
@@ -3051,8 +3044,22 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
         return KeyReadyResult::kReady;  // abort
     }
 
-    return streamCompareID(&last_id, &sitem.group->last_id) > 0 ? KeyReadyResult::kReady
-                                                                : KeyReadyResult::kNotReady;
+    // An empty stream has nothing to serve: s->last_id only records the last generated id and
+    // survives XDEL and XTRIM.
+    if (!s->length)
+      return KeyReadyResult::kNotReady;
+
+    streamID last_id;
+    StreamLastValidID(s, &last_id);
+
+    // XREADGROUP only blocks on '>', which asks for entries the group has not delivered yet.
+    // XREAD blocks on a concrete id and must stay blocked until an entry reaches it.
+    if (opts->read_group) {
+      return streamCompareID(&last_id, &sitem.group->last_id) > 0 ? KeyReadyResult::kReady
+                                                                  : KeyReadyResult::kNotReady;
+    }
+    return streamCompareID(&last_id, &sitem.id.val) >= 0 ? KeyReadyResult::kReady
+                                                         : KeyReadyResult::kNotReady;
   };
 
   if (auto status =
@@ -3085,8 +3092,11 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
         return OpStatus::OK;
       }
 
-      if (sitem.id.val.ms == UINT64_MAX || sitem.id.val.seq == UINT64_MAX) {
-        range_opts.start.val = sitem.group->last_id;  // only for '>'
+      // '>' is encoded as UINT64_MAX-UINT64_MAX and is only accepted for XREADGROUP, so the start
+      // comes from the group. A plain XREAD has no group and reads from the id it asked for, even
+      // when that id happens to carry a UINT64_MAX component.
+      if (opts->read_group && sitem.id.val.ms == UINT64_MAX && sitem.id.val.seq == UINT64_MAX) {
+        range_opts.start.val = sitem.group->last_id;
         StreamIncrID(&range_opts.start.val);
       }
 

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -457,6 +457,76 @@ TEST_F(StreamFamilyTest, XReadBlockOnEmptiedStream) {
   EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
 }
 
+// A blocked XREAD asks for entries starting at a concrete id. An XADD below that id awakens the
+// watch queue, but the reader must stay blocked instead of being served an empty record list.
+TEST_F(StreamFamilyTest, XReadBlockIgnoresEntriesBelowRequestedId) {
+  Run({"xadd", "foo", "1-0", "k", "v"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xread", "block", "0", "streams", "foo", "5-0"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  // The wake is processed on the shard thread, so give it a window to land before concluding
+  // that the reader stayed blocked.
+  pp_->at(1)->Await([&] { return Run({"xadd", "foo", "2-0", "k", "v"}); });
+  EXPECT_FALSE(WaitUntilCondition([&] { return !IsConnBlocked("IO0"); }, 100ms))
+      << "the reader woke on an entry below the requested id";
+
+  pp_->at(1)->Await([&] { return Run({"xadd", "foo", "6-0", "k", "v"}); });
+  reader.Join();
+  const auto& stream_resp = resp.GetVec()[0].GetVec();
+  EXPECT_THAT(stream_resp, ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(stream_resp[1].GetVec()[0].GetVec(), ElementsAre("6-0", ArrLen(2)));
+}
+
+// The entry that awakens a blocked XREADGROUP can be gone by the time the readiness check runs.
+// s->last_id survives it, so the check must not report the emptied stream as ready.
+TEST_F(StreamFamilyTest, XReadGroupBlockIgnoresWakeFromRemovedEntry) {
+  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  pp_->at(1)->Await([&] {
+    Run({"multi"});
+    Run({"xadd", "foo", "1-0", "k", "v"});
+    Run({"xdel", "foo", "1-0"});
+    return Run({"exec"});
+  });
+  EXPECT_FALSE(WaitUntilCondition([&] { return !IsConnBlocked("IO0"); }, 100ms))
+      << "the reader woke on an entry that the same transaction removed";
+
+  pp_->at(1)->Await([&] { return Run({"xadd", "foo", "2-0", "k", "v"}); });
+  reader.Join();
+  const auto& stream_resp = resp.GetVec()[0].GetVec();
+  EXPECT_THAT(stream_resp, ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(stream_resp[1].GetVec()[0].GetVec(), ElementsAre("2-0", ArrLen(2)));
+}
+
+// The '>' sentinel is UINT64_MAX-UINT64_MAX, but a plain XREAD may legitimately request an id
+// with a UINT64_MAX component. Such a read has no consumer group to resolve the start from.
+TEST_F(StreamFamilyTest, XReadBlockOnMaxMsId) {
+  Run({"xadd", "foo", "1-0", "k", "v"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xread", "block", "0", "streams", "foo", "18446744073709551615-0"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  pp_->at(1)->Await([&] { return Run({"xadd", "foo", "18446744073709551615-2", "k", "v"}); });
+  reader.Join();
+  const auto& stream_resp = resp.GetVec()[0].GetVec();
+  EXPECT_THAT(stream_resp, ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(stream_resp[1].GetVec()[0].GetVec(),
+              ElementsAre("18446744073709551615-2", ArrLen(2)));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockHonorsCount) {
   Run({"xgroup", "create", "foo", "group", "0", "MKSTREAM"});
 


### PR DESCRIPTION
related to: https://github.com/dragonflydb/dragonfly/issues/7903

Summary: Fixes BLOCK wake-up readiness for XREAD/XREADGROUP so blocked readers only resume when the requested stream ID is actually reachable.

Changes:

- Compute watch readiness from the stream’s last valid entry ID and treat empty streams as not-ready.
- For XREADGROUP, compare against the consumer-group last delivered ID; for plain XREAD, compare against the requested start ID.
- Gate handling of the '>' sentinel (MAX-MAX) to XREADGROUP to avoid dereferencing a null group in XREAD.
- Add regression tests for below-threshold wakeups, wakeups from removed entries, and IDs containing UINT64_MAX components.

Technical Notes: Prevents spurious unblock events that previously returned empty record lists instead of continuing to block.