### PR TITLE
CI: do not print successful gtest output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  GTEST_BRIEF: 1
+
 jobs:
   # Do not rename this job name without updating any matching required status check in repository settings.
   pre-commit:


### PR DESCRIPTION
If a unit test fails, the CI log is full of RAN/OK noise from passed tests which makes the real error scroll off the page. add `GTEST_BRIEF` to make only the failed test print its results.