### PR TITLE
CI: wait for release sync before running package-install tests

### DIFF
--- a/.github/workflows/generate-osrepo-site.yml
+++ b/.github/workflows/generate-osrepo-site.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Download packages
         working-directory: tools/packaging/osrepos
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/fetch-releases.py $SiteRoot
 
       - name: Import GPG key
@@ -90,6 +92,11 @@ jobs:
         run: |
           gcloud storage rm ${{ secrets.GCP_PACKAGES_BUCKET }}/**
           gcloud storage rsync $SiteRoot ${{ secrets.GCP_PACKAGES_BUCKET }} --recursive --delete-unmatched-destination-objects
+
+      - name: Disable caching for repo metadata
+        run: |
+          gcloud storage objects update "${{ secrets.GCP_PACKAGES_BUCKET }}/deb/dists/**" --cache-control="no-cache, max-age=0"
+          gcloud storage objects update "${{ secrets.GCP_PACKAGES_BUCKET }}/rpm/repodata/**" --cache-control="no-cache, max-age=0"
 
       - name: Verify deployed site
         run: |

--- a/.github/workflows/generate-osrepo-site.yml
+++ b/.github/workflows/generate-osrepo-site.yml
@@ -76,11 +76,33 @@ jobs:
       - name: GCloud setup
         uses: 'google-github-actions/setup-gcloud@v3'
 
+      - name: Log locally built metadata
+        working-directory: tools/packaging/osrepos
+        run: |
+          echo "=== APT Packages (local) ==="
+          cat $SiteRoot/deb/dists/noble/main/binary-amd64/Packages
+          echo ""
+          echo "=== RPM repomd.xml (local) ==="
+          cat $SiteRoot/rpm/repodata/repomd.xml
+
       - name: Deploy site
         working-directory: tools/packaging/osrepos
         run: |
           gcloud storage rm ${{ secrets.GCP_PACKAGES_BUCKET }}/**
           gcloud storage rsync $SiteRoot ${{ secrets.GCP_PACKAGES_BUCKET }} --recursive --delete-unmatched-destination-objects
+
+      - name: Verify deployed site
+        run: |
+          echo "=== APT Packages (public) ==="
+          curl -s https://packages.dragonflydb.io/deb/dists/noble/main/binary-amd64/Packages
+          echo ""
+          echo "=== RPM repomd.xml (public) ==="
+          curl -s https://packages.dragonflydb.io/rpm/repodata/repomd.xml
+          echo ""
+          echo "=== Response headers (APT) ==="
+          curl -sI https://packages.dragonflydb.io/deb/dists/noble/main/binary-amd64/Packages
+          echo "=== Response headers (RPM) ==="
+          curl -sI https://packages.dragonflydb.io/rpm/repodata/repomd.xml
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/package-install.yml
+++ b/.github/workflows/package-install.yml
@@ -20,6 +20,13 @@ jobs:
           curl -Lo /etc/yum.repos.d/dragonfly.repo https://packages.dragonflydb.io/dragonfly.repo
           dnf clean all
           dnf makecache
+
+          echo "=== repomd.xml ==="
+          curl -s https://packages.dragonflydb.io/rpm/repodata/repomd.xml
+          echo ""
+          echo "=== dnf info ==="
+          dnf info dragonfly
+
           dnf -y install dragonfly
           dragonfly --version
 
@@ -36,6 +43,13 @@ jobs:
           curl -Lo /usr/share/keyrings/dragonfly-keyring.public https://packages.dragonflydb.io/pgp-key.public
           curl -Lo /etc/apt/sources.list.d/dragonfly.sources https://packages.dragonflydb.io/dragonfly.sources
           apt update
+
+          echo "=== Packages index ==="
+          curl -s https://packages.dragonflydb.io/deb/dists/noble/main/binary-amd64/Packages
+          echo ""
+          echo "=== apt-cache policy ==="
+          apt-cache policy dragonfly
+
           apt install -y dragonfly
           dragonfly --version
 

--- a/.github/workflows/package-install.yml
+++ b/.github/workflows/package-install.yml
@@ -15,6 +15,10 @@ jobs:
     container:
       image: ghcr.io/romange/fedora:30
     steps:
+      - uses: actions/checkout@v6
+      - name: Wait for repo version
+        if: github.event_name == 'workflow_run'
+        run: python3 tools/packaging/osrepos/scripts/wait_for_repo_version.py
       - name: Install on fedora
         run: |
           curl -Lo /etc/yum.repos.d/dragonfly.repo https://packages.dragonflydb.io/dragonfly.repo
@@ -36,6 +40,10 @@ jobs:
     container:
       image: ghcr.io/romange/ubuntu:noble
     steps:
+      - uses: actions/checkout@v6
+      - name: Wait for repo version
+        if: github.event_name == 'workflow_run'
+        run: python3 tools/packaging/osrepos/scripts/wait_for_repo_version.py
       - name: Install on ubuntu
         run: |
           apt update

--- a/tools/packaging/osrepos/scripts/fetch-releases.py
+++ b/tools/packaging/osrepos/scripts/fetch-releases.py
@@ -53,8 +53,11 @@ class Package:
 
 def collect_download_urls() -> list[Package]:
     packages = []
-    # TODO retry logic
-    response = requests.get(RELEASE_URL)
+    headers = {}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(RELEASE_URL, headers=headers)
     releases = response.json()
     for release in releases[:5]:
         for asset in release["assets"]:

--- a/tools/packaging/osrepos/scripts/wait_for_repo_version.py
+++ b/tools/packaging/osrepos/scripts/wait_for_repo_version.py
@@ -1,0 +1,61 @@
+import json
+import os
+import sys
+import time
+import urllib.request
+
+RELEASES_URL = "https://api.github.com/repos/dragonflydb/dragonfly/releases"
+DEB_PACKAGES_URL = "https://packages.dragonflydb.io/deb/dists/noble/main/binary-amd64/Packages"
+
+MAX_RETRIES = 5
+RETRY_DELAY_SECONDS = 60
+
+
+def get_latest_release_version():
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(RELEASES_URL, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        releases = json.loads(resp.read())
+    for release in releases:
+        if not release.get("draft"):
+            return release["tag_name"].lstrip("v")
+    return None
+
+
+def get_repo_version():
+    req = urllib.request.Request(DEB_PACKAGES_URL)
+    with urllib.request.urlopen(req) as resp:
+        text = resp.read().decode()
+    for line in text.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def main():
+    latest = get_latest_release_version()
+    if not latest:
+        print("Could not determine latest release version")
+        return 1
+
+    print(f"Latest GitHub release: {latest}")
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        repo_version = get_repo_version()
+        print(f"Attempt {attempt}/{MAX_RETRIES}: repo version = {repo_version}")
+        if repo_version == latest:
+            print("Versions match.")
+            return 0
+        if attempt < MAX_RETRIES:
+            print(f"Mismatch (expected {latest}). Retrying in {RETRY_DELAY_SECONDS}s...")
+            time.sleep(RETRY_DELAY_SECONDS)
+
+    print(f"FAILED: expected {latest}, repo has {repo_version} after {MAX_RETRIES} attempts")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
When dragonfly release is published the following steps happen:

* the packages website is refreshed: https://packages.dragonflydb.io - refreshed means fetching the latest release, updating the package db (repmod for redhat/fedora, Packages flle for debian), the static site and links
* package install tests are triggered, they fetch and install the latest packages

Sometimes these fail because step 2 tries to download and install the previous version. It seems that the package installer fetches the previous db (repmod/pacakges file) instead of the newly generated one. One theory is that this happens because of CDNs caching old static data (the website is mostly static content) and serving that, which makes the test runner look for old version.

This PR adds a few things:

* A blocking script, it tries 5 times to see if the package version reported by the website https://packages.dragonflydb.io and the github releases are the same. If not it sleeps 1 minute and retries
* Tests are only run after the script passes
* More logs are added to the refresh site workflow and package install workflow
* Caching is disabled for the package db specific files

It cannot claim to fix https://github.com/dragonflydb/dragonfly/issues/7992 which should only be closed after a successful post-release run, but it should help in investigation.

The blocking script is expected to have the following output in normal run
```
python tools/packaging/osrepos/scripts/wait_for_repo_version.py
Latest GitHub release: 1.40.0
Attempt 1/5: repo version = 1.40.0
Versions match.
```