### PR TITLE
chore: Move OAH* non-performance-critical methods to the .cc file.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(dfly_core allocation_tracker.cc bloom.cc topk.cc compact_object.cc c
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc stream_node.cc task_queue.cc
     tx_queue.cc string_set.cc string_map.cc tiering_types.cc top_keys.cc
     detail/bitpacking.cc detail/listpack_wrap.cc detail/listpack.cc
-    oah_entry.cc oah_pair.cc)
+    oah_entry.cc oah_pair.cc oah_ptr.cc oah_set.cc oah_table.cc)
 
 cxx_link(dfly_core base dfly_search_core dfly_page_usage fibers2 jsonpath
     absl::flat_hash_map absl::str_format absl::random_random redis_lib

--- a/src/core/oah_ptr.cc
+++ b/src/core/oah_ptr.cc
@@ -1,0 +1,42 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/oah_ptr.h"
+
+#include "core/oah_entry.h"
+#include "core/oah_pair.h"
+
+namespace dfly {
+
+template <typename Entry>
+ssize_t OAHPtr<Entry>::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+  *realloced = false;
+  if (Empty())
+    return 0;
+  if (!IsVector())
+    return Entry(*slot_).ReallocIfNeeded(page_usage, realloced);
+
+  ssize_t obj_alloc_delta = 0;
+  Vector vec = AsVector();
+  for (TaggedPtr& cell : vec) {
+    Entry entry(cell);
+    if (entry) {
+      bool inner_moved = false;
+      obj_alloc_delta += entry.ReallocIfNeeded(page_usage, &inner_moved);
+      *realloced |= inner_moved;
+    }
+  }
+  if (page_usage->IsPageForObjectUnderUtilized(Raw())) {
+    vec.Realloc();
+    *realloced = true;
+  }
+  return obj_alloc_delta;
+}
+
+// Keep these explicit instantiations in sync with the OAH table entry types.
+template ssize_t OAHPtr<OAHEntry>::ReallocIfNeeded(PageUsage*, bool*);
+
+template ssize_t OAHPtr<OAHPair>::ReallocIfNeeded(PageUsage*, bool*);
+
+}  // namespace dfly

