### PR TITLE
 fix(ci): validate dependency cache restores

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -80,8 +80,7 @@ runs:
         if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
           echo "::error title=ccache::ccache-save is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so writes don't collide across configs."
           exit 1
-        fi
-
+          fi
     - name: Restore/save cache (ccache)
       if: ${{ inputs.enable-ccache == 'true' }}
       # - Reuse compiled objects across runners so unchanged files are not recompiled.
@@ -102,7 +101,7 @@ runs:
       # - hashFiles() includes dependency definitions, dependency build settings, and patches. Add any new file that
       #   changes a dependency's fetched source or build output, or an old cache could be restored incorrectly.
       # - internal.cmake, sanitizers, and cxx-flags affect the compiler settings inherited by dependencies, so each
-      #   setting combination needs its own cache entry.
+      #   setting combination needs its own cache entry. Hash flags to keep the key shell-safe and delimiter-stable.
       # - ccache is separate: it caches individual object files and also covers src/.
       if: inputs.enable-deps-cache == 'true'
       id: deps-cache-key
@@ -113,12 +112,24 @@ runs:
           echo "::error title=deps-cache::enable-deps-cache is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so deps caches don't collide across configs."
           exit 1
         fi
-        HASH="${{ hashFiles('src/external_libs.cmake', 'CMakeLists.txt', 'src/CMakeLists.txt', 'helio/cmake/third_party.cmake', 'helio/cmake/internal.cmake', 'patches/**', 'helio/patches/**') }}"
-        if [ -z "${HASH}" ]; then
+        DEPS_CACHE_HASH="${{ hashFiles('src/external_libs.cmake', 'CMakeLists.txt', 'src/CMakeLists.txt', 'helio/cmake/third_party.cmake', 'helio/cmake/internal.cmake', 'patches/**', 'helio/patches/**') }}"
+        if [ -z "${DEPS_CACHE_HASH}" ]; then
           echo "::error title=deps-cache::hashFiles() matched no files - refusing to cache under a degenerate key. Check the file list in this step."
           exit 1
         fi
-        echo "key=dfly-deps-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}-${{ inputs.cxx-flags }}-${{ inputs.with-aws }}-${HASH}" >> "${GITHUB_OUTPUT}"
+        # Hash the CXX_FLAGS to avoid whitespaces in the key
+        CXX_FLAGS_HASH=$(printf '%s' "${{ inputs.cxx-flags }}" | sha256sum | cut -d ' ' -f1)
+        # set named outputs key, paths, and manifest_path for use by the restore/save steps below
+        {
+          echo "key=dfly-deps-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}-${CXX_FLAGS_HASH}-${{ inputs.with-aws }}-${DEPS_CACHE_HASH}"
+          echo 'paths<<EOF'
+          echo '${{ inputs.build-dir }}/third_party'
+          echo '${{ inputs.build-dir }}/_deps'
+          echo '${{ inputs.build-dir }}/.ninja_log'
+          echo '${{ inputs.build-dir }}/CMakeFiles/*_project-complete'
+          echo 'EOF'
+          echo 'manifest_path=${{ inputs.build-dir }}/.deps-cache-manifest'
+        } >> "${GITHUB_OUTPUT}"
 
     - name: Restore cache (deps)
       # - actions/cache/restore only downloads a cache; unlike the combined cache action, it never saves automatically.
@@ -129,6 +140,8 @@ runs:
       #   that Ninja built it. On a fresh (or tar-restored) tree without the log, Ninja re-runs every ExternalProject
       #   step regardless of file mtimes - and re-running the non-idempotent AWS 'patch -p1' against already-patched
       #   sources fails the build. Restoring .ninja_log makes Ninja treat the cached third_party/_deps work as done.
+      # - Manifest validation intentionally excludes mtimes: the tar round-trip regression test verifies they survive.
+      # - Archive restoration so Ninja can continue trusting the restored build log.
       # - CMakeFiles/*_project-complete are the final ExternalProject markers; caching them keeps the hit fully clean.
       # - Paths are workspace-relative because actions/cache runs inside the job's container, where host paths do not
       #   exist.
