### PR TITLE
fix(tiering): Generic upload routine

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1001,6 +1001,13 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   if (!IsValid(from_res.it))
     return OpStatus::KEY_NOTFOUND;
 
+  // We must prepare tiered values for transfer to break any back references from disk to this key
+  if (auto* ts = op_args.shard->tiered_storage(); ts && from_res.it->second.IsExternal()) {
+    if (!ts->PrepareKeyForTransfer(op_args.db_cntx.db_index, key, &from_res.it->second))
+      return OpStatus::IO_ERROR;
+    from_res.post_updater.ResyncBaseline();  // the read may have uploaded the value
+  }
+
   // Ensure target database exists.
   db_slice.ActivateDb(target_db);
 
@@ -1067,6 +1074,13 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
     OpStatus status = MaterializeHashForDb0Search(0, from_key, &from_res, op_args.shard);
     if (status != OpStatus::OK)
       return status;
+  }
+
+  // We must prepare tiered values for transfer to break any back references from disk to this key
+  if (auto* ts = es->tiered_storage(); ts && from_res.it->second.IsExternal()) {
+    if (!ts->PrepareKeyForTransfer(op_args.db_cntx.db_index, from_key, &from_res.it->second))
+      return OpStatus::IO_ERROR;
+    from_res.post_updater.ResyncBaseline();  // the read may have uploaded the value
   }
 
   bool is_prior_list = false;

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -929,6 +929,13 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   if (!IsValid(from_res.it))
     return OpStatus::KEY_NOTFOUND;
 
+  // We must prepare tiered values for transfer to break any back references from disk to this key
+  if (auto* ts = op_args.shard->tiered_storage(); ts && from_res.it->second.IsExternal()) {
+    if (!ts->PrepareKeyForTransfer(op_args.db_cntx.db_index, key, &from_res.it->second))
+      return OpStatus::IO_ERROR;
+    from_res.post_updater.ResyncBaseline();  // the read may have uploaded the value
+  }
+
   // Ensure target database exists.
   db_slice.ActivateDb(target_db);
 
@@ -978,6 +985,13 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
 
   if (from_key == to_key)
     return destination_should_not_exist ? OpStatus::KEY_EXISTS : OpStatus::OK;
+
+  // We must prepare tiered values for transfer to break any back references from disk to this key
+  if (auto* ts = es->tiered_storage(); ts && from_res.it->second.IsExternal()) {
+    if (!ts->PrepareKeyForTransfer(op_args.db_cntx.db_index, from_key, &from_res.it->second))
+      return OpStatus::IO_ERROR;
+    from_res.post_updater.ResyncBaseline();  // the read may have uploaded the value
+  }
 
   bool is_prior_list = false;
   auto to_res = db_slice.FindMutable(op_args.db_cntx, to_key);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -287,7 +287,8 @@ auto ExecuteW(Transaction* tx, F&& f,
       };
 
       es->tiered_storage()->Read(std::make_pair(op_args.db_cntx.db_index, key),
-                                 pv.GetExternalSlice(), D{}, std::move(read_cb), false);
+                                 pv.GetExternalSlice(), D{}, std::move(read_cb),
+                                 tiering::ReadOptions{.read_only = false});
       return CbVariant<T>{std::move(fut)};
     }
 
@@ -561,7 +562,8 @@ OpResult<CbVariant<uint32_t>> OpSet(const OpArgs& op_args, string_view key,
     };
 
     op_args.shard->tiered_storage()->Read(std::make_pair(op_args.db_cntx.db_index, key),
-                                          pv.GetExternalSlice(), D{}, std::move(read_cb), false);
+                                          pv.GetExternalSlice(), D{}, std::move(read_cb),
+                                          tiering::ReadOptions{.read_only = false});
     return CbVariant<uint32_t>{std::move(fut)};
   }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -311,7 +311,8 @@ auto ExecuteW(Transaction* tx, F&& f,
       };
 
       es->tiered_storage()->Read(std::make_pair(op_args.db_cntx.db_index, key),
-                                 pv.GetExternalSlice(), D{}, std::move(read_cb), false);
+                                 pv.GetExternalSlice(), D{}, std::move(read_cb),
+                                 tiering::ReadOptions{.read_only = false});
       return CbVariant<T>{std::move(fut)};
     }
 
@@ -589,7 +590,8 @@ OpResult<CbVariant<uint32_t>> OpSet(const OpArgs& op_args, string_view key,
     };
 
     op_args.shard->tiered_storage()->Read(std::make_pair(op_args.db_cntx.db_index, key),
-                                          pv.GetExternalSlice(), D{}, std::move(read_cb), false);
+                                          pv.GetExternalSlice(), D{}, std::move(read_cb),
+                                          tiering::ReadOptions{.read_only = false});
     return CbVariant<uint32_t>{std::move(fut)};
   }
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -580,16 +580,13 @@ bool TieredStorage::PrepareKeyForTransfer(DbIndex dbid, string_view key, PrimeVa
 
   DCHECK(!pv->IsCool());  // FindMutableInternal warms cooled values up
 
-  // Full size values don't have the key encoded
   tiering::DiskSegment segment = pv->GetExternalSlice();
-  if (OccupiesWholePages(segment.length))
-    return true;
-
-  // Force upload with bare decoder
   util::fb2::Future<bool> done;
-  auto cb = [done](io::Result<tiering::BareDecoder*> res) mutable {
-    done.Resolve(res.has_value());
-  };
+  auto cb = [done](auto res) mutable { done.Resolve(res.has_value()); };
+
+  // Force upload value with bare decoder. Ensure:
+  // 1. No small bins endoded keys back reference the key
+  // 2. No pending reads back reference the key
   Read(KeyRef{dbid, key}, segment, tiering::BareDecoder{}, std::move(cb),
        tiering::ReadOptions{.read_only = false, .force_upload = true});
   return done.Get();

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -227,7 +227,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   bool NotifyFetched(const OwnedEntryId& id, tiering::DiskSegment segment,
-                     tiering::Decoder* decoder) override;
+                     tiering::Decoder* decoder, const tiering::ReadOptions& options) override;
 
   bool NotifyDelete(tiering::DiskSegment segment, bool in_memory) override;
 
@@ -240,23 +240,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   // Set value to be an in-memory type again. Update memory stats.
   void Upload(DbIndex dbid, string_view key, string_view value, PrimeValue* pv) {
     DCHECK(!value.empty());
-    switch (pv->GetExternalRep()) {
-      case CompactObj::ExternalRep::STRING: {
-        pv->Materialize(value, true);
-        break;
-      }
-      case CompactObj::ExternalRep::SERIALIZED_MAP: {
-        tiering::ListpackMapDecoder decoder{};
-        decoder.Initialize(value);
-        decoder.Upload(pv);
-        break;
-      }
-      case CompactObj::ExternalRep::LIST_NODE: {
-        LOG(DFATAL) << "LIST_NODE should not be uploaded to PrimeValue";
-        break;
-      }
-    };
-
+    tiering::BareDecoder decoder;
+    decoder.slice = value;
+    decoder.Upload(pv);
     AccountTieredUpload(*pv, value.size(), key, db_slice_.GetDBTable(dbid));
   }
 
