### PR TITLE
feat(server): add per-slot tiered_bytes to DFLYCLUSTER GETSLOTINFO

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -359,7 +359,8 @@ void ElementAccess::Commit(string_view new_value) const {
       updater_.post_updater.ReduceHeapUsage();
     }
     if (is_external) {
-      EngineShard::tlocal()->tiered_storage()->Delete(context_.db_index, &updater_.it->second);
+      EngineShard::tlocal()->tiered_storage()->Delete(context_.db_index, key_,
+                                                      &updater_.it->second);
     }
     updater_.it->second.SetString(new_value);
     updater_.post_updater.Run();

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -130,7 +130,7 @@ OpStatus OpLoadChunk(const OpArgs& op_args, std::string_view blob, std::string_v
       // existing key might not necessarily be SBF, it could be HASH/JSON, and indexed
       RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, op_res->it->second, op_args.shard);
       db_slice.RemoveExpire(op_args.db_cntx.db_index, op_res->it);
-      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &op_res->it->second);
+      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, key, &op_res->it->second);
     }
 
     op_res->it->second.SetSBF(load_result.value());

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -713,7 +713,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgParser parser, CommandContext* 
   rb->StartArray(slots_stats.size());
 
   for (const auto& slot_data : slots_stats) {
-    rb->StartArray(9);
+    rb->StartArray(slot_data.second.tiered_bytes > 0 ? 11 : 9);
     rb->SendLong(slot_data.first);
     rb->SendBulkString("key_count");
     rb->SendLong(slot_data.second.key_count);
@@ -728,6 +728,12 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgParser parser, CommandContext* 
     rb->SendBulkString("memory_bytes");
     rb->SendLong(slot_data.second.memory_bytes +
                  slot_data.second.key_count * sizeof(CompactObj) * 2);
+
+    // Disk bytes held by the slot's offloaded entries; reported only when non-zero.
+    if (slot_data.second.tiered_bytes > 0) {
+      rb->SendBulkString("tiered_bytes");
+      rb->SendLong(slot_data.second.tiered_bytes);
+    }
   }
 }
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -654,12 +654,18 @@ class ClusterMemoryTest : public ClusterFamilyTest {
     int64_t total_reads = 0;
     int64_t total_writes = 0;
     int64_t memory_bytes = 0;
+    int64_t tiered_bytes = 0;  // reported only when non-zero
   };
 
   SlotInfo GetSlotInfo(SlotId slot) {
     auto resp = RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(slot)});
     const auto& row = resp.GetVec()[0].GetVec();
-    return SlotInfo{*row[2].GetInt(), *row[4].GetInt(), *row[6].GetInt(), *row[8].GetInt()};
+    SlotInfo info{*row[2].GetInt(), *row[4].GetInt(), *row[6].GetInt(), *row[8].GetInt()};
+    if (row.size() >= 11) {
+      EXPECT_EQ(row[9], "tiered_bytes");
+      info.tiered_bytes = *row[10].GetInt();
+    }
+    return info;
   }
 
   // GETSLOTINFO adds a fixed per-key table-space term.
@@ -672,10 +678,14 @@ class ClusterMemoryTest : public ClusterFamilyTest {
     SlotInfo info = GetSlotInfo(slot);
     EXPECT_EQ(info.key_count, 0);
     EXPECT_EQ(info.memory_bytes, 0);
+    EXPECT_EQ(info.tiered_bytes, 0);
   }
 
+  // The slot ledgers must mirror the db-wide ones.
   void ExpectSlotMirrorsDb(SlotId slot) {
-    EXPECT_EQ(RawSlotMemory(slot), int64_t(GetMetrics().db_stats[0].obj_memory_usage));
+    auto db_stats = GetMetrics().db_stats[0];
+    EXPECT_EQ(RawSlotMemory(slot), int64_t(db_stats.obj_memory_usage));
+    EXPECT_EQ(GetSlotInfo(slot).tiered_bytes, int64_t(db_stats.tiered_used_bytes));
   }
 };
 
