### PR TITLE
refactor: tune OAH for memory consumption

### DIFF
--- a/src/core/oah_map.h
+++ b/src/core/oah_map.h
@@ -151,8 +151,8 @@ class OAHMap : public OAHTable<OAHPair> {
   // a fresh insert.
   bool AddPairImpl(std::string_view content, uint32_t len, TaggedPtr new_tp, bool replace,
                    TaggedPtr* old_out) {
-    if (size_ >= entries_.size()) [[unlikely]] {
-      Reserve(BucketCount() * 2);
+    if (size_ >= entries_.size() * kOverloadFactor) [[unlikely]] {
+      GrowCapacity(BucketCount() * 2);
     }
     assert(Capacity() >= kDisplacementSize);
 

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -62,8 +62,8 @@ class OAHSet : public OAHTable<OAHEntry> {
 
  private:
   bool AddImpl(std::string_view content, uint32_t len, uint32_t ttl_sec) {
-    if (size_ >= entries_.size()) [[unlikely]] {
-      Reserve(BucketCount() * 2);
+    if (size_ >= entries_.size() * kOverloadFactor) [[unlikely]] {
+      GrowCapacity(BucketCount() * 2);
     }
     assert(Capacity() >= kDisplacementSize);
 

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -114,6 +114,19 @@ TEST(OAHKeyCodec, HeaderContentMatchesDecode) {
   check(non_ascii);
 }
 
+TEST_F(OAHSetTest, ShrinkUsesOverloadAwareTarget) {
+  for (unsigned i = 0; i < 4; ++i) {
+    EXPECT_TRUE(ss_->Add(absl::StrCat("member", i)));
+  }
+  ss_->Reserve(128 * OAHSet::kOverloadFactor);
+  EXPECT_EQ(ss_->BucketCount(), 128);
+
+  // The legacy caller asks for eight buckets. OAH ignores that DenseSet-oriented
+  // target and retains its legal 16-bucket minimum.
+  ss_->Shrink(8);
+  EXPECT_EQ(ss_->BucketCount(), OAHSet::kMinBucketCount);
+}
+
 TEST_F(OAHSetTest, AsciiEncoding) {
   string ascii_key(80, 'a');                // 80 ascii chars -> 70 packed bytes
   string boundary(128, 'b');                // largest ascii-encodable key
@@ -371,8 +384,8 @@ TEST_F(OAHSetTest, OAHSetAddFindTest) {
     EXPECT_EQ(KeyOf(*e), s);
   }
 
-  // ~10000 elements at load factor 1 (grow when size_ >= table size).
-  EXPECT_EQ(ss.BucketCount(), 16384);
+  // ~10000 elements at kOverloadFactor=2 (grow when size_ >= table size * 2).
+  EXPECT_EQ(ss.BucketCount(), 8192);
 }
 
 TEST_F(OAHSetTest, Basic) {
@@ -1372,7 +1385,8 @@ void BM_Grow(benchmark::State& state) {
     state.PauseTiming();
     OAHSet tmp;
     src.Fill(&tmp);
-    CHECK_EQ(tmp.BucketCount(), elems);
+    // Fill reserves via UpperBoundSize().
+    CHECK_EQ(tmp.BucketCount(), elems / OAHSet::kOverloadFactor);
     state.ResumeTiming();
     for (const auto& str : strs) {
       tmp.Add(str);
@@ -1444,7 +1458,7 @@ void BM_Shrink(benchmark::State& state) {
     ss.Clear();
     src.Fill(&ss);
     ss.Reserve(kGrowTo);
-    CHECK_EQ(ss.BucketCount(), kGrowTo);
+    CHECK_EQ(ss.BucketCount(), kGrowTo / OAHSet::kOverloadFactor);
     state.ResumeTiming();
     ss.Shrink(kShrinkTo);
   }
@@ -1511,10 +1525,11 @@ TEST_P(ShrinkTest, BasicShrink) {
     EXPECT_TRUE(ss_->Add(strs.back()));
   }
 
-  // Grow to a larger size
-  ss_->Reserve(1 << 22);
+  // Grow to a larger size.
+  constexpr size_t kGrownBuckets = 1u << 22;
+  ss_->Reserve(kGrownBuckets * OAHSet::kOverloadFactor);
   size_t original_bucket_count = ss_->BucketCount();
-  EXPECT_EQ(original_bucket_count, 1u << 22);
+  EXPECT_EQ(original_bucket_count, kGrownBuckets);
 
   // Shrink to the parameterized size
   ss_->Shrink(shrink_to);
@@ -1562,7 +1577,7 @@ TEST_F(OAHSetTest, ShrinkWithTTL) {
   }
 
   // Grow to larger size
-  ss_->Reserve(1 << 22);
+  ss_->Reserve((1u << 22) * OAHSet::kOverloadFactor);
 
   // Set time to 50 - this will expire elements with TTL <= 50
   ss_->set_time(50);
@@ -1617,8 +1632,9 @@ TEST_F(OAHSetTest, ScanWithShrinkBetweenCalls) {
   EXPECT_NE(cursor, 0u) << "Should not finish in one iteration";
 
   // Grow to large size in the middle of scanning
-  ss_->Reserve(1 << 22);
-  EXPECT_EQ(ss_->BucketCount(), 1u << 22);
+  constexpr size_t kGrownBuckets = 1u << 22;
+  ss_->Reserve(kGrownBuckets * OAHSet::kOverloadFactor);
+  EXPECT_EQ(ss_->BucketCount(), kGrownBuckets);
   EXPECT_GT(ss_->BucketCount(), initial_bucket_count);
 
   // Continue scanning a bit after Grow

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -42,9 +42,13 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   using Buckets = std::vector<TaggedPtr, StatelessAllocator<TaggedPtr>>;
 
  public:
-  static constexpr std::uint32_t kShiftLog = 2;                         // TODO make template
+  static constexpr std::uint32_t kShiftLog = 4;                         // TODO make template
   static constexpr std::uint32_t kMinCapacityLog = kShiftLog;           // should be >= ShiftLog
   static constexpr std::uint32_t kDisplacementSize = (1 << kShiftLog);  // TODO check
+
+  // Table grows once live entries reach capacity * kOverloadFactor (200% load, by default).
+  static constexpr std::uint32_t kOverloadFactor = 2;
+  static constexpr size_t kMinBucketCount = 1u << kMinCapacityLog;
 
   class iterator {
    public:
@@ -194,27 +198,21 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     FreeAllSlots();
   }
 
+  // Reserves enough capacity to hold `sz` live entries without triggering a resize.
   void Reserve(size_t sz) {
-    sz = absl::bit_ceil(sz);
-    if (sz > entries_.size()) {
-      capacity_log_ = std::max(kMinCapacityLog, uint32_t(absl::bit_width(sz) - 1));
-      size_t prev_size = entries_.size();
-      entries_.resize(Capacity());
-      Rehash(prev_size);
-    }
-    assert(entries_.size() >= kDisplacementSize);
+    GrowCapacity((sz + kOverloadFactor - 1) / kOverloadFactor);
   }
 
-  // TODO rewrite using extended hash approach
-  //
-  // Shrinks the table to new_size (power of 2, >= 1 << kMinCapacityLog and >= element count).
+  // Shrinks toward `new_size` buckets, never below what's needed for live entries at
+  // kOverloadFactor. No-op if not smaller than the current bucket count.
   void Shrink(size_t new_size) {
-    assert(absl::has_single_bit(new_size));
-    assert(new_size >= (1u << kMinCapacityLog));
-    assert(new_size < entries_.size());
+    size_t required = size_ / kOverloadFactor + (size_ % kOverloadFactor != 0);
+    size_t target = absl::bit_ceil(std::max({new_size, kMinBucketCount, required}));
+    if (target >= BucketCount())
+      return;
 
     size_t prev_size = entries_.size();
-    capacity_log_ = absl::bit_width(new_size) - 1;
+    capacity_log_ = absl::bit_width(target) - 1;
 
     // Process from low to high (opposite of Grow/Rehash).
     for (size_t i = 0; i < prev_size; ++i) {
@@ -430,6 +428,18 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   }
 
  protected:
+  // Grows the table so entries_.size() >= bucket_capacity (power of 2), rehashing in place.
+  void GrowCapacity(size_t bucket_capacity) {
+    bucket_capacity = absl::bit_ceil(bucket_capacity);
+    if (bucket_capacity > entries_.size()) {
+      capacity_log_ = std::max(kMinCapacityLog, uint32_t(absl::bit_width(bucket_capacity) - 1));
+      size_t prev_size = entries_.size();
+      entries_.resize(Capacity());
+      Rehash(prev_size);
+    }
+    assert(entries_.size() >= kDisplacementSize);
+  }
+
   static uint64_t Hash(std::string_view str) {
     constexpr uint64_t kHashSeed = 24061983;
     return rapidhashMicro_withSeed(str.data(), str.size(), kHashSeed);

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -7,6 +7,7 @@
 #include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "core/oah_set.h"
 #include "facade/facade_test.h"
 #include "server/test_utils.h"
 
@@ -812,13 +813,16 @@ TEST_F(SetFamilyTest, FieldTtlDeletesEmptySet) {
 TEST_F(SetFamilyTest, ShrinkMemoryAccountingSet) {
   TEST_current_time_ms = kMemberExpiryBase * 1000;
 
-  // Phase 1: Grow bucket_count to 128 by adding 60 members.
-  for (int i = 0; i < 60; i++) {
+  // OAH's 200% overload factor needs more inserts to grow beyond the target it
+  // will choose for the 10 surviving members.
+  const int initial_members = g_use_oah_set ? 200 : 60;
+  const int members_to_remove = initial_members - 10;
+  for (int i = 0; i < initial_members; i++) {
     Run({"SADDEX", "s1", "1000", absl::StrCat("temp", i)});
   }
 
-  // Phase 2: Remove 50, keep 10, bucket_count stays 128.
-  for (int i = 0; i < 50; i++) {
+  // Phase 2: Remove most members while retaining a large bucket array.
+  for (int i = 0; i < members_to_remove; i++) {
     Run({"SREM", "s1", absl::StrCat("temp", i)});
   }
 
@@ -826,17 +830,17 @@ TEST_F(SetFamilyTest, ShrinkMemoryAccountingSet) {
   for (int i = 0; i < 10; i++) {
     Run({"SADDEX", "s1", "1", absl::StrCat("exp", i)});
   }
-  // 20 total (10 long + 10 short), bucket_count = 128.
+  // 20 total (10 long + 10 short).
 
   // Phase 4: Expire the short-TTL members.
   AdvanceTime(2000);
 
-  // UpperBoundSize = 20, optimal = 32 < 128 → Shrink.
+  // Reaping leaves 10 live members and must reduce the much larger bucket array.
   int64_t shrink_result = CheckedInt({"SHRINK", "s1"});
   EXPECT_GT(shrink_result, 0) << "SHRINK must actually shrink the set";
 
   // Must not crash in FindMutable → DCHECK.
-  Run({"SREM", "s1", "temp50"});
+  Run({"SREM", "s1", absl::StrCat("temp", members_to_remove)});
   EXPECT_THAT(Run({"SCARD", "s1"}), IntArg(9));
 }
 


### PR DESCRIPTION
Tune OAH allocation and compaction around its 2× overload factor, reducing bucket memory while ensuring SHRINK never selects an invalid capacity.
Updates reserve/growth logic and OAH-enabled regression, benchmark, and sizing expectations for the new capacity behavior.
