### PR TITLE
fix(tiered): stop RENAME and MOVE from corrupting values in shared disk pages

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1192,6 +1192,12 @@ void DbSlice::ReleaseOffloadedValue(DbIndex db_ind, PrimeValue* pv) {
     shard_owner()->tiered_storage()->Delete(db_ind, pv);
 }
 
+bool DbSlice::UnstashValueForKeyChange(DbIndex db_ind, string_view key, PrimeValue* pv) {
+  if (!pv->IsExternal())
+    return true;
+  return shard_owner()->tiered_storage()->UnstashForKeyChange(db_ind, key, pv);
+}
+
 OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
                                         const ExpireParams& params) {
   constexpr uint64_t kPersistValue = 0;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -309,6 +309,11 @@ class DbSlice {
   // and reports no heap allocation, so overwriting it drops the only reference to its disk extent.
   void ReleaseOffloadedValue(DbIndex db_ind, PrimeValue* pv);
 
+  // Must be called before moving a value to another key or db, as RENAME and MOVE do. An offloaded
+  // value that shares a disk page is recovered by the key hash stored in that page, so it is read
+  // back into memory. Returns false if reading it failed.
+  [[nodiscard]] bool UnstashValueForKeyChange(DbIndex db_ind, std::string_view key, PrimeValue* pv);
+
   // Update entry expiration. Return expiration timepoint in abs milliseconds, or -1 if the entry
   // already expired and was deleted;
   facade::OpResult<int64_t> UpdateExpire(const Context& cntx, Iterator prime_it,

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -929,6 +929,11 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   if (!IsValid(from_res.it))
     return OpStatus::KEY_NOTFOUND;
 
+  // A value sharing a disk page is recovered during defragmentation by the key hash serialized
+  // into that page, so it must come back to memory before it is stored under another db.
+  if (!db_slice.UnstashValueForKeyChange(op_args.db_cntx.db_index, key, &from_res.it->second))
+    return OpStatus::IO_ERROR;
+
   // Ensure target database exists.
   db_slice.ActivateDb(target_db);
 
@@ -978,6 +983,12 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
 
   if (from_key == to_key)
     return destination_should_not_exist ? OpStatus::KEY_EXISTS : OpStatus::OK;
+
+  // A value sharing a disk page is recovered during defragmentation by the key hash serialized
+  // into that page, so it must come back to memory before it is stored under another key. Done
+  // before the destination is looked up, so only one updater is alive across the blocking read.
+  if (!db_slice.UnstashValueForKeyChange(op_args.db_cntx.db_index, from_key, &from_res.it->second))
+    return OpStatus::IO_ERROR;
 
   bool is_prior_list = false;
   auto to_res = db_slice.FindMutable(op_args.db_cntx, to_key);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -567,6 +567,66 @@ void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
   op_manager_->DeleteOffloaded(dbid, segment);
 }
 
+bool TieredStorage::UnstashForKeyChange(DbIndex dbid, string_view key, PrimeValue* pv) {
+  // A cool value keeps its copy in memory, and a value owning whole pages is recovered by its
+  // segment alone. Only bin entries are looked up by the key hash serialized into the page.
+  if (!pv->IsExternal() || pv->IsCool())
+    return true;
+
+  tiering::DiskSegment segment = pv->GetExternalSlice();
+  if (OccupiesWholePages(segment.length))
+    return true;
+
+  const CompactObj::ExternalRep rep = pv->GetExternalRep();
+  TResult<string> fut;
+  auto resolve = [fut](io::Result<string_view> res) mutable {
+    fut.Resolve(res.transform([](string_view sv) { return string{sv}; }));
+  };
+
+  // Decode with the representation the value was stashed as: the read may also trigger an upload,
+  // and a mismatched decoder would restore the value as the wrong type.
+  switch (rep) {
+    case CompactObj::ExternalRep::STRING:
+      // GetView() returns the decoded value, so it is materialized below as non-raw.
+      Read(KeyRef{dbid, key}, segment, tiering::StringDecoder{*pv},
+           [resolve](io::Result<tiering::StringDecoder*> res) mutable {
+             resolve(res.transform([](tiering::StringDecoder* d) { return d->GetView(); }));
+           });
+      break;
+    case CompactObj::ExternalRep::SERIALIZED_MAP:
+      Read(KeyRef{dbid, key}, segment, tiering::ListpackMapDecoder{},
+           [resolve](io::Result<tiering::ListpackMapDecoder*> res) mutable {
+             resolve(res.transform([](tiering::ListpackMapDecoder* d) {
+               detail::ListpackWrap lw = d->Get();
+               return string_view{reinterpret_cast<const char*>(lw.GetPointer()), lw.UsedBytes()};
+             }));
+           });
+      break;
+    case CompactObj::ExternalRep::LIST_NODE:
+      LOG(DFATAL) << "List nodes are not addressed by a key";
+      return true;
+  }
+
+  io::Result<string> res = fut.Get();
+  if (!res)
+    return false;
+
+  // The read itself uploads the value on a second touch, in which case nothing is left on disk.
+  // Otherwise restore it here and free the page entry; the heap delta is picked up by the
+  // caller's AutoUpdater, so no memory statistics are touched.
+  if (pv->IsExternal()) {
+    if (rep == CompactObj::ExternalRep::STRING) {
+      pv->Materialize(*res, false);
+    } else {
+      tiering::ListpackMapDecoder decoder{};
+      decoder.Initialize(*res);
+      decoder.Upload(pv);
+    }
+    op_manager_->DeleteOffloaded(dbid, segment);
+  }
+  return true;
+}
+
 void TieredStorage::CancelStash(tiering::PendingId id, tiering::FragmentRef fragment_ref) {
   DCHECK(fragment_ref.HasStashPending());
   DCHECK(std::holds_alternative<KeyRef>(id) || std::holds_alternative<tiering::ListNodeId>(id));

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -94,6 +94,12 @@ class TieredStorage : public TieredStorageBase {
   // Delete value, must be offloaded (external type)
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
 
+  // Call before an offloaded value is stored under a different key or db. A value sharing a disk
+  // page is recovered during defragmentation by the key hash serialized into that page, which the
+  // move invalidates, so it is read back into memory. Blocking. No-op for anything else.
+  // Returns false if the value could not be read.
+  bool UnstashForKeyChange(DbIndex dbid, std::string_view key, PrimeValue* pv);
+
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(tiering::DiskSegment segment) const;
 
@@ -272,6 +278,10 @@ class TieredStorage : public TieredStorageBase {
   }
 
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {
+  }
+
+  bool UnstashForKeyChange(DbIndex dbid, std::string_view key, PrimeValue* pv) {
+    return true;
   }
 
   bool HasModificationPending(tiering::DiskSegment segment) const {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -649,6 +649,116 @@ TEST_F(OffloadedOverwriteTest, BloomLoadChunk) {
   ExpectExtentReleased();
 }
 
+// Values below kMinOccupancySize share a 4KB page through SmallBins. The page records the hash of
+// the key each value was stashed under, and defragmentation locates the owner by that hash, so a
+// value must not change keys while it sits in a bin.
+class SmallBinKeyMoveTest : public PureDiskTSTest {
+ protected:
+  static constexpr int kNum = 40;
+
+  static string Value(int i) {
+    return absl::StrCat(absl::StrFormat("%03d", i), BuildString(197, 'a' + i % 26));
+  }
+
+  // Fills a whole bin page and returns once it has been stashed.
+  void FillBin() {
+    for (int i = 0; i < kNum; i++)
+      Run({"SET", absl::StrCat("k", i), Value(i)});
+    ExpectConditionWithinTimeout(
+        [&] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 20; });
+  }
+
+  // Drops everything but `keep`, which forces the bin below half a page and triggers defrag.
+  void DropAllBut(string_view keep) {
+    for (int i = 0; i < kNum; i++) {
+      string key = absl::StrCat("k", i);
+      if (key != keep)
+        Run({"DEL", key});
+    }
+    ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  }
+
+  // Nothing may still claim to be external once the last disk extent is gone.
+  void ExpectNoDanglingExternal() {
+    auto metrics = GetMetrics();
+    if (metrics.tiered_stats.allocated_bytes == 0) {
+      EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u)
+          << "entry still external while no disk space is allocated";
+    }
+  }
+
+  // Refills the bins so the freed page gets handed out again and overwritten.
+  void ReusePage() {
+    for (int i = kNum; i < 3 * kNum; i++)
+      Run({"SET", absl::StrCat("n", i), Value(i)});
+    ExpectConditionWithinTimeout(
+        [&] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 20; });
+  }
+};
+
+TEST_F(SmallBinKeyMoveTest, RenameKeepsValueReadable) {
+  FillBin();
+
+  EXPECT_EQ(Run({"RENAME", "k5", "moved"}), "OK");
+
+  DropAllBut("k5");  // k5 no longer exists; drops every other key in the page
+  ExpectNoDanglingExternal();
+
+  ReusePage();
+  EXPECT_EQ(Run({"GET", "moved"}), Value(5));
+}
+
+// The destination shares the page with the source, so releasing its extent (which RENAME does)
+// makes the page fragmented and would otherwise queue it for defragmentation right away.
+TEST_F(SmallBinKeyMoveTest, RenameOverNeighbourInSamePage) {
+  FillBin();
+
+  EXPECT_EQ(Run({"RENAME", "k5", "k6"}), "OK");
+
+  for (int i = 10; i < 24; i++)  // fragment the page without emptying it
+    Run({"DEL", absl::StrCat("k", i)});
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  ExpectNoDanglingExternal();
+
+  ReusePage();
+  EXPECT_EQ(Run({"GET", "k6"}), Value(5));
+}
+
+// Hashes are stashed as listpacks, so they take the other decoding path out of a bin.
+TEST_F(SmallBinKeyMoveTest, RenameOffloadedHashKeepsFields) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_experimental_hash_support, true);
+  UpdateFromFlags();
+
+  // Fields must stay below the listpack limit: a StringMap hash is never stashed.
+  auto field = [](int i) { return absl::StrCat("v", i, BuildString(40, 'a' + i % 26)); };
+
+  for (int i = 0; i < 60; i++)
+    Run({"HSET", absl::StrCat("h", i), "f1", field(i), "f2", absl::StrCat("second-", i)});
+  ExpectConditionWithinTimeout(
+      [&] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 20; });
+
+  EXPECT_EQ(Run({"RENAME", "h5", "moved"}), "OK");
+
+  EXPECT_EQ(Run({"HGET", "moved", "f1"}), field(5));
+  EXPECT_EQ(Run({"HGET", "moved", "f2"}), "second-5");
+  EXPECT_EQ(Run({"TYPE", "moved"}), "hash");
+}
+
+TEST_F(SmallBinKeyMoveTest, MoveToAnotherDbKeepsValueReadable) {
+  FillBin();
+
+  EXPECT_THAT(Run({"MOVE", "k5", "1"}), IntArg(1));
+
+  DropAllBut("k5");
+  ExpectNoDanglingExternal();
+
+  ReusePage();
+  Run({"SELECT", "1"});
+  EXPECT_EQ(Run({"GET", "k5"}), Value(5));
+  Run({"SELECT", "0"});
+}
+
 // Test FLUSHALL while reading entries
 TEST_F(PureDiskTSTest, FlushAll) {
   const int kNum = 500;


### PR DESCRIPTION
A value smaller than `kMinOccupancySize` shares a 4KB disk page with others through `SmallBins`.
The page records the *key hash* each value was stashed under, and defragmentation uses that hash to find the owner - so a value must not change keys while it sits in a bin. `RENAME` and `MOVE` did exactly that, and the result was silent data corruption.

Root cause:

`SmallBins::SerializeBin` writes `CompactObj::HashCode(key)` (and the dbid) into the page.
`ShardOpManager::Defragment` recovers each entry with `prime.FindFirst(hash, predicate)`. After the key changes, that lookup no longer resolves, the entry is silently skipped (`continue`), and the page is freed while the destination `PrimeValue` still points into it. Once the freed page is handed out again, `GET` on the renamed key returns **another key's value** - no error, no crash.

Observed on a live server (40 x 200 byte values, `--tiered_min_value_size=64`): after the defrag the instance reports `tiered_entries=1` with `tiered_allocated_bytes=0` - a dangling external reference - and after the page is reused the renamed key returns a neighbour's data.

`MOVE` has the identical defect, since the page records the dbid too.

Fix:

The value is read back into memory before it leaves its key, so the stale binding never exists:

- `TieredStorage::UnstashForKeyChange`, called from `OpRen` and `OpMove` through `DbSlice::UnstashValueForKeyChange`
- only bin-backed values pay for it: a cool value already has its copy in memory, and a value owning whole pages is recovered by its segment alone
- `RENAME` / `MOVE` now return `IO_ERROR` if that read fails
- blocking on tiered storage is not new to `RENAME`: the cross-shard path already reads through `Renamer::SerializeSrc` -> `DumpToString`

