### PR TITLE
feat(server): Add defrag table segments command

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 #include <ranges>
 #include <utility>
 #include <vector>
@@ -52,6 +53,13 @@ class DashTable : public detail::DashTableBase {
   using const_bucket_iterator = Iterator<true, true>;
   using bucket_iterator = Iterator<false, true>;
   using Cursor = detail::DashCursor;
+
+  struct SegmentVisitResult {
+    using SegmentRef = std::pair<uint32_t, SegmentType*>;
+    Cursor next;
+    // pointer must be consumed without yielding, or it can be invalidated.
+    std::optional<SegmentRef> id_and_pointer{std::nullopt};
+  };
 
   struct HotBuckets {
     static constexpr size_t kRegularBuckets = 4;
@@ -421,7 +429,7 @@ class DashTable : public detail::DashTableBase {
   // iterators holding pointers to it as these will become invalid on relocation.
   bool TryRelocateSegment(size_t segment_id);
 
-  template <typename Cb> Cursor VisitSegment(Cursor cursor, Cb cb);
+  SegmentVisitResult VisitSegment(Cursor cursor);
 
  private:
   enum class InsertMode {
@@ -1280,11 +1288,10 @@ bool DashTable<_Key, _Value, Policy>::TryRelocateSegment(size_t segment_id) {
 }
 
 template <typename _Key, typename _Value, typename Policy>
-template <typename Cb>
-auto DashTable<_Key, _Value, Policy>::VisitSegment(Cursor cursor, Cb cb) -> Cursor {
+auto DashTable<_Key, _Value, Policy>::VisitSegment(Cursor cursor) -> SegmentVisitResult {
   uint32_t sid = cursor.segment_id(global_depth_);
   if (sid >= segment_.size())
-    return Cursor::end();
+    return {Cursor::end(), std::nullopt};
 
   auto* seg = segment_[sid];
   sid = seg->segment_id();
@@ -1293,8 +1300,7 @@ auto DashTable<_Key, _Value, Policy>::VisitSegment(Cursor cursor, Cb cb) -> Curs
   if (const auto nid = NextSeg(sid); nid < segment_.size())
     next = Cursor{global_depth_, static_cast<uint32_t>(nid), 0};
 
-  cb(sid, seg);
-  return next;
+  return {next, std::make_pair(sid, seg)};
 }
 
 template <typename _Key, typename _Value, typename Policy>

--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -421,6 +421,8 @@ class DashTable : public detail::DashTableBase {
   // iterators holding pointers to it as these will become invalid on relocation.
   bool TryRelocateSegment(size_t segment_id);
 
+  template <typename Cb> Cursor VisitSegment(Cursor cursor, Cb cb);
+
  private:
   enum class InsertMode {
     kInsertIfNotFound,
@@ -1275,6 +1277,24 @@ bool DashTable<_Key, _Value, Policy>::TryRelocateSegment(size_t segment_id) {
   A::deallocate(allocator, segment, 1);
 
   return true;
+}
+
+template <typename _Key, typename _Value, typename Policy>
+template <typename Cb>
+auto DashTable<_Key, _Value, Policy>::VisitSegment(Cursor cursor, Cb cb) -> Cursor {
+  uint32_t sid = cursor.segment_id(global_depth_);
+  if (sid >= segment_.size())
+    return Cursor::end();
+
+  auto* seg = segment_[sid];
+  sid = seg->segment_id();
+
+  Cursor next = Cursor::end();
+  if (const auto nid = NextSeg(sid); nid < segment_.size())
+    next = Cursor{global_depth_, static_cast<uint32_t>(nid), 0};
+
+  cb(sid, seg);
+  return next;
 }
 
 template <typename _Key, typename _Value, typename Policy>

--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -421,6 +421,8 @@ class DashTable : public detail::DashTableBase {
     return stash_unloaded_;
   }
 
+  template <typename Cb> Cursor VisitSegment(Cursor cursor, Cb cb);
+
  private:
   enum class InsertMode {
     kInsertIfNotFound,
@@ -1198,6 +1200,24 @@ auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
   } while (!fetched);
 
   return Cursor{global_depth_, sid, bid};
+}
+
+template <typename _Key, typename _Value, typename Policy>
+template <typename Cb>
+auto DashTable<_Key, _Value, Policy>::VisitSegment(Cursor cursor, Cb cb) -> Cursor {
+  uint32_t sid = cursor.segment_id(global_depth_);
+  if (sid >= segment_.size())
+    return Cursor::end();
+
+  auto* seg = segment_[sid];
+  sid = seg->segment_id();
+
+  Cursor next = Cursor::end();
+  if (const auto nid = NextSeg(sid); nid < segment_.size())
+    next = Cursor{global_depth_, static_cast<uint32_t>(nid), 0};
+
+  cb(sid, seg);
+  return next;
 }
 
 template <typename _Key, typename _Value, typename Policy>

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -1758,6 +1758,74 @@ TEST_F(DashTest, SplitBug) {
   EXPECT_EQ(746, table.size());
 }
 
+namespace {
+
+void GrowSegments(Dash64& dt) {
+  for (uint64_t i = 0; i < 4000; ++i)
+    dt.Insert(i, i);
+
+  ASSERT_EQ(dt.depth(), 3);
+  ASSERT_EQ(dt.unique_segments(), 8);
+}
+
+void FreeItemsForMerge(Dash64& dt) {
+  for (uint64_t i = 200; i < 4000; ++i)
+    dt.Erase(i);
+}
+
+}  // namespace
+
+TEST_F(DashTest, VisitSegmentOnce) {
+  GrowSegments(dt_);
+  FreeItemsForMerge(dt_);
+
+  // create aliases so that visiting over them is exercised
+  ASSERT_TRUE(dt_.Merge(0, 1).merged);
+  ASSERT_EQ(dt_.GetSegment(0), dt_.GetSegment(1));
+
+  std::unordered_set<Dash64::Segment_t*> visited;
+  Dash64::Cursor cursor;
+  do {
+    cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto* segment) {
+      EXPECT_EQ(sid, segment->segment_id());
+      EXPECT_EQ(segment, dt_.GetSegment(sid));
+      EXPECT_TRUE(visited.insert(segment).second);
+    });
+  } while (cursor);
+
+  // each segment visited exactly once
+  EXPECT_EQ(visited.size(), dt_.unique_segments());
+}
+
+TEST_F(DashTest, VisitSegmentCursorSurvivesGrowth) {
+  auto cursor = dt_.VisitSegment(Dash64::Cursor{}, [](size_t sid, auto*) { EXPECT_EQ(sid, 0); });
+
+  GrowSegments(dt_);
+
+  vector<size_t> visited;
+  do {
+    cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto*) { visited.push_back(sid); });
+  } while (cursor);
+
+  // global depth grows from 1->3, so bits in next segment id of cursor go from 1->100 i.e. 4
+  EXPECT_EQ(visited, (vector<size_t>{4, 5, 6, 7}));
+}
+
+TEST_F(DashTest, VisitSegmentCursorAfterMerge) {
+  GrowSegments(dt_);
+  FreeItemsForMerge(dt_);
+
+  auto cursor = dt_.VisitSegment(Dash64::Cursor{}, [](size_t sid, auto*) { EXPECT_EQ(sid, 0); });
+  ASSERT_EQ(cursor.segment_id(dt_.depth()), 1);
+  ASSERT_TRUE(dt_.Merge(0, 1).merged);
+
+  cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto* segment) {
+    EXPECT_EQ(sid, 0);
+    EXPECT_EQ(segment, dt_.GetSegment(0));
+  });
+  EXPECT_EQ(cursor.segment_id(dt_.depth()), 2);
+}
+
 /**
  ______     _      _   _               _______        _
 |  ____|   (_)    | | (_)             |__   __|      | |

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -1786,11 +1786,13 @@ TEST_F(DashTest, VisitSegmentOnce) {
   std::unordered_set<Dash64::Segment_t*> visited;
   Dash64::Cursor cursor;
   do {
-    cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto* segment) {
-      EXPECT_EQ(sid, segment->segment_id());
-      EXPECT_EQ(segment, dt_.GetSegment(sid));
-      EXPECT_TRUE(visited.insert(segment).second);
-    });
+    auto [next, segment] = dt_.VisitSegment(cursor);
+    cursor = next;
+    ASSERT_TRUE(segment);
+    const auto [sid, ptr] = *segment;
+    EXPECT_EQ(sid, ptr->segment_id());
+    EXPECT_EQ(ptr, dt_.GetSegment(sid));
+    EXPECT_TRUE(visited.insert(ptr).second);
   } while (cursor);
 
   // each segment visited exactly once
@@ -1798,13 +1800,18 @@ TEST_F(DashTest, VisitSegmentOnce) {
 }
 
 TEST_F(DashTest, VisitSegmentCursorSurvivesGrowth) {
-  auto cursor = dt_.VisitSegment(Dash64::Cursor{}, [](size_t sid, auto*) { EXPECT_EQ(sid, 0); });
+  auto [cursor, first] = dt_.VisitSegment(Dash64::Cursor{});
+  ASSERT_TRUE(first);
+  EXPECT_EQ(first->first, 0);
 
   GrowSegments(dt_);
 
   vector<size_t> visited;
   do {
-    cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto*) { visited.push_back(sid); });
+    auto [next, segment] = dt_.VisitSegment(cursor);
+    cursor = next;
+    ASSERT_TRUE(segment);
+    visited.push_back(segment->first);
   } while (cursor);
 
   // global depth grows from 1->3, so bits in next segment id of cursor go from 1->100 i.e. 4
@@ -1815,14 +1822,17 @@ TEST_F(DashTest, VisitSegmentCursorAfterMerge) {
   GrowSegments(dt_);
   FreeItemsForMerge(dt_);
 
-  auto cursor = dt_.VisitSegment(Dash64::Cursor{}, [](size_t sid, auto*) { EXPECT_EQ(sid, 0); });
+  auto [cursor, first] = dt_.VisitSegment(Dash64::Cursor{});
+  ASSERT_TRUE(first);
+  EXPECT_EQ(first->first, 0);
   ASSERT_EQ(cursor.segment_id(dt_.depth()), 1);
   ASSERT_TRUE(dt_.Merge(0, 1).merged);
 
-  cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto* segment) {
-    EXPECT_EQ(sid, 0);
-    EXPECT_EQ(segment, dt_.GetSegment(0));
-  });
+  auto [next, segment] = dt_.VisitSegment(cursor);
+  cursor = next;
+  ASSERT_TRUE(segment);
+  EXPECT_EQ(segment->first, 0);
+  EXPECT_EQ(segment->second, dt_.GetSegment(0));
   EXPECT_EQ(cursor.segment_id(dt_.depth()), 2);
 }
 

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -1595,6 +1595,55 @@ TEST_F(DashTest, SplitBug) {
   EXPECT_EQ(746, table.size());
 }
 
+TEST_F(DashTest, VisitSegmentOnce) {
+  for (uint64_t i = 0; i < 4000; ++i) {
+    dt_.Insert(i, i);
+  }
+
+  ASSERT_EQ(dt_.depth(), 3);
+  ASSERT_EQ(dt_.unique_segments(), 8);
+
+  // create aliases so that visiting over them is exercised
+  for (uint64_t i = 200; i < 4000; ++i) {
+    dt_.Erase(i);
+  }
+
+  ASSERT_EQ(dt_.GetSegment(0)->local_depth(), 3);
+  ASSERT_EQ(dt_.GetSegment(1)->local_depth(), 3);
+
+  ASSERT_TRUE(dt_.Merge(0, 1).merged);
+
+  ASSERT_EQ(dt_.depth(), 3);
+  ASSERT_EQ(dt_.GetSegmentCount(), 8);
+  ASSERT_EQ(dt_.unique_segments(), 7);
+
+  ASSERT_EQ(dt_.GetSegment(0), dt_.GetSegment(1));
+  ASSERT_EQ(dt_.GetSegment(0)->segment_id(), 0);
+
+  ASSERT_EQ(dt_.GetSegment(0)->local_depth(), 2);
+
+  auto calls = 0;
+  std::unordered_set<Dash64::Segment_t*> visited;
+
+  Dash64::Cursor cursor;
+  do {
+    const auto before = calls;
+    cursor = dt_.VisitSegment(cursor, [&](size_t sid, auto* segment) {
+      ++calls;
+      EXPECT_EQ(sid, segment->segment_id());
+      EXPECT_EQ(segment, dt_.GetSegment(sid));
+      EXPECT_TRUE(visited.insert(segment).second);
+    });
+    EXPECT_EQ(calls, before + 1);
+
+  } while (cursor);
+
+  // each segment visited exactly once
+  EXPECT_EQ(calls, dt_.unique_segments());
+  EXPECT_EQ(visited.size(), dt_.unique_segments());
+  EXPECT_FALSE(cursor);
+}
+
 /**
  ______     _      _   _               _______        _
 |  ____|   (_)    | | (_)             |__   __|      | |

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1990,10 +1990,10 @@ void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
     // only relocate one segment at a time, must not yield, if it yields, then new bucket iterators
     // might be created, and then we might relocate the segment and break their held pointers
     FiberAtomicGuard g;
-    cursor = pt.VisitSegment(cursor, [&](size_t segment_id, auto* seg_ptr) {
-      if (page_usage->IsPageForObjectUnderUtilized(seg_ptr))
-        pt.TryRelocateSegment(segment_id);
-    });
+    const auto [next, segment] = pt.VisitSegment(cursor);
+    cursor = next;
+    if (segment && page_usage->IsPageForObjectUnderUtilized(segment->second))
+      pt.TryRelocateSegment(segment->first);
   } while (cursor && !page_usage->QuotaDepleted());
   db_table->segment_defrag_cursor = cursor;
 }

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1978,9 +1978,9 @@ unique_ptr<base::Histogram> DbSlice::StopSampleValues(DbIndex db_ind) {
   return unique_ptr<base::Histogram>{exchange(db.sample_values_hist, nullptr)};
 }
 
-void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
+bool DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
   if (!IsDbValid(db_ind))
-    return;
+    return true;
 
   DbTable* db_table = GetDBTable(db_ind);
   PrimeTable& pt = db_table->prime;
@@ -1997,6 +1997,7 @@ void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
     });
   } while (cursor && !page_usage->QuotaDepleted());
   db_table->segment_defrag_cursor = cursor;
+  return !cursor;
 }
 
 void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool async) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1978,9 +1978,9 @@ unique_ptr<base::Histogram> DbSlice::StopSampleValues(DbIndex db_ind) {
   return unique_ptr<base::Histogram>{exchange(db.sample_values_hist, nullptr)};
 }
 
-bool DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
+void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
   if (!IsDbValid(db_ind))
-    return true;
+    return;
 
   DbTable* db_table = GetDBTable(db_ind);
   PrimeTable& pt = db_table->prime;
@@ -1996,7 +1996,6 @@ bool DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
     });
   } while (cursor && !page_usage->QuotaDepleted());
   db_table->segment_defrag_cursor = cursor;
-  return !cursor;
 }
 
 void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool async) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1978,6 +1978,27 @@ unique_ptr<base::Histogram> DbSlice::StopSampleValues(DbIndex db_ind) {
   return unique_ptr<base::Histogram>{exchange(db.sample_values_hist, nullptr)};
 }
 
+void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
+  if (!IsDbValid(db_ind))
+    return;
+
+  DbTable* db_table = GetDBTable(db_ind);
+  PrimeTable& pt = db_table->prime;
+
+  detail::DashCursor cursor = db_table->segment_defrag_cursor;
+  do {
+    // only relocate one segment at a time, must not yield, if it yields, then new bucket iterators
+    // might be created, and then we might relocate the segment and break their held pointers
+    FiberAtomicGuard g;
+    cursor = pt.VisitSegment(cursor, [&](size_t, auto* seg_ptr) {
+      if (page_usage->IsPageForObjectUnderUtilized(seg_ptr)) {
+        // relocate the segment using first arg segment id
+      }
+    });
+  } while (cursor && !page_usage->QuotaDepleted());
+  db_table->segment_defrag_cursor = cursor;
+}
+
 void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool async) {
   FiberAtomicGuard guard;
   size_t table_before = table->table_memory();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1990,10 +1990,9 @@ bool DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
     // only relocate one segment at a time, must not yield, if it yields, then new bucket iterators
     // might be created, and then we might relocate the segment and break their held pointers
     FiberAtomicGuard g;
-    cursor = pt.VisitSegment(cursor, [&](size_t, auto* seg_ptr) {
-      if (page_usage->IsPageForObjectUnderUtilized(seg_ptr)) {
-        // relocate the segment using first arg segment id
-      }
+    cursor = pt.VisitSegment(cursor, [&](size_t segment_id, auto* seg_ptr) {
+      if (page_usage->IsPageForObjectUnderUtilized(seg_ptr))
+        pt.TryRelocateSegment(segment_id);
     });
   } while (cursor && !page_usage->QuotaDepleted());
   db_table->segment_defrag_cursor = cursor;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1965,9 +1965,9 @@ unique_ptr<base::Histogram> DbSlice::StopSampleValues(DbIndex db_ind) {
   return unique_ptr<base::Histogram>{exchange(db.sample_values_hist, nullptr)};
 }
 
-void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
+bool DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
   if (!IsDbValid(db_ind))
-    return;
+    return true;
 
   DbTable* db_table = GetDBTable(db_ind);
   PrimeTable& pt = db_table->prime;
@@ -1984,6 +1984,7 @@ void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
     });
   } while (cursor && !page_usage->QuotaDepleted());
   db_table->segment_defrag_cursor = cursor;
+  return !cursor;
 }
 
 void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool async) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1965,6 +1965,27 @@ unique_ptr<base::Histogram> DbSlice::StopSampleValues(DbIndex db_ind) {
   return unique_ptr<base::Histogram>{exchange(db.sample_values_hist, nullptr)};
 }
 
+void DbSlice::DefragTableSegments(DbIndex db_ind, PageUsage* page_usage) {
+  if (!IsDbValid(db_ind))
+    return;
+
+  DbTable* db_table = GetDBTable(db_ind);
+  PrimeTable& pt = db_table->prime;
+
+  detail::DashCursor cursor = db_table->segment_defrag_cursor;
+  do {
+    // only relocate one segment at a time, must not yield, if it yields, then new bucket iterators
+    // might be created, and then we might relocate the segment and break their held pointers
+    FiberAtomicGuard g;
+    cursor = pt.VisitSegment(cursor, [&](size_t, auto* seg_ptr) {
+      if (page_usage->IsPageForObjectUnderUtilized(seg_ptr)) {
+        // relocate the segment using first arg segment id
+      }
+    });
+  } while (cursor && !page_usage->QuotaDepleted());
+  db_table->segment_defrag_cursor = cursor;
+}
+
 void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool async) {
   FiberAtomicGuard guard;
   size_t table_before = table->table_memory();

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -559,7 +559,8 @@ class DbSlice {
   // Returns a histogram of sampled values.
   std::unique_ptr<base::Histogram> StopSampleValues(DbIndex db_ind);
 
-  void DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
+  // Returns true if the traversal reached the end of the selected database table.
+  bool DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
 
  private:
   void PreUpdateBlocking(DbIndex db_ind, const Iterator& it);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -559,8 +559,7 @@ class DbSlice {
   // Returns a histogram of sampled values.
   std::unique_ptr<base::Histogram> StopSampleValues(DbIndex db_ind);
 
-  // Returns true if the traversal reached the end of the selected database table.
-  bool DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
+  void DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
 
  private:
   void PreUpdateBlocking(DbIndex db_ind, const Iterator& it);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -559,6 +559,8 @@ class DbSlice {
   // Returns a histogram of sampled values.
   std::unique_ptr<base::Histogram> StopSampleValues(DbIndex db_ind);
 
+  void DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
+
  private:
   void PreUpdateBlocking(DbIndex db_ind, const Iterator& it);
   void PostUpdate(DbIndex db_ind, std::string_view key);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -557,6 +557,8 @@ class DbSlice {
   // Returns a histogram of sampled values.
   std::unique_ptr<base::Histogram> StopSampleValues(DbIndex db_ind);
 
+  void DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
+
  private:
   void PreUpdateBlocking(DbIndex db_ind, const Iterator& it);
   void PostUpdate(DbIndex db_ind, std::string_view key);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -557,7 +557,8 @@ class DbSlice {
   // Returns a histogram of sampled values.
   std::unique_ptr<base::Histogram> StopSampleValues(DbIndex db_ind);
 
-  void DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
+  // Returns true if the traversal reached the end of the selected database table.
+  bool DefragTableSegments(DbIndex db_ind, PageUsage* page_usage);
 
  private:
   void PreUpdateBlocking(DbIndex db_ind, const Iterator& it);

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -927,11 +927,15 @@ TEST_F(DefragDflyEngineTest, SegmentsRelocated) {
     auto collect_addresses = [&] {
       absl::flat_hash_map<size_t, uintptr_t> seg_ptrs;
       PrimeTable::Cursor cursor;
-      do
-        cursor = table.VisitSegment(cursor, [&](auto sid, auto* p) {
-          seg_ptrs.emplace(sid, reinterpret_cast<uintptr_t>(p));
-        });
-      while (cursor);
+      do {
+        auto [next, segment] = table.VisitSegment(cursor);
+        cursor = next;
+        if (!segment) {
+          ADD_FAILURE() << "Valid cursor did not resolve to a segment";
+          return seg_ptrs;
+        }
+        seg_ptrs.emplace(segment->first, reinterpret_cast<uintptr_t>(segment->second));
+      } while (cursor);
       return seg_ptrs;
     };
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -913,6 +913,54 @@ TEST_F(DefragDflyEngineTest, DefragEventuallyFinishes) {
   });
 }
 
+TEST_F(DefragDflyEngineTest, SegmentsRelocated) {
+  // runs defrag on all segments, checks whether the state is consistent afterwards
+  constexpr size_t kKeys = 5000;
+  Run({"DEBUG", "POPULATE", std::to_string(kKeys), "key", "32"});
+
+  shard_set->pool()->AwaitFiberOnAll([&](unsigned, ProactorBase*) {
+    auto* shard = EngineShard::tlocal();
+    auto& slice = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
+    auto* db = slice.GetDBTable(0);
+    auto& table = db->prime;
+
+    auto collect_addresses = [&] {
+      absl::flat_hash_map<size_t, uintptr_t> seg_ptrs;
+      PrimeTable::Cursor cursor;
+      do
+        cursor = table.VisitSegment(cursor, [&](auto sid, auto* p) {
+          seg_ptrs.emplace(sid, reinterpret_cast<uintptr_t>(p));
+        });
+      while (cursor);
+      return seg_ptrs;
+    };
+
+    const auto before = collect_addresses();
+    const size_t size_before = table.size();
+    ASSERT_GT(before.size(), 1u);
+
+    PageUsage page_usage{CollectPageStats::NO, 0, CycleQuota::Unlimited()};
+    page_usage.SetForceReallocate(true);
+
+    EXPECT_TRUE(slice.DefragTableSegments(0, &page_usage));
+
+    const auto after = collect_addresses();
+
+    EXPECT_EQ(after.size(), before.size());
+    EXPECT_EQ(table.size(), size_before);
+
+    for (const auto& [sid, old_address] : before) {
+      ASSERT_TRUE(after.contains(sid));
+      EXPECT_NE(after.at(sid), old_address);
+    }
+  });
+
+  EXPECT_EQ(CheckedInt({"DBSIZE"}), kKeys);
+  // check some random keys
+  for (size_t i = 0; i < kKeys; i += 341)
+    EXPECT_EQ(CheckedInt({"STRLEN", absl::StrFormat("key:%d", i)}), 32);
+}
+
 TEST_F(DflyEngineTest, Issue752) {
   // https://github.com/dragonflydb/dragonfly/issues/752
   // local_result_ member was not reset between commands

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -942,7 +942,7 @@ TEST_F(DefragDflyEngineTest, SegmentsRelocated) {
     PageUsage page_usage{CollectPageStats::NO, 0, CycleQuota::Unlimited()};
     page_usage.SetForceReallocate(true);
 
-    EXPECT_TRUE(slice.DefragTableSegments(0, &page_usage));
+    slice.DefragTableSegments(0, &page_usage);
 
     const auto after = collect_addresses();
 

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -224,6 +224,8 @@ void MemoryCmd::Run(CmdArgParser parser) {
         "    ADDRESS <address>",
         "        Returns whether <address> is known to be allocated internally by any of the "
         "backing heaps",
+        "DEFRAGMENT-SEGMENTS [threshold]",
+        "    Tries to free memory by moving DashTable segments from sparsely used memory pages.",
         "DEFRAGMENT [threshold]",
         "    Tries to free memory by moving allocations around from sparsely used memory pages.",
         "    If a threshold is supplied, it is used to determine if data will be moved from the "
@@ -279,6 +281,10 @@ void MemoryCmd::Run(CmdArgParser parser) {
     return Track(parser);
   }
 
+  if (parser.Check("DEFRAGMENT-SEGMENTS")) {
+    return DefragmentSegments(parser);
+  }
+
   if (parser.Check("DEFRAGMENT")) {
     static const float default_threshold =
         absl::GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
@@ -304,6 +310,32 @@ void MemoryCmd::Run(CmdArgParser parser) {
 
   const string err = UnknownSubCmd(parser.Next(), "MEMORY");
   return cmd_cntx_->SendError(err, kSyntaxErrType);
+}
+
+void MemoryCmd::DefragmentSegments(CmdArgParser parser) {
+  static const float default_threshold = absl::GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
+  const float threshold = parser.NextOrDefault(default_threshold);
+  if (const auto err = parser.TakeError(); err)
+    return cmd_cntx_->SendError(err.MakeReply());
+
+  const auto* conn_cntx = cmd_cntx_->server_conn_cntx();
+  // Only defragment currently selected db
+  Namespace* ns = conn_cntx->ns;
+  const DbIndex db_ind = conn_cntx->db_index();
+
+  std::vector<CollectedPageStats> results(shard_set->size());
+  shard_set->pool()->AwaitFiberOnAll([threshold, ns, db_ind, &results](util::ProactorBase*) {
+    if (auto* shard = EngineShard::tlocal(); shard) {
+      PageUsage page_usage{CollectPageStats::YES, threshold,
+                           CycleQuota{CycleQuota::kDefaultDefragQuota}};
+      ns->GetDbSlice(shard->shard_id()).DefragTableSegments(db_ind, &page_usage);
+      results[shard->shard_id()] = page_usage.CollectedStats();
+    }
+  });
+
+  const CollectedPageStats merged = CollectedPageStats::Merge(std::move(results), threshold);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx_->rb());
+  return rb->SendVerbatimString(merged.ToString());
 }
 
 namespace {

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -328,25 +328,19 @@ void MemoryCmd::DefragmentSegments(CmdArgParser parser) {
   const DbIndex db_ind = conn_cntx->db_index();
 
   std::vector<CollectedPageStats> results(shard_set->size());
-  std::atomic_bool completed{true};
-  shard_set->pool()->AwaitFiberOnAll(
-      [threshold, ns, db_ind, &results, &completed](util::ProactorBase*) {
-        if (auto* shard = EngineShard::tlocal(); shard) {
-          PageUsage page_usage{CollectPageStats::YES, threshold,
-                               CycleQuota{CycleQuota::kDefaultDefragQuota}};
-          const ShardId sid = shard->shard_id();
-          if (!ns->GetDbSlice(sid).DefragTableSegments(db_ind, &page_usage))
-            completed.store(false, memory_order_relaxed);
-          results[sid] = page_usage.CollectedStats();
-        }
-      });
+  shard_set->pool()->AwaitFiberOnAll([threshold, ns, db_ind, &results](util::ProactorBase*) {
+    if (auto* shard = EngineShard::tlocal(); shard) {
+      PageUsage page_usage{CollectPageStats::YES, threshold,
+                           CycleQuota{CycleQuota::kDefaultDefragQuota}};
+      const ShardId sid = shard->shard_id();
+      ns->GetDbSlice(sid).DefragTableSegments(db_ind, &page_usage);
+      results[sid] = page_usage.CollectedStats();
+    }
+  });
 
   const CollectedPageStats merged = CollectedPageStats::Merge(std::move(results), threshold);
-  std::string response = merged.ToString();
-  const auto done = completed.load(memory_order_relaxed) ? "true" : "false";
-  absl::StrAppend(&response, "\nTraversal complete: ", done);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx_->rb());
-  return rb->SendVerbatimString(response);
+  return rb->SendVerbatimString(merged.ToString());
 }
 
 namespace {

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -289,8 +289,10 @@ void MemoryCmd::Run(CmdArgParser parser) {
     static const float default_threshold =
         absl::GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
     const float threshold = parser.NextOrDefault(default_threshold);
-    if (const auto err = parser.TakeError(); err)
-      return cmd_cntx_->SendError(err.MakeReply());
+    if (!parser.Finalize())
+      return cmd_cntx_->SendError(parser.TakeError().MakeReply());
+    if (!(threshold > 0.0 && threshold <= 1.0))
+      return cmd_cntx_->SendError("Threshold must be between 0 and 1");
 
     std::vector<CollectedPageStats> results(shard_set->size());
     shard_set->pool()->AwaitFiberOnAll([threshold, &results](util::ProactorBase*) {
@@ -315,8 +317,10 @@ void MemoryCmd::Run(CmdArgParser parser) {
 void MemoryCmd::DefragmentSegments(CmdArgParser parser) {
   static const float default_threshold = absl::GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
   const float threshold = parser.NextOrDefault(default_threshold);
-  if (const auto err = parser.TakeError(); err)
-    return cmd_cntx_->SendError(err.MakeReply());
+  if (!parser.Finalize())
+    return cmd_cntx_->SendError(parser.TakeError().MakeReply());
+  if (!(threshold > 0.0 && threshold <= 1.0))
+    return cmd_cntx_->SendError("Threshold must be between 0 and 1");
 
   const auto* conn_cntx = cmd_cntx_->server_conn_cntx();
   // Only defragment currently selected db
@@ -324,18 +328,25 @@ void MemoryCmd::DefragmentSegments(CmdArgParser parser) {
   const DbIndex db_ind = conn_cntx->db_index();
 
   std::vector<CollectedPageStats> results(shard_set->size());
-  shard_set->pool()->AwaitFiberOnAll([threshold, ns, db_ind, &results](util::ProactorBase*) {
-    if (auto* shard = EngineShard::tlocal(); shard) {
-      PageUsage page_usage{CollectPageStats::YES, threshold,
-                           CycleQuota{CycleQuota::kDefaultDefragQuota}};
-      ns->GetDbSlice(shard->shard_id()).DefragTableSegments(db_ind, &page_usage);
-      results[shard->shard_id()] = page_usage.CollectedStats();
-    }
-  });
+  std::atomic_bool completed{true};
+  shard_set->pool()->AwaitFiberOnAll(
+      [threshold, ns, db_ind, &results, &completed](util::ProactorBase*) {
+        if (auto* shard = EngineShard::tlocal(); shard) {
+          PageUsage page_usage{CollectPageStats::YES, threshold,
+                               CycleQuota{CycleQuota::kDefaultDefragQuota}};
+          const ShardId sid = shard->shard_id();
+          if (!ns->GetDbSlice(sid).DefragTableSegments(db_ind, &page_usage))
+            completed.store(false, memory_order_relaxed);
+          results[sid] = page_usage.CollectedStats();
+        }
+      });
 
   const CollectedPageStats merged = CollectedPageStats::Merge(std::move(results), threshold);
+  std::string response = merged.ToString();
+  const auto done = completed.load(memory_order_relaxed) ? "true" : "false";
+  absl::StrAppend(&response, "\nTraversal complete: ", done);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx_->rb());
-  return rb->SendVerbatimString(merged.ToString());
+  return rb->SendVerbatimString(response);
 }
 
 namespace {

--- a/src/server/memory_cmd.h
+++ b/src/server/memory_cmd.h
@@ -23,6 +23,7 @@ class MemoryCmd {
   void ArenaStats(facade::CmdArgParser parser);
   void Usage(std::string_view key, bool account_key_memory_usage);
   void Track(facade::CmdArgParser parser);
+  void DefragmentSegments(facade::CmdArgParser parser);
 
   CommandContext* cmd_cntx_;
   ServerFamily* owner_;

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -786,7 +786,21 @@ TEST_F(ServerFamilyTest, MemoryArenaSummary) {
 }
 
 TEST_F(ServerFamilyTest, MemoryParserErrorHandling) {
-  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "not-a-float"}), ErrArg("not a valid float"));
+  constexpr auto no_float = "not a valid float";
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "not-a-float"}), ErrArg(no_float));
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "nofloat"}), ErrArg(no_float));
+
+  constexpr auto threshold_err = "Threshold must be between 0 and 1";
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "2"}), ErrArg(threshold_err));
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "2"}), ErrArg(threshold_err));
+}
+
+TEST_F(ServerFamilyTest, MemoryDefragSegments) {
+  auto resp = Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "0.9"});
+  EXPECT_THAT(resp.GetString(), HasSubstr("Traversal complete:"));
+
+  resp = Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "0.9", "xyz"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
 TEST_F(ServerFamilyTest, InfoReplicationMemoryNoReplicas) {

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -797,7 +797,8 @@ TEST_F(ServerFamilyTest, MemoryParserErrorHandling) {
 
 TEST_F(ServerFamilyTest, MemoryDefragSegments) {
   auto resp = Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "0.9"});
-  EXPECT_THAT(resp.GetString(), HasSubstr("Traversal complete:"));
+  EXPECT_THAT(resp.GetString(), HasSubstr("Page usage threshold: 90"));
+  ;
 
   resp = Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "0.9", "xyz"});
   EXPECT_THAT(resp, ErrArg("syntax error"));

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -786,7 +786,22 @@ TEST_F(ServerFamilyTest, MemoryArenaSummary) {
 }
 
 TEST_F(ServerFamilyTest, MemoryParserErrorHandling) {
-  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "not-a-float"}), ErrArg("not a valid float"));
+  constexpr auto no_float = "not a valid float";
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "not-a-float"}), ErrArg(no_float));
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "nofloat"}), ErrArg(no_float));
+
+  constexpr auto threshold_err = "Threshold must be between 0 and 1";
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "2"}), ErrArg(threshold_err));
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "2"}), ErrArg(threshold_err));
+}
+
+TEST_F(ServerFamilyTest, MemoryDefragSegments) {
+  auto resp = Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "0.9"});
+  EXPECT_THAT(resp.GetString(),
+              AnyOf(HasSubstr("Traversal complete: true"), HasSubstr("Traversal complete: false")));
+
+  resp = Run({"MEMORY", "DEFRAGMENT-SEGMENTS", "0.9", "xyz"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
 TEST_F(ServerFamilyTest, InfoReplicationMemoryNoReplicas) {

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -124,10 +124,11 @@ DbTable::~DbTable() {
 }
 
 void DbTable::Clear() {
-  prime.size();
   prime.Clear();
   mcflag.Clear();
   stats = DbTableStats{};
+  expire_cursor = PrimeTable::Cursor::end();
+  segment_defrag_cursor = PrimeTable::Cursor::end();
 }
 
 PrimeIterator DbTable::Launder(PrimeIterator it, string_view key) {

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -136,6 +136,7 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
   mutable DbTableStats stats;
   std::unique_ptr<SlotStats[]> slots_stats;
   PrimeTable::Cursor expire_cursor;
+  PrimeTable::Cursor segment_defrag_cursor;
 
   struct SampleTopKeys {
     TopKeys* top_keys = nullptr;


### PR DESCRIPTION

introduces command to defrag table segments
`MEMORY DEFRAGMENT-SEGMENTS <threshold>`

For currently selected namespace and db index, for all shards, this command iterates over the db slice->db table->prime table->segments, and then defragments them one at a time.

The command is quota bound which is set to 150us. The state between invocations is stored in the db table object as a cursor. Like normal defrag, this operation also ends once the cursor is done and does not loop back to start, even if quota is left.

The defragmentation of one segment (which is basically reallocation) is not yieldable, it does not stop in the middle no matter how large the internal vectors are. Quota is only checked after a segment is relocated.