### PR TITLE
refactor(ci): extract Actions cache logic

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -75,12 +75,8 @@ runs:
       if: ${{ inputs.enable-ccache == 'true' && inputs.ccache-save == 'true' }}
       shell: bash
       run: |
-        # Refuse to write to a shared cache scope: reject an empty/whitespace suffix or the literal "default".
-        suffix="${{ inputs.cache-key-suffix }}"
-        if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
-          echo "::error title=ccache::ccache-save is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so writes don't collide across configs."
-          exit 1
-          fi
+        source "${GITHUB_ACTION_PATH}/scripts/actions_cache_ccache_helper.sh"
+        actions_cache_ccache_validate_suffix "${{ inputs.cache-key-suffix }}"
     - name: Restore/save cache (ccache)
       if: ${{ inputs.enable-ccache == 'true' }}
       # - Reuse compiled objects across runners so unchanged files are not recompiled.
@@ -107,29 +103,13 @@ runs:
       id: deps-cache-key
       shell: bash
       run: |
-        suffix="${{ inputs.cache-key-suffix }}"
-        if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
-          echo "::error title=deps-cache::enable-deps-cache is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so deps caches don't collide across configs."
-          exit 1
-        fi
-        DEPS_CACHE_HASH="${{ hashFiles('src/external_libs.cmake', 'CMakeLists.txt', 'src/CMakeLists.txt', 'helio/cmake/third_party.cmake', 'helio/cmake/internal.cmake', 'patches/**', 'helio/patches/**') }}"
-        if [ -z "${DEPS_CACHE_HASH}" ]; then
-          echo "::error title=deps-cache::hashFiles() matched no files - refusing to cache under a degenerate key. Check the file list in this step."
-          exit 1
-        fi
-        # Hash the CXX_FLAGS to avoid whitespaces in the key
-        CXX_FLAGS_HASH=$(printf '%s' "${{ inputs.cxx-flags }}" | sha256sum | cut -d ' ' -f1)
-        # set named outputs key, paths, and manifest_path for use by the restore/save steps below
-        {
-          echo "key=dfly-deps-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-${{ inputs.cxx-compiler }}-${{ inputs.sanitizers }}-${CXX_FLAGS_HASH}-${{ inputs.with-aws }}-${DEPS_CACHE_HASH}"
-          echo 'paths<<EOF'
-          echo '${{ inputs.build-dir }}/third_party'
-          echo '${{ inputs.build-dir }}/_deps'
-          echo '${{ inputs.build-dir }}/.ninja_log'
-          echo '${{ inputs.build-dir }}/CMakeFiles/*_project-complete'
-          echo 'EOF'
-          echo 'manifest_path=${{ inputs.build-dir }}/.deps-cache-manifest'
-        } >> "${GITHUB_OUTPUT}"
+        source "${GITHUB_ACTION_PATH}/scripts/actions_cache_deps_helper.sh"
+        actions_cache_deps_set_key \
+          "${{ inputs.cache-key-suffix }}" \
+          "${{ hashFiles('src/external_libs.cmake', 'CMakeLists.txt', 'src/CMakeLists.txt', 'helio/cmake/third_party.cmake', 'helio/cmake/internal.cmake', 'patches/**', 'helio/patches/**') }}" \
+          "${{ runner.os }}" "${{ runner.arch }}" "${{ inputs.build-type }}" \
+          "${{ inputs.cxx-compiler }}" "${{ inputs.sanitizers }}" "${{ inputs.cxx-flags }}" \
+          "${{ inputs.with-aws }}" "${{ inputs.build-dir }}"
 
     - name: Restore cache (deps)
       # - actions/cache/restore only downloads a cache; unlike the combined cache action, it never saves automatically.
@@ -161,34 +141,12 @@ runs:
       id: deps-cache-validate
       shell: bash
       run: |
