### PR TITLE
fix(tiered): release the disk extent when a value is overwritten in place

### DIFF
--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -130,6 +130,7 @@ OpStatus OpLoadChunk(const OpArgs& op_args, std::string_view blob, std::string_v
       // existing key might not necessarily be SBF, it could be HASH/JSON, and indexed
       RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, op_res->it->second, op_args.shard);
       db_slice.RemoveExpire(op_args.db_cntx.db_index, op_res->it);
+      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &op_res->it->second);
     }
 
     op_res->it->second.SetSBF(load_result.value());

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1187,6 +1187,11 @@ pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(uint64_t now_ms, bool ca
   return {rel_ms, ms_timestamp};
 }
 
+void DbSlice::ReleaseOffloadedValue(DbIndex db_ind, PrimeValue* pv) {
+  if (pv->IsExternal())
+    shard_owner()->tiered_storage()->Delete(db_ind, pv);
+}
+
 OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
                                         const ExpireParams& params) {
   constexpr uint64_t kPersistValue = 0;
@@ -1242,6 +1247,7 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrUpdateInternal(const Context& cntx
 
   auto& it = res.it;
 
+  ReleaseOffloadedValue(cntx.db_index, &it->second);
   it->second = std::move(obj);
 
   if (expire_at_ms) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -305,6 +305,10 @@ class DbSlice {
   OpResult<ItAndUpdater> AddNew(const Context& cntx, std::string_view key, PrimeValue obj,
                                 uint64_t expire_at_ms);
 
+  // Must be called before overwriting a value in place. An offloaded value keeps its data on disk
+  // and reports no heap allocation, so overwriting it drops the only reference to its disk extent.
+  void ReleaseOffloadedValue(DbIndex db_ind, PrimeValue* pv);
+
   // Update entry expiration. Return expiration timepoint in abs milliseconds, or -1 if the entry
   // already expired and was deleted;
   facade::OpResult<int64_t> UpdateExpire(const Context& cntx, Iterator prime_it,

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1001,6 +1001,7 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
 
   if (IsValid(to_res.it)) {
     to_res.post_updater.ReduceHeapUsage();
+    db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &to_res.it->second);
     to_res.it->second = std::move(from_obj);
 
     if (exp_ts) {

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -530,6 +530,7 @@ OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_st
       VLOG(1) << "got invalid JSON string '" << json_str << "' cannot be saved";
       return OpStatus::INVALID_JSON;
     }
+    op_args.GetDbSlice().ReleaseOffloadedValue(op_args.db_cntx.db_index, &it_res->it->second);
     it_res->it->second.Reset();
   }
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -560,7 +560,16 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewE
 
     // does not store the values, merely sets the encoding.
     // TODO: why not store the values as well?
-    InitSet(vals, &co);
+    if (co.IsExternal()) {
+      // Build the replacement first: freeing the disk extent is irreversible, while a bad_alloc
+      // inside InitSet is reported to the client as OOM and must leave the value readable.
+      PrimeValue replacement;
+      InitSet(vals, &replacement);
+      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &co);
+      co = std::move(replacement);
+    } else {
+      InitSet(vals, &co);
+    }
   }
 
   uint32_t res = 0;

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -518,6 +518,137 @@ TEST_F(PureDiskTSTest, OffloadingStrategy) {
   }
 }
 
