### PR TITLE
fix(server): Make egress throttling limit global

### DIFF
--- a/src/server/detail/egress_throttle.cc
+++ b/src/server/detail/egress_throttle.cc
@@ -64,11 +64,15 @@ uint64_t EgressThrottler::WakeTime(uint64_t now_us) const {
 }
 
 void EgressThrottler::Record(uint64_t bytes, bool high_prio) {
+  if (!limit_)
+    return;
+
   RecordAt(bytes, high_prio, NowUs());
 }
 
 void EgressThrottler::Throttle() const {
-  DCHECK_GT(limit_, 0u);
+  if (!limit_)
+    return;
 
   while (true) {
     uint64_t now = NowUs();

--- a/src/server/detail/egress_throttle.cc
+++ b/src/server/detail/egress_throttle.cc
@@ -68,6 +68,8 @@ void EgressThrottler::Record(uint64_t bytes, bool high_prio) {
 }
 
 void EgressThrottler::Throttle() const {
+  DCHECK_GT(limit_, 0u);
+
   while (true) {
     uint64_t now = NowUs();
     uint64_t wake = WakeTime(now);

--- a/src/server/detail/egress_throttle.h
+++ b/src/server/detail/egress_throttle.h
@@ -29,15 +29,12 @@ class EgressThrottler {
   // Block fiber until egress limit is available again.
   void Throttle() const;
 
+ protected:
   // Advances the TATs for `bytes` observed at time `now_us`.
   void RecordAt(uint64_t bytes, bool high_prio, uint64_t now_us);
 
   // Returns 0 if the loop may proceed at `now_us`, otherwise the us timestamp to sleep until.
   uint64_t WakeTime(uint64_t now_us) const;
-
-  bool IsEnabled() const {
-    return limit_ > 0;
-  }
 
  private:
   uint64_t limit_;             // bytes/second

--- a/src/server/detail/egress_throttle.h
+++ b/src/server/detail/egress_throttle.h
@@ -35,6 +35,10 @@ class EgressThrottler {
   // Returns 0 if the loop may proceed at `now_us`, otherwise the us timestamp to sleep until.
   uint64_t WakeTime(uint64_t now_us) const;
 
+  bool IsEnabled() const {
+    return limit_ > 0;
+  }
+
  private:
   uint64_t limit_;             // bytes/second
   uint64_t total_tat_ = 0;     // theoretical arrival time (us) for all egress

--- a/src/server/detail/egress_throttle_test.cc
+++ b/src/server/detail/egress_throttle_test.cc
@@ -17,9 +17,17 @@ constexpr uint64_t kT0 = 1'700'000'000'000'000ULL;
 constexpr uint64_t kTau = 50'000;              // matches kBurstToleranceUs (50ms) in the .cc
 constexpr uint64_t kMicrosPerSec = 1'000'000;  // matches the .cc
 
+struct OpenEgressThrottler : EgressThrottler {
+  explicit OpenEgressThrottler(size_t limit) : EgressThrottler(limit) {
+  }
+
+  using EgressThrottler::RecordAt;
+  using EgressThrottler::WakeTime;
+};
+
 // Under the limit the loop is never throttled.
 TEST(EgressThrottlerTest, ConformingProceeds) {
-  EgressThrottler t{1'000'000};  // 1 MB/s
+  OpenEgressThrottler t{1'000'000};  // 1 MB/s
   t.RecordAt(40'000, false, kT0);
   EXPECT_EQ(t.WakeTime(kT0), 0u);  // only 0.04s worth, within burst tolerance
 }
@@ -27,7 +35,7 @@ TEST(EgressThrottlerTest, ConformingProceeds) {
 // Sending a full second of budget at once forces a wait until the schedule catches up.
 TEST(EgressThrottlerTest, OverBudgetSleepsUntilSchedule) {
   const uint64_t limit = 1'000'000;
-  EgressThrottler t{limit};
+  OpenEgressThrottler t{limit};
 
   t.RecordAt(limit, false, kT0);  // 1 second worth of bytes at t0
   // total_tat_ = kT0 + 1s. It is conforming once now >= total_tat_ - tau.
@@ -42,7 +50,7 @@ TEST(EgressThrottlerTest, OverBudgetSleepsUntilSchedule) {
 // is still under its reserved (low priority) share (progress guarantee).
 TEST(EgressThrottlerTest, HighPrioDoesNotStarveLowPrio) {
   const uint64_t limit = 1'000'000;
-  EgressThrottler t{limit};
+  OpenEgressThrottler t{limit};
 
   // A huge high priority burst saturates the total budget for many seconds, yet the loop (which has
   // sent nothing) is still allowed to proceed because its own reserved share is untouched.
@@ -54,7 +62,7 @@ TEST(EgressThrottlerTest, HighPrioDoesNotStarveLowPrio) {
 // total saturation.
 TEST(EgressThrottlerTest, LowPrioThrottledAfterReservedShare) {
   const uint64_t limit = 1'000'000;
-  EgressThrottler t{limit};
+  OpenEgressThrottler t{limit};
 
   // Saturate the total budget via high priority load.
   t.RecordAt(10 * limit, true, kT0);
@@ -68,7 +76,7 @@ TEST(EgressThrottlerTest, LowPrioThrottledAfterReservedShare) {
 // current head, never rewinding the TAT.
 TEST(EgressThrottlerTest, BackwardClockDoesNotRewind) {
   const uint64_t limit = 1'000'000;
-  EgressThrottler t{limit};
+  OpenEgressThrottler t{limit};
 
   t.RecordAt(limit, false, kT0 + kMicrosPerSec);
   uint64_t wake_before = t.WakeTime(kT0);

--- a/src/server/detail/egress_throttle_test.cc
+++ b/src/server/detail/egress_throttle_test.cc
@@ -17,6 +17,7 @@ constexpr uint64_t kT0 = 1'700'000'000'000'000ULL;
 constexpr uint64_t kTau = 50'000;              // matches kBurstToleranceUs (50ms) in the .cc
 constexpr uint64_t kMicrosPerSec = 1'000'000;  // matches the .cc
 
+// Open protected functions to public for testing
 struct OpenEgressThrottler : EgressThrottler {
   explicit OpenEgressThrottler(size_t limit) : EgressThrottler(limit) {
   }

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -291,6 +291,9 @@ void JournalStreamer::AsyncWrite(bool force_send) {
   total_sent_ += in_flight_bytes_;
   last_async_write_time_ = base::CycleClock::Now();
 
+  if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
+    throttler->get().Record(in_flight_bytes_, false);
+
   const auto v_size = cur_buf.buf.size();
   absl::InlinedVector<iovec, 8> v(v_size);
 
@@ -480,6 +483,9 @@ void RestoreStreamer::Run() {
       stats_.iter_skips++;
       continue;
     }
+
+    if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
+      throttler->get().Throttle();
 
     cursor = pt->TraverseBuckets(cursor, [&](PrimeTable::bucket_iterator it) {
       if (!cntx_->IsRunning())  // Could be cancelled any time as Traverse may preempt

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -291,8 +291,7 @@ void JournalStreamer::AsyncWrite(bool force_send) {
   total_sent_ += in_flight_bytes_;
   last_async_write_time_ = base::CycleClock::Now();
 
-  if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
-    throttler->get().Record(in_flight_bytes_, false);
+  ServerState::tlocal()->GetEgressThrottler().Record(in_flight_bytes_, false);
 
   const auto v_size = cur_buf.buf.size();
   absl::InlinedVector<iovec, 8> v(v_size);
@@ -484,8 +483,8 @@ void RestoreStreamer::Run() {
       continue;
     }
 
-    if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
-      throttler->get().Throttle();
+    // Throttle main loop if we are over the egress limit
+    ServerState::tlocal()->GetEgressThrottler().Throttle();
 
     cursor = pt->TraverseBuckets(cursor, [&](PrimeTable::bucket_iterator it) {
       if (!cntx_->IsRunning())  // Could be cancelled any time as Traverse may preempt

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1024,7 +1024,6 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("pipeline_squash");
   config_registry.RegisterMutable("lua_mem_gc_threshold");
   config_registry.RegisterMutable("background_debug_jobs");
-  config_registry.RegisterMutable("snapshot_egress_limit_bytes");
 
   RegisterMutableFlags(&config_registry,
                        base::GetFlagNames(FLAGS_write_connection_throttling_sleep_usec), []() {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -47,7 +47,6 @@ ABSL_DECLARE_FLAG(uint32_t, num_shards);
 ABSL_DECLARE_FLAG(bool, rdb_sbf_chunked);
 ABSL_DECLARE_FLAG(bool, serialize_hnsw_index);
 ABSL_DECLARE_FLAG(bool, deserialize_hnsw_index);
-ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes);
 ABSL_DECLARE_FLAG(std::string, dbfilename);
 
 namespace dfly {
@@ -2031,7 +2030,7 @@ TEST_F(RdbTest, SnapshotEgressThrottle) {
   };
 
   // Baseline save with no limit to measure the machine's serialization capacity.
-  SetFlag(&FLAGS_snapshot_egress_limit_bytes, strings::MemoryBytesFlag{0});
+  Run({"config", "set", "snapshot_egress_limit_bytes", "0"});
   auto [t_base, bytes] = save_and_measure();
   ASSERT_GT(bytes, 1u << 20) << "populated dataset too small to test throttling";
 
@@ -2043,7 +2042,7 @@ TEST_F(RdbTest, SnapshotEgressThrottle) {
   uint64_t shards = shard_set->size();
   double target_sec = std::max(2.0, t_base * 8);
   uint64_t limit = uint64_t(bytes / shards / target_sec);
-  SetFlag(&FLAGS_snapshot_egress_limit_bytes, strings::MemoryBytesFlag{limit});
+  Run({"config", "set", "snapshot_egress_limit_bytes", absl::StrCat(limit)});
   auto [t_lim, bytes2] = save_and_measure();
 
   double rate = double(bytes2) / t_lim;

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -6,6 +6,8 @@
 
 #include <mimalloc.h>
 
+#include "server/detail/egress_throttle.h"
+
 extern "C" {
 #include "redis/zmalloc.h"
 }
@@ -18,6 +20,7 @@ extern "C" {
 #include "facade/facade_stats.h"
 #include "server/common.h"
 #include "server/journal/journal.h"
+#include "strings/human_readable.h"
 #include "util/listener_interface.h"
 
 namespace rng = std::ranges;
@@ -41,6 +44,11 @@ ABSL_FLAG(size_t, serialization_max_chunk_size, 64_KB,
           "serialization. 0 - to disable streaming mode");
 ABSL_FLAG(uint32_t, max_squashed_cmd_num, 100,
           "Max number of commands squashed in a single shard during squash optimizaiton");
+
+ABSL_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes, 0,
+          "Per-shard-thread socket egress bandwidth budget in bytes/second. Each shard throttles "
+          "its snapshot traversal loop to stay under this rate. Accepts human-readable sizes "
+          "(e.g. 100mb, 1gb). 0 disables throttling.");
 
 namespace dfly {
 
@@ -252,11 +260,12 @@ void ServerState::UpdateFromFlags() {
   rss_oom_deny_ratio = absl::GetFlag(FLAGS_rss_oom_deny_ratio);
   serialization_max_chunk_size = absl::GetFlag(FLAGS_serialization_max_chunk_size);
   max_squash_cmd_num = absl::GetFlag(FLAGS_max_squashed_cmd_num);
+  egress_throttler_.SetLimit(absl::GetFlag(FLAGS_snapshot_egress_limit_bytes));
 }
 
 vector<string> ServerState::GetMutableFlagNames() {
   return base::GetFlagNames(FLAGS_rss_oom_deny_ratio, FLAGS_serialization_max_chunk_size,
-                            FLAGS_max_squashed_cmd_num);
+                            FLAGS_max_squashed_cmd_num, FLAGS_snapshot_egress_limit_bytes);
 }
 
 Interpreter* ServerState::BorrowInterpreter() {
@@ -283,6 +292,13 @@ ServerState* ServerState::SafeTLocal() {
   // https://stackoverflow.com/a/75622732
   asm volatile("");
   return state_;
+}
+
+std::optional<std::reference_wrapper<detail::EgressThrottler>> ServerState::GetEgressThrottler() {
+  if (egress_throttler_.IsEnabled())
+    return std::ref(egress_throttler_);
+  else
+    return std::nullopt;
 }
 
 bool ServerState::ShouldLogSlowCmd(unsigned latency_usec) const {

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -294,13 +294,6 @@ ServerState* ServerState::SafeTLocal() {
   return state_;
 }
 
-std::optional<std::reference_wrapper<detail::EgressThrottler>> ServerState::GetEgressThrottler() {
-  if (egress_throttler_.IsEnabled())
-    return std::ref(egress_throttler_);
-  else
-    return std::nullopt;
-}
-
 bool ServerState::ShouldLogSlowCmd(unsigned latency_usec) const {
   return slow_log_shard_.IsEnabled() && latency_usec >= log_slower_than_usec;
 }

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -254,7 +254,9 @@ class ServerState {  // public struct - to allow initialization.
   }
 
   // If egress throttling is enabled, returns the per-thread throttler with updated limits
-  std::optional<std::reference_wrapper<detail::EgressThrottler>> GetEgressThrottler();
+  detail::EgressThrottler& GetEgressThrottler() {
+    return egress_throttler_;
+  }
 
   bool ShouldLogSlowCmd(unsigned latency_usec) const;
 

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -13,6 +13,7 @@
 #include "server/acl/acl_log.h"
 #include "server/channel_store.h"
 #include "server/common_types.h"
+#include "server/detail/egress_throttle.h"
 #include "server/script_mgr.h"
 #include "server/slowlog.h"
 #include "util/sliding_counter.h"
@@ -252,6 +253,9 @@ class ServerState {  // public struct - to allow initialization.
     return thread_index_;
   }
 
+  // If egress throttling is enabled, returns the per-thread throttler with updated limits
+  std::optional<std::reference_wrapper<detail::EgressThrottler>> GetEgressThrottler();
+
   bool ShouldLogSlowCmd(unsigned latency_usec) const;
 
   Stats stats;
@@ -332,6 +336,8 @@ class ServerState {  // public struct - to allow initialization.
 
   absl::flat_hash_map<std::string, base::Histogram> call_latency_histos_;
   uint32_t thread_index_ = 0;
+
+  detail::EgressThrottler egress_throttler_{0};
 
   mutable uint64_t used_mem_last_read_usec_ = 0;
   mutable MemoryUsageStats

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -253,7 +253,6 @@ class ServerState {  // public struct - to allow initialization.
     return thread_index_;
   }
 
-  // If egress throttling is enabled, returns the per-thread throttler with updated limits
   detail::EgressThrottler& GetEgressThrottler() {
     return egress_throttler_;
   }

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -28,10 +28,7 @@
 #include "util/fibers/synchronization.h"
 
 ABSL_FLAG(bool, background_snapshotting, false, "Whether to run snapshot as a background fiber");
-ABSL_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes, 0,
-          "Per-shard-thread socket egress bandwidth budget in bytes/second. Each shard throttles "
-          "its snapshot traversal loop to stay under this rate. Accepts human-readable sizes "
-          "(e.g. 100mb, 1gb). 0 disables throttling.");
+
 ABSL_FLAG(bool, serialize_hnsw_index, false, "Serialize HNSW vector index graph structure");
 ABSL_FLAG(bool, serialization_tagged_chunks, true,
           "Allow serializer output to be split into tagged chunks and reassembled by receiver");
@@ -50,10 +47,6 @@ thread_local absl::flat_hash_set<SliceSnapshot*> tl_slice_snapshots;
 // Controls the chunks size for pushing serialized data. The larger the chunk the more CPU
 // it may require (especially with compression), and less responsive the server may be.
 constexpr size_t kMinBlobSize = 8_KB;
-
-uint64_t CurrentEgressLimitBytes() {
-  return absl::GetFlag(FLAGS_snapshot_egress_limit_bytes);
-}
 
 }  // namespace
 
@@ -210,10 +203,8 @@ void SliceSnapshot::IterateBucketsFb(bool send_full_sync_cut) {
 
       // Suspend the traversal loop if we are exceeding the egress budget, letting
       // high priority writes drain first. Guarantees the loop its reserved share.
-      if (uint64_t limit = CurrentEgressLimitBytes(); limit > 0) {
-        throttler_.SetLimit(limit);  // Re-read to pick up CONFIG SET
-        throttler_.Throttle();
-      }
+      if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
+        throttler->get().Throttle();
     } while (snapshot_cursor_);
 
     // Wait for all the outstanding delayed entries and serialize them as well.
@@ -298,10 +289,8 @@ void SliceSnapshot::HandleFlushData(std::string data) {
 
   // Track egress just before the socket write. Attribute it to a high priority (out of order)
   // write when we don't run on the snapshot fiber.
-  if (uint64_t limit = CurrentEgressLimitBytes(); limit > 0) {
-    throttler_.SetLimit(limit);
-    throttler_.Record(serialized, !snapshot_fb_.IsActive());
-  }
+  if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
+    throttler->get().Record(serialized, !snapshot_fb_.IsActive());
 
   // Blocking point.
   consumer_->ConsumeData(std::move(data), base_cntx_);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -203,8 +203,7 @@ void SliceSnapshot::IterateBucketsFb(bool send_full_sync_cut) {
 
       // Suspend the traversal loop if we are exceeding the egress budget, letting
       // high priority writes drain first. Guarantees the loop its reserved share.
-      if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
-        throttler->get().Throttle();
+      ServerState::tlocal()->GetEgressThrottler().Throttle();
     } while (snapshot_cursor_);
 
     // Wait for all the outstanding delayed entries and serialize them as well.
@@ -289,8 +288,7 @@ void SliceSnapshot::HandleFlushData(std::string data) {
 
   // Track egress just before the socket write. Attribute it to a high priority (out of order)
   // write when we don't run on the snapshot fiber.
-  if (auto throttler = ServerState::tlocal()->GetEgressThrottler(); throttler)
-    throttler->get().Record(serialized, !snapshot_fb_.IsActive());
+  ServerState::tlocal()->GetEgressThrottler().Record(serialized, !snapshot_fb_.IsActive());
 
   // Blocking point.
   consumer_->ConsumeData(std::move(data), base_cntx_);


### PR DESCRIPTION
Previously we tracked egress _per_ operation - it means that if we had two replicas, we tracked it for each replication flow separately. Two snapshots - for each snapshot separately, etc.

With the number of "operations" increasing or decreasing, the setting would have to be adjusted every time to stay below a **global** limit

This PR makes all "snapshot operations" use a single thread local EgressThrottler

What this PR not includes is: we don't differentiate between disk and network traffic, so a disk snapshot will be counted as well. Something important to fix? Disks probably should never be tracked?