@@ -370,7 +356,8 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
 
 bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
                                                   tiering::DiskSegment segment,
-                                                  tiering::Decoder* decoder) {
+                                                  tiering::Decoder* decoder,
+                                                  const tiering::ReadOptions& options) {
   ++stats_.total_fetches;
 
   if (const auto* i = std::get_if<uintptr_t>(&id); i) {
@@ -383,8 +370,8 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
 
   tiering::Decoder::UploadMetrics metrics = decoder->GetMetrics();
 
-  // We must upload the value if it was modified
-  bool should_upload = metrics.modified;
+  // We must upload the value if it was modified or the caller forces it
+  bool should_upload = metrics.modified || options.force_upload;
 
   // Snapshotting casuses reads that are not from clients, so ignore request to upload
   // List tiering uploads on it own rules from the ends
@@ -418,7 +405,7 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
   if (const auto* key = std::get_if<tiering::DbKeyId>(&id); key) {
     auto* pv = Find(key->first, key->second);
     if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
-      if (metrics.modified || pv->WasTouched()) {
+      if (metrics.modified || pv->WasTouched() || options.force_upload) {
         ++stats_.total_uploads;
         decoder->Upload(pv);
         AccountTieredUpload(*pv, segment.length, key->second, db_slice_.GetDBTable(key->first));
@@ -462,7 +449,8 @@ void TieredStorage::ShardOpManager::EnqueueForDefrag(tiering::DiskSegment segmen
   stats_.pending_defrags++;
   Enqueue(
       kFragmentedBin, segment, tiering::BareDecoder{},
-      [this](io::Result<tiering::Decoder*> res) { stats_.pending_defrags--; }, true);
+      [this](io::Result<tiering::Decoder*> res) { stats_.pending_defrags--; },
+      tiering::ReadOptions{.read_only = true});
 }
 
 void TieredStorage::ShardOpManager::RetireColdEntries(size_t additional_memory) {
@@ -520,10 +508,10 @@ void TieredStorage::CancelLoad(tiering::DiskSegment segment) {
 void TieredStorage::ReadInternal(tiering::ReadId id, const tiering::DiskSegment& segment,
                                  const tiering::Decoder& decoder,
                                  std::function<void(io::Result<tiering::Decoder*>)> cb,
-                                 bool read_only) {
+                                 tiering::ReadOptions options) {
   // TODO: improve performance by avoiding one more function wrap
   op_manager_->Enqueue(std::visit([](auto&& value) -> tiering::PendingId { return value; }, id),
-                       segment, decoder, std::move(cb), read_only);
+                       segment, decoder, std::move(cb), options);
 }
 
 void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDescriptor& blobs,
@@ -584,6 +572,27 @@ void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
   }
   fragment_ref.ClearOffloaded();
   op_manager_->DeleteOffloaded(dbid, segment);
+}
+
+bool TieredStorage::PrepareKeyForTransfer(DbIndex dbid, string_view key, PrimeValue* pv) {
+  if (!pv->IsExternal())
+    return true;
+
+  DCHECK(!pv->IsCool());  // FindMutableInternal warms cooled values up
+
+  // Full size values don't have the key encoded
+  tiering::DiskSegment segment = pv->GetExternalSlice();
+  if (OccupiesWholePages(segment.length))
+    return true;
+
+  // Force upload with bare decoder
+  util::fb2::Future<bool> done;
+  auto cb = [done](io::Result<tiering::BareDecoder*> res) mutable {
+    done.Resolve(res.has_value());
+  };
+  Read(KeyRef{dbid, key}, segment, tiering::BareDecoder{}, std::move(cb),
+       tiering::ReadOptions{.read_only = false, .force_upload = true});
+  return done.Get();
 }
 
 void TieredStorage::CancelStash(tiering::PendingId id, tiering::FragmentRef fragment_ref) {
@@ -922,7 +931,7 @@ util::fb2::Future<bool> TieredStorage::MaterializeForIndexing(DbIndex dbid, stri
           (*res)->GetMutable();
         fut.Resolve(res.has_value());
       },
-      false /* read_only */);
+      tiering::ReadOptions{.read_only = false});
   return fut;
 }
 
@@ -1031,7 +1040,7 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
     future.Resolve(res.transform([&modf](auto* d) { return modf(d->Write()); }));
   };
   ts->Read(KeyRef{dbid, key}, value.GetExternalSlice(), tiering::StringDecoder{value},
-           std::move(cb), false);
+           std::move(cb), tiering::ReadOptions{.read_only = false});
 
   return future;
 }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -570,16 +570,13 @@ bool TieredStorage::PrepareKeyForTransfer(DbIndex dbid, string_view key, PrimeVa
 
   DCHECK(!pv->IsCool());  // FindMutableInternal warms cooled values up
 
-  // Full size values don't have the key encoded
   tiering::DiskSegment segment = pv->GetExternalSlice();
-  if (OccupiesWholePages(segment.length))
-    return true;
-
-  // Force upload with bare decoder
   util::fb2::Future<bool> done;
-  auto cb = [done](io::Result<tiering::BareDecoder*> res) mutable {
-    done.Resolve(res.has_value());
-  };
+  auto cb = [done](auto res) mutable { done.Resolve(res.has_value()); };
+
+  // Force upload value with bare decoder. Ensure:
+  // 1. No small bins endoded keys back reference the key
+  // 2. No pending reads back reference the key
   Read(KeyRef{dbid, key}, segment, tiering::BareDecoder{}, std::move(cb),
        tiering::ReadOptions{.read_only = false, .force_upload = true});
   return done.Get();

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -225,7 +225,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   bool NotifyFetched(const OwnedEntryId& id, tiering::DiskSegment segment,
-                     tiering::Decoder* decoder) override;
+                     tiering::Decoder* decoder, const tiering::ReadOptions& options) override;
 
   bool NotifyDelete(tiering::DiskSegment segment, bool in_memory) override;
 
@@ -238,23 +238,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   // Set value to be an in-memory type again. Update memory stats.
   void Upload(DbIndex dbid, string_view key, string_view value, PrimeValue* pv) {
     DCHECK(!value.empty());
-    switch (pv->GetExternalRep()) {
-      case CompactObj::ExternalRep::STRING: {
-        pv->Materialize(value, true);
-        break;
-      }
-      case CompactObj::ExternalRep::SERIALIZED_MAP: {
-        tiering::ListpackMapDecoder decoder{};
-        decoder.Initialize(value);
-        decoder.Upload(pv);
-        break;
-      }
-      case CompactObj::ExternalRep::LIST_NODE: {
-        LOG(DFATAL) << "LIST_NODE should not be uploaded to PrimeValue";
-        break;
-      }
-    };
-
+    tiering::BareDecoder decoder;
+    decoder.slice = value;
+    decoder.Upload(pv);
     AccountTieredUpload(*pv, value.size(), key, db_slice_.GetDBTable(dbid));
   }
 