+// Overwriting an offloaded value in place must release its disk extent, otherwise it is
+// orphaned forever and the FLUSHALL invariant CHECK_EQ(tiered_entries, 0) aborts the process.
+TEST_F(PureDiskTSTest, RenameOverOffloadedDestination) {
+  const string src_value = BuildString(3000, 'a');
+  Run({"SET", "src", src_value});
+  Run({"SET", "dst", BuildString(3000, 'b')});
+
+  ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 2; });
+  ASSERT_EQ(GetMetrics().tiered_stats.allocated_bytes, 2 * 4096u);
+
+  EXPECT_EQ(Run({"RENAME", "src", "dst"}), "OK");
+
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 1u);
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 4096u; });
+  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 4096u);
+
+  EXPECT_EQ(Run({"GET", "dst"}), src_value);
+
+  Run({"FLUSHALL"});
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
+}
+
+// Same defect reached through DbSlice::AddOrUpdate instead of RENAME.
+TEST_F(PureDiskTSTest, SortStoreOverOffloadedDestination) {
+  Run({"RPUSH", "src", "3", "1", "2"});  // small list, stays in memory
+  Run({"SET", "dst", BuildString(3000, 'b')});
+
+  ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 1; });
+  ASSERT_EQ(GetMetrics().tiered_stats.allocated_bytes, 4096u);
+
+  EXPECT_THAT(Run({"SORT", "src", "STORE", "dst"}), IntArg(3));
+
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
+  EXPECT_THAT(Run({"LRANGE", "dst", "0", "-1"}), RespArray(ElementsAre("1", "2", "3")));
+
+  Run({"FLUSHALL"});
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
+}
+
+// The remaining in-place overwrite paths reach the value through DbSlice::AddOrFind and retype it,
+// which drops the external reference silently: CompactObj::HasAllocated() is false for an external
+// value, so Init*()/Reset() free nothing.
+class OffloadedOverwriteTest : public PureDiskTSTest {
+ protected:
+  // Offloads a 3000 byte string under `key` and returns once it occupies exactly one disk page.
+  void OffloadString(string_view key) {
+    Run({"SET", key, BuildString(3000, 'b')});
+    ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 1; });
+    ASSERT_EQ(GetMetrics().tiered_stats.allocated_bytes, 4096u);
+  }
+
+  // The extent must be gone, and FLUSHALL must not trip CHECK_EQ(tiered_entries, 0).
+  void ExpectExtentReleased() {
+    EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
+    ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
+    Run({"FLUSHALL"});
+  }
+};
+
+TEST_F(OffloadedOverwriteTest, SetInterStore) {
+  Run({"SADD", "s1", "a", "b", "c"});
+  OffloadString("dst");
+
+  EXPECT_THAT(Run({"SINTERSTORE", "dst", "s1"}), IntArg(3));
+
+  EXPECT_EQ(Run({"TYPE", "dst"}), "set");
+  EXPECT_THAT(Run({"SCARD", "dst"}), IntArg(3));
+  ExpectExtentReleased();
+}
+
+TEST_F(OffloadedOverwriteTest, ZUnionStore) {
+  Run({"ZADD", "z1", "1", "a", "2", "b"});
+  OffloadString("dst");
+
+  EXPECT_THAT(Run({"ZUNIONSTORE", "dst", "1", "z1"}), IntArg(2));
+
+  EXPECT_EQ(Run({"TYPE", "dst"}), "zset");
+  EXPECT_EQ(Run({"ZSCORE", "dst", "b"}), "2");
+  ExpectExtentReleased();
+}
+
+TEST_F(OffloadedOverwriteTest, ZRangeStore) {
+  Run({"ZADD", "z1", "1", "a", "2", "b"});
+  OffloadString("dst");
+
+  EXPECT_THAT(Run({"ZRANGESTORE", "dst", "z1", "0", "-1"}), IntArg(2));
+
+  EXPECT_EQ(Run({"TYPE", "dst"}), "zset");
+  ExpectExtentReleased();
+}
+
+TEST_F(OffloadedOverwriteTest, JsonSet) {
+  OffloadString("dst");
+
+  EXPECT_EQ(Run({"JSON.SET", "dst", "$", R"({"a":1})"}), "OK");
+
+  EXPECT_EQ(Run({"JSON.GET", "dst"}), R"({"a":1})");
+  ExpectExtentReleased();
+}
+
+TEST_F(OffloadedOverwriteTest, BloomLoadChunk) {
+  Run({"BF.RESERVE", "src", "0.01", "100"});
+  Run({"BF.ADD", "src", "hello"});
+
+  struct Chunk {
+    int64_t cursor;
+    string data;
+  };
+  vector<Chunk> chunks;
+  for (int64_t cursor = 0;;) {
+    auto resp = Run({"BF.SCANDUMP", "src", absl::StrCat(cursor)});
+    const auto& vec = resp.GetVec();
+    ASSERT_EQ(vec.size(), 2u);
+    cursor = *vec[0].GetInt();
+    if (cursor == 0)
+      break;
+    chunks.push_back({cursor, vec[1].GetString()});
+  }
+  ASSERT_FALSE(chunks.empty());
+
+  OffloadString("dst");
+
+  for (const auto& [cursor, data] : chunks)
+    EXPECT_EQ(Run({"BF.LOADCHUNK", "dst", absl::StrCat(cursor), data}), "OK");
+
+  EXPECT_THAT(Run({"BF.EXISTS", "dst", "hello"}), IntArg(1));
+  ExpectExtentReleased();
+}
+
 // Test FLUSHALL while reading entries
 TEST_F(PureDiskTSTest, FlushAll) {
   const int kNum = 500;

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -253,18 +253,25 @@ OpResult<DbSlice::ItAndUpdater> PrepareZEntry(const ZSetFamily::ZParams& zparams
   auto& it = add_res.it;
   PrimeValue& pv = it->second;
   if (add_res.is_new || zparams.override) {
+    // Allocated before the value is released below: freeing the disk extent is irreversible,
+    // while a bad_alloc here is reported to the client as OOM and must leave the value readable.
+    unsigned encoding = OBJ_ENCODING_LISTPACK;
+    void* robj_ptr = nullptr;
+    if (member_len > server.max_map_field_len) {
+      encoding = OBJ_ENCODING_SKIPLIST;
+      robj_ptr = CompactObj::AllocateMR<detail::SortedMap>();
+    } else {
+      robj_ptr = lpNew(0);
+    }
+
     // If we're overwriting an existing key (not a new one), we need to remove it from
     // search indexes first. This prevents crashes when the key is indexed (e.g., HASH or JSON).
     if (!add_res.is_new && zparams.override) {
       RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, pv, op_args.shard);
+      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &pv);
     }
 
-    if (member_len > server.max_map_field_len) {
-      pv.InitRobj(OBJ_ZSET, OBJ_ENCODING_SKIPLIST, CompactObj::AllocateMR<detail::SortedMap>());
-    } else {
-      unsigned char* lp = lpNew(0);
-      pv.InitRobj(OBJ_ZSET, OBJ_ENCODING_LISTPACK, lp);
-    }
+    pv.InitRobj(OBJ_ZSET, encoding, robj_ptr);
   } else {
     if (it->second.ObjType() != OBJ_ZSET)
       return OpStatus::WRONG_TYPE;


### PR DESCRIPTION
An offloaded value reports no heap allocation, so overwriting it in place silently dropped the only reference to its disk extent. The extent leaked, and the next `FLUSHALL` aborted on `CHECK_EQ(db_ptr->stats.tiered_entries, 0u)` (db_slice.cc) - a `CHECK`, so it aborts in release builds too.

For the paths that also retype the key the state was **unrecoverable**: after the overwrite the value is no longer external, so `PerformDeletionAtomic` cannot release it and `RemoveOffloadedEntriesFromTieredStorage` finds nothing to delete — every subsequent `FLUSHALL`/`FLUSHDB` aborted, even on an empty keyspace.

Root cause:

Seven sites overwrite an existing `PrimeValue` in place. Most reach it through `AddOrFind(key, std::nullopt)` — deliberately untyped so the command may *retype* the key - and then call `InitRobj` / `InitSet` / `Reset` / `SetSBF`. All of those go through `CompactObj::SetMeta`, which frees only `if (HasAllocated())`, and `HasAllocated()` is false for `EXTERNAL_TAG`.

Changes:

- add `DbSlice::ReleaseOffloadedValue()` and call it before every in-place overwrite:
  - `OpRen` - `RENAME` / `RENAMENX`
  - `DbSlice::AddOrUpdateInternal` - `SORT ... STORE`, `RESTORE`, rdb load
  - `set_family` `OpAdd` - `SINTERSTORE` / `SUNIONSTORE` / `SDIFFSTORE`
  - `zset_family` `PrepareZEntry` - `ZUNIONSTORE` / `ZINTERSTORE` / `ZDIFFSTORE` / `ZRANGESTORE` /
    `GEORADIUS ... STORE`
  - `json_family` `SetFullJson` - `JSON.SET`
  - `bloom_family` `OpLoadChunk` - `BF.LOADCHUNK`
- in `set_family` and `zset_family` the replacement is now built *before* the release: freeing the extent is irreversible, while a `bad_alloc` there is caught in `Transaction::RunCallback` and returned as `OUT_OF_MEMORY`, so the old value has to stay readable. The other five sites need no reordering - they receive an already-constructed value, or allocate nothing after the release.
- 7 regression tests in `tiered_storage_test.cc`, each confirmed failing before the fix.

Verified clean and left unchanged: `hset_family` (both sites already check `IsExternal()`), `string_family` / `bitops_family` / `hll_family` (already release), and the typed `AddOrFind` sites for types that never offload.
