### PR TITLE
fix: delete a destination of another type on an empty *STORE result

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -521,9 +521,10 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewE
   // to overwrite the key. However, if the set is empty it means we should delete the
   // key if it exists.
   if (overwrite && (vals_it.begin() == vals_it.end())) {
-    auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SET);
-    if (res_it) {
-      db_slice.DelMutable(op_args.db_cntx, std::move(*res_it));
+    // Lookup is untyped: an empty result deletes the destination regardless of its type.
+    auto res_it = db_slice.FindMutable(op_args.db_cntx, key);
+    if (IsValid(res_it.it)) {
+      db_slice.DelMutable(op_args.db_cntx, std::move(res_it));
       if (journal_update && op_args.shard->journal()) {
         RecordJournal(op_args, "DEL"sv, ArgSlice{key});
       }

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -844,4 +844,13 @@ TEST_F(SetFamilyTest, ShrinkMemoryAccountingSet) {
   EXPECT_THAT(Run({"SCARD", "s1"}), IntArg(9));
 }
 
+// An empty result deletes the destination regardless of its previous type.
+TEST_F(SetFamilyTest, EmptyStoreDeletesForeignTypeDest) {
+  for (std::string_view cmd : {"SINTERSTORE"sv, "SUNIONSTORE"sv, "SDIFFSTORE"sv}) {
+    Run({"SET", "dest", "hello"});
+    EXPECT_THAT(Run({cmd, "dest", "nx1", "nx2"}), IntArg(0)) << cmd;
+    EXPECT_THAT(Run({"EXISTS", "dest"}), IntArg(0)) << cmd;
+  }
+}
+
 }  // namespace dfly

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1955,9 +1955,10 @@ OpResult<ZSetFamily::AddResult> ZSetFamily::OpAdd(const OpArgs& op_args,
   auto& db_slice = op_args.GetDbSlice();
 
   if (zparams.override && members.empty()) {
-    auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
-    if (res_it && IsValid(res_it->it)) {
-      db_slice.DelMutable(op_args.db_cntx, std::move(*res_it));
+    // Lookup is untyped: an empty result deletes the destination regardless of its type.
+    auto res_it = db_slice.FindMutable(op_args.db_cntx, key);
+    if (IsValid(res_it.it)) {
+      db_slice.DelMutable(op_args.db_cntx, std::move(res_it));
       if (zparams.journal_update && op_args.shard->journal()) {
         RecordJournal(op_args, "DEL"sv, ArgSlice{key});
       }

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -1424,4 +1424,18 @@ TEST_F(ZSetFamilyTest, ZCountMinGreaterThanMaxCrash) {
   EXPECT_THAT(resp, IntArg(0));
 }
 
+// An empty result deletes the destination regardless of its previous type.
+TEST_F(ZSetFamilyTest, EmptyStoreDeletesForeignTypeDest) {
+  for (std::string_view cmd : {"ZUNIONSTORE"sv, "ZINTERSTORE"sv, "ZDIFFSTORE"sv}) {
+    Run({"SET", "dest", "hello"});
+    EXPECT_THAT(Run({cmd, "dest", "2", "nx1", "nx2"}), IntArg(0)) << cmd;
+    EXPECT_THAT(Run({"EXISTS", "dest"}), IntArg(0)) << cmd;
+  }
+
+  Run({"SET", "dest", "hello"});
+  Run({"ZADD", "src", "1", "a"});
+  EXPECT_THAT(Run({"ZRANGESTORE", "dest", "src", "5", "9"}), IntArg(0));
+  EXPECT_THAT(Run({"EXISTS", "dest"}), IntArg(0));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
An empty result of S{INTER,UNION,DIFF}STORE, Z{UNION,INTER,DIFF}STORE and ZRANGESTORE must delete the destination key regardless of its type - *STORE commands never check the destination type. The delete branch used a typed lookup, so a destination holding another type (e.g. a string) got WRONG_TYPE and silently survived:

    SET dest hello
    SINTERSTORE dest nx1 nx2   → 0
    EXISTS dest                → 1   (expected 0, verified against Valkey 9.1.1)

The fix switches the empty-result branches in set and zset OpAdd to an untyped lookup. The branch already journals DEL, which now also covers this case.