@@ -366,7 +352,8 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
 
 bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
                                                   tiering::DiskSegment segment,
-                                                  tiering::Decoder* decoder) {
+                                                  tiering::Decoder* decoder,
+                                                  const tiering::ReadOptions& options) {
   ++stats_.total_fetches;
 
   if (const auto* i = std::get_if<uintptr_t>(&id); i) {
@@ -379,8 +366,8 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
 
   tiering::Decoder::UploadMetrics metrics = decoder->GetMetrics();
 
-  // We must upload the value if it was modified
-  bool should_upload = metrics.modified;
+  // We must upload the value if it was modified or the caller forces it
+  bool should_upload = metrics.modified || options.force_upload;
 
   // Snapshotting casuses reads that are not from clients, so ignore request to upload
   // List tiering uploads on it own rules from the ends
@@ -414,7 +401,7 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
   if (const auto* key = std::get_if<tiering::DbKeyId>(&id); key) {
     auto* pv = Find(key->first, key->second);
     if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
-      if (metrics.modified || pv->WasTouched()) {
+      if (metrics.modified || pv->WasTouched() || options.force_upload) {
         ++stats_.total_uploads;
         decoder->Upload(pv);
         AccountTieredUpload(*pv, segment.length, key->second, db_slice_.GetDBTable(key->first));
@@ -458,7 +445,8 @@ void TieredStorage::ShardOpManager::EnqueueForDefrag(tiering::DiskSegment segmen
   stats_.pending_defrags++;
   Enqueue(
       kFragmentedBin, segment, tiering::BareDecoder{},
-      [this](io::Result<tiering::Decoder*> res) { stats_.pending_defrags--; }, true);
+      [this](io::Result<tiering::Decoder*> res) { stats_.pending_defrags--; },
+      tiering::ReadOptions{.read_only = true});
 }
 
 void TieredStorage::ShardOpManager::RetireColdEntries(size_t additional_memory) {
@@ -516,10 +504,10 @@ void TieredStorage::CancelLoad(tiering::DiskSegment segment) {
 void TieredStorage::ReadInternal(tiering::ReadId id, const tiering::DiskSegment& segment,
                                  const tiering::Decoder& decoder,
                                  std::function<void(io::Result<tiering::Decoder*>)> cb,
-                                 bool read_only) {
+                                 tiering::ReadOptions options) {
   // TODO: improve performance by avoiding one more function wrap
   op_manager_->Enqueue(std::visit([](auto&& value) -> tiering::PendingId { return value; }, id),
-                       segment, decoder, std::move(cb), read_only);
+                       segment, decoder, std::move(cb), options);
 }
 
 void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDescriptor& blobs,
@@ -574,6 +562,27 @@ void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
   }
   fragment_ref.ClearOffloaded();
   op_manager_->DeleteOffloaded(dbid, segment);
+}
+
+bool TieredStorage::PrepareKeyForTransfer(DbIndex dbid, string_view key, PrimeValue* pv) {
+  if (!pv->IsExternal())
+    return true;
+
+  DCHECK(!pv->IsCool());  // FindMutableInternal warms cooled values up
+
+  // Full size values don't have the key encoded
+  tiering::DiskSegment segment = pv->GetExternalSlice();
+  if (OccupiesWholePages(segment.length))
+    return true;
+
+  // Force upload with bare decoder
+  util::fb2::Future<bool> done;
+  auto cb = [done](io::Result<tiering::BareDecoder*> res) mutable {
+    done.Resolve(res.has_value());
+  };
+  Read(KeyRef{dbid, key}, segment, tiering::BareDecoder{}, std::move(cb),
+       tiering::ReadOptions{.read_only = false, .force_upload = true});
+  return done.Get();
 }
 
 void TieredStorage::CancelStash(tiering::PendingId id, tiering::FragmentRef fragment_ref) {
@@ -976,7 +985,7 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
     future.Resolve(res.transform([&modf](auto* d) { return modf(d->Write()); }));
   };
   ts->Read(KeyRef{dbid, key}, value.GetExternalSlice(), tiering::StringDecoder{value},
-           std::move(cb), false);
+           std::move(cb), tiering::ReadOptions{.read_only = false});
 
   return future;
 }

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -71,13 +71,13 @@ class TieredStorage : public TieredStorageBase {
   // Enqueue read external value with generic decoder.
   template <typename D, typename F>
   void Read(tiering::ReadId id, const tiering::DiskSegment& segment, const D& decoder, F&& f,
-            bool read_only = true) {
+            tiering::ReadOptions options = {}) {
     // TODO(vlad): untangle endless callback wrapping!
     // Templates don't consider implicit conversions, so explicitly convert to std::function
     auto wrapped_cb = [f = std::forward<F>(f)](io::Result<tiering::Decoder*> res) mutable {
       f(res.transform([](auto* d) { return static_cast<D*>(d); }));
     };
-    ReadInternal(id, segment, decoder, wrapped_cb, read_only);
+    ReadInternal(id, segment, decoder, wrapped_cb, options);
   }
 
   // Returns StashDescriptor if a value should be stashed.
@@ -97,6 +97,11 @@ class TieredStorage : public TieredStorageBase {
   void Delete(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
   // List node fragments carry no key; per-slot counters cannot follow them.
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
+
+  // Prepre key to be transferred between databases / renamed.
+  // Tiered storage must invalidate all back references to it: serialized
+  // small bin entries that store (dbid, key) pair to recover the key are deleted
+  bool PrepareKeyForTransfer(DbIndex dbid, std::string_view key, PrimeValue* pv);
 
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(tiering::DiskSegment segment) const;
@@ -142,7 +147,8 @@ class TieredStorage : public TieredStorageBase {
  private:
   void ReadInternal(tiering::ReadId, const tiering::DiskSegment& segment,
                     const tiering::Decoder& decoder,
-                    std::function<void(io::Result<tiering::Decoder*>)> cb, bool read_only);
+                    std::function<void(io::Result<tiering::Decoder*>)> cb,
+                    tiering::ReadOptions options = {});
 
   // Moves pv contents to the cool storage and updates pv to point to it.
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
@@ -267,7 +273,7 @@ class TieredStorage : public TieredStorageBase {
 
   template <typename D, typename F>
   void Read(tiering::ReadId id, const tiering::DiskSegment& segment, const D& decoder, F&& f,
-            bool read_only = true) {
+            tiering::ReadOptions options = {}) {
   }
 
   template <typename T>
@@ -289,6 +295,10 @@ class TieredStorage : public TieredStorageBase {
   }
 
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {
+  }
+
+  bool PrepareKeyForTransfer(DbIndex dbid, std::string_view key, PrimeValue* pv) {
+    return true;
   }
 
   bool HasModificationPending(tiering::DiskSegment segment) const {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -70,13 +70,13 @@ class TieredStorage : public TieredStorageBase {
   // Enqueue read external value with generic decoder.
   template <typename D, typename F>
   void Read(tiering::ReadId id, const tiering::DiskSegment& segment, const D& decoder, F&& f,
-            bool read_only = true) {
+            tiering::ReadOptions options = {}) {
     // TODO(vlad): untangle endless callback wrapping!
     // Templates don't consider implicit conversions, so explicitly convert to std::function
     auto wrapped_cb = [f = std::forward<F>(f)](io::Result<tiering::Decoder*> res) mutable {
       f(res.transform([](auto* d) { return static_cast<D*>(d); }));
     };
-    ReadInternal(id, segment, decoder, wrapped_cb, read_only);
+    ReadInternal(id, segment, decoder, wrapped_cb, options);
   }
 
   // Returns StashDescriptor if a value should be stashed.
@@ -94,6 +94,11 @@ class TieredStorage : public TieredStorageBase {
 
   // Delete value, must be offloaded (external type)
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
+
+  // Prepre key to be transferred between databases / renamed.
+  // Tiered storage must invalidate all back references to it: serialized
+  // small bin entries that store (dbid, key) pair to recover the key are deleted
+  bool PrepareKeyForTransfer(DbIndex dbid, std::string_view key, PrimeValue* pv);
 
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(tiering::DiskSegment segment) const;
@@ -134,7 +139,8 @@ class TieredStorage : public TieredStorageBase {
  private:
   void ReadInternal(tiering::ReadId, const tiering::DiskSegment& segment,
                     const tiering::Decoder& decoder,
-                    std::function<void(io::Result<tiering::Decoder*>)> cb, bool read_only);
+                    std::function<void(io::Result<tiering::Decoder*>)> cb,
+                    tiering::ReadOptions options = {});
 
   // Moves pv contents to the cool storage and updates pv to point to it.
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
@@ -259,7 +265,7 @@ class TieredStorage : public TieredStorageBase {
 
   template <typename D, typename F>
   void Read(tiering::ReadId id, const tiering::DiskSegment& segment, const D& decoder, F&& f,
-            bool read_only = true) {
+            tiering::ReadOptions options = {}) {
   }
 
   template <typename T>
@@ -278,6 +284,10 @@ class TieredStorage : public TieredStorageBase {
   }
 
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {
+  }
+
+  bool PrepareKeyForTransfer(DbIndex dbid, std::string_view key, PrimeValue* pv) {
+    return true;
   }
 
   bool HasModificationPending(tiering::DiskSegment segment) const {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -98,9 +98,9 @@ class TieredStorage : public TieredStorageBase {
   // List node fragments carry no key; per-slot counters cannot follow them.
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
 
-  // Prepre key to be transferred between databases / renamed.
-  // Tiered storage must invalidate all back references to it: serialized
-  // small bin entries that store (dbid, key) pair to recover the key are deleted
+  // Prepare key to be transferred between databases / renamed.
+  // Tiered storage must invalidate all back references to it: values in small bins serializing
+  // the key and pending reads referencing the key
   bool PrepareKeyForTransfer(DbIndex dbid, std::string_view key, PrimeValue* pv);
 
   // Returns true if there is a pending modification for the given segment.

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -95,9 +95,9 @@ class TieredStorage : public TieredStorageBase {
   // Delete value, must be offloaded (external type)
   void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
 
-  // Prepre key to be transferred between databases / renamed.
-  // Tiered storage must invalidate all back references to it: serialized
-  // small bin entries that store (dbid, key) pair to recover the key are deleted
+  // Prepare key to be transferred between databases / renamed.
+  // Tiered storage must invalidate all back references to it: values in small bins serializing
+  // the key and pending reads referencing the key
   bool PrepareKeyForTransfer(DbIndex dbid, std::string_view key, PrimeValue* pv);
 
   // Returns true if there is a pending modification for the given segment.

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -495,8 +495,7 @@ TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
   EXPECT_EQ(Run({"GET", "moved"}), val(victim));
 
   Run({"FLUSHALL"});
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 0u);
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
 }
 
 // discovers and defragments a large number of bins that became fragmented while there was no upload

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -621,29 +621,6 @@ TEST_F(PureDiskTSTest, OffloadingStrategy) {
   }
 }
 
-// Overwriting an offloaded value in place must release its disk extent, otherwise it is
-// orphaned forever and the FLUSHALL invariant CHECK_EQ(tiered_entries, 0) aborts the process.
-TEST_F(PureDiskTSTest, RenameOverOffloadedDestination) {
-  const string src_value = BuildString(3000, 'a');
-  Run({"SET", "src", src_value});
-  Run({"SET", "dst", BuildString(3000, 'b')});
-
-  ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 2; });
-  ASSERT_EQ(GetMetrics().tiered_stats.allocated_bytes, 2 * 4096u);
-
-  EXPECT_EQ(Run({"RENAME", "src", "dst"}), "OK");
-
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 1u);
-  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 4096u; });
-  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 4096u);
-
-  EXPECT_EQ(Run({"GET", "dst"}), src_value);
-
-  Run({"FLUSHALL"});
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
-  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
-}
-
 // Same defect reached through DbSlice::AddOrUpdate instead of RENAME.
 TEST_F(PureDiskTSTest, SortStoreOverOffloadedDestination) {
   Run({"RPUSH", "src", "3", "1", "2"});  // small list, stays in memory

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -626,29 +626,6 @@ TEST_F(PureDiskTSTest, OffloadingStrategy) {
   }
 }
 
-// Overwriting an offloaded value in place must release its disk extent, otherwise it is
-// orphaned forever and the FLUSHALL invariant CHECK_EQ(tiered_entries, 0) aborts the process.
-TEST_F(PureDiskTSTest, RenameOverOffloadedDestination) {
-  const string src_value = BuildString(3000, 'a');
-  Run({"SET", "src", src_value});
-  Run({"SET", "dst", BuildString(3000, 'b')});
-
-  ExpectConditionWithinTimeout([&] { return GetMetrics().db_stats[0].tiered_entries == 2; });
-  ASSERT_EQ(GetMetrics().tiered_stats.allocated_bytes, 2 * 4096u);
-
-  EXPECT_EQ(Run({"RENAME", "src", "dst"}), "OK");
-
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 1u);
-  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 4096u; });
-  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 4096u);
-
-  EXPECT_EQ(Run({"GET", "dst"}), src_value);
-
-  Run({"FLUSHALL"});
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 0u);
-  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
-}
-
 // Same defect reached through DbSlice::AddOrUpdate instead of RENAME.
 TEST_F(PureDiskTSTest, SortStoreOverOffloadedDestination) {
   Run({"RPUSH", "src", "3", "1", "2"});  // small list, stays in memory

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -460,7 +460,50 @@ TEST_F(TieredStorageTest, Defrag) {
   EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
 }
 
-// Verify that the background defrag scan (RunDefragScan, driven by the periodic heartbeat)
+// Offloaded small bin values reference their key back by (dbid, key) pair, so moving/renaming the
+// key has to invalidate (delete) the offloaded value
+TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
+  auto is_offloaded = [&](string_view key) {
+    return pp_->at(0)->AwaitBrief([&] {
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      auto it = db.GetDBTable(0)->prime.Find(key);
+      return IsValid(it) && it->second.IsExternal();
+    });
+  };
+  auto val = [](int i) { return string(600, char('a' + i)); };
+
+  const int kNum = 16;
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("k", i), val(i)});
+  ExpectConditionWithinTimeout(
+      [this] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 7u; });
+
+  int victim = -1;
+  for (int i = 0; i < kNum && victim < 0; i++)
+    if (is_offloaded(absl::StrCat("k", i)))
+      victim = i;
+  ASSERT_GE(victim, 0);
+  const string vkey = absl::StrCat("k", victim);
+
+  ASSERT_EQ(Run({"RENAME", vkey, "moved"}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_FALSE(is_offloaded("moved"));
+  EXPECT_THAT(Run({"EXISTS", vkey}), IntArg(0));
+
+  // Free the victim's shared page via defrag, then reuse it and check the renamed value survived.
+  for (int i = 0; i < kNum; i++)
+    if (i != victim)
+      Run({"DEL", absl::StrCat("k", i)});
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("r", i), string(600, char('0' + i % 10))});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(Run({"GET", "moved"}), val(victim));
+
+  Run({"FLUSHALL"});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 0u);
+}
+
 // discovers and defragments a large number of bins that became fragmented while there was no upload
 // budget (so the immediate defrag path in NotifyDelete was skipped). Also checks that once
 // everything is compacted the scan does no further work (dynamic / low-cpu behaviour).

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -455,49 +455,7 @@ TEST_F(TieredStorageTest, Defrag) {
   EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
 }
 