-        manifest_path="${GITHUB_WORKSPACE}/${{ steps.deps-cache-key.outputs.manifest_path }}"
-        cd "${GITHUB_WORKSPACE}"
-        shopt -s nullglob  #  -> unmatched glob expands to nothing
-        mapfile -t cache_paths <<< "${{ steps.deps-cache-key.outputs.paths }}"
-        expanded_cache_paths=()
-        for cache_path in "${cache_paths[@]}"; do
-          expanded_cache_paths+=($cache_path)
-        done
-        validation_status=0
-        python3 "${GITHUB_WORKSPACE}/tools/deps_cache_manifest.py" validate \
-          --root "${GITHUB_WORKSPACE}" --manifest "${manifest_path}" \
-          "${expanded_cache_paths[@]}" || validation_status=$?
-        case "${validation_status}" in
-          0)
-            echo "deps_cache_is_valid=true" >> "${GITHUB_OUTPUT}"
-            ;;
-          1|3)
-            echo "::warning title=deps-cache::Invalid or unreadable restored dependency cache; discarding local restore, attempting remote deletion, and rebuilding dependencies"
-            echo "Discarding restored paths for cache key: ${{ steps.deps-cache-key.outputs.key }}"
-            # Remove the local restored dependency files and manifest. The next step deletes this cache remotely.
-            rm -rf "${expanded_cache_paths[@]}" "${manifest_path}"
-            echo "deps_cache_is_valid=false" >> "${GITHUB_OUTPUT}"
-            ;;
-          *)
-            echo "::error title=deps-cache::Manifest validation failed with infrastructure error ${validation_status}"
-            exit "${validation_status}"
-            ;;
-        esac
+        source "${GITHUB_ACTION_PATH}/scripts/actions_cache_deps_helper.sh"
+        actions_cache_deps_validate_restore \
+          "${GITHUB_WORKSPACE}" \
+          "${GITHUB_WORKSPACE}/${{ steps.deps-cache-key.outputs.manifest_path }}" \
+          "${{ steps.deps-cache-key.outputs.paths }}" \
+          "${{ steps.deps-cache-key.outputs.key }}"
 
     - name: Delete invalid remote cache (deps)
       # Delete before rebuilding so a successful cold build can save under this immutable key. For PRs, also try the
@@ -198,58 +156,21 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        cache_key="${{ steps.deps-cache-key.outputs.key }}"
-        if ! command -v curl >/dev/null 2>&1; then
-          echo "::warning title=deps-cache::'curl' not found; remote cache remains until reaped"
-        else
-          cache_refs=("${{ github.ref }}")
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # An invalid PR hit may have been restored from its base branch.
-            cache_refs+=("refs/heads/${{ github.base_ref }}")
-          fi
-          deleted=false
-          for cache_ref in "${cache_refs[@]}"; do
-            # gh is absent from the build container - use its REST API through curl instead.
-            if curl --fail --silent --show-error --output /dev/null \
-              --request DELETE \
-              --header "Accept: application/vnd.github+json" \
-              --header "Authorization: Bearer ${GH_TOKEN}" \
-              --header "X-GitHub-Api-Version: 2022-11-28" \
-              --get \
-              --data-urlencode "key=${cache_key}" \
-              --data-urlencode "ref=${cache_ref}" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/caches"; then
-              echo "Removed remote dependency cache: ${cache_key} (ref: ${cache_ref})"
-              deleted=true
-              break
-            fi
-          done
-          if [ "${deleted}" = false ]; then
-            echo "::warning title=deps-cache::Could not delete remote cache; it may require 'actions: write' permission"
-          fi
-        fi
+        source "${GITHUB_ACTION_PATH}/scripts/actions_cache_deps_helper.sh"
+        actions_cache_deps_delete_invalid_remote \
+          "${{ steps.deps-cache-key.outputs.key }}" "${{ github.ref }}" \
+          "${{ github.event_name }}" "${{ github.base_ref }}" "${{ github.repository }}"
 
     - name: Report cache status (deps)
       # - Only exact cache keys are used (no restore-keys), so a hit means the config matches the saved artifacts.
       if: always() && inputs.enable-deps-cache == 'true'
       shell: bash
       run: |
