### PR TITLE
chore(hll): sync hyperloglog.c with valkey upstream

### DIFF
--- a/src/core/page_usage/page_usage_stats.cc
+++ b/src/core/page_usage/page_usage_stats.cc
@@ -35,7 +35,7 @@ constexpr auto kHistSignificantFigures = 3;
 HllBufferPtr InitHllPtr() {
   HllBufferPtr p;
   p.size = getDenseHllSize();
-  p.hll = new uint8_t[p.size];
+  p.hll = new uint8_t[p.size + 1];
   CHECK_EQ(0, createDenseHll(p));
   return p;
 }

--- a/src/redis/config.h
+++ b/src/redis/config.h
@@ -110,6 +110,39 @@
 #define unlikely(x) (x)
 #endif
 
+#if defined(__has_attribute)
+#if __has_attribute(no_sanitize)
+#define VALKEY_NO_SANITIZE(sanitizer) __attribute__((no_sanitize(sanitizer)))
+#endif
+#endif
+#if !defined(VALKEY_NO_SANITIZE)
+#define VALKEY_NO_SANITIZE(sanitizer)
+#endif
+
+/* Check if we can compile x86 SIMD code */
+#if defined(__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4)) && defined(__has_attribute) && __has_attribute(target)
+#define HAVE_X86_SIMD 1
+#else
+#define HAVE_X86_SIMD 0
+#endif
+
+#if HAVE_X86_SIMD
+#define ATTRIBUTE_TARGET_SSE2 __attribute__((target("sse2")))
+#define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2")))
+#define ATTRIBUTE_TARGET_AVX512 __attribute__((target("avx512f,avx512bw,avx512vl")))
+#else
+#define ATTRIBUTE_TARGET_SSE2
+#define ATTRIBUTE_TARGET_AVX2
+#define ATTRIBUTE_TARGET_AVX512
+#endif
+
+/* Check if we can compile ARM SIMD code */
+#if defined(__aarch64__) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
+#define HAVE_ARM_NEON 1
+#else
+#define HAVE_ARM_NEON 0
+#endif
+
 /* Define rdb_fsync_range to sync_file_range() on Linux, otherwise we use
  * the plain fsync() call. */
 #if (defined(__linux__) && defined(SYNC_FILE_RANGE_WAIT_BEFORE))

--- a/src/redis/hyperloglog.c
+++ b/src/redis/hyperloglog.c
@@ -1,7 +1,7 @@
-/* hyperloglog.c - Redis HyperLogLog probabilistic cardinality approximation.
- * This file implements the algorithm and the exported Redis commands.
+/* hyperloglog.c - HyperLogLog probabilistic cardinality approximation.
+ * This file implements the algorithm and the exported commands.
  *
- * Copyright (c) 2014, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2014, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,25 +28,44 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Last synced with valkey 06d30f293
+ */
 
 #include "redis/hyperloglog.h"
 
+#include <stdint.h>
 #include <math.h>
 #include <string.h>
 
+#include "redis/config.h"
 #include "redis/redis_aux.h"
 #include "redis/util.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-/* The Redis HyperLogLog implementation is based on the following ideas:
+#if HAVE_X86_SIMD
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
+#define __MM_MALLOC_H
+#include <immintrin.h>
+#endif
+
+#if HAVE_ARM_NEON
+#include <arm_neon.h>
+#endif
+
+/* The HyperLogLog implementation is based on the following ideas:
  *
  * * The use of a 64 bit hash function as proposed in [1], in order to estimate
  *   cardinalities larger than 10^9, at the cost of just 1 additional bit per
  *   register.
  * * The use of 16384 6-bit registers for a great level of accuracy, using
  *   a total of 12k per key.
- * * The use of the Redis string data type. No new type is introduced.
+ * * The use of the string data type. No new type is introduced.
  * * No attempt is made to compress the data structure as in [1]. Also the
  *   algorithm used is the original HyperLogLog Algorithm as in [2], with
  *   the only difference that a 64 bit hash function is used, so no correction
@@ -58,7 +77,7 @@
  * [2] P. Flajolet, Éric Fusy, O. Gandouet, and F. Meunier. Hyperloglog: The
  *     analysis of a near-optimal cardinality estimation algorithm.
  *
- * Redis uses two representations:
+ * We use two representations:
  *
  * 1) A "dense" representation where every entry is represented by
  *    a 6-bit integer.
@@ -93,7 +112,7 @@
  * Dense representation
  * ===
  *
- * The dense representation used by Redis is the following:
+ * The dense representation is the following:
  *
  * +--------+--------+--------+------//      //--+
  * |11000000|22221111|33333322|55444444 ....     |
@@ -183,23 +202,23 @@
  * when this implementation switches to the dense representation is
  * configured via the define HLL_SPARSE_MAX_BYTES.
  */
+
 #define HLL_SPARSE_MAX_BYTES 3000
 
 struct hllhdr {
-  char magic[4];       /* "HYLL" */
-  uint8_t encoding;    /* HLL_DENSE or HLL_SPARSE. */
-  uint8_t notused[3];  /* Reserved for future use, must be zero. */
-  uint8_t card[8];     /* Cached cardinality, little endian. */
-  uint8_t registers[]; /* Data bytes. */
+    char magic[4];       /* "HYLL" */
+    uint8_t encoding;    /* HLL_DENSE or HLL_SPARSE. */
+    uint8_t notused[3];  /* Reserved for future use, must be zero. */
+    uint8_t card[8];     /* Cached cardinality, little endian. */
+    uint8_t registers[]; /* Data bytes. */
 };
 
 /* The cached cardinality MSB is used to signal validity of the cached value. */
 #define HLL_INVALIDATE_CACHE(hdr) (hdr)->card[7] |= (1 << 7)
 #define HLL_VALID_CACHE(hdr) (((hdr)->card[7] & (1 << 7)) == 0)
 
-#define HLL_P 14 /* The greater is P, the smaller the error. */
-#define HLL_Q                                                                           \
-  (64 - HLL_P)                         /* The number of bits of the hash value used for \
+#define HLL_P 14                       /* The greater is P, the smaller the error. */
+#define HLL_Q (64 - HLL_P)             /* The number of bits of the hash value used for \
                                           determining the number of leading zeros. */
 #define HLL_REGISTERS (1 << HLL_P)     /* With P=14, 16384 registers. */
 #define HLL_P_MASK (HLL_REGISTERS - 1) /* Mask to index register. */