@@ -729,6 +739,7 @@ TEST_F(ClusterTieredTest, SlotCountersFollowOffloadAndDelete) {
   WaitForOffload(1);
 
   EXPECT_EQ(RawSlotMemory(slot), 0);
+  EXPECT_GT(GetSlotInfo(slot).tiered_bytes, 0);
 
   EXPECT_EQ(CheckedInt({"DEL", kKey}), 1);
   ExpectSlotEmpty(slot);
@@ -758,6 +769,7 @@ TEST_F(ClusterTieredTest, SlotCountersReleasedOnFlushSlots) {
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
 
   EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", absl::StrCat(slot), absl::StrCat(slot)}),
             "OK");
@@ -772,6 +784,7 @@ TEST_F(ClusterTieredTest, SlotCountersReleasedOnExpiry) {
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
 
   EXPECT_EQ(CheckedInt({"PEXPIRE", kKey, "10"}), 1);
   AdvanceTime(100);
@@ -801,6 +814,7 @@ TEST_F(ClusterTieredTest, SlotCountersFollowUploadAndAppend) {
 TEST_F(ClusterTieredTest, SlotCountersReleasedOnConfigSlotRemoval) {
   Run({"debug", "populate", "20", "key", "3000", "SLOTS", "1", "1"});
   WaitForOffload(20);
+  ASSERT_GT(GetSlotInfo(1).tiered_bytes, 0);
 
   ConfigSingleNodeCluster("abc");
   ExpectConditionWithinTimeout([&]() { return CheckedInt({"dbsize"}) == 0; });
@@ -819,7 +833,8 @@ class ClusterTieredCoolingTest : public ClusterTieredTest {
   }
 };
 
-// Cool values are tracked by the cool cache only, so the slot ledger does not include them.
+// A cool value is invisible to the RAM ledger but still holds its disk extent, so it counts
+// in tiered_bytes only.
 TEST_F(ClusterTieredCoolingTest, CoolSlotCountersReleasedOnFlushSlots) {
   const string kKey = "cool-flush";
   const SlotId slot = KeySlot(kKey);
@@ -829,6 +844,7 @@ TEST_F(ClusterTieredCoolingTest, CoolSlotCountersReleasedOnFlushSlots) {
 
   ExpectSlotMirrorsDb(slot);
   EXPECT_EQ(RawSlotMemory(slot), 0);
+  EXPECT_GT(GetSlotInfo(slot).tiered_bytes, 0);
 
   EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", absl::StrCat(slot), absl::StrCat(slot)}),
             "OK");
@@ -838,19 +854,21 @@ TEST_F(ClusterTieredCoolingTest, CoolSlotCountersReleasedOnFlushSlots) {
   EXPECT_EQ(GetMetrics().db_stats[0].obj_memory_usage, 0u);
 }
 
-// Warming a cool value up returns its bytes to the ledger, accounted exactly once.
+// Warming a cool value up returns its bytes to the RAM ledger and releases the disk extent.
 TEST_F(ClusterTieredCoolingTest, CoolSlotCountersReleasedOnWarmup) {
   const string kKey = "cool-warm";
   const SlotId slot = KeySlot(kKey);
 
   EXPECT_EQ(Run({"SET", kKey, string(4096, 'x')}), "OK");
   WaitForOffload(1);
+  ASSERT_GT(GetSlotInfo(slot).tiered_bytes, 0);
   StopOffloading();
 
   EXPECT_EQ(Run({"GET", kKey}), string(4096, 'x'));
 
   ExpectSlotMirrorsDb(slot);
   EXPECT_GT(RawSlotMemory(slot), 0);
+  EXPECT_EQ(GetSlotInfo(slot).tiered_bytes, 0);
 }
 
 #endif  // WITH_TIERING

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -370,24 +370,37 @@ template <typename F> struct CallbackConsumer : public DbSlice::ChangeConsumerIn
 
 }  // namespace
 
+namespace {
+
+void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotStats::*stat,
+                    string_view name) {
+  if (delta == 0 || !db->slots_stats)
+    return;
+
+  const SlotId sid = KeySlot(key);
+  uint64_t& value = db->slots_stats[sid].*stat;
+  if (delta < 0 && value < uint64_t(-delta)) {
+    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot " << name << ": " << value << " + "
+                           << delta << ", slot: " << sid;
+    delta = -int64_t(value);
+  }
+  value += delta;
+}
+
+}  // namespace
+
 void AccountObjectMemory(string_view key, unsigned type, int64_t delta, DbTable* db) {
   DCHECK_NE(db, nullptr);
   if (delta == 0)
     return;
 
   db->stats.AddTypeMemoryUsage(type, delta);
+  UpdateSlotStat(key, delta, db, &SlotStats::memory_bytes, "memory usage");
+}
 
-  if (!db->slots_stats)
-    return;
-
-  const SlotId sid = KeySlot(key);
-  uint64_t& slot_memory = db->slots_stats[sid].memory_bytes;
-  if (delta < 0 && slot_memory < uint64_t(-delta)) {
-    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot memory usage: " << slot_memory
-                           << " + " << delta << ", slot: " << sid;
-    delta = -int64_t(slot_memory);
-  }
-  slot_memory += delta;
+void AccountSlotTieredBytes(string_view key, int64_t delta, DbTable* db) {
+  DCHECK_NE(db, nullptr);
+  UpdateSlotStat(key, delta, db, &SlotStats::tiered_bytes, "tiered usage");
 }
 
 #define ADD(x) (x) += o.x
@@ -1214,9 +1227,9 @@ pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(uint64_t now_ms, bool ca
   return {rel_ms, ms_timestamp};
 }
 
-void DbSlice::ReleaseOffloadedValue(DbIndex db_ind, PrimeValue* pv) {
+void DbSlice::ReleaseOffloadedValue(DbIndex db_ind, std::string_view key, PrimeValue* pv) {
   if (pv->IsExternal())
-    shard_owner()->tiered_storage()->Delete(db_ind, pv);
+    shard_owner()->tiered_storage()->Delete(db_ind, key, pv);
 }
 
 OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
@@ -1274,7 +1287,7 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrUpdateInternal(const Context& cntx
 
   auto& it = res.it;
 
-  ReleaseOffloadedValue(cntx.db_index, &it->second);
+  ReleaseOffloadedValue(cntx.db_index, key, &it->second);
   it->second = std::move(obj);
 
   if (expire_at_ms) {
@@ -1753,7 +1766,7 @@ void DbSlice::RemoveOffloadedEntriesFromTieredStorage(absl::Span<const DbIndex> 
     do {
       cursor = db_ptr->prime.Traverse(cursor, [&](PrimeIterator it) {
         if (it->second.IsExternal()) {
-          tiered_storage->Delete(index, &it->second);
+          tiered_storage->Delete(index, it->first.GetSlice(&scratch), &it->second);
         } else if (it->second.HasStashPending()) {
           tiered_storage->CancelStash(std::make_pair(index, it->first.GetSlice(&scratch)),
                                       &it->second);
@@ -1973,7 +1986,7 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
     string_view key = del_it->first.GetSlice(&scratch);
     shard_owner()->tiered_storage()->CancelStash(std::make_pair(table->index, key), &pv);
   } else if (pv.IsExternal()) {
-    shard_owner()->tiered_storage()->Delete(table->index, &del_it->second);
+    shard_owner()->tiered_storage()->Delete(table->index, del_it.key(), &del_it->second);
   }
 
   ssize_t value_heap_size = pv.MallocUsed(), key_size_used = del_it->first.MallocUsed();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -380,8 +380,10 @@ void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotSt
   const SlotId sid = KeySlot(key);
   uint64_t& value = db->slots_stats[sid].*stat;
   if (delta < 0 && value < uint64_t(-delta)) {
-    LOG_EVERY_T(DFATAL, 1) << "Encountered underflow of per-slot " << name << ": " << value << " + "
-                           << delta << ", slot: " << sid;
+    // Legacy glog used in release builds does not support LOG_EVERY_T(DFATAL, ...).
+    LOG_EVERY_T(ERROR, 1) << "Encountered underflow of per-slot " << name << ": " << value << " + "
+                          << delta << ", slot: " << sid;
+    DCHECK(false);
     delta = -int64_t(value);
   }
   value += delta;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -35,6 +35,9 @@ using facade::OpResult;
 // All of them track resident RAM.
 void AccountObjectMemory(std::string_view key, unsigned type, int64_t delta, DbTable* db);
 
+// Applies a delta to the owning slot's tiered_bytes - disk bytes held by the slot's entries.
+void AccountSlotTieredBytes(std::string_view key, int64_t delta, DbTable* db);
+
 struct DbStats : public DbTableStats {
   // number of active keys.
   size_t key_count = 0;
@@ -315,7 +318,7 @@ class DbSlice {
 
   // Must be called before overwriting a value in place. An offloaded value keeps its data on disk
   // and reports no heap allocation, so overwriting it drops the only reference to its disk extent.
-  void ReleaseOffloadedValue(DbIndex db_ind, PrimeValue* pv);
+  void ReleaseOffloadedValue(DbIndex db_ind, std::string_view key, PrimeValue* pv);
 
   // Update entry expiration. Return expiration timepoint in abs milliseconds, or -1 if the entry
   // already expired and was deleted;

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1001,7 +1001,7 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
 
   if (IsValid(to_res.it)) {
     to_res.post_updater.ReduceHeapUsage();
-    db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &to_res.it->second);
+    db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, to_key, &to_res.it->second);
     to_res.it->second = std::move(from_obj);
 
     if (exp_ts) {

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -149,7 +149,7 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   }
   res.post_updater.ReduceHeapUsage();
   if (res.it->second.IsExternal()) {
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
   }
   res.it->second.SetString(hll);
   return std::min(updated, 1);
@@ -325,7 +325,7 @@ OpResult<int> PFMergeInternal(string_view key, Transaction* tx, SinkReplyBuilder
     auto& res = *op_res;
     if (!res.is_new && res.it->second.IsExternal()) {
       res.post_updater.ReduceHeapUsage();
-      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
     }
     res.it->second.SetString(hll);
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -530,7 +530,7 @@ OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_st
       VLOG(1) << "got invalid JSON string '" << json_str << "' cannot be saved";
       return OpStatus::INVALID_JSON;
     }
-    op_args.GetDbSlice().ReleaseOffloadedValue(op_args.db_cntx.db_index, &it_res->it->second);
+    op_args.GetDbSlice().ReleaseOffloadedValue(op_args.db_cntx.db_index, key, &it_res->it->second);
     it_res->it->second.Reset();
   }
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -566,7 +566,7 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewE
       // inside InitSet is reported to the client as OOM and must leave the value readable.
       PrimeValue replacement;
       InitSet(vals, &replacement);
-      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &co);
+      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, key, &co);
       co = std::move(replacement);
     } else {
       InitSet(vals, &co);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -285,7 +285,7 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
     string new_val = prepend ? absl::StrCat(val, slice) : absl::StrCat(slice, val);
     res.post_updater.ReduceHeapUsage();
     if (res.it->second.IsExternal()) {
-      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &res.it->second);
+      op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &res.it->second);
     }
     res.it->second.SetString(new_val);
     return true;
@@ -345,7 +345,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
 
   add_res.post_updater.ReduceHeapUsage();
   if (add_res.it->second.IsExternal()) {
-    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, &add_res.it->second);
+    op_args.shard->tiered_storage()->Delete(op_args.db_cntx.db_index, key, &add_res.it->second);
   }
   add_res.it->second.SetString(str);
 
@@ -982,7 +982,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
 
   // If value is external, mark it as deleted
   if (prime_value.IsExternal()) {
-    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, &prime_value);
+    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, it_upd->it.key(), &prime_value);
   }
 
   // overwrite existing entry.

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -65,12 +65,13 @@ DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
 }
 
 SlotStats& SlotStats::operator+=(const SlotStats& o) {
-  static_assert(sizeof(SlotStats) == 32);
+  static_assert(sizeof(SlotStats) == 40);
 
   ADD(key_count);
   ADD(total_reads);
   ADD(total_writes);
   ADD(memory_bytes);
+  ADD(tiered_bytes);
   return *this;
 }
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -47,6 +47,7 @@ struct SlotStats {
   uint64_t total_reads = 0;
   uint64_t total_writes = 0;
   uint64_t memory_bytes = 0;
+  uint64_t tiered_bytes = 0;
   SlotStats& operator+=(const SlotStats& o);
 };
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -93,6 +93,7 @@ constexpr uint32_t kMaxPendingDefrags = 100;
 void AccountTieredUpload(const FragmentRef& fragment_ref, size_t tiered_len, string_view key,
                          DbTable* db) {
   AccountObjectMemory(key, fragment_ref.ObjType(), fragment_ref.MallocUsed(), db);
+  AccountSlotTieredBytes(key, -int64_t(tiered_len), db);
   db->stats.tiered_entries--;
   db->stats.tiered_used_bytes -= tiered_len;
 }
@@ -268,6 +269,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       pv->SetStashPending(false);
       table->stats.tiered_entries++;
       table->stats.tiered_used_bytes += segment.length;
+      AccountSlotTieredBytes(key.second, segment.length, table);
       stats_.total_stashes++;
 
       StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
@@ -355,10 +357,11 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
       // We remove it from both cool storage and the offline storage; the value becomes a
       // regular in-memory one, so it returns to the RAM ledger.
       pv = ts_->DeleteCool(item.record);
-      AccountObjectMemory(item_key, pv.ObjType(), pv.MallocUsed(), db_slice_.GetDBTable(dbid));
-      auto* stats = GetDbTableStats(dbid);
-      stats->tiered_entries--;
-      stats->tiered_used_bytes -= segment.length;
+      DbTable* table = db_slice_.GetDBTable(dbid);
+      AccountObjectMemory(item_key, pv.ObjType(), pv.MallocUsed(), table);
+      AccountSlotTieredBytes(item_key, -int64_t(segment.length), table);
+      table->stats.tiered_entries--;
+      table->stats.tiered_used_bytes -= segment.length;
     } else {
       // Cut out relevant part of value and restore it to memory
       string_view value = page.substr(item_segment.offset - segment.offset, item_segment.length);
@@ -562,6 +565,12 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
     stats_.total_clients_throttled++;
     *backpressure = stash_backpressure_[{dbid, string{key}}];
   }