-        if [ "${{ steps.deps-cache-restore.outputs.cache-hit }}" != "true" ]; then
-          STATUS="MISS - no matching cache found, full cold third-party build expected"
-        elif [ "${{ steps.deps-cache-validate.outputs.deps_cache_is_valid }}" = "true" ]; then
-          STATUS="VERIFIED HIT (exact key match) - manifest, third_party/_deps, and Ninja build log restored"
-        elif [ -z "${{ steps.deps-cache-validate.outputs.deps_cache_is_valid }}" ]; then
-          STATUS="UNKNOWN - exact cache hit was not validated"
-        else
-          STATUS="INVALID HIT - restored cache failed manifest validation; rebuilding dependencies locally"
-        fi
-        echo "Third-party deps cache: ${STATUS}"
-        echo "  primary key: ${{ steps.deps-cache-key.outputs.key }}"
-        {
-          echo "### Third-party deps cache"
-          echo "- **${STATUS}**"
-          echo "- primary key: \`${{ steps.deps-cache-key.outputs.key }}\`"
-        } >> "${GITHUB_STEP_SUMMARY}"
+        source "${GITHUB_ACTION_PATH}/scripts/actions_cache_deps_helper.sh"
+        actions_cache_deps_report_status \
+          "${{ steps.deps-cache-restore.outputs.cache-hit }}" \
+          "${{ steps.deps-cache-validate.outputs.deps_cache_is_valid }}" \
+          "${{ steps.deps-cache-key.outputs.key }}"
 
     - name: Configure CMake
       shell: bash
@@ -326,18 +247,11 @@ runs:
       if: success() && inputs.enable-deps-cache == 'true' && (steps.deps-cache-restore.outputs.cache-hit != 'true' || steps.deps-cache-validate.outputs.deps_cache_is_valid == 'false')
       shell: bash
       run: |
-        manifest_path="${GITHUB_WORKSPACE}/${{ steps.deps-cache-key.outputs.manifest_path }}"
-        cd "${GITHUB_WORKSPACE}"
-        shopt -s nullglob
-        mapfile -t cache_paths <<< "${{ steps.deps-cache-key.outputs.paths }}"
-        expanded_cache_paths=()
-        for cache_path in "${cache_paths[@]}"; do
-          expanded_cache_paths+=($cache_path)
-        done
-        # The manifest is excluded from this list because it cannot describe itself.
-        python3 "${GITHUB_WORKSPACE}/tools/deps_cache_manifest.py" generate \
-          --root "${GITHUB_WORKSPACE}" --manifest "${manifest_path}" \
-          "${expanded_cache_paths[@]}"
+        source "${GITHUB_ACTION_PATH}/scripts/actions_cache_deps_helper.sh"
+        actions_cache_deps_generate_manifest \
+          "${GITHUB_WORKSPACE}" \
+          "${GITHUB_WORKSPACE}/${{ steps.deps-cache-key.outputs.manifest_path }}" \
+          "${{ steps.deps-cache-key.outputs.paths }}"
 
     - name: Save cache (deps)
       # - Save only after configuration and build succeed. Later test failures must not discard a valid deps cache.