--- a/src/core/oah_ptr.h
+++ b/src/core/oah_ptr.h
@@ -120,29 +120,7 @@ template <typename Entry> class OAHPtr {
   // Defragments fragmented buffers under this slot: the entry's string, or for a vector every inner
   // entry plus the array. Returns the cumulative usable-size delta; *realloced is set if anything
   // moved.
-  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
-    *realloced = false;
-    if (Empty())
-      return 0;
-    if (!IsVector())
-      return Entry(*slot_).ReallocIfNeeded(page_usage, realloced);
-
-    ssize_t obj_alloc_delta = 0;
-    Vector vec = AsVector();
-    for (TaggedPtr& cell : vec) {
-      Entry entry(cell);
-      if (entry) {
-        bool inner_moved = false;
-        obj_alloc_delta += entry.ReallocIfNeeded(page_usage, &inner_moved);
-        *realloced |= inner_moved;
-      }
-    }
-    if (page_usage->IsPageForObjectUnderUtilized(Raw())) {
-      vec.Realloc();
-      *realloced = true;
-    }
-    return obj_alloc_delta;
-  }
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   char* Raw() const {
     return reinterpret_cast<char*>(*slot_ & ~oah::kTagMask);

--- a/src/core/oah_set.cc
+++ b/src/core/oah_set.cc
@@ -1,0 +1,21 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/oah_set.h"
+
+namespace dfly {
+
+void OAHSet::Fill(OAHSet* other) {
+  assert(other->entries_.empty());
+  other->Reserve(UpperBoundSize());
+  other->set_time(time_now());
+  for (auto it = begin(), it_end = end(); it != it_end; ++it) {
+    // Copy the stored (already-encoded) content verbatim -- no decode/re-encode round-trip.
+    const oah::key::Stored s = (*it).StoredKey();
+    const uint32_t ttl = it.HasExpiry() ? it.ExpiryTime() - time_now() : UINT32_MAX;
+    other->AddImpl({s.content, s.header.content_size}, s.header.len, ttl);
+  }
+}
+
+}  // namespace dfly

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -48,17 +48,7 @@ class OAHSet : public OAHTable<OAHEntry> {
   }
 
   // TODO: Consider using chunks for this as in StringSet
-  void Fill(OAHSet* other) {
-    assert(other->entries_.empty());
-    other->Reserve(UpperBoundSize());
-    other->set_time(time_now());
-    for (auto it = begin(), it_end = end(); it != it_end; ++it) {
-      // Copy the stored (already-encoded) content verbatim -- no decode/re-encode round-trip.
-      const oah::key::Stored s = (*it).StoredKey();
-      const uint32_t ttl = it.HasExpiry() ? it.ExpiryTime() - time_now() : UINT32_MAX;
-      other->AddImpl({s.content, s.header.content_size}, s.header.len, ttl);
-    }
-  }
+  void Fill(OAHSet* other);
 
  private:
   bool AddImpl(std::string_view content, uint32_t len, uint32_t ttl_sec) {

--- a/src/core/oah_table.cc
+++ b/src/core/oah_table.cc
@@ -1,0 +1,133 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/oah_table.h"
+
+#include "core/oah_entry.h"
+#include "core/oah_pair.h"
+
+namespace dfly {
+
+template <typename Entry> OAHTable<Entry>::~OAHTable() {
+  FreeAllSlots();
+}
+
+template <typename Entry> void OAHTable<Entry>::Shrink(size_t new_size) {
+  size_t required = size_ / kOverloadFactor + (size_ % kOverloadFactor != 0);
+  size_t target = absl::bit_ceil(std::max({new_size, kMinBucketCount, required}));
+  if (target >= BucketCount())
+    return;
+
+  size_t prev_size = entries_.size();
+  capacity_log_ = absl::bit_width(target) - 1;
+
+  // Process from low to high (opposite of Grow/Rehash).
+  for (size_t i = 0; i < prev_size; ++i) {
+    ShrinkBucket(i);
+  }
+
+  entries_.resize(Capacity());
+  entries_.shrink_to_fit();
+}
+
+template <typename Entry> void OAHTable<Entry>::Clear() {
+  FreeAllSlots();
+  capacity_log_ = 0;
+  entries_.resize(0);
+  size_ = 0;
+  obj_alloc_used_ = 0;
+  ptr_vectors_alloc_used_ = 0;
+  expiration_used_ = false;
+}
+
+template <typename Entry> uint32_t OAHTable<Entry>::ClearStep(uint32_t start, uint32_t count) {
+  const uint32_t total = entries_.size();
+  const uint32_t end = std::min(total, start + count);
+  for (uint32_t i = start; i < end; ++i) {
+    auto bucket = At(i);
+    if (bucket.Empty())
+      continue;
+
+    if (bucket.IsVector()) {
+      auto vec = bucket.AsVector();
+      for (TaggedPtr& cell : vec) {
+        Entry entry(cell);
+        if (entry) {
+          obj_alloc_used_ -= entry.AllocSize();
+          --size_;
+        }
+      }
+      ptr_vectors_alloc_used_ -= vec.AllocSize();
+    } else {
+      obj_alloc_used_ -= bucket[0].AllocSize();
+      --size_;
+    }
+    bucket.Clear();
+  }
+  // Match Clear() semantics: once incrementally cleared empty, the TTL flag is stale.
+  if (size_ == 0)
+    expiration_used_ = false;
+  return end;
+}
+
+template <typename Entry> size_t OAHTable<Entry>::SizeSlow() {
+  if (expiration_used_)
+    CollectExpired();
+  return size_;
+}
+
+template <typename Entry> void OAHTable<Entry>::GrowCapacity(size_t bucket_capacity) {
+  bucket_capacity = absl::bit_ceil(bucket_capacity);
+  if (bucket_capacity > entries_.size()) {
+    capacity_log_ = std::max(kMinCapacityLog, uint32_t(absl::bit_width(bucket_capacity) - 1));
+    size_t prev_size = entries_.size();
+    entries_.resize(Capacity());
+    Rehash(prev_size);
+  }
+  assert(entries_.size() >= kDisplacementSize);
+}
+
+template <typename Entry> void OAHTable<Entry>::FreeAllSlots() {
+  for (size_t i = 0, n = entries_.size(); i < n; ++i) {
+    if (entries_[i])
+      At(i).Clear();
+  }
+}
+
+template <typename Entry> void OAHTable<Entry>::CollectExpired() {
+  if (time_now_ == 0)
+    return;
+  const uint32_t now = time_now_;
+  for (size_t b = 0, n = entries_.size(); b < n; ++b) {
+    if (!entries_[b])
+      continue;
+    auto bucket = At(b);
+    for (uint32_t i = 0, m = bucket.ElementsNum(); i < m; ++i) {
+      auto entry = bucket[i];
+      if (entry && entry.HasExpiry() && entry.GetExpiry() <= now)
+        entry.ExpireIfNeeded(now, &size_, &obj_alloc_used_);
+    }
+  }
+}
+
+// Keep these explicit instantiations in sync with the OAH table entry types.
+template OAHTable<OAHEntry>::~OAHTable();
+template void OAHTable<OAHEntry>::Shrink(size_t);
+template void OAHTable<OAHEntry>::Clear();
+template uint32_t OAHTable<OAHEntry>::ClearStep(uint32_t, uint32_t);
+template size_t OAHTable<OAHEntry>::SizeSlow();
+template void OAHTable<OAHEntry>::GrowCapacity(size_t);
+template void OAHTable<OAHEntry>::FreeAllSlots();
+template void OAHTable<OAHEntry>::CollectExpired();
+
+template OAHTable<OAHPair>::~OAHTable();
+template void OAHTable<OAHPair>::Shrink(size_t);
+template void OAHTable<OAHPair>::Clear();
+template uint32_t OAHTable<OAHPair>::ClearStep(uint32_t, uint32_t);
+template size_t OAHTable<OAHPair>::SizeSlow();
+template void OAHTable<OAHPair>::GrowCapacity(size_t);
+template void OAHTable<OAHPair>::FreeAllSlots();
+template void OAHTable<OAHPair>::CollectExpired();
+
+}  // namespace dfly

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -194,9 +194,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   OAHTable(const OAHTable&) = delete;
   OAHTable& operator=(const OAHTable&) = delete;
 
-  ~OAHTable() {
-    FreeAllSlots();
-  }
+  ~OAHTable();
 
   // Reserves enough capacity to hold `sz` live entries without triggering a resize.
   void Reserve(size_t sz) {
@@ -204,66 +202,16 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   }
 
   // Shrinks toward `new_size` buckets, never below what's needed for live entries at
-  // kOverloadFactor. No-op if not smaller than the current bucket count.
-  void Shrink(size_t new_size) {
-    size_t required = size_ / kOverloadFactor + (size_ % kOverloadFactor != 0);
-    size_t target = absl::bit_ceil(std::max({new_size, kMinBucketCount, required}));
-    if (target >= BucketCount())
-      return;
+  // kOverloadFactor. No-op if not smaller than the current bucket count. Uses the raw
+  // (possibly stale, pre-expiry) size_ as the floor to avoid an extra full-table pass;
+  // ShrinkBucket() still reaps expired entries during compaction.
+  void Shrink(size_t new_size);
 
-    size_t prev_size = entries_.size();
-    capacity_log_ = absl::bit_width(target) - 1;
-
-    // Process from low to high (opposite of Grow/Rehash).
-    for (size_t i = 0; i < prev_size; ++i) {
-      ShrinkBucket(i);
-    }
-
-    entries_.resize(Capacity());
-    entries_.shrink_to_fit();
-  }
-
-  void Clear() {
-    FreeAllSlots();
-    capacity_log_ = 0;
-    entries_.resize(0);
-    size_ = 0;
-    obj_alloc_used_ = 0;
-    ptr_vectors_alloc_used_ = 0;
-    expiration_used_ = false;
-  }
+  void Clear();
 
   // Incrementally clears [start, start+count). Returns the next bucket index; equals
   // Capacity() when the table is empty. Mirrors DenseSet::ClearStep (AsyncDeleter).
-  uint32_t ClearStep(uint32_t start, uint32_t count) {
-    const uint32_t total = entries_.size();
-    const uint32_t end = std::min(total, start + count);
-    for (uint32_t i = start; i < end; ++i) {
-      auto bucket = At(i);
-      if (bucket.Empty())
-        continue;
-
-      if (bucket.IsVector()) {
-        auto vec = bucket.AsVector();
-        for (TaggedPtr& cell : vec) {
-          Entry entry(cell);
-          if (entry) {
-            obj_alloc_used_ -= entry.AllocSize();
-            --size_;
-          }
-        }
-        ptr_vectors_alloc_used_ -= vec.AllocSize();
-      } else {
-        obj_alloc_used_ -= bucket[0].AllocSize();
-        --size_;
-      }
-      bucket.Clear();
-    }
-    // Match Clear() semantics: once incrementally cleared empty, the TTL flag is stale.
-    if (size_ == 0)
-      expiration_used_ = false;
-    return end;
-  }
+  uint32_t ClearStep(uint32_t start, uint32_t count);
 
   /**
    * stable scanning api. has the same guarantees as redis scan command.
@@ -421,24 +369,11 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     return expiration_used_;
   }
 
-  size_t SizeSlow() {
-    if (expiration_used_)
-      CollectExpired();
-    return size_;
-  }
+  size_t SizeSlow();
 
  protected:
   // Grows the table so entries_.size() >= bucket_capacity (power of 2), rehashing in place.
-  void GrowCapacity(size_t bucket_capacity) {
-    bucket_capacity = absl::bit_ceil(bucket_capacity);
-    if (bucket_capacity > entries_.size()) {
-      capacity_log_ = std::max(kMinCapacityLog, uint32_t(absl::bit_width(bucket_capacity) - 1));
-      size_t prev_size = entries_.size();
-      entries_.resize(Capacity());
-      Rehash(prev_size);
-    }
-    assert(entries_.size() >= kDisplacementSize);
-  }
+  void GrowCapacity(size_t bucket_capacity);
 
   static uint64_t Hash(std::string_view str) {
     constexpr uint64_t kHashSeed = 24061983;
@@ -455,37 +390,18 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   }
 
   // Frees the blob/vector of every non-empty bucket. Used by ~OAHTable and Clear().
-  void FreeAllSlots() {
-    for (size_t i = 0, n = entries_.size(); i < n; ++i) {
-      if (entries_[i])
-        At(i).Clear();
-    }
-  }
+  void FreeAllSlots();
 
   // Reaps every expired entry so size_ becomes the live count. Nulls slots the same way the
   // iterator and Erase do, which is safe under fixed-window displacement probing.
-  void CollectExpired() {
-    if (time_now_ == 0)
-      return;
-    const uint32_t now = time_now_;
-    for (size_t b = 0, n = entries_.size(); b < n; ++b) {
-      if (!entries_[b])
-        continue;
-      auto bucket = At(b);
-      for (uint32_t i = 0, m = bucket.ElementsNum(); i < m; ++i) {
-        auto entry = bucket[i];
-        if (entry && entry.HasExpiry() && entry.GetExpiry() <= now)
-          entry.ExpireIfNeeded(now, &size_, &obj_alloc_used_);
-      }
-    }
-  }
+  void CollectExpired();
 
   // was Grow in StringSet
   void Rehash(uint32_t prev_size) {
     if (prev_size == 0) {
       return;
     }
-    // we should prevent moving elements before current possition to avoid double processing.
+    // We should prevent moving elements before current position to avoid double processing.
     // Detach the first mix_size slots into locals; each `bucket` view is freed explicitly
     // after its entries are redistributed into entries_ (a TaggedPtr slot has no dtor).
     constexpr size_t mix_size = (2 << kShiftLog) - 1;
@@ -519,8 +435,8 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     bucket.Clear();
   }
 
-  // it is inefficient for now,
-  // TODO predict new position by current position and extended hash
+  // It is inefficient for now.
+  // TODO: predict new position by current position and extended hash.
   void ShrinkBucket(uint32_t bucket_id) {
     // Detach the slot bits into a local; `bucket` views the local and is freed
     // explicitly below (At(new_bucket_id) writes into entries_, never this local).
@@ -570,7 +486,7 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
       if (uint32_t empties = (data == uint64_t(0)).GetMSBs())
         return bid + off + std::countr_zero(empties);
     }
-    // TODO add expiration logic
+    // TODO: add expiration logic.
     const uint32_t ext = GetExtensionPoint(bid);
     assert(ext < entries_.size());
     return ext;


### PR DESCRIPTION
Summary: This PR moves several non-hot-path OAH* method definitions out of headers into dedicated .cc files, aiming to reduce header bloat and improve build/compile times.

Changes:

- Added oah_table.cc and moved OAHTable methods (e.g. Shrink, Clear, CollectExpired) out of oah_table.h.
- Added oah_ptr.cc and moved OAHPtr::ReallocIfNeeded out of oah_ptr.h.
- Added oah_set.cc and moved OAHSet::Fill out of oah_set.h.
- Introduced explicit template instantiations for the supported OAH entry types (OAHEntry and OAHPair) in the new translation units.
- Updated src/core/CMakeLists.txt to compile/link the new .cc files into dfly_core.

Technical Notes: The out-of-line template member definitions rely on explicit instantiation in the new .cc files to ensure symbols are emitted for the supported specializations.