+}
+
+void TieredStorage::Delete(DbIndex dbid, std::string_view key, FragmentRef fragment_ref) {
+  AccountSlotTieredBytes(key, -int64_t(fragment_ref.GetExternalSlice().second),
+                         op_manager_->db_slice_.GetDBTable(dbid));
+  Delete(dbid, fragment_ref);
 }
 
 void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
@@ -843,8 +852,9 @@ PrimeValue TieredStorage::Warmup(DbIndex dbid, std::string_view key, PrimeValue:
   // We remove it from both cool storage and the offline storage. The value returns to RAM,
   // so it returns to the RAM ledger as well.
   PrimeValue hot = DeleteCool(item.record);
-  AccountObjectMemory(key, hot.ObjType(), hot.MallocUsed(),
-                      op_manager_->db_slice_.GetDBTable(dbid));
+  DbTable* table = op_manager_->db_slice_.GetDBTable(dbid);
+  AccountObjectMemory(key, hot.ObjType(), hot.MallocUsed(), table);
+  AccountSlotTieredBytes(key, -int64_t(segment.length), table);
   op_manager_->DeleteOffloaded(dbid, segment);
   return hot;
 }

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -92,6 +92,8 @@ class TieredStorage : public TieredStorageBase {
                          BackPressureFuture* backpressure);
 
   // Delete value, must be offloaded (external type)
+  void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
+  // List node fragments carry no key; per-slot counters cannot follow them.
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
 
   // Returns true if there is a pending modification for the given segment.
@@ -269,6 +271,9 @@ class TieredStorage : public TieredStorageBase {
 
   void Stash(DbIndex dbid, std::string_view key, const StashDescriptor& blobs,
              BackPressureFuture* backpressure) {
+  }
+
+  void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref) {
   }
 
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -268,7 +268,7 @@ OpResult<DbSlice::ItAndUpdater> PrepareZEntry(const ZSetFamily::ZParams& zparams
     // search indexes first. This prevents crashes when the key is indexed (e.g., HASH or JSON).
     if (!add_res.is_new && zparams.override) {
       RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, pv, op_args.shard);
-      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, &pv);
+      db_slice.ReleaseOffloadedValue(op_args.db_cntx.db_index, key, &pv);
     }
 
     pv.InitRobj(OBJ_ZSET, encoding, robj_ptr);


### PR DESCRIPTION
Second part of #7956: `DFLYCLUSTER GETSLOTINFO` reports a new optional `tiered_bytes` field - disk bytes held by the slot's offloaded entries - present only when non-zero, so the output is unchanged for non-tiered deployments.

Fixes #7955