--- a/.github/actions/builder/scripts/actions_cache_ccache_helper.sh
+++ b/.github/actions/builder/scripts/actions_cache_ccache_helper.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# This file is not standalone - source it from the builder action or cache-reaper workflow;
+# Do not set any shell options - assume callers own shell options such as set -euo pipefail.
+
+actions_cache_ccache_validate_suffix() {
+  local suffix="$1"
+
+  if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
+    echo "::error title=ccache::ccache-save is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so writes don't collide across configs."
+    return 1
+  fi
+}
+
+actions_cache_ccache_print_repo_usage() {
+  local jq_script
+
+  read -r -d '' jq_script <<'JQ' || true
+    def cat:
+      if (.key | test("^ccache-dfly-ccache-")) then "ccache"
+      elif (.key | test("^dfly-deps-")) then "3rd-party deps"
+      else "other" end;
+    (map(.sizeInBytes) | add // 0) as $total
+    | (group_by(cat) | map({cat: (.[0] | cat), count: length, mb: ((map(.sizeInBytes) | add) / 1048576 | floor)})
+       | sort_by(-.mb)) as $groups
+    | "Repo cache: \($total/1048576|floor) MB used, \(length) caches",
+      ($groups[] | "  \(.cat): \(.count) caches, \(.mb) MB")
+# The terminator must be unindented and contain no other characters.
+JQ
+
+  gh cache list --limit 10000 --json sizeInBytes,key --jq "$jq_script"
+}
+
+actions_cache_ccache_reap() {
+  local event_name="$1"
+  local pr_ref="$2"
+  local before_count
+  local deleted
+  local id
+  local key
+  local ref
+  local stale
+  local stale_jq_script
+
+  echo "== Before cleanup =="
+  actions_cache_ccache_print_repo_usage || true
+
+  if [[ "$event_name" == "pull_request" ]]; then
+    before_count=$(gh cache list --ref "$pr_ref" --limit 10000 --json id --jq 'length' || echo '?')
+    echo "PR closed - deleting all caches for $pr_ref ($before_count found)"
+    if ! gh cache delete --all --ref "$pr_ref" --succeed-on-no-caches; then
+      echo "::warning::Some caches for $pr_ref may not have been deleted; 7-day/LRU will reclaim leftovers."
+    fi
+    echo "Deleted $before_count cache(s) for $pr_ref"
+  else
+    echo "Scheduled cleanup - keeping newest cache per (ref, config)"
+    read -r -d '' stale_jq_script <<'JQ' || true
+      [ .[] | select(.key | test("^ccache-dfly-ccache-|^dfly-deps-")) ]
+      | group_by(
+          .ref + "|"
+          + (.key | sub("-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$|-[0-9a-f]{64}$"; ""))
+        )
+      | map(sort_by(.createdAt) | .[:-1])
+      | flatten[]
+      | "\(.id)\t\(.ref)\t\(.key)"
+# The terminator must be unindented and contain no other characters.
+JQ
+    stale=$(gh cache list --limit 10000 --json id,key,ref,createdAt --jq "$stale_jq_script")
+    if [[ -z "$stale" ]]; then
+      echo "No stale duplicate caches."
+    else
+      deleted=0
+      while IFS=$'\t' read -r id ref key; do
+        [[ -n "$id" ]] || continue
+        echo "Deleting stale cache: $key (ref=$ref, id=$id)"
+        if gh cache delete "$id"; then
+          deleted=$((deleted + 1))
+        else
+          echo "::warning::failed to delete id=$id"
+        fi
+      done <<< "$stale"
+      echo "Deleted $deleted stale duplicate cache(s)"
+    fi
+  fi
+
+  echo "== After cleanup =="
+  actions_cache_ccache_print_repo_usage || true
+}

--- a/.github/actions/builder/scripts/actions_cache_deps_helper.sh
+++ b/.github/actions/builder/scripts/actions_cache_deps_helper.sh
@@ -50,7 +50,6 @@ actions_cache_deps_expand_paths() {
   local -a cache_paths
   local -a matched_paths
 
-  shopt -s nullglob
   mapfile -t cache_paths <<< "$paths"
   output_paths=()
   for cache_path in "${cache_paths[@]}"; do
@@ -71,6 +70,13 @@ actions_cache_deps_validate_restore() {
   manifest_tool="$(dirname "${BASH_SOURCE[0]}")/deps_cache_manifest.py"
   cd "$workspace" || return
   actions_cache_deps_expand_paths "$paths" expanded_cache_paths
+  #  Handle a broken cache restore restore where none of the expected paths exist after extraction.
+  if ((${#expanded_cache_paths[@]} == 0)); then
+    echo "::warning title=deps-cache::Restored dependency cache contains none of the expected paths; rebuilding dependencies locally"
+    rm -f "$manifest_path"
+    echo "deps_cache_is_valid=false" >> "$GITHUB_OUTPUT"
+    return
+  fi
   python3 "$manifest_tool" validate \
     --root "$workspace" --manifest "$manifest_path" \
     "${expanded_cache_paths[@]}" || validation_status=$?

--- a/.github/actions/builder/scripts/actions_cache_deps_helper.sh
+++ b/.github/actions/builder/scripts/actions_cache_deps_helper.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+# This file is not standalone - source it from the builder action
+# Do not set any shell options - assume callers own shell options such as set -euo pipefail.
+
+actions_cache_deps_validate_suffix() {
+  local suffix="$1"
+
+  if [[ -z "${suffix//[[:space:]]/}" || "$suffix" == "default" ]]; then
+    echo "::error title=deps-cache::enable-deps-cache is 'true' but cache-key-suffix is empty or 'default'. Pass a specific cache-key-suffix (e.g. the container image) so deps caches don't collide across configs."
+    return 1
+  fi
+}
+
+actions_cache_deps_set_key() {
+  local suffix="$1"
+  local deps_cache_hash="$2"
+  local runner_os="$3"
+  local runner_arch="$4"
+  local build_type="$5"
+  local cxx_compiler="$6"
+  local sanitizers="$7"
+  local cxx_flags="$8"
+  local with_aws="$9"
+  local build_dir="${10}"
+  local cxx_flags_hash
+
+  actions_cache_deps_validate_suffix "$suffix" || return
+  if [[ -z "$deps_cache_hash" ]]; then
+    echo "::error title=deps-cache::hashFiles() matched no files - refusing to cache under a degenerate key. Check the file list in this step."
+    return 1
+  fi
+  cxx_flags_hash=$(printf '%s' "$cxx_flags" | sha256sum | cut -d ' ' -f1)
+  {
+    echo "key=dfly-deps-${suffix}-${runner_os}-${runner_arch}-${build_type}-${cxx_compiler}-${sanitizers}-${cxx_flags_hash}-${with_aws}-${deps_cache_hash}"
+    echo 'paths<<EOF'
+    echo "${build_dir}/third_party"
+    echo "${build_dir}/_deps"
+    echo "${build_dir}/.ninja_log"
+    echo "${build_dir}/CMakeFiles/*_project-complete"
+    echo 'EOF'
+    echo "manifest_path=${build_dir}/.deps-cache-manifest"
+  } >> "$GITHUB_OUTPUT"
+}
+
+actions_cache_deps_expand_paths() {
+  local paths="$1"
+  local -n output_paths="$2"
+  local cache_path
+  local -a cache_paths
+  local -a matched_paths
+
+  shopt -s nullglob
+  mapfile -t cache_paths <<< "$paths"
+  output_paths=()
+  for cache_path in "${cache_paths[@]}"; do
+    mapfile -t matched_paths < <(compgen -G "$cache_path" | sort)
+    output_paths+=("${matched_paths[@]}")
+  done
+}
+
+actions_cache_deps_validate_restore() {
+  local workspace="$1"
+  local manifest_path="$2"
+  local paths="$3"
+  local cache_key="$4"
+  local manifest_tool
+  local validation_status=0
+  local -a expanded_cache_paths
+
+  manifest_tool="$(dirname "${BASH_SOURCE[0]}")/deps_cache_manifest.py"
+  cd "$workspace" || return
+  actions_cache_deps_expand_paths "$paths" expanded_cache_paths
+  python3 "$manifest_tool" validate \
+    --root "$workspace" --manifest "$manifest_path" \
+    "${expanded_cache_paths[@]}" || validation_status=$?
+  case "$validation_status" in
+    0)
+      echo "deps_cache_is_valid=true" >> "$GITHUB_OUTPUT"
+      ;;
+    1 | 3)
+      echo "::warning title=deps-cache::Invalid or unreadable restored dependency cache; discarding local restore, attempting remote deletion, and rebuilding dependencies"
+      echo "Discarding restored paths for cache key: $cache_key"
+      rm -rf "${expanded_cache_paths[@]}" "$manifest_path"
+      echo "deps_cache_is_valid=false" >> "$GITHUB_OUTPUT"
+      ;;
+    *)
+      echo "::error title=deps-cache::Manifest validation failed with infrastructure error $validation_status"
+      return "$validation_status"
+      ;;
+  esac
+}
+
+actions_cache_deps_delete_invalid_remote() {
+  local cache_key="$1"
+  local ref="$2"
+  local event_name="$3"
+  local base_ref="$4"
+  local repository="$5"
+  local cache_ref
+  local deleted=false
+  local -a cache_refs=("$ref")
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "::warning title=deps-cache::'curl' not found; remote cache remains until reaped"
+    return
+  fi
+  if [[ "$event_name" == "pull_request" ]]; then
+    cache_refs+=("refs/heads/$base_ref")
+  fi
+  for cache_ref in "${cache_refs[@]}"; do
+    if curl --fail --silent --show-error --output /dev/null \
+      --request DELETE \
+      --header "Accept: application/vnd.github+json" \
+      --header "Authorization: Bearer ${GH_TOKEN}" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      --get \
+      --data-urlencode "key=$cache_key" \
+      --data-urlencode "ref=$cache_ref" \
+      "https://api.github.com/repos/${repository}/actions/caches"; then
+      echo "Removed remote dependency cache: $cache_key (ref: $cache_ref)"
+      deleted=true
+      break
+    fi
+  done
+  if [[ "$deleted" == false ]]; then
+    echo "::warning title=deps-cache::Could not delete remote cache; it may require 'actions: write' permission"
+  fi
+}
+
+actions_cache_deps_report_status() {
+  local cache_hit="$1"
+  local is_valid="$2"
+  local key="$3"
+  local status
+
+  if [[ "$cache_hit" != "true" ]]; then
+    status="MISS - no matching cache found, full cold third-party build expected"
+  elif [[ "$is_valid" == "true" ]]; then
+    status="VERIFIED HIT (exact key match) - manifest, third_party/_deps, and Ninja build log restored"
+  elif [[ -z "$is_valid" ]]; then
+    status="UNKNOWN - exact cache hit was not validated"
+  else
+    status="INVALID HIT - restored cache failed manifest validation; rebuilding dependencies locally"
+  fi
+  echo "Third-party deps cache: $status"
+  echo "  primary key: $key"
+}
+
+actions_cache_deps_generate_manifest() {
+  local workspace="$1"
+  local manifest_path="$2"
+  local paths="$3"
+  local manifest_tool
+  local -a expanded_cache_paths
+
+  manifest_tool="$(dirname "${BASH_SOURCE[0]}")/deps_cache_manifest.py"
+  cd "$workspace" || return
+  actions_cache_deps_expand_paths "$paths" expanded_cache_paths
+  python3 "$manifest_tool" generate \
+    --root "$workspace" --manifest "$manifest_path" \
+    "${expanded_cache_paths[@]}"
+}

--- a/.github/actions/builder/scripts/deps_cache_manifest.py
+++ b/.github/actions/builder/scripts/deps_cache_manifest.py
@@ -3,15 +3,15 @@
 """Generate and validate dependency-cache manifests.
 
 Usage:
-    python3 tools/deps_cache_manifest.py generate --root BUILD_DIR --manifest FILE PATH [...]
-    python3 tools/deps_cache_manifest.py validate --root BUILD_DIR --manifest FILE PATH [...]
+    python3 .github/actions/builder/scripts/deps_cache_manifest.py generate --root BUILD_DIR --manifest FILE PATH [...]
+    python3 .github/actions/builder/scripts/deps_cache_manifest.py validate --root BUILD_DIR --manifest FILE PATH [...]
 
 Requires Python 3.8 or newer.
 
 The CI builder saves this manifest with its dependency cache. On an exact cache hit it
 regenerates the manifest before CMake/Ninja; a mismatch means the restored tree is
 discarded locally and that job cold-builds dependencies instead of failing repeatedly.
-Run tools/test_deps_cache_manifest.sh after changing this tool or cache-validation behavior;
+Run .github/actions/builder/scripts/test_deps_cache_manifest.sh after changing this tool or cache-validation behavior;
 it is the regression harness for manifest generation, validation, and archive restoration.
 Timestamps are intentionally excluded because cache archive tools do not consistently
 preserve nanosecond precision.

--- a/.github/actions/builder/scripts/test_deps_cache_manifest.sh
+++ b/.github/actions/builder/scripts/test_deps_cache_manifest.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 
-# Tests for tools/deps_cache_manifest.py.
-# - Run with: bash tools/test_deps_cache_manifest.sh
+# Tests for the builder action's dependency-cache manifest validator.
+# - Run with: bash .github/actions/builder/scripts/test_deps_cache_manifest.sh
 # - Set RUN_MANIFEST_BENCHMARK=1 to time manifest generation and validation for a 1,000-file fixture.
 # - Default tests:
 #   1) Confirm a tar archive can be extracted and still pass manifest validation, with file mtimes unchanged.
 #   2) Confirm validation rejects changed, added, deleted, unreadable, or unsupported cache entries and malformed
 #      manifests.
-# - No build directory is needed. Keep this script and deps_cache_manifest.py in tools/ , the test creates its own
-#   temporary workspace.
+# - No build directory is needed; the test creates its own temporary workspace.
 
 set -euo pipefail
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-manifest_tool="$repo_root/tools/deps_cache_manifest.py"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+manifest_tool="$script_dir/deps_cache_manifest.py"
 workspace=$(mktemp -d)
 template="$workspace/template"
 

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -26,6 +26,9 @@ jobs:
       contents: read   # required to check out the cache helper script
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Ensures the sourced script is from the trusted target branch revision
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - name: Reap caches
         shell: bash
         env:

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -23,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write   # required to delete caches
+      contents: read   # required to check out the cache helper script
     steps:
+      - uses: actions/checkout@v5
       - name: Reap caches
         shell: bash
         env:
@@ -32,78 +34,5 @@ jobs:
           PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
           set -euo pipefail
-
-          # - Print live repository-wide cache usage before and after cleanup.
-          # - Sum `gh cache list` results instead of the asynchronous cache-usage API, which can lag after deletions.
-          # - Group usage into ccache, third-party dependencies cache, and other caches.
-          # - ccache-action automatically prefixes each persisted ccache key with "ccache-".
-          print_repo_cache_usage() {
-            gh cache list --limit 10000 --json sizeInBytes,key --jq '
-              def cat:
-                if (.key | test("^ccache-dfly-ccache-")) then "ccache"
-                elif (.key | test("^dfly-deps-")) then "3rd-party deps"
-                else "other" end;
-              (map(.sizeInBytes) | add // 0) as $total
-              | (group_by(cat) | map({cat: (.[0] | cat), count: length, mb: ((map(.sizeInBytes) | add) / 1048576 | floor)})
-                 | sort_by(-.mb)) as $groups
-              | "Repo cache: \($total/1048576|floor) MB used, \(length) caches",
-                ($groups[] | "  \(.cat): \(.count) caches, \(.mb) MB")
-            '
-          }
-
-          echo "== Before cleanup =="
-          print_repo_cache_usage || true
-
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then # pr closed - > delete only caches for this PR
-            # - Delete every cache scoped to the closed pull request's ref.
-            # - The count is informational - failure to read it must not prevent cleanup.
-            before_count=$(gh cache list --ref "$PR_REF" --limit 10000 --json id --jq 'length' || echo '?')
-            echo "PR closed - deleting all caches for $PR_REF ($before_count found)"
-            if ! gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches; then
-              echo "::warning::Some caches for $PR_REF may not have been deleted; 7-day/LRU will reclaim leftovers."
-            fi
-            echo "Deleted $before_count cache(s) for $PR_REF"
-          else # scheduled cleanup
-            # - Keep the newest cache for each ref and supported dependency-cache configuration, delete older duplicates.
-            # - ccache keys add a timestamp on every save, so remove that timestamp before grouping.
-            # - Dependency keys end in a content hash; remove it to group obsolete definitions by configuration.
-            # - This relies on ccache keys ending in timestamps and deps keys ending in a 64-hex content hash. Update
-            #   the grouping expression if either key shape changes, so their configurations cannot collide.
-            # - Key shapes: ccache-dfly-ccache-<config>-<timestamp> and dfly-deps-<config>-<dependency-files-sha256>.
-            # - Inspect live keys with: `gh cache list -R dragonflydb/dragonfly --limit 100`
-            stale=$(gh cache list --limit 10000 --json id,key,ref,createdAt --jq '
-                # Keep only ccache and dependency-cache entries created by this workflow.
-                [ .[] | select(
-                    .key | test("^ccache-dfly-ccache-|^dfly-deps-")
-                  ) ]
-                # Group entries that share a ref and configuration, ignoring each key's changing suffix.
-                | group_by(
-                    .ref + "|"
-                    + (.key | sub("-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$|-[0-9a-f]{64}$"; ""))
-                  )
-                # Sort each group from oldest to newest and remove the newest entry.
-                | map(sort_by(.createdAt) | .[:-1])
-                # Turn the remaining duplicate groups into individual cache entries.
-                | flatten[]
-                # Print fields for the shell deletion loop.
-                | "\(.id)\t\(.ref)\t\(.key)"')
-            if [ -z "$stale" ]; then
-              echo "No stale duplicate caches."
-            else
-              echo "Scheduled cleanup - keeping newest cache per (ref, config)"
-              deleted=0
-              while IFS=$'\t' read -r id ref key; do
-                [ -n "$id" ] || continue
-                echo "Deleting stale cache: $key (ref=$ref, id=$id)"
-                if gh cache delete "$id"; then
-                  deleted=$((deleted + 1))
-                else
-                  echo "::warning::failed to delete id=$id"
-                fi
-              done <<< "$stale"
-              echo "Deleted $deleted stale duplicate cache(s)"
-            fi
-          fi
-
-          echo "== After cleanup =="
-          print_repo_cache_usage || true
+          source "${GITHUB_WORKSPACE}/.github/actions/builder/scripts/actions_cache_ccache_helper.sh"
+          actions_cache_ccache_reap "$GITHUB_EVENT_NAME" "$PR_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Test dependency-cache manifest
         if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Debug' && matrix.compiler.cxx == 'g++' && matrix.sanitizers == 'NoSanitizers'
         # run only once for both pull requests and pushes.
-        run: bash tools/test_deps_cache_manifest.sh
+        run: bash .github/actions/builder/scripts/test_deps_cache_manifest.sh
 
       - name: Build Dragonfly
         uses: ./.github/actions/builder


### PR DESCRIPTION
This PR refactors cache logic into a bash script and fixes a bug:
- Extract ccache and dependency-cache Bash code into reusable helpers.
- Move the helpers, dependency-cache manifest tool, and its regression test
  under .github/actions/builder.
- Fix scheduled cache reaping by passing its jq program through a literal
  heredoc.