-// Offloaded small bin values reference their key back by (dbid, key) pair, so moving/renaming the
-// key has to invalidate (delete) the offloaded value
-TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
-  auto is_offloaded = [&](string_view key) {
-    return pp_->at(0)->AwaitBrief([&] {
-      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
-      auto it = db.GetDBTable(0)->prime.Find(key);
-      return IsValid(it) && it->second.IsExternal();
-    });
-  };
-  auto val = [](int i) { return string(600, char('a' + i)); };
-
-  const int kNum = 16;
-  for (int i = 0; i < kNum; i++)
-    Run({"SET", absl::StrCat("k", i), val(i)});
-  ExpectConditionWithinTimeout(
-      [this] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 7u; });
-
-  int victim = -1;
-  for (int i = 0; i < kNum && victim < 0; i++)
-    if (is_offloaded(absl::StrCat("k", i)))
-      victim = i;
-  ASSERT_GE(victim, 0);
-  const string vkey = absl::StrCat("k", victim);
-
-  ASSERT_EQ(Run({"RENAME", vkey, "moved"}), "OK");
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_FALSE(is_offloaded("moved"));
-  EXPECT_THAT(Run({"EXISTS", vkey}), IntArg(0));
-
-  // Free the victim's shared page via defrag, then reuse it and check the renamed value survived.
-  for (int i = 0; i < kNum; i++)
-    if (i != victim)
-      Run({"DEL", absl::StrCat("k", i)});
-  for (int i = 0; i < kNum; i++)
-    Run({"SET", absl::StrCat("r", i), string(600, char('0' + i % 10))});
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_EQ(Run({"GET", "moved"}), val(victim));
-
-  Run({"FLUSHALL"});
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
-}
-
+// Verify that the background defrag scan (RunDefragScan, driven by the periodic heartbeat)
 // discovers and defragments a large number of bins that became fragmented while there was no upload
 // budget (so the immediate defrag path in NotifyDelete was skipped). Also checks that once
 // everything is compacted the scan does no further work (dynamic / low-cpu behaviour).