@@ -137,21 +150,98 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: |
-          ${{ inputs.build-dir }}/third_party
-          ${{ inputs.build-dir }}/_deps
-          ${{ inputs.build-dir }}/.ninja_log
-          ${{ inputs.build-dir }}/CMakeFiles/*_project-complete
+          ${{ steps.deps-cache-key.outputs.paths }}
+          ${{ steps.deps-cache-key.outputs.manifest_path }}
         key: ${{ steps.deps-cache-key.outputs.key }}
+
+    - name: Validate restored cache (deps)
+      # A cache archive can restore successfully yet contain an incomplete or inconsistent dependency tree.
+      # Validate (using the manifest) before calling CMake/Ninja. On failure discard local paths, attempt remote deletion, and cold-build.
+      if: inputs.enable-deps-cache == 'true' && steps.deps-cache-restore.outputs.cache-hit == 'true'
+      id: deps-cache-validate
+      shell: bash
+      run: |
+        manifest_path="${GITHUB_WORKSPACE}/${{ steps.deps-cache-key.outputs.manifest_path }}"
+        cd "${GITHUB_WORKSPACE}"
+        shopt -s nullglob  #  -> unmatched glob expands to nothing
+        mapfile -t cache_paths <<< "${{ steps.deps-cache-key.outputs.paths }}"
+        expanded_cache_paths=()
+        for cache_path in "${cache_paths[@]}"; do
+          expanded_cache_paths+=($cache_path)
+        done
+        validation_status=0
+        python3 "${GITHUB_WORKSPACE}/tools/deps_cache_manifest.py" validate \
+          --root "${GITHUB_WORKSPACE}" --manifest "${manifest_path}" \
+          "${expanded_cache_paths[@]}" || validation_status=$?
+        case "${validation_status}" in
+          0)
+            echo "deps_cache_is_valid=true" >> "${GITHUB_OUTPUT}"
+            ;;
+          1|3)
+            echo "::warning title=deps-cache::Invalid or unreadable restored dependency cache; discarding local restore, attempting remote deletion, and rebuilding dependencies"
+            echo "Discarding restored paths for cache key: ${{ steps.deps-cache-key.outputs.key }}"
+            # Remove the local restored dependency files and manifest. The next step deletes this cache remotely.
+            rm -rf "${expanded_cache_paths[@]}" "${manifest_path}"
+            echo "deps_cache_is_valid=false" >> "${GITHUB_OUTPUT}"
+            ;;
+          *)
+            echo "::error title=deps-cache::Manifest validation failed with infrastructure error ${validation_status}"
+            exit "${validation_status}"
+            ;;
+        esac
+
+    - name: Delete invalid remote cache (deps)
+      # Delete before rebuilding so a successful cold build can save under this immutable key. For PRs, also try the
+      # base ref because the invalid exact hit may have been restored from that scope.
+      if: inputs.enable-deps-cache == 'true' && steps.deps-cache-validate.outputs.deps_cache_is_valid == 'false'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        cache_key="${{ steps.deps-cache-key.outputs.key }}"
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "::warning title=deps-cache::'curl' not found; remote cache remains until reaped"
+        else
+          cache_refs=("${{ github.ref }}")
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # An invalid PR hit may have been restored from its base branch.
+            cache_refs+=("refs/heads/${{ github.base_ref }}")
+          fi
+          deleted=false
+          for cache_ref in "${cache_refs[@]}"; do
+            # gh is absent from the build container - use its REST API through curl instead.
+            if curl --fail --silent --show-error --output /dev/null \
+              --request DELETE \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --get \
+              --data-urlencode "key=${cache_key}" \
+              --data-urlencode "ref=${cache_ref}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/caches"; then
+              echo "Removed remote dependency cache: ${cache_key} (ref: ${cache_ref})"
+              deleted=true
+              break
+            fi
+          done
+          if [ "${deleted}" = false ]; then
+            echo "::warning title=deps-cache::Could not delete remote cache; it may require 'actions: write' permission"
+          fi
+        fi
 
     - name: Report cache status (deps)
       # - Only exact cache keys are used (no restore-keys), so a hit means the config matches the saved artifacts.
       if: always() && inputs.enable-deps-cache == 'true'
       shell: bash
       run: |
-        if [ "${{ steps.deps-cache-restore.outputs.cache-hit }}" = "true" ]; then
-          STATUS="FULL HIT (exact key match) - third_party/_deps and Ninja build log restored"
-        else
+        if [ "${{ steps.deps-cache-restore.outputs.cache-hit }}" != "true" ]; then
           STATUS="MISS - no matching cache found, full cold third-party build expected"
+        elif [ "${{ steps.deps-cache-validate.outputs.deps_cache_is_valid }}" = "true" ]; then
+          STATUS="VERIFIED HIT (exact key match) - manifest, third_party/_deps, and Ninja build log restored"
+        elif [ -z "${{ steps.deps-cache-validate.outputs.deps_cache_is_valid }}" ]; then
+          STATUS="UNKNOWN - exact cache hit was not validated"
+        else
+          STATUS="INVALID HIT - restored cache failed manifest validation; rebuilding dependencies locally"
         fi
         echo "Third-party deps cache: ${STATUS}"
         echo "  primary key: ${{ steps.deps-cache-key.outputs.key }}"
@@ -230,35 +320,35 @@ runs:
           ccache -s || true
         fi
 
+    - name: Generate cache manifest (deps)
+      # actions/cache/save can only archive existing paths. Generate the manifest after the cold build,
+      # before the external save action archives the dependency tree and its manifest together.
+      if: success() && inputs.enable-deps-cache == 'true' && (steps.deps-cache-restore.outputs.cache-hit != 'true' || steps.deps-cache-validate.outputs.deps_cache_is_valid == 'false')
+      shell: bash
+      run: |
+        manifest_path="${GITHUB_WORKSPACE}/${{ steps.deps-cache-key.outputs.manifest_path }}"
+        cd "${GITHUB_WORKSPACE}"
+        shopt -s nullglob
+        mapfile -t cache_paths <<< "${{ steps.deps-cache-key.outputs.paths }}"
+        expanded_cache_paths=()
+        for cache_path in "${cache_paths[@]}"; do
+          expanded_cache_paths+=($cache_path)
+        done
+        # The manifest is excluded from this list because it cannot describe itself.
+        python3 "${GITHUB_WORKSPACE}/tools/deps_cache_manifest.py" generate \
+          --root "${GITHUB_WORKSPACE}" --manifest "${manifest_path}" \
+          "${expanded_cache_paths[@]}"
+
     - name: Save cache (deps)
       # - Save only after configuration and build succeed. Later test failures must not discard a valid deps cache.
       # - Never save a failed or cancelled build: it may contain incomplete artifacts.
-      # - Do not save when this step already restored the requested cache. There is nothing new to upload, and saving
-      #   it again would create an unnecessary copy for this run's branch or pull request.
-      if: success() && inputs.enable-deps-cache == 'true' && steps.deps-cache-restore.outputs.cache-hit != 'true'
+      # - Do not save after a verified cache hit. There is nothing new to upload, and saving it again would create an
+      #   unnecessary copy for this run's branch or pull request. An invalid hit is rebuilt and save is attempted;
+      #   if remote deletion failed, Actions caches retain the existing key because they cannot be overwritten.
+      if: success() && inputs.enable-deps-cache == 'true' && (steps.deps-cache-restore.outputs.cache-hit != 'true' || steps.deps-cache-validate.outputs.deps_cache_is_valid == 'false')
       uses: actions/cache/save@v5
       with:
         path: |
-          ${{ inputs.build-dir }}/third_party
-          ${{ inputs.build-dir }}/_deps
-          ${{ inputs.build-dir }}/.ninja_log
-          ${{ inputs.build-dir }}/CMakeFiles/*_project-complete
+          ${{ steps.deps-cache-key.outputs.paths }}
+          ${{ steps.deps-cache-key.outputs.manifest_path }}
         key: ${{ steps.deps-cache-key.outputs.key }}
-
-    - name: Clear cache on build failure (deps)
-      # - On failure of a cold build, clear the cache record so the next run rebuilds instead of reusing partial work.
-      # - Leave an exact hit in place: it was a valid, previously-saved cache and this run's failure is unrelated to it.
-      # - --ref limits deletion to this run's ref. Without it, a matching pull-request key could delete main's cache.
-      # - Skip cleanup when key computation failed before producing a key.
-      if: failure() && inputs.enable-deps-cache == 'true' && steps.deps-cache-key.outputs.key != '' && steps.deps-cache-restore.outputs.cache-hit != 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        echo "Build failed - clearing third-party deps cache key so the next run doesn't reuse it:"
-        echo "  ${{ steps.deps-cache-key.outputs.key }} (ref: ${{ github.ref }})"
-        if ! command -v gh >/dev/null 2>&1; then
-          echo "::warning::'gh' CLI not found - skipping cache cleanup. Clear manually: gh cache delete '${{ steps.deps-cache-key.outputs.key }}' --ref '${{ github.ref }}'"
-        elif ! gh cache delete "${{ steps.deps-cache-key.outputs.key }}" --repo "${{ github.repository }}" --ref "${{ github.ref }}"; then
-          echo "::warning::Could not delete deps cache (missing 'actions: write' permission on forked PRs, or nothing saved under this key yet). Clear manually: gh cache delete '${{ steps.deps-cache-key.outputs.key }}' --ref '${{ github.ref }}'"
-        fi

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -38,7 +38,7 @@ jobs:
           # - Group usage into ccache, third-party dependencies cache, and other caches.
           # - ccache-action automatically prefixes each persisted ccache key with "ccache-".
           print_repo_cache_usage() {
-            gh cache list --limit 1000 --json sizeInBytes,key --jq '
+            gh cache list --limit 10000 --json sizeInBytes,key --jq '
               def cat:
                 if (.key | test("^ccache-dfly-ccache-")) then "ccache"
                 elif (.key | test("^dfly-deps-")) then "3rd-party deps"
@@ -54,28 +54,43 @@ jobs:
           echo "== Before cleanup =="
           print_repo_cache_usage || true
 
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then # pr closed - > delete only caches for this PR
             # - Delete every cache scoped to the closed pull request's ref.
             # - The count is informational - failure to read it must not prevent cleanup.
-            before_count=$(gh cache list --ref "$PR_REF" --limit 1000 --json id --jq 'length' || echo '?')
+            before_count=$(gh cache list --ref "$PR_REF" --limit 10000 --json id --jq 'length' || echo '?')
             echo "PR closed - deleting all caches for $PR_REF ($before_count found)"
             if ! gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches; then
               echo "::warning::Some caches for $PR_REF may not have been deleted; 7-day/LRU will reclaim leftovers."
             fi
             echo "Deleted $before_count cache(s) for $PR_REF"
-          else
-            # - Keep the newest cache for each ref and configuration; delete older duplicates.
+          else # scheduled cleanup
+            # - Keep the newest cache for each ref and supported dependency-cache configuration, delete older duplicates.
             # - ccache keys add a timestamp on every save, so remove that timestamp before grouping.
             # - Dependency keys end in a content hash; remove it to group obsolete definitions by configuration.
-            echo "Scheduled dedup - keeping newest per (ref, config), deleting older copies"
-            stale=$(gh cache list --limit 1000 --json id,key,ref,createdAt \
-              --jq '[ .[] | select(.key|test("^ccache-dfly-ccache-|^dfly-deps-")) ]
-                    | group_by(.ref + "|" + (.key | sub("-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$|-[0-9a-f]{64}$";"")))
-                    | map(sort_by(.createdAt) | .[:-1]) | flatten
-                    | .[] | "\(.id)\t\(.ref)\t\(.key)"')
+            # - This relies on ccache keys ending in timestamps and deps keys ending in a 64-hex content hash. Update
+            #   the grouping expression if either key shape changes, so their configurations cannot collide.
+            # - Key shapes: ccache-dfly-ccache-<config>-<timestamp> and dfly-deps-<config>-<dependency-files-sha256>.
+            # - Inspect live keys with: `gh cache list -R dragonflydb/dragonfly --limit 100`
+            stale=$(gh cache list --limit 10000 --json id,key,ref,createdAt --jq '
+                # Keep only ccache and dependency-cache entries created by this workflow.
+                [ .[] | select(
+                    .key | test("^ccache-dfly-ccache-|^dfly-deps-")
+                  ) ]
+                # Group entries that share a ref and configuration, ignoring each key's changing suffix.
+                | group_by(
+                    .ref + "|"
+                    + (.key | sub("-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$|-[0-9a-f]{64}$"; ""))
+                  )
+                # Sort each group from oldest to newest and remove the newest entry.
+                | map(sort_by(.createdAt) | .[:-1])
+                # Turn the remaining duplicate groups into individual cache entries.
+                | flatten[]
+                # Print fields for the shell deletion loop.
+                | "\(.id)\t\(.ref)\t\(.key)"')
             if [ -z "$stale" ]; then
               echo "No stale duplicate caches."
             else
+              echo "Scheduled cleanup - keeping newest cache per (ref, config)"
               deleted=0
               while IFS=$'\t' read -r id ref key; do
                 [ -n "$id" ] || continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Do not rename this job name without updating any matching required status check in repository settings.
   pre-commit:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -116,6 +117,11 @@ jobs:
           echo "disk space is:"
           df -h
           echo "-----------------------------"
+
+      - name: Test dependency-cache manifest
+        if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Debug' && matrix.compiler.cxx == 'g++' && matrix.sanitizers == 'NoSanitizers'
+        # run only once for both pull requests and pushes.
+        run: bash tools/test_deps_cache_manifest.sh
 
       - name: Build Dragonfly
         uses: ./.github/actions/builder

--- a/tools/deps_cache_manifest.py
+++ b/tools/deps_cache_manifest.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+"""Generate and validate dependency-cache manifests.
+
+Usage:
+    python3 tools/deps_cache_manifest.py generate --root BUILD_DIR --manifest FILE PATH [...]
+    python3 tools/deps_cache_manifest.py validate --root BUILD_DIR --manifest FILE PATH [...]
+
+Requires Python 3.8 or newer.
+
+The CI builder saves this manifest with its dependency cache. On an exact cache hit it
+regenerates the manifest before CMake/Ninja; a mismatch means the restored tree is
+discarded locally and that job cold-builds dependencies instead of failing repeatedly.
+Run tools/test_deps_cache_manifest.sh after changing this tool or cache-validation behavior;
+it is the regression harness for manifest generation, validation, and archive restoration.
+Timestamps are intentionally excluded because cache archive tools do not consistently
+preserve nanosecond precision.
+Hardlink topology is intentionally not recorded; cache correctness depends on each path's
+contents rather than its inode identity.
+
+Exit status:
+    0: manifest generated or restored cache matches.
+    1: restored cache or manifest differs from the generated manifest.
+    2: invalid invocation or configuration.
+    3: unexpected filesystem or runtime error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+# Manifest body schema. Changing it causes incompatible restored caches to fail validation and rebuild.
+FORMAT = "deps-cache-manifest-v2"
+
+
+def fail(message: str) -> NoReturn:
+    print(f"deps-cache-manifest: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def mismatch(message: str) -> NoReturn:
+    print(f"deps-cache-manifest: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def requested_path(root: Path, requested: str) -> Path | None:
+    path = Path(requested)
+    if path.is_absolute() or ".." in path.parts:
+        fail(f"cached path must be a relative path below the root: {requested}")
+    full_path = root / path
+    if not os.path.lexists(full_path):
+        return None
+    try:
+        full_path.resolve().relative_to(root)
+    except ValueError:
+        fail(f"cached path resolves outside the root: {requested}")
+    return full_path
+
+
+def walk(path: Path):
+    stack = [(path, path.lstat())]
+    while stack:
+        current, metadata = stack.pop()
+        yield current, metadata
+        if stat.S_ISDIR(metadata.st_mode):
+            with os.scandir(current) as entries:
+                stack.extend(
+                    (Path(entry.path), entry.stat(follow_symlinks=False)) for entry in entries
+                )
+
+
+def relative_path(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def record_path(
+    root: Path, path: Path, metadata: os.stat_result, checksums: dict[Path, str]
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "path": relative_path(root, path),
+        "mode": stat.S_IMODE(metadata.st_mode),
+    }
+
+    if stat.S_ISREG(metadata.st_mode):
+        record.update(type="file", size=metadata.st_size, sha256=checksums[path])
+    elif stat.S_ISDIR(metadata.st_mode):
+        record["type"] = "directory"
+    elif stat.S_ISLNK(metadata.st_mode):
+        record.update(type="symlink", target=os.readlink(path))
+    else:
+        mismatch(f"unsupported filesystem type at {record['path']}")
+    return record
+
+
+def build_manifest(root: Path, requested: list[str], workers: int) -> bytes:
+    entries: list[tuple[Path, os.stat_result]] = []
+    for item in requested:
+        path = requested_path(root, item)
+        if path is not None:
+            entries.extend(walk(path))
+
+    entries.sort(key=lambda entry: os.fsencode(relative_path(root, entry[0])))
+    metadata_by_path = dict(entries)
+    paths = list(dict.fromkeys(path for path, _ in entries))
+    regular_files = [path for path in paths if stat.S_ISREG(metadata_by_path[path].st_mode)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        checksums = dict(zip(regular_files, executor.map(hash_file, regular_files)))
+
+    records = [record_path(root, path, metadata_by_path[path], checksums) for path in paths]
+    header = {"format": FORMAT, "paths": requested}
+    lines = [json.dumps(header, separators=(",", ":"), sort_keys=True)]
+    lines.extend(json.dumps(record, separators=(",", ":"), sort_keys=True) for record in records)
+    return ("\n".join(lines) + "\n").encode()
+
+
+def validate_header(contents: bytes, requested: list[str]) -> None:
+    try:
+        header = json.loads(contents.split(b"\n", 1)[0])
+    except json.JSONDecodeError:
+        mismatch("manifest header is not valid JSON")
+    if not isinstance(header, dict) or header.get("format") != FORMAT:
+        actual_format = header.get("format") if isinstance(header, dict) else None
+        mismatch(f"manifest format {actual_format!r} does not match expected {FORMAT!r}")
+    if header.get("paths") != requested:
+        mismatch("manifest requested paths do not match the validation invocation")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--workers", type=int, default=min(os.cpu_count() or 1, 8))
+    parser.add_argument("paths", nargs="+")
+    arguments = parser.parse_args()
+    if arguments.workers < 1:
+        parser.error("--workers must be positive")
+    return arguments
+
+
+def main() -> None:
+    if sys.version_info < (3, 8):
+        fail("Python 3.8 or newer is required")
+    arguments = parse_args()
+    root = arguments.root.resolve()
+    if not root.is_dir():
+        fail(f"root is not a directory: {root}")
+
+    if arguments.command == "generate":
+        arguments.manifest.write_bytes(build_manifest(root, arguments.paths, arguments.workers))
+        return
+
+    if not arguments.manifest.is_file():
+        mismatch(f"manifest is missing: {arguments.manifest}")
+    saved_contents = arguments.manifest.read_bytes()
+    validate_header(saved_contents, arguments.paths)
+    if saved_contents != build_manifest(root, arguments.paths, arguments.workers):
+        mismatch(f"restored cache does not match {arguments.manifest}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"deps-cache-manifest: unexpected error: {error}", file=sys.stderr)
+        raise SystemExit(3)

--- a/tools/test_deps_cache_manifest.sh
+++ b/tools/test_deps_cache_manifest.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+# Tests for tools/deps_cache_manifest.py.
+# - Run with: bash tools/test_deps_cache_manifest.sh
+# - Set RUN_MANIFEST_BENCHMARK=1 to time manifest generation and validation for a 1,000-file fixture.
+# - Default tests:
+#   1) Confirm a tar archive can be extracted and still pass manifest validation, with file mtimes unchanged.
+#   2) Confirm validation rejects changed, added, deleted, unreadable, or unsupported cache entries and malformed
+#      manifests.
+# - No build directory is needed. Keep this script and deps_cache_manifest.py in tools/ , the test creates its own
+#   temporary workspace.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+manifest_tool="$repo_root/tools/deps_cache_manifest.py"
+workspace=$(mktemp -d)
+template="$workspace/template"
+
+cleanup() {
+  rm -rf "$workspace"
+}
+trap cleanup EXIT
+
+now_ns() {
+  python3 -c 'import time; print(time.time_ns())'
+}
+
+elapsed_ms() {
+  echo $((($2 - $1) / 1000000))
+}
+
+make_case() {
+  local case_dir="$workspace/case"
+  rm -rf "$case_dir"
+  cp -a "$template" "$case_dir"
+  python3 "$manifest_tool" generate --root "$case_dir" --manifest "$case_dir/manifest" cache
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/manifest" cache
+  printf '%s\n' "$case_dir"
+}
+
+expect_failure() {
+  local description="$1"
+  local expected_status="$2"
+  local command="$3"
+  local case_dir
+  case_dir=$(make_case)
+  bash -c "$command" -- "$case_dir"
+  local actual_status=0
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/manifest" cache \
+    >/dev/null 2>&1 || actual_status=$?
+  case ",$expected_status," in
+    *",$actual_status,"*) ;;
+    *)
+      echo "expected exit $expected_status for $description, got $actual_status" >&2
+      exit 1
+      ;;
+  esac
+  echo "PASS: $description"
+}
+
+expect_accepted_after_tar_round_trip() {
+  local case_dir
+  case_dir=$(make_case)
+  tar --posix -cf "$workspace/cache.tar" -P -C "$case_dir" cache
+  mkdir "$workspace/restored"
+  tar -xf "$workspace/cache.tar" -P -C "$workspace/restored"
+  cp "$case_dir/manifest" "$workspace/restored/manifest"
+  if [ "$(stat -c '%Y.%y' "$case_dir/cache/nested/file-0001")" != \
+    "$(stat -c '%Y.%y' "$workspace/restored/cache/nested/file-0001")" ]; then
+    echo "tar did not preserve mtime; Ninja will re-run patch steps" >&2
+    exit 1
+  fi
+  python3 "$manifest_tool" validate --root "$workspace/restored" \
+    --manifest "$workspace/restored/manifest" cache
+  echo "PASS: tar round-trip"
+}
+
+expect_accepted_with_missing_optional_path() {
+  local case_dir
+  case_dir=$(make_case)
+  rm -rf "$case_dir/cache"
+  python3 "$manifest_tool" generate --root "$case_dir" --manifest "$case_dir/optional-manifest" \
+    cache optional-path
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/optional-manifest" \
+    cache optional-path
+  echo "PASS: missing optional paths"
+}
+
+expect_failure_with_requested_paths() {
+  local description="$1"
+  local expected_status="$2"
+  shift 2
+  local case_dir
+  case_dir=$(make_case)
+  local actual_status=0
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/manifest" "$@" \
+    >/dev/null 2>&1 || actual_status=$?
+  if [ "$actual_status" -ne "$expected_status" ]; then
+    echo "expected exit $expected_status for $description, got $actual_status" >&2
+    exit 1
+  fi
+  echo "PASS: $description"
+}
+
+expect_rejected_path_escape() {
+  local case_dir
+  case_dir=$(make_case)
+  mkdir "$workspace/outside"
+  ln -s "$workspace/outside" "$case_dir/escape"
+  local actual_status=0
+  python3 "$manifest_tool" generate --root "$case_dir" --manifest "$case_dir/escape-manifest" escape \
+    >/dev/null 2>&1 || actual_status=$?
+  if [ "$actual_status" -ne 2 ]; then
+    echo "expected exit 2 for symlinked requested-path escape, got $actual_status" >&2
+    exit 1
+  fi
+  echo "PASS: symlinked requested-path escape"
+}
+
+expect_deduplicated_overlapping_paths() {
+  local case_dir
+  case_dir=$(make_case)
+  python3 "$manifest_tool" generate --root "$case_dir" --manifest "$case_dir/overlapping-manifest" \
+    cache cache/nested
+  tail -n +2 "$case_dir/manifest" > "$case_dir/single-records"
+  tail -n +2 "$case_dir/overlapping-manifest" > "$case_dir/overlapping-records"
+  cmp "$case_dir/single-records" "$case_dir/overlapping-records"
+  echo "PASS: overlapping requested paths are deduplicated"
+}
+
+expect_large_file_chunking() {
+  local case_dir
+  case_dir=$(make_case)
+  python3 -c 'import sys; open(sys.argv[1], "wb").write(b"x" * (3 * 1024 * 1024))' \
+    "$case_dir/cache/large-file"
+  python3 "$manifest_tool" generate --root "$case_dir" --manifest "$case_dir/manifest" cache
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/manifest" cache
+  echo "PASS: multi-chunk regular file"
+}
+
+expect_unsupported_filesystem_entry() {
+  local case_dir
+  case_dir=$(make_case)
+  if ! mkfifo "$case_dir/cache/fifo"; then
+    echo "SKIP: unsupported filesystem entry (mkfifo unavailable)"
+    return
+  fi
+  local actual_status=0
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/manifest" cache \
+    >/dev/null 2>&1 || actual_status=$?
+  if [ "$actual_status" -ne 1 ]; then
+    echo "expected exit 1 for unsupported filesystem entry, got $actual_status" >&2
+    exit 1
+  fi
+  echo "PASS: unsupported filesystem entry"
+}
+
+mkdir -p "$template/cache/nested"
+printf 'cache fixture 0001\n' > "$template/cache/nested/file-0001"
+printf 'cache fixture 0002\n' > "$template/cache/nested/file-0002"
+ln -s nested/file-0001 "$template/cache/link"
+
+if [ "${RUN_MANIFEST_BENCHMARK:-0}" = "1" ]; then
+  timing_template="$workspace/timing-template"
+  mkdir -p "$timing_template/cache/nested"
+  for number in $(seq 1 1000); do
+    printf -v file_name 'file-%04d' "$number"
+    printf 'cache fixture %04d\n' "$number" > "$timing_template/cache/nested/$file_name"
+  done
+  ln -s nested/file-0001 "$timing_template/cache/link"
+
+  case_dir="$workspace/timed-case"
+  cp -a "$timing_template" "$case_dir"
+  started=$(now_ns)
+  python3 "$manifest_tool" generate --root "$case_dir" --manifest "$case_dir/manifest" cache
+  manifest_generate_ms=$(elapsed_ms "$started" "$(now_ns)")
+  started=$(now_ns)
+  python3 "$manifest_tool" validate --root "$case_dir" --manifest "$case_dir/manifest" cache
+  manifest_validate_ms=$(elapsed_ms "$started" "$(now_ns)")
+  echo "Timing for 1,000 regular files, 2 directories, and 1 symlink:"
+  echo "  generate: ${manifest_generate_ms} ms"
+  echo "  validate: ${manifest_validate_ms} ms"
+fi
+
+expect_accepted_after_tar_round_trip
+expect_accepted_with_missing_optional_path
+expect_failure_with_requested_paths "requested-path invocation drift" 1 cache cache/nested
+expect_rejected_path_escape
+expect_deduplicated_overlapping_paths
+expect_large_file_chunking
+expect_failure "same-size regular-file content change" 1 \
+  'printf "other fixture 0001\n" > "$1/cache/nested/file-0001"'
+expect_failure "regular-file size change" 1 \
+  'printf "larger content\n" >> "$1/cache/nested/file-0001"'
+expect_failure "regular-file deletion" 1 \
+  'rm "$1/cache/nested/file-0001"'
+expect_failure "selected cache directory deletion" 1 \
+  'rm -rf "$1/cache"'
+expect_failure "new regular file" 1 \
+  'printf "new\n" > "$1/cache/nested/new-file"'
+expect_failure "regular-file permission change" 1 \
+  'chmod 600 "$1/cache/nested/file-0001"'
+expect_failure "unreadable regular file" 1,3 \
+  'chmod 000 "$1/cache/nested/file-0001"'
+expect_failure "new directory" 1 \
+  'mkdir "$1/cache/new-directory"'
+expect_failure "directory permission change" 1 \
+  'chmod 700 "$1/cache/nested"'
+expect_failure "symlink target change" 1 \
+  'rm "$1/cache/link" && ln -s nested/file-0002 "$1/cache/link"'
+expect_failure "symlink deletion" 1 \
+  'rm "$1/cache/link"'
+expect_unsupported_filesystem_entry
+expect_failure "truncated manifest" 1 \
+  ': > "$1/manifest"'
+expect_failure "invalid manifest format" 1 \
+  'sed -i "1c\\deps-cache-manifest-v999" "$1/manifest"'
+expect_failure "invalid manifest record" 1 \
+  'printf "deps-cache-manifest-v1\nnot-json\n" > "$1/manifest"'
+
+echo "All manifest mutation checks passed."


### PR DESCRIPTION
- Add a manifest tool that validates exact dependency-cache restores.
- Discard invalid restores and delete remote entries before rebuilding
  so a successful build can save a replacement under the immutable key.
- Cache Ninja's build log and ExternalProject completion markers to stop
  restored dependency work from being rerun.
- Add a standalone fixture test and run it once per CI workflow.
- Reap older ccache and dependency-cache entries, keeping the newest
  per ref and configuration.
- Document that renaming pre-commit requires matching required-check
  changes in repository settings.