### PR TITLE
fix: avoid command latency cycle conversion overflow

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -317,15 +317,21 @@ void CommandContext::ReuseInternal() {
   cid_ = nullptr;
   tx_ = nullptr;
   tail_args_ = {};
-  start_time_usec = 0;
+  start_cycle = 0;
 }
 
 void CommandContext::RecordLatency(const facade::ParsedArgs& tail_args) const {
-  DCHECK_GT(start_time_usec, 0u);
-  int64_t after = base::CycleClock::ToUsec(base::CycleClock::Now());
+  DCHECK_GT(start_cycle, 0u);
+  const uint64_t end_cycle = base::CycleClock::Now();
+  if (end_cycle < start_cycle) {
+    LOG(ERROR) << "Cycle clock moved backwards while recording " << cid_->name()
+               << " latency: start=" << start_cycle << ", end=" << end_cycle
+               << ", frequency=" << base::CycleClock::Frequency();
+    return;
+  }
 
   ServerState* ss = ServerState::SafeTLocal();  // Might have migrated thread, read after invocation
-  int64_t execution_time_usec = after - start_time_usec;
+  uint64_t execution_time_usec = base::CycleClock::ToUsec(end_cycle - start_cycle);
 
   cid_->RecordLatency(ss->thread_index(), execution_time_usec);
   DCHECK(conn_cntx_ != nullptr);

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -454,7 +454,7 @@ class CommandContext : public facade::ParsedCommand {
     return tail_args_;
   }
 
-  uint64_t start_time_usec = 0;
+  uint64_t start_cycle = 0;
 
  protected:
   void ReuseInternal() final;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1655,7 +1655,7 @@ DispatchResult Service::InvokeCmd(const facade::ParsedArgs& tail_args, CommandCo
   DCHECK(cid);
   DCHECK(!cid->Validate(tail_args));
 
-  cmd_cntx->start_time_usec = base::CycleClock::ToUsec(base::CycleClock::Now());
+  cmd_cntx->start_cycle = base::CycleClock::Now();
 
   ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   auto* builder = cmd_cntx->rb();
@@ -1664,7 +1664,8 @@ DispatchResult Service::InvokeCmd(const facade::ParsedArgs& tail_args, CommandCo
 
   ServerState& ss = *ServerState::tlocal();
 
-  if ((cid->opt_mask() & CO::DENYOOM) && ss.ShouldDenyOnOOM(cmd_cntx->start_time_usec)) {
+  if ((cid->opt_mask() & CO::DENYOOM) &&
+      ss.ShouldDenyOnOOM(base::CycleClock::ToUsec(cmd_cntx->start_cycle))) {
     cmd_cntx->SendError(ErrorReply{OpStatus::OUT_OF_MEMORY});
     return DispatchResult::OOM;
   }


### PR DESCRIPTION
## Summary
- retain command start times as raw cycle counts
- convert only the elapsed cycle delta to microseconds before recording latency
- discard samples when the cycle clock moves backwards

Fixes #7969