@@ -1104,6 +1062,49 @@ TEST_F(TieredStorageTest, HashFieldExpiryOnOffloaded) {
   EXPECT_THAT(Run({"HLEN", "k0"}), IntArg(26));
   string expected_a = string{31, 'x'} + 'a';
   EXPECT_EQ(Run({"HGET", "k0", string{1, 'a'}}), expected_a);
+}
+
+// Offloaded small bin values reference their key back by (dbid, key) pair, so moving/renaming the
+// key has to invalidate (delete) the offloaded value
+TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
+  auto is_offloaded = [&](string_view key) {
+    return pp_->at(0)->AwaitBrief([&] {
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      auto it = db.GetDBTable(0)->prime.Find(key);
+      return IsValid(it) && it->second.IsExternal();
+    });
+  };
+  auto val = [](int i) { return string(600, char('a' + i)); };
+
+  const int kNum = 16;
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("k", i), val(i)});
+  ExpectConditionWithinTimeout(
+      [this] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 7u; });
+
+  int victim = -1;
+  for (int i = 0; i < kNum && victim < 0; i++)
+    if (is_offloaded(absl::StrCat("k", i)))
+      victim = i;
+  ASSERT_GE(victim, 0);
+  const string vkey = absl::StrCat("k", victim);
+
+  ASSERT_EQ(Run({"RENAME", vkey, "moved"}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_FALSE(is_offloaded("moved"));
+  EXPECT_THAT(Run({"EXISTS", vkey}), IntArg(0));
+
+  // Free the victim's shared page via defrag, then reuse it and check the renamed value survived.
+  for (int i = 0; i < kNum; i++)
+    if (i != victim)
+      Run({"DEL", absl::StrCat("k", i)});
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("r", i), string(600, char('0' + i % 10))});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(Run({"GET", "moved"}), val(victim));
+
+  Run({"FLUSHALL"});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
 }
 
 class ListNodeTieringTest : public TieredStorageTest {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -460,49 +460,7 @@ TEST_F(TieredStorageTest, Defrag) {
   EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
 }
 
-// Offloaded small bin values reference their key back by (dbid, key) pair, so moving/renaming the
-// key has to invalidate (delete) the offloaded value
-TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
-  auto is_offloaded = [&](string_view key) {
-    return pp_->at(0)->AwaitBrief([&] {
-      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
-      auto it = db.GetDBTable(0)->prime.Find(key);
-      return IsValid(it) && it->second.IsExternal();
-    });
-  };
-  auto val = [](int i) { return string(600, char('a' + i)); };
-
-  const int kNum = 16;
-  for (int i = 0; i < kNum; i++)
-    Run({"SET", absl::StrCat("k", i), val(i)});
-  ExpectConditionWithinTimeout(
-      [this] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 7u; });
-
-  int victim = -1;
-  for (int i = 0; i < kNum && victim < 0; i++)
-    if (is_offloaded(absl::StrCat("k", i)))
-      victim = i;
-  ASSERT_GE(victim, 0);
-  const string vkey = absl::StrCat("k", victim);
-
-  ASSERT_EQ(Run({"RENAME", vkey, "moved"}), "OK");
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_FALSE(is_offloaded("moved"));
-  EXPECT_THAT(Run({"EXISTS", vkey}), IntArg(0));
-
-  // Free the victim's shared page via defrag, then reuse it and check the renamed value survived.
-  for (int i = 0; i < kNum; i++)
-    if (i != victim)
-      Run({"DEL", absl::StrCat("k", i)});
-  for (int i = 0; i < kNum; i++)
-    Run({"SET", absl::StrCat("r", i), string(600, char('0' + i % 10))});
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_EQ(Run({"GET", "moved"}), val(victim));
-
-  Run({"FLUSHALL"});
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
-}
-
+// Verify that the background defrag scan (RunDefragScan, driven by the periodic heartbeat)
 // discovers and defragments a large number of bins that became fragmented while there was no upload
 // budget (so the immediate defrag path in NotifyDelete was skipped). Also checks that once
 // everything is compacted the scan does no further work (dynamic / low-cpu behaviour).
