### PR TITLE
feat: reduce min_capacity for OAHTable

### DIFF
--- a/src/core/oah_map.h
+++ b/src/core/oah_map.h
@@ -151,9 +151,7 @@ class OAHMap : public OAHTable<OAHPair> {
   // a fresh insert.
   bool AddPairImpl(std::string_view content, uint32_t len, TaggedPtr new_tp, bool replace,
                    TaggedPtr* old_out) {
-    if (size_ >= entries_.size() * kOverloadFactor) [[unlikely]] {
-      GrowCapacity(BucketCount() * 2);
-    }
+    TryGrow();
     assert(Capacity() >= kDisplacementSize);
 
     uint64_t hash = Hash(content);

--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -49,9 +49,6 @@ class OAHMapTest : public ::testing::Test {
     InitTLStatelessAllocMR(PMR_NS::get_default_resource());
   }
 
-  static void TearDownTestSuite() {
-  }
-
   void SetUp() override {
     m_ = new OAHMap;
     generator_.seed(0);
@@ -135,6 +132,26 @@ TEST_F(OAHMapTest, Basic) {
   ASSERT_TRUE(value.has_value());
   EXPECT_EQ(*value, "baraaaaaaaaaaaa2"sv);
   EXPECT_FALSE(m_->GetValue("missing").has_value());
+}
+
+TEST_F(OAHMapTest, ShrinkToMinimumBuckets) {
+  m_->Reserve(1);
+  EXPECT_EQ(m_->BucketCount(), OAHMap::kMinBucketCount);
+
+  EXPECT_TRUE(m_->AddOrUpdate("first", "one"));
+  EXPECT_TRUE(m_->AddOrUpdate("second", "two"));
+  m_->Reserve(128 * OAHMap::kOverloadFactor);
+  m_->Shrink(1);
+  EXPECT_EQ(m_->BucketCount(), OAHMap::kMinBucketCount);
+
+  EXPECT_EQ(m_->GetValue("first"), std::optional{"one"sv});
+  EXPECT_EQ(m_->GetValue("second"), std::optional{"two"sv});
+
+  for (unsigned i = 2; i < 34; ++i)
+    EXPECT_TRUE(m_->AddOrUpdate(absl::StrCat("member", i), "value"));
+  EXPECT_TRUE(m_->AddOrUpdate("member34", "value"));
+  EXPECT_EQ(m_->BucketCount(), 32u);
+  EXPECT_EQ(m_->GetValue("first"), std::optional{"one"sv});
 }
 
 TEST_F(OAHMapTest, EmptyKeyAndValue) {

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -52,9 +52,7 @@ class OAHSet : public OAHTable<OAHEntry> {
 
  private:
   bool AddImpl(std::string_view content, uint32_t len, uint32_t ttl_sec) {
-    if (size_ >= entries_.size() * kOverloadFactor) [[unlikely]] {
-      GrowCapacity(BucketCount() * 2);
-    }
+    TryGrow();
     assert(Capacity() >= kDisplacementSize);
 
     uint64_t hash = Hash(content);

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -46,9 +46,6 @@ class OAHSetTest : public ::testing::Test {
     InitTLStatelessAllocMR(PMR_NS::get_default_resource());
   }
 
-  static void TearDownTestSuite() {
-  }
-
   void SetUp() override {
     ss_ = new OAHSet;
     generator_.seed(0);
@@ -121,10 +118,50 @@ TEST_F(OAHSetTest, ShrinkUsesOverloadAwareTarget) {
   ss_->Reserve(128 * OAHSet::kOverloadFactor);
   EXPECT_EQ(ss_->BucketCount(), 128);
 
-  // The legacy caller asks for eight buckets. OAH ignores that DenseSet-oriented
-  // target and retains its legal 16-bucket minimum.
+  // The requested target is above OAH's minimum.
   ss_->Shrink(8);
+  EXPECT_EQ(ss_->BucketCount(), 8u);
+}
+
+TEST_F(OAHSetTest, ShrinkToMinimumBuckets) {
+  ss_->Reserve(1);
   EXPECT_EQ(ss_->BucketCount(), OAHSet::kMinBucketCount);
+
+  vector<string> keys = {"first", "second"};
+  for (const string& key : keys)
+    EXPECT_TRUE(ss_->Add(key));
+
+  ss_->Reserve(128 * OAHSet::kOverloadFactor);
+  ss_->Shrink(1);
+  EXPECT_EQ(ss_->BucketCount(), OAHSet::kMinBucketCount);
+  ss_->Reserve(16);  // The physical probe slots already satisfy this reservation.
+  EXPECT_EQ(ss_->BucketCount(), OAHSet::kMinBucketCount);
+
+  const auto scan_all = [this] {
+    unordered_set<string> result;
+    uint32_t cursor = 0;
+    do {
+      cursor = ss_->Scan(cursor, [&](string_view key) { result.emplace(key); });
+    } while (cursor != 0);
+    return result;
+  };
+
+  EXPECT_TRUE(ss_->Add("expired", 1));
+  ss_->set_time(1);
+  EXPECT_EQ(scan_all(), unordered_set<string>(keys.begin(), keys.end()));
+
+  for (size_t i = keys.size(); i < 34; ++i) {
+    keys.push_back(absl::StrCat("member", i));
+    EXPECT_TRUE(ss_->Add(keys.back()));
+  }
+
+  EXPECT_EQ(scan_all(), unordered_set<string>(keys.begin(), keys.end()));
+
+  keys.push_back("member34");
+  EXPECT_TRUE(ss_->Add(keys.back()));  // Grows from the compact minimum representation.
+  EXPECT_EQ(ss_->BucketCount(), 32u);
+  for (const string& key : keys)
+    EXPECT_TRUE(ss_->Contains(key));
 }
 
 TEST_F(OAHSetTest, AsciiEncoding) {

--- a/src/core/oah_table.cc
+++ b/src/core/oah_table.cc
@@ -78,9 +78,9 @@ template <typename Entry> size_t OAHTable<Entry>::SizeSlow() {
 }
 
 template <typename Entry> void OAHTable<Entry>::GrowCapacity(size_t bucket_capacity) {
-  bucket_capacity = absl::bit_ceil(bucket_capacity);
+  bucket_capacity = std::max(kMinBucketCount, absl::bit_ceil(bucket_capacity));
   if (bucket_capacity > entries_.size()) {
-    capacity_log_ = std::max(kMinCapacityLog, uint32_t(absl::bit_width(bucket_capacity) - 1));
+    capacity_log_ = uint32_t(absl::bit_width(bucket_capacity) - 1);
     size_t prev_size = entries_.size();
     entries_.resize(Capacity());
     Rehash(prev_size);

--- a/src/core/oah_table.h
+++ b/src/core/oah_table.h
@@ -43,12 +43,12 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
 
  public:
   static constexpr std::uint32_t kShiftLog = 4;                         // TODO make template
-  static constexpr std::uint32_t kMinCapacityLog = kShiftLog;           // should be >= ShiftLog
   static constexpr std::uint32_t kDisplacementSize = (1 << kShiftLog);  // TODO check
 
   // Table grows once live entries reach capacity * kOverloadFactor (200% load, by default).
   static constexpr std::uint32_t kOverloadFactor = 2;
-  static constexpr size_t kMinBucketCount = 1u << kMinCapacityLog;
+  // Keep capacity_log_ nonzero in nonempty tables.
+  static constexpr size_t kMinBucketCount = 2;
 
   class iterator {
    public:
@@ -375,6 +375,18 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
   // Grows the table so entries_.size() >= bucket_capacity (power of 2), rehashing in place.
   void GrowCapacity(size_t bucket_capacity);
 
+  // Grows the table once size_ crosses the overload threshold. GrowCapacity takes a
+  // bucket_capacity target, so divide by kOverloadFactor to undo Reserve()'s scaling.
+  void TryGrow() {
+    if (size_ >= entries_.size() * kOverloadFactor) [[unlikely]] {
+      size_t target = size_ + 1;
+      if constexpr (kOverloadFactor > 1) {
+        target = (target + kOverloadFactor - 1) / kOverloadFactor;
+      }
+      GrowCapacity(target);
+    }
+  }
+
   static uint64_t Hash(std::string_view str) {
     constexpr uint64_t kHashSeed = 24061983;
     return rapidhashMicro_withSeed(str.data(), str.size(), kHashSeed);
@@ -404,8 +416,9 @@ template <typename Entry> class OAHTable {  // Open Addressing Hash table
     // We should prevent moving elements before current position to avoid double processing.
     // Detach the first mix_size slots into locals; each `bucket` view is freed explicitly
     // after its entries are redistributed into entries_ (a TaggedPtr slot has no dtor).
-    constexpr size_t mix_size = (2 << kShiftLog) - 1;
-    std::array<TaggedPtr, mix_size> old_buckets{};
+    constexpr size_t kMixSize = (2 << kShiftLog) - 1;
+    std::array<TaggedPtr, kMixSize> old_buckets{};
+    const size_t mix_size = std::min<size_t>(prev_size, old_buckets.size());
     for (size_t i = 0; i < mix_size; ++i) {
       old_buckets[i] = entries_[i];
       entries_[i] = 0;


### PR DESCRIPTION
Summary: Reduce the minimum bucket count for OAHTable so OAHMap/OAHSet can shrink to a more compact representation for tiny sizes.

Changes:

- Replace ad-hoc overload resize checks with a shared TryGrow() helper used by the map/set insertion paths.
- Clamp GrowCapacity() to a new kMinBucketCount (2) and adjust rehash mixing logic to safely handle very small tables.
- Extend unit tests to cover shrink-to-minimum behavior, correctness after regrowth, and TTL-aware scanning from the compact state.