@@ -211,6 +230,26 @@ struct hllhdr {
 #define HLL_SPARSE 1 /* Sparse encoding. */
 #define HLL_RAW 255  /* Only used internally, never exposed. */
 #define HLL_MAX_ENCODING 1
+
+#if HAVE_X86_SIMD || HAVE_ARM_NEON
+#define SIMD_SUPPORTED 1
+static int simd_enabled = 1;
+#else
+#define SIMD_SUPPORTED 0
+#endif
+
+#if HAVE_X86_SIMD
+#define HLL_USE_AVX2 (simd_enabled && __builtin_cpu_supports("avx2"))
+#else
+#define HLL_USE_AVX2 0
+#endif
+
+#if defined(__aarch64__) && HAVE_ARM_NEON
+#define HLL_USE_NEON (simd_enabled)
+#else
+#define HLL_USE_NEON 0
+#endif
+
 
 /* =========================== Low level bit macros ========================= */
 
@@ -341,31 +380,31 @@ struct hllhdr {
 
 /* Store the value of the register at position 'regnum' into variable 'target'.
  * 'p' is an array of unsigned bytes. */
-#define HLL_DENSE_GET_REGISTER(target, p, regnum)             \
-  do {                                                        \
-    uint8_t* _p = (uint8_t*)p;                                \
-    unsigned long _byte = regnum * HLL_BITS / 8;              \
-    unsigned long _fb = regnum * HLL_BITS & 7;                \
-    unsigned long _fb8 = 8 - _fb;                             \
-    unsigned long b0 = _p[_byte];                             \
-    unsigned long b1 = _p[_byte + 1];                         \
-    target = ((b0 >> _fb) | (b1 << _fb8)) & HLL_REGISTER_MAX; \
-  } while (0)
+#define HLL_DENSE_GET_REGISTER(target, p, regnum)                 \
+    do {                                                          \
+        uint8_t *_p = (uint8_t *)p;                               \
+        unsigned long _byte = regnum * HLL_BITS / 8;              \
+        unsigned long _fb = regnum * HLL_BITS & 7;                \
+        unsigned long _fb8 = 8 - _fb;                             \
+        unsigned long b0 = _p[_byte];                             \
+        unsigned long b1 = _p[_byte + 1];                         \
+        target = ((b0 >> _fb) | (b1 << _fb8)) & HLL_REGISTER_MAX; \
+    } while (0)
 
 /* Set the value of the register at position 'regnum' to 'val'.
  * 'p' is an array of unsigned bytes. */
-#define HLL_DENSE_SET_REGISTER(p, regnum, val)    \
-  do {                                            \
-    uint8_t* _p = (uint8_t*)p;                    \
-    unsigned long _byte = (regnum)*HLL_BITS / 8;  \
-    unsigned long _fb = (regnum)*HLL_BITS & 7;    \
-    unsigned long _fb8 = 8 - _fb;                 \
-    unsigned long _v = (val);                     \
-    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb);      \
-    _p[_byte] |= _v << _fb;                       \
-    _p[_byte + 1] &= ~(HLL_REGISTER_MAX >> _fb8); \
-    _p[_byte + 1] |= _v >> _fb8;                  \
-  } while (0)
+#define HLL_DENSE_SET_REGISTER(p, regnum, val)         \
+    do {                                               \
+        uint8_t *_p = (uint8_t *)p;                    \
+        unsigned long _byte = (regnum) * HLL_BITS / 8; \
+        unsigned long _fb = (regnum) * HLL_BITS & 7;   \
+        unsigned long _fb8 = 8 - _fb;                  \
+        unsigned long _v = (val);                      \
+        _p[_byte] &= ~(HLL_REGISTER_MAX << _fb);       \
+        _p[_byte] |= _v << _fb;                        \
+        _p[_byte + 1] &= ~(HLL_REGISTER_MAX >> _fb8);  \
+        _p[_byte + 1] |= _v >> _fb8;                   \
+    } while (0)
 
 /* Macros to access the sparse representation.
  * The macros parameter is expected to be an uint8_t pointer. */
@@ -382,117 +421,102 @@ struct hllhdr {
 #define HLL_SPARSE_VAL_MAX_LEN 4
 #define HLL_SPARSE_ZERO_MAX_LEN 64
 #define HLL_SPARSE_XZERO_MAX_LEN 16384
-#define HLL_SPARSE_VAL_SET(p, val, len)                       \
-  do {                                                        \
-    *(p) = (((val)-1) << 2 | ((len)-1)) | HLL_SPARSE_VAL_BIT; \
-  } while (0)
+#define HLL_SPARSE_VAL_SET(p, val, len)                               \
+    do {                                                              \
+        *(p) = (((val) - 1) << 2 | ((len) - 1)) | HLL_SPARSE_VAL_BIT; \
+    } while (0)
 #define HLL_SPARSE_ZERO_SET(p, len) \
-  do {                              \
-    *(p) = (len)-1;                 \
-  } while (0)
-#define HLL_SPARSE_XZERO_SET(p, len)         \
-  do {                                       \
-    int _l = (len)-1;                        \
-    *(p) = (_l >> 8) | HLL_SPARSE_XZERO_BIT; \
-    *((p) + 1) = (_l & 0xff);                \
-  } while (0)
+    do {                            \
+        *(p) = (len) - 1;           \
+    } while (0)
+#define HLL_SPARSE_XZERO_SET(p, len)             \
+    do {                                         \
+        int _l = (len) - 1;                      \
+        *(p) = (_l >> 8) | HLL_SPARSE_XZERO_BIT; \
+        *((p) + 1) = (_l & 0xff);                \
+    } while (0)
 #define HLL_ALPHA_INF 0.721347520444481703680 /* constant for 0.5/ln(2) */
 
 /* ========================= HyperLogLog algorithm  ========================= */
 
 /* Our hash function is MurmurHash2, 64 bit version.
- * It was modified for Redis in order to provide the same result in
+ * It was modified in order to provide the same result in
  * big and little endian archs (endian neutral). */
-uint64_t MurmurHash64A(const void* key, int len, unsigned int seed) {
-  const uint64_t m = 0xc6a4a7935bd1e995;
-  const int r = 47;
-  uint64_t h = seed ^ (len * m);
-  const uint8_t* data = (const uint8_t*)key;
-  const uint8_t* end = data + (len - (len & 7));
+VALKEY_NO_SANITIZE("alignment")
+uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
+    const uint64_t m = 0xc6a4a7935bd1e995;
+    const int r = 47;
+    uint64_t h = seed ^ (len * m);
+    const uint8_t *data = (const uint8_t *)key;
+    const uint8_t *end = data + (len - (len & 7));
 
-  while (data != end) {
-    uint64_t k;
+    while (data != end) {
+        uint64_t k;
 
 #if (BYTE_ORDER == LITTLE_ENDIAN)
 #ifdef USE_ALIGNED_ACCESS
-    memcpy(&k, data, sizeof(uint64_t));
+        memcpy(&k, data, sizeof(uint64_t));
 #else
-    k = *((uint64_t*)data);
+        k = *((uint64_t *)data);
 #endif
 #else
-    k = (uint64_t)data[0];
-    k |= (uint64_t)data[1] << 8;
-    k |= (uint64_t)data[2] << 16;
-    k |= (uint64_t)data[3] << 24;
-    k |= (uint64_t)data[4] << 32;
-    k |= (uint64_t)data[5] << 40;
-    k |= (uint64_t)data[6] << 48;
-    k |= (uint64_t)data[7] << 56;
+        k = (uint64_t)data[0];
+        k |= (uint64_t)data[1] << 8;
+        k |= (uint64_t)data[2] << 16;
+        k |= (uint64_t)data[3] << 24;
+        k |= (uint64_t)data[4] << 32;
+        k |= (uint64_t)data[5] << 40;
+        k |= (uint64_t)data[6] << 48;
+        k |= (uint64_t)data[7] << 56;
 #endif
 
-    k *= m;
-    k ^= k >> r;
-    k *= m;
-    h ^= k;
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+        h ^= k;
+        h *= m;
+        data += 8;
+    }
+
+    switch (len & 7) {
+    case 7: h ^= (uint64_t)data[6] << 48;   /* fall-thru */
+    case 6: h ^= (uint64_t)data[5] << 40;   /* fall-thru */
+    case 5: h ^= (uint64_t)data[4] << 32;   /* fall-thru */
+    case 4: h ^= (uint64_t)data[3] << 24;   /* fall-thru */
+    case 3: h ^= (uint64_t)data[2] << 16;   /* fall-thru */
+    case 2: h ^= (uint64_t)data[1] << 8;    /* fall-thru */
+    case 1: h ^= (uint64_t)data[0]; h *= m; /* fall-thru */
+    };
+
+    h ^= h >> r;
     h *= m;
-    data += 8;
-  }
-
-  switch (len & 7) {
-    case 7:
-      h ^= (uint64_t)data[6] << 48; /* fall-thru */
-    case 6:
-      h ^= (uint64_t)data[5] << 40; /* fall-thru */
-    case 5:
-      h ^= (uint64_t)data[4] << 32; /* fall-thru */
-    case 4:
-      h ^= (uint64_t)data[3] << 24; /* fall-thru */
-    case 3:
-      h ^= (uint64_t)data[2] << 16; /* fall-thru */
-    case 2:
-      h ^= (uint64_t)data[1] << 8; /* fall-thru */
-    case 1:
-      h ^= (uint64_t)data[0];
-      h *= m; /* fall-thru */
-  };
-
-  h ^= h >> r;
-  h *= m;
-  h ^= h >> r;
-  return h;
+    h ^= h >> r;
+    return h;
 }
 
 /* Given a string element to add to the HyperLogLog, returns the length
  * of the pattern 000..1 of the element hash. As a side effect 'regp' is
  * set to the register index this element hashes to. */
-int hllPatLen(unsigned char* ele, size_t elesize, long* regp) {
-  uint64_t hash, bit, index;
-  int count;
+int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
+    uint64_t hash, index;
+    int count;
 
-  /* Count the number of zeroes starting from bit HLL_REGISTERS
-   * (that is a power of two corresponding to the first bit we don't use
-   * as index). The max run can be 64-P+1 = Q+1 bits.
-   *
-   * Note that the final "1" ending the sequence of zeroes must be
-   * included in the count, so if we find "001" the count is 3, and
-   * the smallest count possible is no zeroes at all, just a 1 bit
-   * at the first position, that is a count of 1.
-   *
-   * This may sound like inefficient, but actually in the average case
-   * there are high probabilities to find a 1 after a few iterations. */
-  hash = MurmurHash64A(ele, elesize, 0xadc83b19ULL);
-  index = hash & HLL_P_MASK;      /* Register index. */
-  hash >>= HLL_P;                 /* Remove bits used to address the register. */
-  hash |= ((uint64_t)1 << HLL_Q); /* Make sure the loop terminates
-                                     and count will be <= Q+1. */
-  bit = 1;
-  count = 1; /* Initialized to 1 since we count the "00000...1" pattern. */
-  while ((hash & bit) == 0) {
-    count++;
-    bit <<= 1;
-  }
-  *regp = (int)index;
-  return count;
+    /* Count the number of zeroes starting from bit HLL_REGISTERS
+     * (that is a power of two corresponding to the first bit we don't use
+     * as index). The max run can be 64-P+1 = Q+1 bits.
+     *
+     * Note that the final "1" ending the sequence of zeroes must be
+     * included in the count, so if we find "001" the count is 3, and
+     * the smallest count possible is no zeroes at all, just a 1 bit
+     * at the first position, that is a count of 1. */
+    hash = MurmurHash64A(ele, elesize, 0xadc83b19ULL);
+    index = hash & HLL_P_MASK;      /* Register index. */
+    hash >>= HLL_P;                 /* Remove bits used to address the register. */
+    hash |= ((uint64_t)1 << HLL_Q); /* Make sure count will be <= Q+1. */
+    count = 1;                      /* Initialized to 1 since we count the "00000...1" pattern. */
+    count += __builtin_ctzll(hash);
+    *regp = (int)index;
+    return count;
 }
 
 /* ================== Dense representation implementation  ================== */
@@ -507,16 +531,16 @@ int hllPatLen(unsigned char* ele, size_t elesize, long* regp) {
  * The function always succeed, however if as a result of the operation
  * the approximated cardinality changed, 1 is returned. Otherwise 0
  * is returned. */
-int hllDenseSet(uint8_t* registers, long index, uint8_t count) {
-  uint8_t oldcount;
+int hllDenseSet(uint8_t *registers, long index, uint8_t count) {
+    uint8_t oldcount;
 
-  HLL_DENSE_GET_REGISTER(oldcount, registers, index);
-  if (count > oldcount) {
-    HLL_DENSE_SET_REGISTER(registers, index, count);
-    return 1;
-  } else {
-    return 0;
-  }
+    HLL_DENSE_GET_REGISTER(oldcount, registers, index);
+    if (count > oldcount) {
+        HLL_DENSE_SET_REGISTER(registers, index, count);
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 /* "Add" the element in the dense hyperloglog data structure.
@@ -525,72 +549,71 @@ int hllDenseSet(uint8_t* registers, long index, uint8_t count) {
  *
  * This is just a wrapper to hllDenseSet(), performing the hashing of the
  * element in order to retrieve the index and zero-run count. */
-int hllDenseAdd(uint8_t* registers, unsigned char* ele, size_t elesize) {
-  long index;
-  uint8_t count = hllPatLen(ele, elesize, &index);
-  /* Update the register if this element produced a longer run of zeroes. */
-  return hllDenseSet(registers, index, count);
+static int hllDenseAdd(uint8_t *registers, unsigned char *ele, size_t elesize) {
+    long index;
+    uint8_t count = hllPatLen(ele, elesize, &index);
+    /* Update the register if this element produced a longer run of zeroes. */
+    return hllDenseSet(registers, index, count);
 }
 
 /* Compute the register histogram in the dense representation. */
-void hllDenseRegHisto(uint8_t* registers, int* reghisto) {
-  int j;
+void hllDenseRegHisto(uint8_t *registers, int *reghisto) {
+    int j;
 
-  /* Redis default is to use 16384 registers 6 bits each. The code works
-   * with other values by modifying the defines, but for our target value
-   * we take a faster path with unrolled loops. */
-  if (HLL_REGISTERS == 16384 && HLL_BITS == 6) {
-    uint8_t* r = registers;
-    unsigned long r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15;
-    for (j = 0; j < 1024; j++) {
-      /* Handle 16 registers per iteration. */
-      r0 = r[0] & 63;
-      r1 = (r[0] >> 6 | r[1] << 2) & 63;
-      r2 = (r[1] >> 4 | r[2] << 4) & 63;
-      r3 = (r[2] >> 2) & 63;
-      r4 = r[3] & 63;
-      r5 = (r[3] >> 6 | r[4] << 2) & 63;
-      r6 = (r[4] >> 4 | r[5] << 4) & 63;
-      r7 = (r[5] >> 2) & 63;
-      r8 = r[6] & 63;
-      r9 = (r[6] >> 6 | r[7] << 2) & 63;
-      r10 = (r[7] >> 4 | r[8] << 4) & 63;
-      r11 = (r[8] >> 2) & 63;
-      r12 = r[9] & 63;
-      r13 = (r[9] >> 6 | r[10] << 2) & 63;
-      r14 = (r[10] >> 4 | r[11] << 4) & 63;
-      r15 = (r[11] >> 2) & 63;
+    /* Default is to use 16384 registers 6 bits each. The code works
+     * with other values by modifying the defines, but for our target value
+     * we take a faster path with unrolled loops. */
+    if (HLL_REGISTERS == 16384 && HLL_BITS == 6) {
+        uint8_t *r = registers;
+        unsigned long r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15;
+        for (j = 0; j < 1024; j++) {
+            /* Handle 16 registers per iteration. */
+            r0 = r[0] & 63;
+            r1 = (r[0] >> 6 | r[1] << 2) & 63;
+            r2 = (r[1] >> 4 | r[2] << 4) & 63;
+            r3 = (r[2] >> 2) & 63;
+            r4 = r[3] & 63;
+            r5 = (r[3] >> 6 | r[4] << 2) & 63;
+            r6 = (r[4] >> 4 | r[5] << 4) & 63;
+            r7 = (r[5] >> 2) & 63;
+            r8 = r[6] & 63;
+            r9 = (r[6] >> 6 | r[7] << 2) & 63;
+            r10 = (r[7] >> 4 | r[8] << 4) & 63;
+            r11 = (r[8] >> 2) & 63;
+            r12 = r[9] & 63;
+            r13 = (r[9] >> 6 | r[10] << 2) & 63;
+            r14 = (r[10] >> 4 | r[11] << 4) & 63;
+            r15 = (r[11] >> 2) & 63;
 
-      reghisto[r0]++;
-      reghisto[r1]++;
-      reghisto[r2]++;
-      reghisto[r3]++;
-      reghisto[r4]++;
-      reghisto[r5]++;
-      reghisto[r6]++;
-      reghisto[r7]++;
-      reghisto[r8]++;
-      reghisto[r9]++;
-      reghisto[r10]++;
-      reghisto[r11]++;
-      reghisto[r12]++;
-      reghisto[r13]++;
-      reghisto[r14]++;
-      reghisto[r15]++;
+            reghisto[r0]++;
+            reghisto[r1]++;
+            reghisto[r2]++;
+            reghisto[r3]++;
+            reghisto[r4]++;
+            reghisto[r5]++;
+            reghisto[r6]++;
+            reghisto[r7]++;
+            reghisto[r8]++;
+            reghisto[r9]++;
+            reghisto[r10]++;
+            reghisto[r11]++;
+            reghisto[r12]++;
+            reghisto[r13]++;
+            reghisto[r14]++;
+            reghisto[r15]++;
 
-      r += 12;
+            r += 12;
+        }
+    } else {
+        for (j = 0; j < HLL_REGISTERS; j++) {
+            unsigned long reg;
+            HLL_DENSE_GET_REGISTER(reg, registers, j);
+            reghisto[reg]++;
+        }
     }
-  } else {
-    for (j = 0; j < HLL_REGISTERS; j++) {
-      unsigned long reg;
-      HLL_DENSE_GET_REGISTER(reg, registers, j);
-      reghisto[reg]++;
-    }
-  }
 }
 
 /* ================== Sparse representation implementation  ================= */
-
 
 /* Convert the HLL with sparse representation given as input in its dense
  * representation. Both representations are represented by SDS strings, and
@@ -598,42 +621,54 @@ void hllDenseRegHisto(uint8_t* registers, int* reghisto) {
  *
  * The function returns C_OK if the sparse representation was valid,
  * otherwise C_ERR is returned if the representation was corrupted. */
-int hllSparseToDense(sds* hll_ptr) {
+int hllSparseToDense(sds *hll_ptr) {
     sds sparse = *hll_ptr, dense;
-    struct hllhdr *hdr, *oldhdr = (struct hllhdr*)sparse;
+    struct hllhdr *hdr, *oldhdr = (struct hllhdr *)sparse;
     int idx = 0, runlen, regval;
-    uint8_t *p = (uint8_t*)sparse, *end = p+sdslen(sparse);
+    uint8_t *p = (uint8_t *)sparse, *end = p + sdslen(sparse);
+    int valid = 1;
 
     /* If the representation is already the right one return ASAP. */
-    hdr = (struct hllhdr*) sparse;
+    hdr = (struct hllhdr *)sparse;
     if (hdr->encoding == HLL_DENSE) return C_OK;
 
     /* Create a string of the right size filled with zero bytes.
      * Note that the cached cardinality is set to 0 as a side effect
      * that is exactly the cardinality of an empty HLL. */
-    dense = sdsnewlen(NULL,HLL_DENSE_SIZE);
-    hdr = (struct hllhdr*) dense;
+    dense = sdsnewlen(NULL, HLL_DENSE_SIZE);
+    hdr = (struct hllhdr *)dense;
     *hdr = *oldhdr; /* This will copy the magic and cached cardinality. */
     hdr->encoding = HLL_DENSE;
 
     /* Now read the sparse representation and set non-zero registers
      * accordingly. */
     p += HLL_HDR_SIZE;
-    while(p < end) {
+    while (p < end) {
         if (HLL_SPARSE_IS_ZERO(p)) {
             runlen = HLL_SPARSE_ZERO_LEN(p);
+            if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+                valid = 0;
+                break;
+            }
             idx += runlen;
             p++;
         } else if (HLL_SPARSE_IS_XZERO(p)) {
             runlen = HLL_SPARSE_XZERO_LEN(p);
+            if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+                valid = 0;
+                break;
+            }
             idx += runlen;
             p += 2;
         } else {
             runlen = HLL_SPARSE_VAL_LEN(p);
             regval = HLL_SPARSE_VAL_VALUE(p);
-            if ((runlen + idx) > HLL_REGISTERS) break; /* Overflow. */
-            while(runlen--) {
-                HLL_DENSE_SET_REGISTER(hdr->registers,idx,regval);
+            if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+                valid = 0;
+                break;
+            }
+            while (runlen--) {
+                HLL_DENSE_SET_REGISTER(hdr->registers, idx, regval);
                 idx++;
             }
             p++;
@@ -642,7 +677,7 @@ int hllSparseToDense(sds* hll_ptr) {
 
     /* If the sparse representation was valid, we expect to find idx
      * set to HLL_REGISTERS. */
-    if (idx != HLL_REGISTERS) {
+    if (!valid || idx != HLL_REGISTERS) {
         sdsfree(dense);
         return C_ERR;
     }
@@ -656,7 +691,7 @@ int hllSparseToDense(sds* hll_ptr) {
 /* Low level function to set the sparse HLL register at 'index' to the
  * specified value if the current value is smaller than 'count'.
  *
- * The object 'hll' is the SDS object holding the HLL. The function requires
+ * The object 'hll_ptr' is the sds string holding the HLL. The function requires
  * a reference to the object in order to be able to enlarge the string if
  * needed.
  *
@@ -667,9 +702,11 @@ int hllSparseToDense(sds* hll_ptr) {
  * As a side effect the function may promote the HLL representation from
  * sparse to dense: this happens when a register requires to be set to a value
  * not representable with the sparse representation, or when the resulting
- * size would be greater than HLL_SPARSE_MAX_BYTES. */
-int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
+ * size would be greater than HLL_SPARSE_MAX_BYTES. '*promoted' is set to 1 when
+ * that happens, so that the caller can observe the encoding change. */
+static int hllSparseSet(sds *hll_ptr, long index, uint8_t count, int *promoted) {
     struct hllhdr *hdr;
+    sds hll = *hll_ptr;
     uint8_t oldcount, *sparse, *end, *p, *prev, *next;
     long first, span;
     long is_zero = 0, is_xzero = 0, is_val = 0, runlen = 0;
@@ -685,28 +722,27 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
      * for future reallocates on incremental growth. But we do not allocate more than
      * 'HLL_SPARSE_MAX_BYTES' bytes for the sparse representation.
      * If the available size of hyperloglog sds string is not enough for the increment
-     * we need, we promote the hypreloglog to dense representation in 'step 3'.
+     * we need, we promote the hyperloglog to dense representation in 'step 3'.
      */
-    sds hll = *hll_ptr;
     if (sdsalloc(hll) < HLL_SPARSE_MAX_BYTES && sdsavail(hll) < 3) {
         size_t newlen = sdslen(hll) + 3;
-        newlen += min(newlen, 300); /* Greediness: double 'newlen' if it is smaller than 300, or add 300 to it when it exceeds 300 */
-        if (newlen > HLL_SPARSE_MAX_BYTES)
-            newlen = HLL_SPARSE_MAX_BYTES;
-        *hll_ptr = sdsResize(hll, newlen);
-        hll = *hll_ptr;
+        newlen +=
+            min(newlen,
+                300); /* Greediness: double 'newlen' if it is smaller than 300, or add 300 to it when it exceeds 300 */
+        if (newlen > HLL_SPARSE_MAX_BYTES) newlen = HLL_SPARSE_MAX_BYTES;
+        hll = *hll_ptr = sdsResize(hll, newlen);
     }
 
     /* Step 1: we need to locate the opcode we need to modify to check
      * if a value update is actually needed. */
-    sparse = p = ((uint8_t*)hll) + HLL_HDR_SIZE;
+    sparse = p = ((uint8_t *)hll) + HLL_HDR_SIZE;
     end = p + sdslen(hll) - HLL_HDR_SIZE;
 
     first = 0;
     prev = NULL; /* Points to previous opcode at the end of the loop. */
     next = NULL; /* Points to the next opcode at the end of the loop. */
     span = 0;
-    while(p < end) {
+    while (p < end) {
         long oplen;
 
         /* Set span to the number of registers covered by this opcode.
@@ -724,14 +760,14 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
             oplen = 2;
         }
         /* Break if this opcode covers the register as 'index'. */
-        if (index <= first+span-1) break;
+        if (index <= first + span - 1) break;
         prev = p;
         p += oplen;
         first += span;
     }
     if (span == 0 || p >= end) return -1; /* Invalid format. */
 
-    next = HLL_SPARSE_IS_XZERO(p) ? p+2 : p+1;
+    next = HLL_SPARSE_IS_XZERO(p) ? p + 2 : p + 1;
     if (next >= end) next = NULL;
 
     /* Cache current opcode type to avoid using the macro again and
@@ -776,7 +812,7 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
 
         /* Case B. */
         if (runlen == 1) {
-            HLL_SPARSE_VAL_SET(p,count,1);
+            HLL_SPARSE_VAL_SET(p, count, 1);
             goto updated;
         }
     }
@@ -784,7 +820,7 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
     /* C) Another trivial to handle case is a ZERO opcode with a len of 1.
      * We can just replace it with a VAL opcode with our value and len of 1. */
     if (is_zero && runlen == 1) {
-        HLL_SPARSE_VAL_SET(p,count,1);
+        HLL_SPARSE_VAL_SET(p, count, 1);
         goto updated;
     }
 
@@ -804,30 +840,30 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
      * of the old one, possibly moving what is on the right a few bytes
      * if the new sequence is longer than the older one. */
     uint8_t seq[5], *n = seq;
-    int last = first+span-1; /* Last register covered by the sequence. */
+    int last = first + span - 1; /* Last register covered by the sequence. */
     int len;
 
     if (is_zero || is_xzero) {
         /* Handle splitting of ZERO / XZERO. */
         if (index != first) {
-            len = index-first;
+            len = index - first;
             if (len > HLL_SPARSE_ZERO_MAX_LEN) {
-                HLL_SPARSE_XZERO_SET(n,len);
+                HLL_SPARSE_XZERO_SET(n, len);
                 n += 2;
             } else {
-                HLL_SPARSE_ZERO_SET(n,len);
+                HLL_SPARSE_ZERO_SET(n, len);
                 n++;
             }
         }
-        HLL_SPARSE_VAL_SET(n,count,1);
+        HLL_SPARSE_VAL_SET(n, count, 1);
         n++;
         if (index != last) {
-            len = last-index;
+            len = last - index;
             if (len > HLL_SPARSE_ZERO_MAX_LEN) {
-                HLL_SPARSE_XZERO_SET(n,len);
+                HLL_SPARSE_XZERO_SET(n, len);
                 n += 2;
             } else {
-                HLL_SPARSE_ZERO_SET(n,len);
+                HLL_SPARSE_ZERO_SET(n, len);
                 n++;
             }
         }
@@ -836,15 +872,15 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
         int curval = HLL_SPARSE_VAL_VALUE(p);
 
         if (index != first) {
-            len = index-first;
-            HLL_SPARSE_VAL_SET(n,curval,len);
+            len = index - first;
+            HLL_SPARSE_VAL_SET(n, curval, len);
             n++;
         }
-        HLL_SPARSE_VAL_SET(n,count,1);
+        HLL_SPARSE_VAL_SET(n, count, 1);
         n++;
         if (index != last) {
-            len = last-index;
-            HLL_SPARSE_VAL_SET(n,curval,len);
+            len = last - index;
+            HLL_SPARSE_VAL_SET(n, curval, len);
             n++;
         }
     }
@@ -853,16 +889,15 @@ int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
      *
      * Note that we already allocated space on the sds string
      * calling sdsResize(). */
-    int seqlen = n-seq;
+    int seqlen = n - seq;
     int oldlen = is_xzero ? 2 : 1;
-    int deltalen = seqlen-oldlen;
+    int deltalen = seqlen - oldlen;
 
-    if (deltalen > 0 &&
-        sdslen(hll) + deltalen > HLL_SPARSE_MAX_BYTES) goto promote;
+    if (deltalen > 0 && sdslen(hll) + deltalen > HLL_SPARSE_MAX_BYTES) goto promote;
     serverAssert(sdslen(hll) + deltalen <= sdsalloc(hll));
-    if (deltalen && next) memmove(next+deltalen,next,end-next);
-    sdsIncrLen(hll,deltalen);
-    memcpy(p,seq,seqlen);
+    if (deltalen && next) memmove(next + deltalen, next, end - next);
+    sdsIncrLen(hll, deltalen);
+    memcpy(p, seq, seqlen);
     end += deltalen;
 
 updated:
@@ -883,15 +918,15 @@ updated:
         }
         /* We need two adjacent VAL opcodes to try a merge, having
          * the same value, and a len that fits the VAL opcode max len. */
-        if (p+1 < end && HLL_SPARSE_IS_VAL(p+1)) {
+        if (p + 1 < end && HLL_SPARSE_IS_VAL(p + 1)) {
             int v1 = HLL_SPARSE_VAL_VALUE(p);
-            int v2 = HLL_SPARSE_VAL_VALUE(p+1);
+            int v2 = HLL_SPARSE_VAL_VALUE(p + 1);
             if (v1 == v2) {
-                int len = HLL_SPARSE_VAL_LEN(p)+HLL_SPARSE_VAL_LEN(p+1);
+                int len = HLL_SPARSE_VAL_LEN(p) + HLL_SPARSE_VAL_LEN(p + 1);
                 if (len <= HLL_SPARSE_VAL_MAX_LEN) {
-                    HLL_SPARSE_VAL_SET(p+1,v1,len);
-                    memmove(p,p+1,end-p);
-                    sdsIncrLen(hll,-1);
+                    HLL_SPARSE_VAL_SET(p + 1, v1, len);
+                    memmove(p, p + 1, end - p);
+                    sdsIncrLen(hll, -1);
                     end--;
                     /* After a merge we reiterate without incrementing 'p'
                      * in order to try to merge the just merged value with
@@ -908,7 +943,7 @@ updated:
     HLL_INVALIDATE_CACHE(hdr);
     return 1;
 
-promote: /* Promote to dense representation. */
+promote:                                         /* Promote to dense representation. */
     if (hllSparseToDense(&hll) == C_ERR) return -1; /* Corrupted HLL. */
     *hll_ptr = hll;
     hdr = (struct hllhdr *)hll;
@@ -918,9 +953,9 @@ promote: /* Promote to dense representation. */
      * convert from sparse to dense a register requires to be updated.
      *
      * Note that this in turn means that PFADD will make sure the command
-     * is propagated to slaves / AOF, so if there is a sparse -> dense
-     * conversion, it will be performed in all the slaves as well. */
-    int dense_retval = hllDenseSet(hdr->registers,index,count);
+     * is propagated to replicas / AOF, so if there is a sparse -> dense
+     * conversion, it will be performed in all the replicas as well. */
+    int dense_retval = hllDenseSet(hdr->registers, index, count);
     serverAssert(dense_retval == 1);
     *promoted = 1;
     return dense_retval;
@@ -932,38 +967,51 @@ promote: /* Promote to dense representation. */
  *
  * This function is actually a wrapper for hllSparseSet(), it only performs
  * the hashing of the element to obtain the index and zeros run length. */
-int hllSparseAdd(sds* hll_ptr, unsigned char *ele, size_t elesize, int* promoted) {
+static int hllSparseAdd(sds *hll_ptr, unsigned char *ele, size_t elesize, int *promoted) {
     long index;
-    uint8_t count = hllPatLen(ele,elesize,&index);
+    uint8_t count = hllPatLen(ele, elesize, &index);
     /* Update the register if this element produced a longer run of zeroes. */
-    return hllSparseSet(hll_ptr,index,count, promoted);
+    return hllSparseSet(hll_ptr, index, count, promoted);
 }
-/* Compute the register histogram in the sparse representation. */
-void hllSparseRegHisto(uint8_t* sparse, int sparselen, int* invalid, int* reghisto) {
-  int idx = 0, runlen, regval;
-  uint8_t *end = sparse + sparselen, *p = sparse;
 
-  while (p < end) {
-    if (HLL_SPARSE_IS_ZERO(p)) {
-      runlen = HLL_SPARSE_ZERO_LEN(p);
-      idx += runlen;
-      reghisto[0] += runlen;
-      p++;
-    } else if (HLL_SPARSE_IS_XZERO(p)) {
-      runlen = HLL_SPARSE_XZERO_LEN(p);
-      idx += runlen;
-      reghisto[0] += runlen;
-      p += 2;
-    } else {
-      runlen = HLL_SPARSE_VAL_LEN(p);
-      regval = HLL_SPARSE_VAL_VALUE(p);
-      idx += runlen;
-      reghisto[regval] += runlen;
-      p++;
+/* Compute the register histogram in the sparse representation. */
+void hllSparseRegHisto(uint8_t *sparse, int sparselen, int *invalid, int *reghisto) {
+    int idx = 0, runlen, regval;
+    uint8_t *end = sparse + sparselen, *p = sparse;
+    int valid = 1;
+
+    while (p < end) {
+        if (HLL_SPARSE_IS_ZERO(p)) {
+            runlen = HLL_SPARSE_ZERO_LEN(p);
+            if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+                valid = 0;
+                break;
+            }
+            idx += runlen;
+            reghisto[0] += runlen;
+            p++;
+        } else if (HLL_SPARSE_IS_XZERO(p)) {
+            runlen = HLL_SPARSE_XZERO_LEN(p);
+            if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+                valid = 0;
+                break;
+            }
+            idx += runlen;
+            reghisto[0] += runlen;
+            p += 2;
+        } else {
+            runlen = HLL_SPARSE_VAL_LEN(p);
+            regval = HLL_SPARSE_VAL_VALUE(p);
+            if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+                valid = 0;
+                break;
+            }
+            idx += runlen;
+            reghisto[regval] += runlen;
+            p++;
+        }
     }
-  }
-  if (idx != HLL_REGISTERS && invalid)
-    *invalid = 1;
+    if ((!valid || idx != HLL_REGISTERS) && invalid) *invalid = 1;
 }
 
 /* ========================= HyperLogLog Count ==============================
@@ -974,63 +1022,61 @@ void hllSparseRegHisto(uint8_t* sparse, int sparselen, int* invalid, int* reghis
 
 /* Implements the register histogram calculation for uint8_t data type
  * which is only used internally as speedup for PFCOUNT with multiple keys. */
-void hllRawRegHisto(uint8_t* registers, int* reghisto) {
-  uint64_t* word = (uint64_t*)registers;
-  uint8_t* bytes;
-  int j;
+void hllRawRegHisto(uint8_t *registers, int *reghisto) {
+    uint64_t *word = (uint64_t *)registers;
+    uint8_t *bytes;
+    int j;
 
-  for (j = 0; j < HLL_REGISTERS / 8; j++) {
-    if (*word == 0) {
-      reghisto[0] += 8;
-    } else {
-      bytes = (uint8_t*)word;
-      reghisto[bytes[0]]++;
-      reghisto[bytes[1]]++;
-      reghisto[bytes[2]]++;
-      reghisto[bytes[3]]++;
-      reghisto[bytes[4]]++;
-      reghisto[bytes[5]]++;
-      reghisto[bytes[6]]++;
-      reghisto[bytes[7]]++;
+    for (j = 0; j < HLL_REGISTERS / 8; j++) {
+        if (*word == 0) {
+            reghisto[0] += 8;
+        } else {
+            bytes = (uint8_t *)word;
+            reghisto[bytes[0]]++;
+            reghisto[bytes[1]]++;
+            reghisto[bytes[2]]++;
+            reghisto[bytes[3]]++;
+            reghisto[bytes[4]]++;
+            reghisto[bytes[5]]++;
+            reghisto[bytes[6]]++;
+            reghisto[bytes[7]]++;
+        }
+        word++;
     }
-    word++;
-  }
 }
 
 /* Helper function sigma as defined in
  * "New cardinality estimation algorithms for HyperLogLog sketches"
  * Otmar Ertl, arXiv:1702.01284 */
 double hllSigma(double x) {
-  if (x == 1.)
-    return INFINITY;
-  double zPrime;
-  double y = 1;
-  double z = x;
-  do {
-    x *= x;
-    zPrime = z;
-    z += x * y;
-    y += y;
-  } while (zPrime != z);
-  return z;
+    if (x == 1.) return INFINITY;
+    double zPrime;
+    double y = 1;
+    double z = x;
+    do {
+        x *= x;
+        zPrime = z;
+        z += x * y;
+        y += y;
+    } while (zPrime != z);
+    return z;
 }
 
 /* Helper function tau as defined in
  * "New cardinality estimation algorithms for HyperLogLog sketches"
  * Otmar Ertl, arXiv:1702.01284 */
 double hllTau(double x) {
-  if (x == 0. || x == 1.)
-    return 0.;
-  double zPrime;
-  double y = 1.0;
-  double z = 1 - x;
-  do {
-    x = sqrt(x);
-    zPrime = z;
-    y *= 0.5;
-    z -= pow(1 - x, 2) * y;
-  } while (zPrime != z);
-  return z / 3;
+    if (x == 0. || x == 1.) return 0.;
+    double zPrime;
+    double y = 1.0;
+    double z = 1 - x;
+    do {
+        x = sqrt(x);
+        zPrime = z;
+        y *= 0.5;
+        z -= pow(1 - x, 2) * y;
+    } while (zPrime != z);
+    return z / 3;
 }
 
 /* Return the approximated cardinality of the set based on the harmonic
@@ -1044,40 +1090,277 @@ double hllTau(double x) {
  * is, hdr->registers will point to an uint8_t array of HLL_REGISTERS element.
  * This is useful in order to speedup PFCOUNT when called against multiple
  * keys (no need to work with 6-bit integers encoding). */
-uint64_t hllCount(struct hllhdr* hdr, int* invalid) {
-  double m = HLL_REGISTERS;
-  double E;
-  int j;
-  /* Note that reghisto size could be just HLL_Q+2, because HLL_Q+1 is
-   * the maximum frequency of the "000...1" sequence the hash function is
-   * able to return. However it is slow to check for sanity of the
-   * input: instead we history array at a safe size: overflows will
-   * just write data to wrong, but correctly allocated, places. */
-  int reghisto[64] = {0};
+uint64_t hllCount(struct hllhdr *hdr, int *invalid) {
+    double m = HLL_REGISTERS;
+    double E;
+    int j;
+    /* Note that reghisto size could be just HLL_Q+2, because HLL_Q+1 is
+     * the maximum frequency of the "000...1" sequence the hash function is
+     * able to return. However it is slow to check for sanity of the
+     * input: instead we history array at a safe size: overflows will
+     * just write data to wrong, but correctly allocated, places. */
+    int reghisto[64] = {0};
 
-  /* Compute register histogram */
-  if (hdr->encoding == HLL_DENSE) {
-    hllDenseRegHisto(hdr->registers, reghisto);
-  } else if (hdr->encoding == HLL_SPARSE) {
-    hllSparseRegHisto(hdr->registers, sdslen((sds)hdr) - HLL_HDR_SIZE, invalid, reghisto);
-  } else if (hdr->encoding == HLL_RAW) {
-    hllRawRegHisto(hdr->registers, reghisto);
-  } else {
-    serverPanic("Unknown HyperLogLog encoding in hllCount()");
-  }
+    /* Compute register histogram */
+    if (hdr->encoding == HLL_DENSE) {
+        hllDenseRegHisto(hdr->registers, reghisto);
+    } else if (hdr->encoding == HLL_SPARSE) {
+        hllSparseRegHisto(hdr->registers, sdslen((sds)hdr) - HLL_HDR_SIZE, invalid, reghisto);
+    } else if (hdr->encoding == HLL_RAW) {
+        hllRawRegHisto(hdr->registers, reghisto);
+    } else {
+        serverPanic("Unknown HyperLogLog encoding in hllCount()");
+    }
 
-  /* Estimate cardinality from register histogram. See:
-   * "New cardinality estimation algorithms for HyperLogLog sketches"
-   * Otmar Ertl, arXiv:1702.01284 */
-  double z = m * hllTau((m - reghisto[HLL_Q + 1]) / (double)m);
-  for (j = HLL_Q; j >= 1; --j) {
-    z += reghisto[j];
-    z *= 0.5;
-  }
-  z += m * hllSigma(reghisto[0] / (double)m);
-  E = llroundl(HLL_ALPHA_INF * m * m / z);
+    /* Estimate cardinality from register histogram. See:
+     * "New cardinality estimation algorithms for HyperLogLog sketches"
+     * Otmar Ertl, arXiv:1702.01284 */
+    double z = m * hllTau((m - reghisto[HLL_Q + 1]) / (double)m);
+    for (j = HLL_Q; j >= 1; --j) {
+        z += reghisto[j];
+        z *= 0.5;
+    }
+    z += m * hllSigma(reghisto[0] / (double)m);
+    E = llroundl(HLL_ALPHA_INF * m * m / z);
 
-  return (uint64_t)E;
+    return (uint64_t)E;
+}
+
+#if 0
+/* Call hllDenseAdd() or hllSparseAdd() according to the HLL encoding. */
+static int hllAdd(robj *o, unsigned char *ele, size_t elesize) {
+    struct hllhdr *hdr = objectGetVal(o);
+    switch (hdr->encoding) {
+    case HLL_DENSE: return hllDenseAdd(hdr->registers, ele, elesize);
+    case HLL_SPARSE: return hllSparseAdd(o, ele, elesize);
+    default: return -1; /* Invalid representation. */
+    }
+}
+#endif
+
+#if HAVE_X86_SIMD
+/* A specialized version of hllMergeDense, optimized for default configurations.
+ *
+ * Requirements:
+ * 1) HLL_REGISTERS == 16384 && HLL_BITS == 6
+ * 2) The CPU supports AVX2 (checked at runtime in hllMergeDense)
+ *
+ * reg_raw: pointer to the raw representation array (16384 bytes, one byte per register)
+ * reg_dense: pointer to the dense representation array (12288 bytes, 6 bits per register)
+ */
+ATTRIBUTE_TARGET_AVX2
+void hllMergeDenseAVX2(uint8_t *reg_raw, const uint8_t *reg_dense) {
+    /* Shuffle indices for unpacking bytes of dense registers
+     * From: {XXXX|AAAB|BBCC|CDDD|EEEF|FFGG|GHHH|XXXX}
+     * To:   {AAA0|BBB0|CCC0|DDD0|EEE0|FFF0|GGG0|HHH0}
+     */
+    const __m256i shuffle = _mm256_setr_epi8( //
+        4, 5, 6, -1,                          //
+        7, 8, 9, -1,                          //
+        10, 11, 12, -1,                       //
+        13, 14, 15, -1,                       //
+        0, 1, 2, -1,                          //
+        3, 4, 5, -1,                          //
+        6, 7, 8, -1,                          //
+        9, 10, 11, -1                         //
+    );
+
+    /* Merge the first 8 registers (6 bytes) normally
+     * as the AVX2 algorithm needs 4 padding bytes at the start */
+    uint8_t val;
+    for (int i = 0; i < 8; i++) {
+        HLL_DENSE_GET_REGISTER(val, reg_dense, i);
+        if (val > reg_raw[i]) {
+            reg_raw[i] = val;
+        }
+    }
+
+    /* Dense to Raw:
+     *
+     * 4 registers in 3 bytes:
+     * {bbaaaaaa|ccccbbbb|ddddddcc}
+     *
+     * LOAD 32 bytes (32 registers) per iteration:
+     * 4(padding) + 12(16 registers) + 12(16 registers) + 4(padding)
+     * {XXXX|AAAB|BBCC|CDDD|EEEF|FFGG|GHHH|XXXX}
+     *
+     * SHUFFLE to:
+     * {AAA0|BBB0|CCC0|DDD0|EEE0|FFF0|GGG0|HHH0}
+     * {bbaaaaaa|ccccbbbb|ddddddcc|00000000} x8
+     *
+     * AVX2 is little endian, each of the 8 groups is a little-endian int32.
+     * A group (int32) contains 3 valid bytes (4 registers) and a zero byte.
+     *
+     * extract registers in each group with AND and SHIFT:
+     * {00aaaaaa|00000000|00000000|00000000} x8 (<<0)
+     * {00000000|00bbbbbb|00000000|00000000} x8 (<<2)
+     * {00000000|00000000|00cccccc|00000000} x8 (<<4)
+     * {00000000|00000000|00000000|00dddddd} x8 (<<6)
+     *
+     * merge the extracted registers with OR:
+     * {00aaaaaa|00bbbbbb|00cccccc|00dddddd} x8
+     *
+     * Finally, compute MAX(reg_raw, merged) and STORE it back to reg_raw
+     */
+
+    /* Skip 8 registers (6 bytes) */
+    const uint8_t *r = reg_dense + 6 - 4;
+    uint8_t *t = reg_raw + 8;
+
+    for (int i = 0; i < HLL_REGISTERS / 32 - 1; ++i) {
+        __m256i x0, x;
+        x0 = _mm256_loadu_si256((__m256i *)r);
+        x = _mm256_shuffle_epi8(x0, shuffle);
+
+        __m256i a1, a2, a3, a4;
+        a1 = _mm256_and_si256(x, _mm256_set1_epi32(0x0000003f));
+        a2 = _mm256_and_si256(x, _mm256_set1_epi32(0x00000fc0));
+        a3 = _mm256_and_si256(x, _mm256_set1_epi32(0x0003f000));
+        a4 = _mm256_and_si256(x, _mm256_set1_epi32(0x00fc0000));
+
+        a2 = _mm256_slli_epi32(a2, 2);
+        a3 = _mm256_slli_epi32(a3, 4);
+        a4 = _mm256_slli_epi32(a4, 6);
+
+        __m256i y1, y2, y;
+        y1 = _mm256_or_si256(a1, a2);
+        y2 = _mm256_or_si256(a3, a4);
+        y = _mm256_or_si256(y1, y2);
+
+        __m256i z = _mm256_loadu_si256((__m256i *)t);
+
+        z = _mm256_max_epu8(z, y);
+
+        _mm256_storeu_si256((__m256i *)t, z);
+
+        r += 24;
+        t += 32;
+    }
+
+    /* Merge the last 24 registers normally
+     * as the AVX2 algorithm needs 4 padding bytes at the end */
+    for (int i = HLL_REGISTERS - 24; i < HLL_REGISTERS; i++) {
+        HLL_DENSE_GET_REGISTER(val, reg_dense, i);
+        if (val > reg_raw[i]) {
+            reg_raw[i] = val;
+        }
+    }
+}
+#endif
+
+#if HAVE_ARM_NEON
+/*
+ * hllMergeDenseNEON is an ARM optimized version of hllMergeDense using NEON
+ *
+ * This function merges HyperLogLog (HLL) dense registers using ARM NEON SIMD instructions.
+ * It extracts 6 bits registers from a dense format, and stores them in raw format
+ *
+ * Parameters:
+ * - reg_raw: Pointer to the raw register array
+ * - reg_dense: Pointer to the dense register array
+ */
+void hllMergeDenseNEON(uint8_t *reg_raw, const uint8_t *reg_dense) {
+    uint8_t *dense_ptr = (uint8_t *)reg_dense;
+    uint8_t *raw_ptr = (uint8_t *)reg_raw;
+
+    uint8x16_t idx = {0, 1, 2, 0xFF,
+                      3, 4, 5, 0xFF,
+                      6, 7, 8, 0xFF,
+                      9, 10, 11, 0xFF};
+
+    // Bit masks for extracting specific bit ranges
+    uint8x16_t mask1 = vreinterpretq_u8_u32(vdupq_n_u32(0x0000003f)); // Bits 0-5
+    uint8x16_t mask2 = vreinterpretq_u8_u32(vdupq_n_u32(0x00000fc0)); // Bits 6-11
+    uint8x16_t mask3 = vreinterpretq_u8_u32(vdupq_n_u32(0x0003f000)); // Bits 12-17
+    uint8x16_t mask4 = vreinterpretq_u8_u32(vdupq_n_u32(0x00fc0000)); // Bits 18-23
+
+    for (int i = 0; i < HLL_REGISTERS / 16 - 1; ++i) {
+        /* Load 16 bytes from dense registers but only the first 12 bytes are processed because they contain
+         * 16 registers, which is copied into 16 bytes raw registers.
+         * The last 4 bytes are ignored because (1) they do not form a complete number of registers, and do not fit
+         * in the 16 bytes. The unprocessed 4 bytes are processed in the next iteration.
+         */
+        uint8x16_t r = vld1q_u8(dense_ptr);
+
+        /* Reorder bytes based on index mapping
+         * Lookup indices
+         *From: {AAAB|BBCC|CDDD}
+         *To:   {AAA0|BBB0|CCC0|DDD0}
+         */
+        uint8x16_t x = vqtbl1q_u8(r, idx);
+
+        // Extract and isolate registers
+        uint8x16_t a1 = vandq_u8(x, mask1);
+        uint8x16_t a2 = vandq_u8(x, mask2);
+        uint8x16_t a3 = vandq_u8(x, mask3);
+        uint8x16_t a4 = vandq_u8(x, mask4);
+
+        // Align extracted values by shifting left
+        uint32x4_t a2_32 = vreinterpretq_u32_u8(a2);
+        a2_32 = vshlq_n_u32(a2_32, 2);
+        a2 = vreinterpretq_u8_u32(a2_32);
+
+        uint32x4_t a3_32 = vreinterpretq_u32_u8(a3);
+        a3_32 = vshlq_n_u32(a3_32, 4);
+        a3 = vreinterpretq_u8_u32(a3_32);
+
+        uint32x4_t a4_32 = vreinterpretq_u32_u8(a4);
+        a4_32 = vshlq_n_u32(a4_32, 6);
+        a4 = vreinterpretq_u8_u32(a4_32);
+
+        // Combine extracted values
+        uint8x16_t y1 = vorrq_u8(a1, a2);
+        uint8x16_t y2 = vorrq_u8(a3, a4);
+        uint8x16_t y = vorrq_u8(y1, y2);
+
+        // Load current raw register values
+        uint8x16_t z = vld1q_u8(raw_ptr);
+
+        // Update raw registers with max values
+        z = vmaxq_u8(z, y);
+
+        // Store updated values
+        vst1q_u8(raw_ptr, z);
+
+        raw_ptr += 16;
+        dense_ptr += 12;
+    }
+
+    /* Process remaining registers, we do this manually because we don't want to over-read 4 bytes */
+    uint8_t val;
+    for (int i = HLL_REGISTERS - 16; i < HLL_REGISTERS; i++) {
+        HLL_DENSE_GET_REGISTER(val, reg_dense, i);
+        if (val > reg_raw[i]) {
+            reg_raw[i] = val; // Update raw register if new value is greater
+        }
+    }
+}
+#endif /* HAVE_ARM_NEON */
+
+/* Merge dense-encoded registers to raw registers array. */
+void hllMergeDense(uint8_t *reg_raw, const uint8_t *reg_dense) {
+#if HAVE_X86_SIMD
+    if (HLL_REGISTERS == 16384 && HLL_BITS == 6) {
+        if (HLL_USE_AVX2) {
+            hllMergeDenseAVX2(reg_raw, reg_dense);
+            return;
+        }
+    }
+#endif
+#if defined(__aarch64__) && HAVE_ARM_NEON && HLL_REGISTERS == 16384 && HLL_BITS == 6
+    if (HLL_USE_NEON) {
+        hllMergeDenseNEON(reg_raw, reg_dense);
+        return;
+    }
+#endif
+
+    uint8_t val;
+    for (int i = 0; i < HLL_REGISTERS; i++) {
+        HLL_DENSE_GET_REGISTER(val, reg_dense, i);
+        if (val > reg_raw[i]) {
+            reg_raw[i] = val;
+        }
+    }
 }
 
 #if 0
@@ -1089,84 +1372,278 @@ uint64_t hllCount(struct hllhdr* hdr, int* invalid) {
  *
  * If the HyperLogLog is sparse and is found to be invalid, C_ERR
  * is returned, otherwise the function always succeeds. */
-int hllMerge(uint8_t* max, robj* hll) {
-  struct hllhdr* hdr = hll->ptr;
-  int i;
+int hllMerge(uint8_t *max, robj *hll) {
+    struct hllhdr *hdr = objectGetVal(hll);
+    int i;
 
-  if (hdr->encoding == HLL_DENSE) {
-    uint8_t val;
+    if (hdr->encoding == HLL_DENSE) {
+        hllMergeDense(max, hdr->registers);
+    } else {
+        uint8_t *p = objectGetVal(hll), *end = p + sdslen(objectGetVal(hll));
+        long runlen, regval;
+        int valid = 1;
 
-    for (i = 0; i < HLL_REGISTERS; i++) {
-      HLL_DENSE_GET_REGISTER(val, hdr->registers, i);
-      if (val > max[i])
-        max[i] = val;
-    }
-  } else {
-    uint8_t *p = hll->ptr, *end = p + sdslen(hll->ptr);
-    long runlen, regval;
-
-    p += HLL_HDR_SIZE;
-    i = 0;
-    while (p < end) {
-      if (HLL_SPARSE_IS_ZERO(p)) {
-        runlen = HLL_SPARSE_ZERO_LEN(p);
-        i += runlen;
-        p++;
-      } else if (HLL_SPARSE_IS_XZERO(p)) {
-        runlen = HLL_SPARSE_XZERO_LEN(p);
-        i += runlen;
-        p += 2;
-      } else {
-        runlen = HLL_SPARSE_VAL_LEN(p);
-        regval = HLL_SPARSE_VAL_VALUE(p);
-        if ((runlen + i) > HLL_REGISTERS)
-          break; /* Overflow. */
-        while (runlen--) {
-          if (regval > max[i])
-            max[i] = regval;
-          i++;
+        p += HLL_HDR_SIZE;
+        i = 0;
+        while (p < end) {
+            if (HLL_SPARSE_IS_ZERO(p)) {
+                runlen = HLL_SPARSE_ZERO_LEN(p);
+                if ((runlen + i) > HLL_REGISTERS) { /* Overflow. */
+                    valid = 0;
+                    break;
+                }
+                i += runlen;
+                p++;
+            } else if (HLL_SPARSE_IS_XZERO(p)) {
+                runlen = HLL_SPARSE_XZERO_LEN(p);
+                if ((runlen + i) > HLL_REGISTERS) { /* Overflow. */
+                    valid = 0;
+                    break;
+                }
+                i += runlen;
+                p += 2;
+            } else {
+                runlen = HLL_SPARSE_VAL_LEN(p);
+                regval = HLL_SPARSE_VAL_VALUE(p);
+                if ((runlen + i) > HLL_REGISTERS) { /* Overflow. */
+                    valid = 0;
+                    break;
+                }
+                while (runlen--) {
+                    if (regval > max[i]) max[i] = regval;
+                    i++;
+                }
+                p++;
+            }
         }
-        p++;
-      }
+        if (!valid || i != HLL_REGISTERS) return C_ERR;
     }
-    if (i != HLL_REGISTERS)
-      return C_ERR;
-  }
-  return C_OK;
+    return C_OK;
+}
+#endif
+
+#if HAVE_X86_SIMD
+/* A specialized version of hllDenseCompress, optimized for default configurations.
+ *
+ * Requirements:
+ * 1) HLL_REGISTERS == 16384 && HLL_BITS == 6
+ * 2) The CPU supports AVX2 (checked at runtime in hllDenseCompress)
+ *
+ * reg_dense: pointer to the dense representation array (12288 bytes, 6 bits per register)
+ * reg_raw: pointer to the raw representation array (16384 bytes, one byte per register)
+ */
+ATTRIBUTE_TARGET_AVX2
+void hllDenseCompressAVX2(uint8_t *reg_dense, const uint8_t *reg_raw) {
+    /* Shuffle indices for packing bytes of dense registers
+     * From: {AAA0|BBB0|CCC0|DDD0|EEE0|FFF0|GGG0|HHH0}
+     * To:   {AAAB|BBCC|CDDD|0000|EEEF|FFGG|GHHH|0000}
+     */
+    const __m256i shuffle = _mm256_setr_epi8( //
+        0, 1, 2,                              //
+        4, 5, 6,                              //
+        8, 9, 10,                             //
+        12, 13, 14,                           //
+        -1, -1, -1, -1,                       //
+        0, 1, 2,                              //
+        4, 5, 6,                              //
+        8, 9, 10,                             //
+        12, 13, 14,                           //
+        -1, -1, -1, -1                        //
+    );
+
+    /* Raw to Dense:
+     *
+     * LOAD 32 bytes (32 registers) per iteration:
+     * {00aaaaaa|00bbbbbb|00cccccc|00dddddd} x8
+     *
+     * AVX2 is little endian, each of the 8 groups is a little-endian int32.
+     * A group (int32) contains 4 registers.
+     *
+     * move the registers to correct positions with AND and SHIFT:
+     * {00aaaaaa|00000000|00000000|00000000} x8 (>>0)
+     * {bb000000|0000bbbb|00000000|00000000} x8 (>>2)
+     * {00000000|cccc0000|000000cc|00000000} x8 (>>4)
+     * {00000000|00000000|dddddd00|00000000} x8 (>>6)
+     *
+     * merge the registers with OR:
+     * {bbaaaaaa|ccccbbbb|ddddddcc|00000000} x8
+     * {AAA0|BBB0|CCC0|DDD0|EEE0|FFF0|GGG0|HHH0}
+     *
+     * SHUFFLE to:
+     * {AAAB|BBCC|CDDD|0000|EEEF|FFGG|GHHH|0000}
+     *
+     * STORE the lower half and higher half respectively:
+     * AAABBBCCCDDD0000
+     *             EEEFFFGGGHHH0000
+     * AAABBBCCCDDDEEEFFFGGGHHH0000
+     *
+     * Note that the last 4 bytes are padding bytes.
+     */
+
+    const uint8_t *r = reg_raw;
+    uint8_t *t = reg_dense;
+
+    for (int i = 0; i < HLL_REGISTERS / 32 - 1; ++i) {
+        __m256i x = _mm256_loadu_si256((__m256i *)r);
+
+        __m256i a1, a2, a3, a4;
+        a1 = _mm256_and_si256(x, _mm256_set1_epi32(0x0000003f));
+        a2 = _mm256_and_si256(x, _mm256_set1_epi32(0x00003f00));
+        a3 = _mm256_and_si256(x, _mm256_set1_epi32(0x003f0000));
+        a4 = _mm256_and_si256(x, _mm256_set1_epi32(0x3f000000));
+
+        a2 = _mm256_srli_epi32(a2, 2);
+        a3 = _mm256_srli_epi32(a3, 4);
+        a4 = _mm256_srli_epi32(a4, 6);
+
+        __m256i y1, y2, y;
+        y1 = _mm256_or_si256(a1, a2);
+        y2 = _mm256_or_si256(a3, a4);
+        y = _mm256_or_si256(y1, y2);
+        y = _mm256_shuffle_epi8(y, shuffle);
+
+        __m128i lower, higher;
+        lower = _mm256_castsi256_si128(y);
+        higher = _mm256_extracti128_si256(y, 1);
+
+        _mm_storeu_si128((__m128i *)t, lower);
+        _mm_storeu_si128((__m128i *)(t + 12), higher);
+
+        r += 32;
+        t += 24;
+    }
+
+    /* Merge the last 32 registers normally
+     * as the AVX2 algorithm needs 4 padding bytes at the end */
+    for (int i = HLL_REGISTERS - 32; i < HLL_REGISTERS; i++) {
+        HLL_DENSE_SET_REGISTER(reg_dense, i, reg_raw[i]);
+    }
+}
+#endif
+
+#if HAVE_ARM_NEON
+/*
+ * hllDenseCompressNEON is ARM optimized version of hllDenseCompress using NEON.
+ *
+ * This function takes a raw register (`reg_raw`) and compresses it into a dense representation (`reg_dense`).
+ * It uses NEON SIMD instructions to process multiple values at once.
+ *
+ * - The first loop processes most of the registers in 16-element blocks using NEON instructions.
+ * - The second loop handles the remaining registers using a direct assignment macro.
+ *
+ */
+void hllDenseCompressNEON(uint8_t *reg_dense, const uint8_t *reg_raw) {
+    /* Shuffle indices for packing bytes of dense registers
+     * From: {AAA0|BBB0|CCC0|DDD0}
+     * To:   {AAAB|BBCC|CDDD|0000}
+     */
+    uint8x16_t idx = {
+        0, 1, 2,               // Extract bytes from lane 0
+        4, 5, 6,               // Extract bytes from lane 1
+        8, 9, 10,              // Extract bytes from lane 2
+        12, 13, 14,            // Extract bytes from lane 3
+        0xFF, 0xFF, 0xFF, 0xFF // Zero out last 4 elements (padding)
+    };
+
+    // Bit masks for extracting first 6 bits from every byte within 32-bit lanes
+    uint32x4_t mask1 = vdupq_n_u32(0x0000003F); // Extract bits 0-5
+    uint32x4_t mask2 = vdupq_n_u32(0x00003F00); // Extract bits 8-13
+    uint32x4_t mask3 = vdupq_n_u32(0x003F0000); // Extract bits 16-21
+    uint32x4_t mask4 = vdupq_n_u32(0x3F000000); // Extract bits 24-29
+
+    uint8_t *r = (uint8_t *)reg_raw;   // Input pointer
+    uint8_t *t = (uint8_t *)reg_dense; // Output pointer
+
+    // Process registers in blocks of 16 using NEON instructions
+    // The last 16 registers are processed separately to avoid overwriting, as the final write is 12 bytes.
+    for (int i = 0; i < HLL_REGISTERS / 16 - 1; i++) {
+        // Load 16 bytes as 4x 32-bit values
+        uint32x4_t x = vld1q_u32((uint32_t *)r);
+
+        // Apply masks to extract a single register from every 4 registers, for every lane
+        uint32x4_t a1 = vandq_u32(x, mask1);
+        uint32x4_t a2 = vandq_u32(x, mask2);
+        uint32x4_t a3 = vandq_u32(x, mask3);
+        uint32x4_t a4 = vandq_u32(x, mask4);
+
+        // Shift extracted bits to align them properly
+        a2 = vshrq_n_u32(a2, 2);
+        a3 = vshrq_n_u32(a3, 4);
+        a4 = vshrq_n_u32(a4, 6);
+
+        uint32x4_t y1 = vorrq_u32(a1, a2);
+        uint32x4_t y2 = vorrq_u32(a3, a4);
+        uint32x4_t y = vorrq_u32(y1, y2);
+
+        // Perform a table lookup to shuffle extracted values and align them in 12 bytes
+        vst1q_u8(t, vqtbl1q_u8(vreinterpretq_u8_u32(y), idx));
+
+        t += 12;
+        r += 16;
+    }
+
+    // Handle the remaining registers individually (12 bytes)
+    for (int i = HLL_REGISTERS - 16; i < HLL_REGISTERS; i++) {
+        HLL_DENSE_SET_REGISTER(reg_dense, i, reg_raw[i]);
+    }
+}
+#endif /* HAVE_ARM_NEON */
+
+/* Compress raw registers to dense representation. */
+void hllDenseCompress(uint8_t *reg_dense, const uint8_t *reg_raw) {
+#if HAVE_X86_SIMD && HLL_REGISTERS == 16384 && HLL_BITS == 6
+    if (HLL_USE_AVX2) {
+        hllDenseCompressAVX2(reg_dense, reg_raw);
+        return;
+    }
+
+#endif
+
+#if HAVE_ARM_NEON && HLL_REGISTERS == 16384 && HLL_BITS == 6
+    if (HLL_USE_NEON) {
+        hllDenseCompressNEON(reg_dense, reg_raw);
+        return;
+    }
+#endif
+
+    for (int i = 0; i < HLL_REGISTERS; i++) {
+        HLL_DENSE_SET_REGISTER(reg_dense, i, reg_raw[i]);
+    }
 }
 
 /* ========================== HyperLogLog commands ========================== */
-robj* createHLLObject(void) {
-  robj* o;
-  struct hllhdr* hdr;
-  sds s;
-  uint8_t* p;
-  int sparselen =
-      HLL_HDR_SIZE +
-      (((HLL_REGISTERS + (HLL_SPARSE_XZERO_MAX_LEN - 1)) / HLL_SPARSE_XZERO_MAX_LEN) * 2);
-  int aux;
 
-  /* Populate the sparse representation with as many XZERO opcodes as
-   * needed to represent all the registers. */
-  aux = HLL_REGISTERS;
-  s = sdsnewlen(NULL, sparselen);
-  p = (uint8_t*)s + HLL_HDR_SIZE;
-  while (aux) {
-    int xzero = HLL_SPARSE_XZERO_MAX_LEN;
-    if (xzero > aux)
-      xzero = aux;
-    HLL_SPARSE_XZERO_SET(p, xzero);
-    p += 2;
-    aux -= xzero;
-  }
-  serverAssert((p - (uint8_t*)s) == sparselen);
+#if 0
+/* Create an HLL object. We always create the HLL using sparse encoding.
+ * This will be upgraded to the dense representation as needed. */
+robj *createHLLObject(void) {
+    robj *o;
+    struct hllhdr *hdr;
+    sds s;
+    uint8_t *p;
+    int sparselen = HLL_HDR_SIZE + (((HLL_REGISTERS + (HLL_SPARSE_XZERO_MAX_LEN - 1)) / HLL_SPARSE_XZERO_MAX_LEN) * 2);
+    int aux;
 
-  /* Create the actual object. */
-  o = createObject(OBJ_STRING, s);
-  hdr = o->ptr;
-  memcpy(hdr->magic, "HYLL", 4);
-  hdr->encoding = HLL_SPARSE;
-  return o;
+    /* Populate the sparse representation with as many XZERO opcodes as
+     * needed to represent all the registers. */
+    aux = HLL_REGISTERS;
+    s = sdsnewlen(NULL, sparselen);
+    p = (uint8_t *)s + HLL_HDR_SIZE;
+    while (aux) {
+        int xzero = HLL_SPARSE_XZERO_MAX_LEN;
+        if (xzero > aux) xzero = aux;
+        HLL_SPARSE_XZERO_SET(p, xzero);
+        p += 2;
+        aux -= xzero;
+    }
+    serverAssert((p - (uint8_t *)s) == sparselen);
+
+    /* Create the actual object. */
+    o = createObject(OBJ_STRING, s);
+    hdr = objectGetVal(o);
+    memcpy(hdr->magic, "HYLL", 4);
+    hdr->encoding = HLL_SPARSE;
+    return o;
 }
 #endif
 
@@ -1207,8 +1684,8 @@ size_t getDenseHllSize() {
 }
 
 size_t getSparseHllInitSize() {
-  return HLL_HDR_SIZE + (((HLL_REGISTERS+(HLL_SPARSE_XZERO_MAX_LEN-1)) /
-                     HLL_SPARSE_XZERO_MAX_LEN)*2);
+  return HLL_HDR_SIZE +
+         (((HLL_REGISTERS + (HLL_SPARSE_XZERO_MAX_LEN - 1)) / HLL_SPARSE_XZERO_MAX_LEN) * 2);
 }
 
 int initSparseHll(struct HllBufferPtr hll_ptr) {
@@ -1219,15 +1696,16 @@ int initSparseHll(struct HllBufferPtr hll_ptr) {
   memset(hll_ptr.hll, 0, hll_ptr.size);
 
   /* Populate the sparse representation with as many XZERO opcodes as
-    * needed to represent all the registers. */
+   * needed to represent all the registers. */
   int aux = HLL_REGISTERS;
   uint8_t* p = (uint8_t*)hll_ptr.hll + HLL_HDR_SIZE;
-  while(aux) {
-      int xzero = HLL_SPARSE_XZERO_MAX_LEN;
-      if (xzero > aux) xzero = aux;
-      HLL_SPARSE_XZERO_SET(p,xzero);
-      p += 2;
-      aux -= xzero;
+  while (aux) {
+    int xzero = HLL_SPARSE_XZERO_MAX_LEN;
+    if (xzero > aux)
+      xzero = aux;
+    HLL_SPARSE_XZERO_SET(p, xzero);
+    p += 2;
+    aux -= xzero;
   }
 
   struct hllhdr* hdr = (struct hllhdr*)hll_ptr.hll;
@@ -1249,11 +1727,13 @@ int createDenseHll(struct HllBufferPtr hll_ptr) {
   return C_OK;
 }
 
-/* This is a copied & modified version of hllSparseToDense() above that does not use robj */
+/* This is a copied & modified version of hllSparseToDense() above that does not use sds.
+ * Keep the run-length overflow checks in sync with it (CVE-2025-32023). */
 int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_hll) {
   struct hllhdr *hdr, *oldhdr = (struct hllhdr*)in_hll.hll;
   int idx = 0, runlen, regval;
   uint8_t *p = (uint8_t*)in_hll.hll, *end = p + in_hll.size;
+  int valid = 1;
 
   if (oldhdr->encoding != HLL_SPARSE)
     return C_ERR;
@@ -1273,17 +1753,27 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
   while (p < end) {
     if (HLL_SPARSE_IS_ZERO(p)) {
       runlen = HLL_SPARSE_ZERO_LEN(p);
+      if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+        valid = 0;
+        break;
+      }
       idx += runlen;
       p++;
     } else if (HLL_SPARSE_IS_XZERO(p)) {
       runlen = HLL_SPARSE_XZERO_LEN(p);
+      if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+        valid = 0;
+        break;
+      }
       idx += runlen;
       p += 2;
     } else {
       runlen = HLL_SPARSE_VAL_LEN(p);
       regval = HLL_SPARSE_VAL_VALUE(p);
-      if ((runlen + idx) > HLL_REGISTERS)
-        break; /* Overflow. */
+      if ((runlen + idx) > HLL_REGISTERS) { /* Overflow. */
+        valid = 0;
+        break;
+      }
       while (runlen--) {
         HLL_DENSE_SET_REGISTER(hdr->registers, idx, regval);
         idx++;
@@ -1294,28 +1784,29 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
 
   /* If the sparse representation was valid, we expect to find idx
    * set to HLL_REGISTERS. */
-  if (idx != HLL_REGISTERS) {
+  if (!valid || idx != HLL_REGISTERS) {
     return C_ERR;
   }
 
   return C_OK;
 }
 
-int pfadd_sparse(sds* hll_ptr, const unsigned char* value,
-                 size_t size, int* promoted) {
-  struct hllhdr* hdr = (struct hllhdr*)(*hll_ptr);
+int pfadd_sparse(sds* hll_ptr, const unsigned char* value, size_t size, int* promoted) {
   int retval = hllSparseAdd(hll_ptr, (unsigned char*)value, size, promoted);
   switch (retval) {
-    case 1:
+    case 1: {
+      /* Re-read the header: hllSparseAdd() may have reallocated the sds string,
+       * or replaced it entirely when promoting to the dense encoding. */
+      struct hllhdr* hdr = (struct hllhdr*)(*hll_ptr);
       HLL_INVALIDATE_CACHE(hdr);
       return 1;
+    }
     default:
       return retval;
   }
 }
 
-int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value,
-                size_t size) {
+int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value, size_t size) {
   if (isValidHLL(hll_ptr) != HLL_VALID_DENSE)
     return C_ERR;
 
@@ -1369,19 +1860,6 @@ int64_t pfcountSingle(struct HllBufferPtr hll_ptr) {
   return card;
 }
 
-/* Merge dense-encoded HLL */
-static void hllMergeDense(uint8_t* registers, struct HllBufferPtr to) {
-  uint8_t val;
-  struct hllhdr* hll_hdr = (struct hllhdr*)to.hll;
-
-  for (int i = 0; i < HLL_REGISTERS; i++) {
-    HLL_DENSE_GET_REGISTER(val, hll_hdr->registers, i);
-    if (val > registers[i]) {
-      registers[i] = val;
-    }
-  }
-}
-
 int64_t pfcountMulti(struct HllBufferPtr* hlls, size_t hlls_count) {
   struct hllhdr* hdr;
   uint8_t max[HLL_HDR_SIZE + HLL_REGISTERS];
@@ -1390,6 +1868,10 @@ int64_t pfcountMulti(struct HllBufferPtr* hlls, size_t hlls_count) {
   memset(max, 0, sizeof(max));
   hdr = (struct hllhdr*)max;
   hdr->encoding = HLL_RAW; /* Special internal-only encoding. */
+
+  /* hllCount() reads the raw registers from hdr->registers, so the merge must
+   * target the same offset and not the start of the buffer. */
+  uint8_t* registers = max + HLL_HDR_SIZE;
   for (size_t j = 0; j < hlls_count; j++) {
     /* Check type and size. */
     struct HllBufferPtr hll = hlls[j];
@@ -1397,7 +1879,7 @@ int64_t pfcountMulti(struct HllBufferPtr* hlls, size_t hlls_count) {
       return C_ERR;
     }
 
-    hllMergeDense(max, hll);
+    hllMergeDense(registers, ((struct hllhdr*)hll.hll)->registers);
   }
 
   /* Compute cardinality of the resulting set. */
@@ -1422,14 +1904,24 @@ int pfmerge(struct HllBufferPtr* in_hlls, size_t in_hlls_count, struct HllBuffer
       return C_ERR;
     }
 
-    hllMergeDense(max, hll);
+    hllMergeDense(max, ((struct hllhdr*)hll.hll)->registers);
   }
 
   struct hllhdr* hdr = (struct hllhdr*)out_hll.hll;
-  for (size_t j = 0; j < HLL_REGISTERS; j++) {
-    hllDenseSet(hdr->registers, j, max[j]);
-  }
+  hllDenseCompress(hdr->registers, max);
   HLL_INVALIDATE_CACHE(hdr);
 
   return C_OK;
+}
+
+/* Test-only knob mirroring valkey's `PFDEBUG SIMD (ON|OFF)`: lets unit tests
+ * check that the AVX2/NEON fast paths agree with the scalar implementation.
+ * Returns 1 if a SIMD fast path is in effect after the call. */
+int hllEnableSimd(int enable) {
+#if SIMD_SUPPORTED
+  simd_enabled = enable;
+#else
+  (void)enable;
+#endif
+  return (HLL_USE_AVX2 || HLL_USE_NEON) ? 1 : 0;
 }

--- a/src/redis/hyperloglog.h
+++ b/src/redis/hyperloglog.h
@@ -11,6 +11,16 @@
  * We do support converting of existing sprase-encoded HLL into dense-encoded, which can be useful
  * for replication, serialization, etc. */
 
+/* hyperloglog.c is kept textually as close to valkey's src/hyperloglog.c as possible so that
+ * re-syncing stays cheap: `git log <sync-point>..origin/unstable -- src/hyperloglog.c` in a valkey
+ * clone lists exactly what is outstanding. Last synced with valkey 06d30f293 ("Fix PFADD corrupted
+ * sparse HLL handling by restoring hllSparseSet return type", 2026-02-10).
+ *
+ * The deliberate differences are: no robj/server.h (the sparse helpers take an sds*, and the
+ * command implementations are replaced by the HllBufferPtr API below); server.hll_sparse_max_bytes
+ * is the compile-time HLL_SPARSE_MAX_BYTES; and the upstream functions that have a Dragonfly
+ * counterpart (hllAdd, hllMerge, createHLLObject) are kept under `#if 0` as its reference. */
+
 enum HllValidness {
   HLL_INVALID,
   HLL_VALID_SPARSE,
@@ -43,7 +53,10 @@ int createDenseHll(struct HllBufferPtr hll_ptr);
 int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_hll);
 
 /* Adds `value` of size `size`, to `hll_ptr`.
- * If `obj` does not have an underlying type of HLL a negative number is returned. */
+ * If `obj` does not have an underlying type of HLL a negative number is returned.
+ * pfadd_sparse() may reallocate `*hll_ptr`, or replace it with a dense-encoded
+ * HLL when the sparse encoding can no longer represent the value; in the latter
+ * case `*promoted` is set to 1. */
 int pfadd_sparse(sds* hll_ptr, const unsigned char* value, size_t size, int* promoted);
 int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value, size_t size);
 
@@ -58,7 +71,15 @@ int64_t pfcountMulti(struct HllBufferPtr* hlls, size_t hlls_count);
 /* Merges array of HLLs pointed to be `in_hlls` of size `in_hlls_count` into `out_hll`.
  * Returns 0 upon success, otherwise a negative number.
  * Failure can occur when any of `in_hlls` or `out_hll` is not a dense-encoded HLL.
- * `out_hll` *can* be one of the elements in `in_hlls`. */
+ * `out_hll` *can* be one of the elements in `in_hlls`. Note that the registers of
+ * `out_hll` are overwritten with the merge result rather than raised to it, so any
+ * cardinality it held that is not also in `in_hlls` is lost. */
 int pfmerge(struct HllBufferPtr* in_hlls, size_t in_hlls_count, struct HllBufferPtr out_hll);
+
+/* Test-only knob mirroring valkey's `PFDEBUG SIMD (ON|OFF)`: enables or disables the
+ * AVX2/NEON fast paths used by pfmerge() and pfcountMulti(), so that tests can check
+ * that they agree with the scalar implementation.
+ * Returns 1 if a SIMD fast path is in effect after the call, 0 otherwise. */
+int hllEnableSimd(int enable);
 
 #endif

--- a/src/redis/hyperloglog.h
+++ b/src/redis/hyperloglog.h
@@ -27,7 +27,18 @@ enum HllValidness {
   HLL_VALID_DENSE,
 };
 
-/* Convenience struct for pointing to an Hll buffer along with its size */
+/* Convenience struct for pointing to an Hll buffer along with its size.
+ *
+ * A dense buffer must have one readable and writable byte past `size`, i.e. the
+ * allocation has to be getDenseHllSize() + 1 bytes even though `size` stays
+ * getDenseHllSize(). HLL_DENSE_GET_REGISTER/HLL_DENSE_SET_REGISTER address the
+ * two bytes a register may straddle unconditionally, so register 16383 - which
+ * ends on a byte boundary and needs only the first - still touches the one after
+ * it. The extra byte never affects the result (the read is masked off and the
+ * write is a no-op), but the access is real: without it, every pfmerge(),
+ * pfcountMulti() and unlucky pfadd_dense() reads and rewrites one byte past the
+ * end. std::string and sds buffers satisfy this through their terminator; a raw
+ * `new uint8_t[getDenseHllSize()]` does not. */
 struct HllBufferPtr {
   unsigned char* hll;
   size_t size;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1863,7 +1863,7 @@ void DbSlice::StartSampleKeys(DbIndex db_ind) {
 
   HllBufferPtr hll_buf;
   hll_buf.size = getDenseHllSize();
-  hll_buf.hll = new uint8_t[hll_buf.size];
+  hll_buf.hll = new uint8_t[hll_buf.size + 1];
   CHECK_EQ(0, createDenseHll(hll_buf));
   db.sample_unique_keys = new DbTable::SampleUniqueKeys;
   db.sample_unique_keys->dense_hll = hll_buf.hll;

--- a/src/server/hll_family_test.cc
+++ b/src/server/hll_family_test.cc
@@ -1,6 +1,18 @@
 // Copyright 2023, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
+extern "C" {
+#include "redis/hyperloglog.h"
+
+/* Internal to hyperloglog.c. Declared here so that the benchmarks at the bottom
+ * can time the two kernels that AVX2/NEON accelerate on their own, without the
+ * validation and cardinality work pfmerge()/pfcountMulti() wrap them in. */
+void hllMergeDense(uint8_t* reg_raw, const uint8_t* reg_dense);
+void hllDenseCompress(uint8_t* reg_dense, const uint8_t* reg_raw);
+}
+
+#include <absl/functional/function_ref.h>
+
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/error.h"
@@ -13,6 +25,62 @@ using namespace util;
 using namespace facade;
 
 namespace dfly {
+
+namespace {
+
+constexpr char kCorruptedHllError[] = "INVALIDOBJ Corrupted HLL object detected.";
+
+// Builds the CVE-2025-32023 payload: a sparse HLL whose XZERO run lengths sum
+// past INT_MAX, so the `idx` cursor wraps negative and the trailing VAL opcode
+// slips past the `(runlen + idx) > HLL_REGISTERS` guard. Before the run-length
+// checks were added to every opcode branch, decoding this wrote a register
+// through a wild pointer and crashed the server.
+std::string MakeOverflowingSparseHll() {
+  // 155486 * 16384 wraps `idx` to a value whose *6 (bits per register) is still
+  // negative, so the resulting byte offset is a huge unsigned number.
+  constexpr int kXZeroOps = 155486;
+
+  std::string hll;
+  hll.reserve(16 + kXZeroOps * 2 + 1);
+  hll.append("HYLL");   // magic
+  hll.push_back(1);     // encoding = HLL_SPARSE
+  hll.append(3, '\0');  // notused
+  hll.append(8, '\0');  // cached cardinality
+  for (int i = 0; i < kXZeroOps; ++i) {
+    hll.push_back('\x7f');  // XZERO, 14-bit length-1 == 16383
+    hll.push_back('\xff');
+  }
+  hll.push_back('\x80');  // VAL: value 1, run length 1
+  return hll;
+}
+
+// Builds a dense HLL whose register i holds value_at(i). Elements added through
+// PFADD only ever produce small register values, which leaves the top bits of
+// the 6-bit registers untested; the SIMD kernels pack and unpack all six, so
+// their tests need registers spanning the whole 0..63 range.
+std::string MakeDenseHll(absl::FunctionRef<unsigned(int)> value_at) {
+  constexpr int kRegisters = 16384;
+  constexpr int kBits = 6;
+
+  // One byte of slack: setting the last register touches the byte just past the
+  // register array, which is the implicit terminator hyperloglog.c relies on.
+  std::vector<uint8_t> buf(getDenseHllSize() + 1, 0);
+  CHECK_EQ(createDenseHll({buf.data(), getDenseHllSize()}), 0);
+
+  uint8_t* regs = buf.data() + (getDenseHllSize() - kRegisters * kBits / 8);
+  for (int i = 0; i < kRegisters; ++i) {
+    const unsigned v = value_at(i) & 63;
+    const unsigned byte = i * kBits / 8;
+    const unsigned fb = (i * kBits) & 7;
+    regs[byte] &= ~(63u << fb);
+    regs[byte] |= v << fb;
+    regs[byte + 1] &= ~(63u >> (8 - fb));
+    regs[byte + 1] |= v >> (8 - fb);
+  }
+  return std::string(reinterpret_cast<char*>(buf.data()), getDenseHllSize());
+}
+
+}  // namespace
 
 class HllFamilyTest : public BaseFamilyTest {
  protected:
@@ -226,5 +294,289 @@ TEST_F(HllFamilyTest, MergeWithInvalidHllFormat) {
                    "\"key with \\\"quotes\\\"\" \"value with \\\\backslashes\\\\\""}),
               ErrArg("INVALIDOBJ Corrupted HLL object detected."));
 }
+
+// CVE-2025-32023. Reading this payload used to run the sparse decoder's cursor
+// past INT_MAX and write a register through a wild pointer; every opcode branch
+// now checks the run length, so all three commands report the HLL as corrupted.
+TEST_F(HllFamilyTest, CorruptedSparseRunLengthOverflow) {
+  const string payload = MakeOverflowingSparseHll();
+  ASSERT_EQ(Run({"set", "overflow", payload}), "OK");
+
+  // PFCOUNT and PFMERGE decode through convertSparseToDenseHll().
+  EXPECT_THAT(Run({"pfcount", "overflow"}), ErrArg(kCorruptedHllError));
+
+  EXPECT_EQ(CheckedInt({"pfadd", "src", "hi"}), 1);
+  EXPECT_THAT(Run({"pfmerge", "dest", "overflow", "src"}), ErrArg(kCorruptedHllError));
+
+  // PFADD decodes through hllSparseSet()'s promote path: the value is far above
+  // HLL_SPARSE_MAX_BYTES, so the very first insert tries to convert to dense.
+  EXPECT_THAT(Run({"pfadd", "overflow", "foo"}), ErrArg(kInvalidHllError));
+}
+
+// Covers the ZERO/XZERO arm of the same guard on an input small enough not to
+// need integer overflow: an over-long run must be rejected, never truncated.
+// (This case was already rejected before the fix, by the trailing
+// `idx != HLL_REGISTERS` check.)
+TEST_F(HllFamilyTest, CorruptedSparseTruncatedRun) {
+  // XZERO covering 16384 registers followed by another one: the second overruns
+  // the register space, and nothing else in the value can make up for it.
+  string hll("HYLL", 4);
+  hll.push_back(1);
+  hll.append(3, '\0');
+  hll.append(8, '\0');
+  for (int i = 0; i < 2; ++i) {
+    hll.push_back('\x7f');
+    hll.push_back('\xff');
+  }
+  ASSERT_EQ(Run({"set", "truncated", hll}), "OK");
+  EXPECT_THAT(Run({"pfcount", "truncated"}), ErrArg(kCorruptedHllError));
+}
+
+// PFCOUNT over several keys merges into a raw register array; it used to write
+// that array HLL_HDR_SIZE bytes too low, so the estimate silently dropped the
+// first 16 registers and counted 16 zeroed ones instead. The union estimate has
+// to match the cardinality of the same keys merged with PFMERGE exactly.
+TEST_F(HllFamilyTest, CountMultipleAgreesWithMerge) {
+  constexpr int kValuesPerKey = 20000;
+  for (int i = 0; i < kValuesPerKey; ++i) {
+    Run({"pfadd", "k1", GenerateUniqueValue(i)});
+    Run({"pfadd", "k2", GenerateUniqueValue(kValuesPerKey + i)});
+  }
+
+  ASSERT_EQ(Run({"pfmerge", "merged", "k1", "k2"}), "OK");
+  const int64_t merged = CheckedInt({"pfcount", "merged"});
+  EXPECT_EQ(CheckedInt({"pfcount", "k1", "k2"}), merged);
+
+  // Sanity check that the shared estimate is in the right ballpark.
+  EXPECT_LT(std::abs(merged - 2.0 * kValuesPerKey) / (2.0 * kValuesPerKey), 0.05);
+}
+
+// The AVX2 / NEON dense<->raw conversions must agree bit for bit with the scalar
+// loops they replace. PFMERGE exercises both directions (hllMergeDense to unpack
+// each input, hllDenseCompress to pack the result); PFCOUNT over several keys
+// exercises the unpack direction on its own.
+TEST_F(HllFamilyTest, SimdMatchesScalar) {
+  if (!hllEnableSimd(1)) {
+    GTEST_SKIP() << "no SIMD fast path on this CPU";
+  }
+
+  // Three patterns that between them put every value in 0..63 into every
+  // position within the 4-registers-per-3-bytes packing group, and that differ
+  // per input so the max() in the merge is exercised too.
+  ASSERT_EQ(Run({"set", "s1", MakeDenseHll([](int i) -> unsigned { return i % 64; })}), "OK");
+  ASSERT_EQ(Run({"set", "s2", MakeDenseHll([](int i) -> unsigned { return (i * 7 + 3) % 64; })}),
+            "OK");
+  ASSERT_EQ(Run({"set", "s3", MakeDenseHll([](int i) -> unsigned { return (i / 64) % 64; })}),
+            "OK");
+
+  ASSERT_EQ(Run({"pfmerge", "simd", "s1", "s2", "s3"}), "OK");
+  const int64_t simd_count = CheckedInt({"pfcount", "s1", "s2", "s3"});
+  const string simd_merged = Run({"get", "simd"}).GetString();
+
+  ASSERT_EQ(hllEnableSimd(0), 0);
+  ASSERT_EQ(Run({"pfmerge", "scalar", "s1", "s2", "s3"}), "OK");
+  const int64_t scalar_count = CheckedInt({"pfcount", "s1", "s2", "s3"});
+  const string scalar_merged = Run({"get", "scalar"}).GetString();
+  hllEnableSimd(1);
+
+  EXPECT_EQ(simd_count, scalar_count);
+  EXPECT_EQ(simd_merged, scalar_merged);
+}
+
+// hllSparseSet() promotes straight to dense when the count cannot be held by a
+// VAL opcode. The generated input has 35 zero bits after the 14-bit HLL
+// register index, giving hllPatLen() a count of 36. It was generated with:
+//   python3 murmur_invert.py --trailing-zeroes 35
+TEST_F(HllFamilyTest, SparseSetPromotesOnLargeCount) {
+  constexpr string_view kPromotingValue = ".K{bTLLX";
+
+  EXPECT_EQ(CheckedInt({"pfadd", "key", kPromotingValue}), 1);
+  EXPECT_EQ(CheckedInt({"strlen", "key"}), getDenseHllSize());
+  EXPECT_EQ(CheckedInt({"pfcount", "key"}), 1);
+}
+
+// Benchmarks comparing the AVX2/NEON kernels against the scalar loops they
+// replace. They call hyperloglog.c directly so that the numbers are not diluted
+// by command parsing, the transaction framework or key lookups:
+//
+//   build-opt/hll_family_test --bench --gtest_filter=-'*' --benchmark_min_time=0.5s
+//
+// The gtest filter matters: without it the 21 tests run first. Use a release
+// build -- at -O0 the scalar C loops are penalized far more than in production.
+namespace {
+
+constexpr int kRegisters = 16384;
+constexpr size_t kDenseRegBytes = kRegisters * 6 / 8;
+
+// Registers of a dense HLL built by MakeDenseHll(), i.e. its buffer past the
+// header. hllMergeDense() takes this rather than the whole HLL.
+const uint8_t* DenseRegisters(const string& hll) {
+  return reinterpret_cast<const uint8_t*>(hll.data()) + (getDenseHllSize() - kDenseRegBytes);
+}
+
+// Register values spanning the full 0..63 range, so that the packing and
+// unpacking of all six bits is timed. `seed` makes sources differ from each
+// other, which keeps the max() in the merge from degenerating.
+unsigned BenchRegister(int seed, int i) {
+  return (i * 2654435761u + seed * 40503u) >> 26;
+}
+
+// Selects the scalar or the SIMD implementation for the duration of a
+// benchmark, restoring the default afterwards. `state.range(0)` is the SIMD
+// flag. The SIMD variants are skipped when the host CPU has neither AVX2 nor
+// NEON, so that the two rows never both report the scalar timing.
+class SimdSelector {
+ public:
+  explicit SimdSelector(benchmark::State& state) {
+    const bool want_simd = state.range(0) != 0;
+    if (want_simd && hllEnableSimd(1) == 0) {
+      state.SkipWithMessage("no AVX2/NEON implementation on this CPU");
+      skipped_ = true;
+    } else if (!want_simd) {
+      hllEnableSimd(0);
+    }
+  }
+
+  ~SimdSelector() {
+    hllEnableSimd(1);
+  }
+
+  bool skipped() const {
+    return skipped_;
+  }
+
+ private:
+  bool skipped_ = false;
+};
+
+// Dense HLLs to merge, plus the HllBufferPtr array pointing at them.
+struct MergeInputs {
+  explicit MergeInputs(int64_t count) {
+    hlls.reserve(count);
+    ptrs.reserve(count);
+    for (int64_t i = 0; i < count; ++i)
+      hlls.push_back(MakeDenseHll([i](int reg) { return BenchRegister(i + 1, reg); }));
+    for (string& hll : hlls)
+      ptrs.push_back({reinterpret_cast<unsigned char*>(hll.data()), hll.size()});
+  }
+
+  vector<string> hlls;
+  vector<HllBufferPtr> ptrs;
+};
+
+}  // namespace
+
+// Dense -> raw: the inner loop of both PFMERGE and a multi-key PFCOUNT.
+static void BM_HllMergeDense(benchmark::State& state) {
+  SimdSelector simd(state);
+  if (simd.skipped())
+    return;
+
+  const string dense = MakeDenseHll([](int i) { return BenchRegister(1, i); });
+  const uint8_t* regs = DenseRegisters(dense);
+  vector<uint8_t> raw(kRegisters, 0);
+
+  while (state.KeepRunning()) {
+    hllMergeDense(raw.data(), regs);
+  }
+  state.SetItemsProcessed(state.iterations() * kRegisters);
+}
+BENCHMARK(BM_HllMergeDense)->ArgName("simd")->Arg(0)->Arg(1);
+
+// Raw -> dense: PFMERGE's write-back step, run once per command.
+//
+// Read the simd:0 row as "the fallback on a CPU without AVX2/NEON", not as the
+// cost of the work itself. HLL_DENSE_SET_REGISTER does four byte-wide
+// read-modify-writes per register, and consecutive registers share bytes, so
+// every load waits on the previous store to forward: the loop is one long
+// dependency chain at ~20 cycles per register. BM_HllDenseCompressUnchained
+// below packs the same bytes without that chain and is ~19x faster while still
+// scalar, which is where most of the simd:1 speedup here actually comes from.
+static void BM_HllDenseCompress(benchmark::State& state) {
+  SimdSelector simd(state);
+  if (simd.skipped())
+    return;
+
+  vector<uint8_t> raw(kRegisters);
+  for (int i = 0; i < kRegisters; ++i)
+    raw[i] = BenchRegister(1, i);
+
+  // One byte of slack: writing the last register touches the byte just past the
+  // register array, the same terminator MakeDenseHll() accounts for.
+  vector<uint8_t> dense(kDenseRegBytes + 1, 0);
+
+  while (state.KeepRunning()) {
+    hllDenseCompress(dense.data(), raw.data());
+  }
+  state.SetItemsProcessed(state.iterations() * kRegisters);
+}
+BENCHMARK(BM_HllDenseCompress)->ArgName("simd")->Arg(0)->Arg(1);
+
+// Scalar reference baseline, not used in production: emits the same bytes as
+// hllDenseCompress() by building each output byte once instead of updating it
+// twice, so no byte is read back after being written. Its only job is to keep
+// the simd:1 number above honest -- comparing AVX2 against *this* isolates the
+// vectorization win from the store-forwarding stall the macro loop pays.
+static void BM_HllDenseCompressUnchained(benchmark::State& state) {
+  vector<uint8_t> raw(kRegisters);
+  for (int i = 0; i < kRegisters; ++i)
+    raw[i] = BenchRegister(1, i);
+
+  vector<uint8_t> dense(kDenseRegBytes + 1, 0);
+  auto compress = [&] {
+    // 4 registers pack into 3 bytes: {bbaaaaaa|ccccbbbb|ddddddcc}.
+    for (int i = 0; i < kRegisters; i += 4) {
+      const uint32_t a = raw[i], b = raw[i + 1], c = raw[i + 2], d = raw[i + 3];
+      uint8_t* out = dense.data() + i * 6 / 8;
+      out[0] = a | (b << 6);
+      out[1] = (b >> 2) | (c << 4);
+      out[2] = (c >> 4) | (d << 2);
+    }
+  };
+
+  // Guard against the reference drifting from the real thing.
+  vector<uint8_t> expected(kDenseRegBytes + 1, 0);
+  hllDenseCompress(expected.data(), raw.data());
+  compress();
+  CHECK(memcmp(dense.data(), expected.data(), kDenseRegBytes) == 0);
+
+  while (state.KeepRunning()) {
+    compress();
+  }
+  state.SetItemsProcessed(state.iterations() * kRegisters);
+}
+BENCHMARK(BM_HllDenseCompressUnchained);
+
+// PFMERGE end to end: one merge per source, then one compress.
+static void BM_PfMerge(benchmark::State& state) {
+  SimdSelector simd(state);
+  if (simd.skipped())
+    return;
+
+  MergeInputs inputs(state.range(1));
+  string out = MakeDenseHll([](int) -> unsigned { return 0; });
+  const HllBufferPtr out_ptr{reinterpret_cast<unsigned char*>(out.data()), out.size()};
+
+  while (state.KeepRunning()) {
+    CHECK_EQ(pfmerge(inputs.ptrs.data(), inputs.ptrs.size(), out_ptr), 0);
+  }
+  state.SetItemsProcessed(state.iterations() * state.range(1) * kRegisters);
+}
+BENCHMARK(BM_PfMerge)->ArgNames({"simd", "sources"})->ArgsProduct({{0, 1}, {1, 8}});
+
+// PFCOUNT over several keys: one merge per source, then the cardinality estimate.
+static void BM_PfCountMulti(benchmark::State& state) {
+  SimdSelector simd(state);
+  if (simd.skipped())
+    return;
+
+  MergeInputs inputs(state.range(1));
+
+  while (state.KeepRunning()) {
+    benchmark::DoNotOptimize(pfcountMulti(inputs.ptrs.data(), inputs.ptrs.size()));
+  }
+  state.SetItemsProcessed(state.iterations() * state.range(1) * kRegisters);
+}
+BENCHMARK(BM_PfCountMulti)->ArgNames({"simd", "sources"})->ArgsProduct({{0, 1}, {1, 8}});
 
 }  // namespace dfly

--- a/src/server/string_stats.cc
+++ b/src/server/string_stats.cc
@@ -12,7 +12,7 @@ namespace {
 
 void MakeHLL(HllBufferPtr* p) {
   p->size = getDenseHllSize();
-  p->hll = new uint8_t[p->size];
+  p->hll = new uint8_t[p->size + 1];
   CHECK_EQ(0, createDenseHll(*p));
 }
 


### PR DESCRIPTION
## Summary

Re-syncs `src/redis/hyperloglog.c`, forked from valkey `56ec1ff1c` two years ago, with upstream `06d30f293`. The file now keeps upstream's own formatting (`src/redis/**` is excluded from pre-commit clang-format, so this is free), which is what makes the remaining diff readable.

**Divergence from upstream: 2139 → 767 differing lines**, and the remainder is accounted for:

| | lines | |
|---|---|---|
| shared library half (lines 1-1620) | **72** | all load-bearing — see below |
| upstream command/reply layer | 695 | `pfaddCommand`/`pfcountCommand`/`pfmergeCommand`/`pfselftestCommand`/`pfdebugCommand`/`isHLLObjectOrReply` vs the `HllBufferPtr` API that replaces them |

The 72 lines in the shared half are: the include block, `HLL_SPARSE_MAX_BYTES` replacing `server.hll_sparse_max_bytes`, dropping the unused `invalid_hll_err`, the `robj`/`objectGetVal` → `sds *`/`hll` conversion in the three sparse helpers, the `promoted` out-param, and five `#if 0`/`#endif` markers. No comment- or formatting-only differences are left. Upstream functions that have a Dragonfly counterpart (`hllAdd`, `hllMerge`, `createHLLObject`) sit under `#if 0` as its reference, which is both cheaper than deleting them and useful documentation; the command/reply layer is genuinely irrelevant here and stays deleted. The provenance note (sync point + the list of deliberate deltas) lives in `hyperloglog.h`, so it costs nothing against upstream.

## Imported from upstream

- **CVE-2025-32023** (`20f5199d9`) — run-length overflow guards on every sparse opcode, not just `VAL`. A sparse payload whose `XZERO` runs sum past `INT_MAX` wrapped the `idx` cursor negative, so the trailing `VAL` slipped past the guard and wrote a register through a wild pointer. Reachable from `PFCOUNT`, `PFMERGE` and `PFADD` on any `SET` string carrying a `HYLL` + sparse header.
- **`__builtin_ctzll()` in `hllPatLen()`** (`744b13e30`) in place of the trailing-zero loop.
- **AVX2 (`3df609ef0`) and ARM NEON (`dd772c490`) `hllMergeDense()`/`hllDenseCompress()` kernels** and their runtime dispatchers. `PFMERGE` and multi-key `PFCOUNT` now go through them. `src/redis/config.h` gains upstream's `HAVE_X86_SIMD`, `HAVE_ARM_NEON`, `ATTRIBUTE_TARGET_*` and `VALKEY_NO_SANITIZE` macros.
- `VALKEY_NO_SANITIZE("alignment")` on `MurmurHash64A`. Including `config.h` also makes `BYTE_ORDER` actually defined there — it previously wasn't, and the little-endian branch was taken only because `0 == 0`.

`06d30f293` itself (an `hllSparseSet` return-type regression from upstream's small-strings refactor) never applied here, but its behaviour — `PFADD` on a corrupted sparse HLL must report `INVALIDOBJ` — is now covered.

## Dragonfly-local bugs the sync exposed

- **`pfcountMulti()` merged into the raw register array `HLL_HDR_SIZE` bytes too low.** `hllCount(HLL_RAW)` reads `hdr->registers` (`max + 16`) but the merge wrote from `max`, so every multi-key `PFCOUNT` dropped registers 0-15 and counted 16 zeroed ones instead. It did not crash only because `encoding = HLL_RAW = 255` is larger than any register value, so the merge never overwrote it.
- **`goto promote` in `hllSparseSet()` jumped over the `sds hll` initialization**, leaving the promote path dereferencing an uninitialized pointer. It needs a hash with 32+ zero bits above the 14-bit register index, so random data reaches it about once in 2³² elements — but `MurmurHash64A` is a bijection on 8-byte inputs, so an element that lands there can be constructed directly (see Tests).
- **`pfadd_sparse()` invalidated the cached cardinality through a stale header pointer** captured before `hllSparseAdd()`, which may `sdsResize` (moving `s_realloc`) or `sdsfree` on promotion. ASAN misses it because sds allocates through mimalloc.

`pfmerge()`'s dense fast path overwrites the destination registers rather than raising them, matching upstream; the header doc is updated to say so. The only caller always passes a freshly created dense HLL, so behaviour is unchanged.

## Tests

5 new cases in `hll_family_test.cc`. Each was checked against the unfixed code rather than trusted on a green pass:

| Test | Unfixed behaviour |
|---|---|
| `CorruptedSparseRunLengthOverflow` | `SIGSEGV` in `convertSparseToDenseHll` via `PFCOUNT` |
| `CountMultipleAgreesWithMerge` | `40207` vs `40332` |
| `SparseSetPromotesOnLargeCount` | no promotion, uninitialized `sds` on the promote path |
| `SimdMatchesScalar` | mutation-tested: 4 injected AVX2 faults (mask, shift, shuffle in both kernels) all caught |
| `CorruptedSparseTruncatedRun` | passes before and after — coverage for the ZERO/XZERO arm, not a regression test |

`SparseSetPromotesOnLargeCount` drives the promote branch through a real `PFADD` rather than calling `hllSparseSet()` directly. Every step of `MurmurHash64A` — multiply by the odd constant `m`, `x ^= x >> 47`, the xors with the seed — is invertible, so for an 8-byte element you can pick the hash you want and solve for the input. The element in the test hashes to 35 zero bits above the register index (count 36); the same inversion reaches any count up to the `HLL_Q + 1 = 51` ceiling.

`SimdMatchesScalar` builds dense HLLs spanning all 64 register values; `PFADD` data only ever fills the low bits, and an earlier version of the test using `PFADD` failed to catch a real fault.

## Benchmarks

5 `--bench` benchmarks in the same file, calling `hyperloglog.c` directly so the numbers are not diluted by command parsing, the transaction framework or key lookups. Each takes a `simd:0`/`simd:1` argument driven by `hllEnableSimd()`; the `simd:1` rows skip themselves on a CPU with neither AVX2 nor NEON, so you never get two rows silently timing the same scalar code.

Build a release binary — at `-O0` the scalar C loops are penalized far more than they are in production:

```
./helio/blaze.sh -release -DWITH_AWS=OFF -DWITH_GCP=OFF
cd build-opt && ninja hll_family_test
```

Then run it pinned to one core. The gtest filter matters: without it the 21 tests run first (`--gtest_filter=-` does *not* skip them — it excludes nothing).

```
$ taskset -c 4 build-opt/hll_family_test --bench --gtest_filter=-'*' --benchmark_min_time=0.5s

Note: Google Test filter = -*
[==========] Running 0 tests from 0 test suites.
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
WARNING: filter "-*" did not match any test; no tests were run
2026-07-30T09:38:41+03:00
Running ./hll_family_test
Run on (24 X 5482 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 1024 KiB (x12)
  L3 Unified 32768 KiB (x2)
Load Average: 1.02, 1.10, 1.73
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
-------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
BM_HllMergeDense/simd:0               12582 ns        12582 ns        41273 items_per_second=1.30219G/s
BM_HllMergeDense/simd:1                 383 ns          383 ns      1821945 items_per_second=42.7621G/s
BM_HllDenseCompress/simd:0            66762 ns        66761 ns        10226 items_per_second=245.411M/s
BM_HllDenseCompress/simd:1              466 ns          466 ns      1502399 items_per_second=35.1731G/s
BM_HllDenseCompressUnchained           3676 ns         3676 ns       187047 items_per_second=4.45658G/s
BM_PfMerge/simd:0/sources:1           77648 ns        77647 ns         8997 items_per_second=211.006M/s
BM_PfMerge/simd:1/sources:1             944 ns          944 ns       744688 items_per_second=17.3546G/s
BM_PfMerge/simd:0/sources:8          154197 ns       154198 ns         4529 items_per_second=850.022M/s
BM_PfMerge/simd:1/sources:8            3625 ns         3624 ns       193324 items_per_second=36.1629G/s
BM_PfCountMulti/simd:0/sources:1      15164 ns        15164 ns        46004 items_per_second=1.08048G/s
BM_PfCountMulti/simd:1/sources:1       3760 ns         3760 ns       186322 items_per_second=4.35774G/s
BM_PfCountMulti/simd:0/sources:8      92929 ns        92930 ns         7535 items_per_second=1.41044G/s
BM_PfCountMulti/simd:1/sources:8       6446 ns         6446 ns       108804 items_per_second=20.3323G/s
```

Both buffers stay L1-resident across iterations, so these are compute-bound figures; a `PFMERGE` over cold keys will look different. CPU scaling is on, as the run's own warning says.

**`BM_HllDenseCompress/simd:0` is not a fair vectorization baseline.** `HLL_DENSE_SET_REGISTER` does four byte-wide read-modify-writes per register and consecutive registers share bytes, so every load waits on the previous store to forward: the loop is one dependency chain at ~20 cycles per register (4.06 ns/register, cv 0.01% over 5 repetitions). `BM_HllDenseCompressUnchained` is a scalar reference — not production code, and `CHECK`ed byte-identical against `hllDenseCompress()` — that builds each output byte once instead of updating it twice:

| | time | vs AVX2 |
|---|---|---|
| `BM_HllDenseCompress/simd:0` (in-tree scalar) | 66762 ns | 143× |
| `BM_HllDenseCompressUnchained` | 3676 ns | **7.9×** |
| `BM_HllDenseCompress/simd:1` (AVX2) | 466 ns | — |

So the 143× is ~18× store-forwarding stall × ~8× vectorization. `BM_HllMergeDense` has no such problem — `HLL_DENSE_GET_REGISTER` is read-only, so its 33× is a genuine width-bound result against 32 registers per AVX2 iteration.

Side note, not addressed here: that leaves ~18× on the table for `hllDenseCompress()` on any build without AVX2 or NEON. It is upstream valkey code, so it belongs upstream rather than as a local divergence in a file this PR is trying to bring *closer* to upstream.

## Also run green

`hll_family_test` (21), `string_family_test` (45), `rdb_test` HLL cases, `tiered_storage_test` PF cases. Release build compiles clean. The NEON kernels are syntax-checked for aarch64 with clang but not executed locally (x86 host) — the ARM CI runner covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