@@ -1109,6 +1067,49 @@ TEST_F(TieredStorageTest, HashFieldExpiryOnOffloaded) {
   EXPECT_THAT(Run({"HLEN", "k0"}), IntArg(26));
   string expected_a = string{31, 'x'} + 'a';
   EXPECT_EQ(Run({"HGET", "k0", string{1, 'a'}}), expected_a);
+}
+
+// Offloaded small bin values reference their key back by (dbid, key) pair, so moving/renaming the
+// key has to invalidate (delete) the offloaded value
+TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
+  auto is_offloaded = [&](string_view key) {
+    return pp_->at(0)->AwaitBrief([&] {
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      auto it = db.GetDBTable(0)->prime.Find(key);
+      return IsValid(it) && it->second.IsExternal();
+    });
+  };
+  auto val = [](int i) { return string(600, char('a' + i)); };
+
+  const int kNum = 16;
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("k", i), val(i)});
+  ExpectConditionWithinTimeout(
+      [this] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 7u; });
+
+  int victim = -1;
+  for (int i = 0; i < kNum && victim < 0; i++)
+    if (is_offloaded(absl::StrCat("k", i)))
+      victim = i;
+  ASSERT_GE(victim, 0);
+  const string vkey = absl::StrCat("k", victim);
+
+  ASSERT_EQ(Run({"RENAME", vkey, "moved"}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_FALSE(is_offloaded("moved"));
+  EXPECT_THAT(Run({"EXISTS", vkey}), IntArg(0));
+
+  // Free the victim's shared page via defrag, then reuse it and check the renamed value survived.
+  for (int i = 0; i < kNum; i++)
+    if (i != victim)
+      Run({"DEL", absl::StrCat("k", i)});
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("r", i), string(600, char('0' + i % 10))});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(Run({"GET", "moved"}), val(victim));
+
+  Run({"FLUSHALL"});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
 }
 
 class ListNodeTieringTest : public TieredStorageTest {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -455,7 +455,50 @@ TEST_F(TieredStorageTest, Defrag) {
   EXPECT_EQ(metrics.tiered_stats.allocated_bytes, 0u);
 }
 
-// Verify that the background defrag scan (RunDefragScan, driven by the periodic heartbeat)
+// Offloaded small bin values reference their key back by (dbid, key) pair, so moving/renaming the
+// key has to invalidate (delete) the offloaded value
+TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
+  auto is_offloaded = [&](string_view key) {
+    return pp_->at(0)->AwaitBrief([&] {
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      auto it = db.GetDBTable(0)->prime.Find(key);
+      return IsValid(it) && it->second.IsExternal();
+    });
+  };
+  auto val = [](int i) { return string(600, char('a' + i)); };
+
+  const int kNum = 16;
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("k", i), val(i)});
+  ExpectConditionWithinTimeout(
+      [this] { return GetMetrics().tiered_stats.small_bins_entries_cnt >= 7u; });
+
+  int victim = -1;
+  for (int i = 0; i < kNum && victim < 0; i++)
+    if (is_offloaded(absl::StrCat("k", i)))
+      victim = i;
+  ASSERT_GE(victim, 0);
+  const string vkey = absl::StrCat("k", victim);
+
+  ASSERT_EQ(Run({"RENAME", vkey, "moved"}), "OK");
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_FALSE(is_offloaded("moved"));
+  EXPECT_THAT(Run({"EXISTS", vkey}), IntArg(0));
+
+  // Free the victim's shared page via defrag, then reuse it and check the renamed value survived.
+  for (int i = 0; i < kNum; i++)
+    if (i != victim)
+      Run({"DEL", absl::StrCat("k", i)});
+  for (int i = 0; i < kNum; i++)
+    Run({"SET", absl::StrCat("r", i), string(600, char('0' + i % 10))});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(Run({"GET", "moved"}), val(victim));
+
+  Run({"FLUSHALL"});
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 0u);
+}
+
 // discovers and defragments a large number of bins that became fragmented while there was no upload
 // budget (so the immediate defrag path in NotifyDelete was skipped). Also checks that once
 // everything is compacted the scan does no further work (dynamic / low-cpu behaviour).

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -500,8 +500,7 @@ TEST_F(PureDiskTSTest, RenameOffloadedSmallBin) {
   EXPECT_EQ(Run({"GET", "moved"}), val(victim));
 
   Run({"FLUSHALL"});
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
-  EXPECT_EQ(GetMetrics().tiered_stats.allocated_bytes, 0u);
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0u; });
 }
 
 // discovers and defragments a large number of bins that became fragmented while there was no upload

--- a/src/server/tiering/common.h
+++ b/src/server/tiering/common.h
@@ -60,4 +60,14 @@ using PendingId = std::variant<uintptr_t, KeyRef, ListNodeId>;
 // Separate kesypaces that are used to fetch tiered values.
 using ReadId = std::variant<KeyRef, ListNodeId>;
 
+struct ReadOptions {
+  bool read_only = true;      // the value won't be modified through the decoder
+  bool force_upload = false;  // restore the value to memory and drop its disk copy once read
+
+  void Merge(const ReadOptions& other) {
+    read_only &= other.read_only;
+    force_upload |= other.force_upload;
+  }
+};
+
 };  // namespace dfly::tiering

--- a/src/server/tiering/decoders.cc
+++ b/src/server/tiering/decoders.cc
@@ -27,12 +27,25 @@ void BareDecoder::Initialize(std::string_view slice) {
 }
 
 void BareDecoder::Upload(void* obj) {
-  ABSL_UNREACHABLE();
+  auto* compact_obj = static_cast<CompactObj*>(obj);
+  switch (compact_obj->GetExternalRep()) {
+    case CompactObj::ExternalRep::STRING:
+      compact_obj->Materialize(slice, true);
+      break;
+    case CompactObj::ExternalRep::SERIALIZED_MAP: {
+      ListpackMapDecoder decoder{};
+      decoder.Initialize(slice);
+      decoder.Upload(compact_obj);
+      break;
+    }
+    case CompactObj::ExternalRep::LIST_NODE:
+      LOG(DFATAL) << "LIST_NODE should not be uploaded to PrimeValue";
+      break;
+  }
 }
 
 Decoder::UploadMetrics BareDecoder::GetMetrics() const {
-  ABSL_UNREACHABLE();
-  return UploadMetrics{};
+  return UploadMetrics{.modified = false, .estimated_mem_usage = slice.size()};
 }
 
 StringDecoder::StringDecoder(const CompactObj& obj) : StringDecoder{obj.GetStrEncoding()} {
@@ -46,7 +59,7 @@ std::unique_ptr<Decoder> StringDecoder::Clone() const {
 }
 
 void StringDecoder::Initialize(std::string_view slice) {
-  slice_ = slice;
+  BareDecoder::Initialize(slice);
   value_ = encoding_.Decode(slice);
 }
 
@@ -55,7 +68,7 @@ void StringDecoder::Upload(void* obj) {
   if (modified_)
     compact_obj->Materialize(value_.view(), false);
   else
-    compact_obj->Materialize(slice_, true);
+    compact_obj->Materialize(slice, true);
 }
 
 Decoder::UploadMetrics StringDecoder::GetMetrics() const {
@@ -80,12 +93,8 @@ std::unique_ptr<Decoder> ListpackMapDecoder::Clone() const {
   return std::make_unique<ListpackMapDecoder>();
 }
 
-void ListpackMapDecoder::Initialize(std::string_view slice) {
-  slice_ = slice;
-}
-
 Decoder::UploadMetrics ListpackMapDecoder::GetMetrics() const {
-  size_t bytes = owned_lw_ ? owned_lw_->UsedBytes() : slice_.size();
+  size_t bytes = owned_lw_ ? owned_lw_->UsedBytes() : slice.size();
   return UploadMetrics{
       .modified = owned_lw_ != nullptr,
       .estimated_mem_usage = bytes,
@@ -106,13 +115,13 @@ detail::ListpackWrap ListpackMapDecoder::Get() const {
   if (owned_lw_)
     return *owned_lw_;
   return detail::ListpackWrap::Readonly(
-      const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(slice_.data())));
+      const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(slice.data())));
 }
 
 detail::ListpackWrap* ListpackMapDecoder::GetMutable() {
   if (!owned_lw_) {
-    uint8_t* lp = (uint8_t*)zmalloc(slice_.size());
-    memcpy(lp, slice_.data(), slice_.size());
+    uint8_t* lp = (uint8_t*)zmalloc(slice.size());
+    memcpy(lp, slice.data(), slice.size());
     owned_lw_ = std::make_unique<detail::ListpackWrap>(lp);
   }
   return owned_lw_.get();
@@ -125,17 +134,9 @@ std::unique_ptr<Decoder> ListNodeDecoder::Clone() const {
   return std::make_unique<ListNodeDecoder>(ql_);
 }
 
-void ListNodeDecoder::Initialize(std::string_view slice) {
-  slice_ = slice;
-}
-
 void ListNodeDecoder::Upload(void* obj) {
   QList::Node* node_obj = reinterpret_cast<QList::Node*>(obj);
-  node_obj->Upload(ql_, slice_);
-}
-
-Decoder::UploadMetrics ListNodeDecoder::GetMetrics() const {
-  return UploadMetrics{.modified = false, .estimated_mem_usage = slice_.size()};
+  node_obj->Upload(ql_, slice);
 }
 
 }  // namespace dfly::tiering

--- a/src/server/tiering/decoders.h
+++ b/src/server/tiering/decoders.h
@@ -43,7 +43,7 @@ struct Decoder {
   virtual void Upload(void* obj) = 0;
 };
 
-// Basic "bare" decoder that just stores the provided slice
+// Basic "generic" decoder that just stores the raw disk slice and can upload any prime value
 struct BareDecoder : public Decoder {
   std::unique_ptr<Decoder> Clone() const override;
   void Initialize(std::string_view slice) override;
@@ -54,7 +54,7 @@ struct BareDecoder : public Decoder {
 };
 
 // Decodes string value with objects StrEncoding
-struct StringDecoder : public Decoder {
+struct StringDecoder : public BareDecoder {
   explicit StringDecoder(const CompactObj& obj);
 
   std::unique_ptr<Decoder> Clone() const override;
@@ -72,17 +72,15 @@ struct StringDecoder : public Decoder {
   explicit StringDecoder(CompactObj::StrEncoding encoding);
 
   bool modified_ = false;
-  std::string_view slice_;
   CompactObj::StrEncoding encoding_;
   dfly::StringOrView value_;
 };
 
 // Decodes listpack maps stored directly as raw listpack bytes on disk.
-struct ListpackMapDecoder : public Decoder {
+struct ListpackMapDecoder : public BareDecoder {
   ~ListpackMapDecoder();
 
   std::unique_ptr<Decoder> Clone() const override;
-  void Initialize(std::string_view slice) override;
   UploadMetrics GetMetrics() const override;
   void Upload(void* obj) override;
 
@@ -93,21 +91,18 @@ struct ListpackMapDecoder : public Decoder {
   dfly::detail::ListpackWrap* GetMutable();
 
  private:
-  std::string_view slice_;
   std::unique_ptr<dfly::detail::ListpackWrap> owned_lw_;
 };
 
 // Decodes QList::Node
-struct ListNodeDecoder : public Decoder {
+struct ListNodeDecoder : public BareDecoder {
   explicit ListNodeDecoder(QList* ql);
   std::unique_ptr<Decoder> Clone() const override;
-  void Initialize(std::string_view slice) override;
-  UploadMetrics GetMetrics() const override;
+  // Initialize and GetMetrics are inherited from BareDecoder (raw slice, unmodified).
   void Upload(void* obj) override;
 
  private:
   QList* ql_;
-  std::string_view slice_;
 };
 
 }  // namespace dfly::tiering

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -57,10 +57,10 @@ void OpManager::Close() {
 }
 
 void OpManager::Enqueue(PendingId id, DiskSegment segment, const Decoder& decoder, ReadCallback cb,
-                        bool read_only) {
+                        ReadOptions options) {
   // Fill pages for prepared read as it has no penalty and potentially covers more small segments
   PrepareRead(segment.ContainingPages())
-      .ForSegment(segment, id, decoder, read_only)
+      .ForSegment(segment, id, decoder, options)
       .read_cbs.emplace_back(std::move(cb));
 }
 
@@ -70,7 +70,7 @@ bool OpManager::HasModificationPending(DiskSegment segment) const {
     return false;
 
   auto* ops_ptr = it->second.Find(segment);
-  return ops_ptr && !ops_ptr->read_only;
+  return ops_ptr && !ops_ptr->options.read_only;
 }
 
 bool OpManager::HasReadPending(PendingId id, DiskSegment segment) const {
@@ -204,7 +204,7 @@ void OpManager::ProcessRead(size_t offset, io::Result<std::string_view> page) {
     // If the item is not being deleted, report is as fetched to be cached potentially.
     // In case it's cached, we might need to delete it.
     if (page.has_value() && !delete_from_storage)
-      delete_from_storage |= NotifyFetched(ko.id, ko.segment, &*ko.decoder);
+      delete_from_storage |= NotifyFetched(ko.id, ko.segment, &*ko.decoder, ko.options);
 
     // If the item is being deleted, check if the full page needs to be deleted.
     if (delete_from_storage)
@@ -219,25 +219,32 @@ void OpManager::ProcessRead(size_t offset, io::Result<std::string_view> page) {
 }
 
 OpManager::EntryOps::EntryOps(OwnedEntryId id, DiskSegment segment, const Decoder& decoder,
-                              bool read_only)
-    : id{std::move(id)}, segment{segment}, decoder{decoder.Clone()}, read_only{read_only} {
+                              ReadOptions options)
+    : id{std::move(id)}, segment{segment}, decoder{decoder.Clone()}, options{options} {
 }
 
 OpManager::EntryOps& OpManager::ReadOp::ForSegment(DiskSegment key_segment, PendingId id,
-                                                   const Decoder& decoder, bool read_only) {
+                                                   const Decoder& decoder, ReadOptions options) {
   DCHECK_GE(key_segment.offset, segment.offset);
   DCHECK_LE(key_segment.length, segment.length);
 
   for (auto& ops : entry_ops) {
     if (ops.segment.offset == key_segment.offset) {
-      auto ops_decoder = ops.decoder.get();
-      DCHECK(typeid(*ops_decoder) == typeid(decoder))
-          << typeid(*ops_decoder).name() << " " << typeid(decoder).name();
-      ops.read_only &= read_only;
+      auto* stored = ops.decoder.get();
+      // We can promote a BareDecoder, but we can't cope with conflicting decoders
+      if (typeid(*stored) != typeid(decoder)) {
+        if (typeid(*stored) == typeid(BareDecoder)) {
+          ops.decoder = decoder.Clone();  // promote generic -> specific
+        } else if (typeid(decoder) != typeid(BareDecoder)) {
+          LOG(DFATAL) << "conflicting decoders on one segment: " << typeid(*stored).name() << " vs "
+                      << typeid(decoder).name();
+        }
+      }
+      ops.options.Merge(options);
       return ops;
     }
   }
-  return entry_ops.emplace_back(ToOwned(id), key_segment, decoder, read_only);
+  return entry_ops.emplace_back(ToOwned(id), key_segment, decoder, options);
 }
 
 OpManager::EntryOps* OpManager::ReadOp::Find(DiskSegment key_segment) {

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -235,9 +235,10 @@ OpManager::EntryOps& OpManager::ReadOp::ForSegment(DiskSegment key_segment, Pend
       if (typeid(*stored) != typeid(decoder)) {
         if (typeid(*stored) == typeid(BareDecoder)) {
           ops.decoder = decoder.Clone();  // promote generic -> specific
-        } else if (typeid(decoder) != typeid(BareDecoder)) {
-          LOG(DFATAL) << "conflicting decoders on one segment: " << typeid(*stored).name() << " vs "
-                      << typeid(decoder).name();
+        } else {
+          CHECK(typeid(decoder) == typeid(BareDecoder))
+              << "conflicting decoders on one segment: " << typeid(*stored).name() << " vs "
+              << typeid(decoder).name();
         }
       }
       ops.options.Merge(options);

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -50,9 +50,10 @@ class OpManager {
 
   // Enqueue callback to be executed once value is read. Trigger read if none is pending yet for
   // this segment. Multiple entries can be obtained from a single segment, but every distinct id
-  // will have it's own independent callback loop that can safely modify the underlying value
+  // will have it's own independent callback loop that can safely modify the underlying value.
+  // BareDecoder can be used to avoid specific decoders - the first specific decoder promotes it
   void Enqueue(PendingId id, DiskSegment segment, const Decoder& decoder, ReadCallback cb,
-               bool read_only = true);
+               ReadOptions options = {});
 
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(DiskSegment segment) const;
@@ -89,9 +90,10 @@ class OpManager {
   // given error
   virtual void NotifyStashed(const OwnedEntryId& id, const io::Result<DiskSegment>& segment) = 0;
 
-  // Notify that an entry was successfully fetched. Includes whether entry was modified.
+  // Notify that an entry was successfully fetched. Includes the merged read options.
   // Returns true if value needs to be deleted from the storage.
-  virtual bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder*) = 0;
+  virtual bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder*,
+                             const ReadOptions& options) = 0;
 
   // Notify delete. Return true if the filled segment needs to be marked as free.
   // Under in_memory this function was called after a read completion as the follow-up delete
@@ -100,7 +102,7 @@ class OpManager {
 
   // Describes pending read futures for a single entry
   struct EntryOps {
-    EntryOps(OwnedEntryId id, DiskSegment segment, const Decoder& decoder, bool read_only);
+    EntryOps(OwnedEntryId id, DiskSegment segment, const Decoder& decoder, ReadOptions options);
 
     // unique identifier for the entry being read. Used to notify higher layers.
     OwnedEntryId id;
@@ -111,7 +113,7 @@ class OpManager {
     // We may have multiple callbacks for the same entry.
     absl::InlinedVector<ReadCallback, 1> read_cbs;
     std::unique_ptr<Decoder> decoder;
-    bool read_only;
+    ReadOptions options;
     bool deleting = false;
   };
 
@@ -121,7 +123,8 @@ class OpManager {
     }
 
     // Get ops for id or create new
-    EntryOps& ForSegment(DiskSegment segment, PendingId id, const Decoder& decoder, bool read_only);
+    EntryOps& ForSegment(DiskSegment segment, PendingId id, const Decoder& decoder,
+                         ReadOptions options);
 
     // Find if there are operations for the given segment, return nullptr otherwise
     EntryOps* Find(DiskSegment segment);

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -72,7 +72,8 @@ struct OpManagerTest : PoolTestBase, OpManager {
     ASSERT_TRUE(inserted);
   }
 
-  bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder* decoder) override {
+  bool NotifyFetched(const OwnedEntryId& id, DiskSegment segment, Decoder* decoder,
+                     const ReadOptions& options) override {
     auto* tdecoder = static_cast<TestDecoder*>(decoder);
     fetched_[id] = std::move(tdecoder->value);
     return false;


### PR DESCRIPTION
Fixes #7976 

Adds a generic upload routine. Uses it to upload values before moving/renaming