### PR TITLE
feat(facade): reclaim (shrink) connection buffers

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -106,7 +106,7 @@ ABSL_FLAG(uint64_t, max_bulk_len, 2u << 30,
           "Maximum bulk length that is "
           "allowed to be accepted when parsing RESP protocol");
 
-ABSL_FLAG(strings::MemoryBytesFlag, max_client_iobuf_len, 1u << 16,
+ABSL_FLAG(strings::MemoryBytesFlag, max_client_iobuf_len, 1u << 15,
           "Maximum io buffer length that is used to read client requests.");
 
 ABSL_FLAG(bool, migrate_connections, true,
@@ -148,11 +148,24 @@ ABSL_FLAG(
 
 ABSL_FLAG(bool, enable_memcache_io_loop_v2, true,
           "Enable the event-driven IoLoopV2 for non-TLS Memcache connections.");
+
 ABSL_FLAG(bool, enable_resp_io_loop_v2, false,
           "Enable the event-driven IoLoopV2 for non-TLS RESP connections.");
+
 ABSL_FLAG(bool, enable_pipeline_squashing_v2, true,
           "Enable vectorized pipeline squashing for the V2 dispatch loop. Groups consecutive "
           "single-shard pipeline commands by shard and executes them in parallel.");
+
+ABSL_FLAG(bool, enable_iobuf_shrink, true,
+          "Enable gradual shrinking of underused client input buffers.");
+
+ABSL_FLAG(uint32_t, iobuf_shrink_min_idle_sec, 30,
+          "Minimum receive-idle time (in seconds) before a client input buffer may shrink.");
+
+ABSL_FLAG(uint32_t, iobuf_shrink_interval_sec, 30,
+          "Minimum time between client input-buffer shrink operations; growth restarts the "
+          "shrink interval.");
+
 ABSL_RETIRED_FLAG(bool, experimental_io_loop_v2, true, "retired.");
 
 using namespace util;
@@ -195,16 +208,30 @@ bool MatchHttp11Line(string_view line) {
 // To use it as RAII object, call the ctor, or if the update should be immediate, call
 // ReadBufTracker::Update() directly.
 struct ReadBufTracker {
-  explicit ReadBufTracker(const io::IoBuf& io_buf, uint32_t conn_id)
-      : io_buf_(io_buf), last_capacity_(io_buf.Capacity()), id_(conn_id) {
+  static constexpr string_view kReasonHttpProbe = "http_probe";
+  static constexpr string_view kReasonConnectionSetup = "connection_setup";
+  static constexpr string_view kReasonNeedMoreInput = "need_more_input";
+  static constexpr string_view kReasonLowUsage = "low_usage";
+  static constexpr string_view kReasonReceiveIdle = "receive_idle";
+  static constexpr string_view kReasonRegister = "register";
+  static constexpr string_view kReasonUnregister = "unregister";
+  static constexpr string_view kReasonRecvProvidedBuffers = "recv_provided_buffers";
+
+  explicit ReadBufTracker(const io::IoBuf& io_buf, uint32_t conn_id,
+                          string_view capacity_change_reason)
+      : io_buf_(io_buf),
+        last_capacity_(io_buf.Capacity()),
+        id_(conn_id),
+        capacity_change_reason_(capacity_change_reason) {
   }
 
   ~ReadBufTracker() {
-    Update(last_capacity_, io_buf_.Capacity(), id_);
+    Update(last_capacity_, io_buf_.Capacity(), id_, capacity_change_reason_);
   }
 
   // Make it static so we may also call it directly without constructing a ReadBufTracker object.
-  static void Update(size_t previous_capacity, size_t new_capacity, uint32_t conn_id) {
+  static void Update(size_t previous_capacity, size_t new_capacity, uint32_t conn_id,
+                     string_view capacity_change_reason) {
     if (previous_capacity == new_capacity)
       return;
     DCHECK(tl_facade_stats);
@@ -223,13 +250,16 @@ struct ReadBufTracker {
         read_buf_capacity -= delta;
     }
     VLOG(2) << "[" << conn_id << "] io_buf capacity changed from " << previous_capacity << " to "
-            << new_capacity << " (read_buf_capacity = " << read_buf_capacity << ")";
+            << new_capacity << " (read_buf_capacity = " << read_buf_capacity << ")"
+            << (capacity_change_reason.empty() ? "" : ", capacity_change_reason=")
+            << capacity_change_reason;
   }
 
  private:
   const io::IoBuf& io_buf_;
   size_t last_capacity_;
   uint32_t id_;
+  string_view capacity_change_reason_;
 };
 
 struct ConnectionMemoryTracker {
@@ -626,6 +656,11 @@ ConnectionStats& __attribute__((noinline)) GetLocalConnStats() {
 }
 
 thread_local uint32_t max_busy_read_cycles_cached = UINT32_MAX;
+thread_local const size_t max_client_iobuf_len_cached = GetFlag(FLAGS_max_client_iobuf_len);
+thread_local const uint32_t iobuf_shrink_min_idle_sec_cached =
+    GetFlag(FLAGS_iobuf_shrink_min_idle_sec);
+thread_local const uint32_t iobuf_shrink_interval_sec_cached =
+    GetFlag(FLAGS_iobuf_shrink_interval_sec);
 thread_local bool always_flush_pipeline_cached = absl::GetFlag(FLAGS_always_flush_pipeline);
 thread_local uint32_t pipeline_squash_limit_cached = absl::GetFlag(FLAGS_pipeline_squash_limit);
 thread_local bool pipeline_prioritize_large_batches_cached =
@@ -848,10 +883,16 @@ void Connection::Shutdown() {
 Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener, SSL_CTX* ctx,
                        ServiceInterface* service)
     : io_buf_(kMinReadSize),
+      io_buf_last_read_time_(time(nullptr)),
+      iobuf_resize_allowed_time_(io_buf_last_read_time_),
+      id_(NextClientId()),
       protocol_(protocol),
       http_listener_(http_listener),
       ssl_ctx_(ctx),
       service_(service),
+      creation_time_(io_buf_last_read_time_),
+      last_interaction_(io_buf_last_read_time_),
+      self_(make_shared<std::monostate>(), this),
       flags_(0) {
   // TODO: to move parser initialization to where we initialize the reply builder.
   switch (protocol) {
@@ -865,15 +906,8 @@ Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener,
       break;
   }
 
-  creation_time_ = time(nullptr);
-  last_interaction_ = creation_time_;
-  id_ = NextClientId();
-
   migration_enabled_ = GetFlag(FLAGS_migrate_connections);
-
-  // Create shared_ptr with empty value and associate it with `this` pointer (aliasing constructor).
-  // We use it for reference counting and accessing `this` (without managing it).
-  self_ = {make_shared<std::monostate>(), this};
+  enable_iobuf_shrink_ = GetFlag(FLAGS_enable_iobuf_shrink);
 
 #ifdef DFLY_USE_SSL
   // Increment reference counter so Listener won't free the context while we're
@@ -884,7 +918,6 @@ Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener,
 #endif
 
   UpdateLibNameVerMap(lib_name_, lib_ver_, +1);
-  migration_allowed_to_register_ = false;
 }
 
 Connection::~Connection() {
@@ -1336,7 +1369,10 @@ io::Result<bool> Connection::CheckForHttpProto() {
     auto buf = io_buf_.AppendBuffer();
     DCHECK(!buf.empty());
 
+    const uint64_t io_buf_generation = io_buf_.generation();
     ::io::Result<size_t> recv_sz = peer->Recv(buf);
+    // io_buf_ should not be modified during the Recv().
+    DCHECK_EQ(io_buf_.generation(), io_buf_generation);
     if (!recv_sz) {
       return make_unexpected(recv_sz.error());
     }
@@ -1346,6 +1382,7 @@ io::Result<bool> Connection::CheckForHttpProto() {
     }
 
     io_buf_.CommitWrite(*recv_sz);
+    UpdateIoBufReadState();
     string_view ib = io::View(io_buf_.InputBuffer());
     if (ib.size() >= 2 && ib[0] == 22 && ib[1] == 3) {
       // We matched the TLS handshake raw data, which means "peer" is a TCP socket.
@@ -1364,10 +1401,12 @@ io::Result<bool> Connection::CheckForHttpProto() {
       return MatchHttp11Line(ib);
     }
     last_len = io_buf_.InputLen();
+    const size_t previous_capacity = io_buf_.Capacity();
     {
-      ReadBufTracker tracker(io_buf_, id_);
+      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonHttpProbe);
       io_buf_.EnsureCapacity(128);
     }
+    UpdateIoBufCapacityChange(previous_capacity);
   } while (last_len < 1024);
 
   return false;
@@ -1405,7 +1444,7 @@ void Connection::ConnectionFlow() {
   // Main loop.
   if (parse_status != ERROR && !ec) {
     {
-      ReadBufTracker tracker(io_buf_, id_);
+      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonConnectionSetup);
       io_buf_.EnsureCapacity(64);
     }
     variant<error_code, Connection::ParserStatus> res;
@@ -1626,8 +1665,11 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
       GetLocalConnStats().num_read_yields++;
 
       fiber_park_spot_ = FiberParkSpot::kParseYield;
+      const uint64_t io_buf_generation = io_buf.generation();
       ThisFiber::Yield();
       fiber_park_spot_ = FiberParkSpot::kNone;
+      // io_buf_ backing storage should not be replaced while read_buffer is retained.
+      DCHECK_EQ(io_buf.generation(), io_buf_generation);
 
       // Note:
       // - read_buffer stays valid across this yield since proactor only calls ReadPendingInput ->
@@ -1800,7 +1842,10 @@ io::Result<size_t> Connection::HandleRecvSocket() {
 
   io::MutableBytes append_buf = io_buf_.AppendBuffer();
   DCHECK(!append_buf.empty());
+  const uint64_t io_buf_generation = io_buf_.generation();
   ::io::Result<size_t> recv_sz = socket_->Recv(append_buf);
+  // io_buf_ should not be modified during the Recv().
+  DCHECK_EQ(io_buf_.generation(), io_buf_generation);
   last_interaction_ = time(nullptr);
 
   // In case the socket was closed orderly, we get 0 bytes read.
@@ -1809,6 +1854,7 @@ io::Result<size_t> Connection::HandleRecvSocket() {
     DVLOG(2) << CONN_ID << "Received " << commit_sz << " bytes from socket";
 
     io_buf_.CommitWrite(commit_sz);
+    UpdateIoBufReadState();
 
     conn_stats.io_read_bytes += commit_sz;
     local_stats_.net_bytes_in += commit_sz;
@@ -1822,7 +1868,6 @@ io::Result<size_t> Connection::HandleRecvSocket() {
 variant<error_code, Connection::ParserStatus> Connection::IoLoop() {
   error_code ec;
   ParserStatus parse_status = OK;
-  size_t max_iobfuf_len = GetFlag(FLAGS_max_client_iobuf_len);
 
   auto* peer = socket_.get();
   recv_buf_.res_len = 0;
@@ -1853,44 +1898,11 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoop() {
       return reply_builder_->GetError();
     }
 
-    if (parse_status == NEED_MORE) {
-      parse_status = OK;
-
-      size_t capacity = io_buf_.Capacity();
-      if (capacity < max_iobfuf_len) {
-        size_t parser_hint = 0;
-        if (redis_parser_)
-          parser_hint = redis_parser_->parselen_hint();  // Could be done for MC as well.
-
-        // If we got a partial request and we managed to parse its
-        // length, make sure we have space to store it instead of
-        // increasing space incrementally.
-        // (Note: The buffer object is only working in power-of-2 sizes,
-        // so there's no danger of accidental O(n^2) behavior.)
-        if (parser_hint > capacity) {
-          ReadBufTracker tracker(io_buf_, id_);
-          io_buf_.Reserve(std::min(max_iobfuf_len, parser_hint));
-        }
-
-        // If we got a partial request because iobuf was full, grow it up to
-        // a reasonable limit to save on Recv() calls.
-        if (reached_capacity && capacity < max_iobfuf_len / 2) {
-          // Last io used most of the io_buf to the end.
-          ReadBufTracker tracker(io_buf_, id_);
-          io_buf_.Reserve(capacity * 2);  // Valid growth range.
-        }
-
-        if (io_buf_.AppendLen() == 0U) {
-          // it can happen with memcached but not for RedisParser, because RedisParser fully
-          // consumes the passed buffer
-          LOG_EVERY_T(WARNING, 10)
-              << CONN_ID
-              << "Maximum io_buf length reached, consider to increase max_client_iobuf_len flag";
-        }
-      }
-    } else if (parse_status != OK) {
+    if (parse_status == ERROR)
       break;
-    }
+
+    MaybeAdjustIoBufCapacity(parse_status, reached_capacity);
+    parse_status = OK;
   } while (peer->IsOpen());
 
   return parse_status;
@@ -2876,7 +2888,7 @@ void Connection::RegisterReadBufCapacity() {
   DCHECK(tl_facade_stats);
   DCHECK(!read_buf_capacity_registered_);
   // Registration includes setting the flag and adding the current buffer capacity.
-  ReadBufTracker::Update(0, io_buf_.Capacity(), id_);
+  ReadBufTracker::Update(0, io_buf_.Capacity(), id_, ReadBufTracker::kReasonRegister);
   read_buf_capacity_registered_ = true;
 }
 
@@ -2884,7 +2896,7 @@ void Connection::UnregisterReadBufCapacity() {
   DCHECK(tl_facade_stats);
   DCHECK(read_buf_capacity_registered_);
   // Unregistration includes clearing the flag and subtracting the current buffer capacity.
-  ReadBufTracker::Update(io_buf_.Capacity(), 0, id_);
+  ReadBufTracker::Update(io_buf_.Capacity(), 0, id_, ReadBufTracker::kReasonUnregister);
   read_buf_capacity_registered_ = false;
 }
 
@@ -3483,9 +3495,9 @@ void Connection::ProcessRecvNotification(const util::FiberSocketBase::RecvNotifi
     return;
   }
 
-  using RecvNoti = util::FiberSocketBase::RecvNotification::RecvCompletion;
-  if (std::holds_alternative<RecvNoti>(n.read_result)) {
-    if (!std::get<RecvNoti>(n.read_result)) {  // false - connection aborted
+  using RecvNotification = util::FiberSocketBase::RecvNotification::RecvCompletion;
+  if (std::holds_alternative<RecvNotification>(n.read_result)) {
+    if (!std::get<RecvNotification>(n.read_result)) {  // false - connection aborted
       io_ec_ = make_error_code(errc::connection_aborted);
       return;
     }
@@ -3494,10 +3506,11 @@ void Connection::ProcessRecvNotification(const util::FiberSocketBase::RecvNotifi
   } else if (std::holds_alternative<io::MutableBytes>(n.read_result)) {  // provided buffer.
     io::MutableBytes buf = std::get<io::MutableBytes>(n.read_result);
     {
-      ReadBufTracker tracker(io_buf_, id_);
+      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonRecvProvidedBuffers);
       io_buf_.WriteAndCommit(buf.data(), buf.size());
     }
     last_interaction_ = time(nullptr);
+    UpdateIoBufReadState();
 
     DCHECK(tl_facade_stats);
     auto& conn_stats = tl_facade_stats->conn_stats;
@@ -3525,6 +3538,7 @@ void Connection::ReadPendingInput() {
   // - EBUSY (device_or_resource_busy, TLS only): another fiber holds the socket, no wake - keep it
   //   latched and retry on a later pass (neither clear it nor set io_ec_).
   // - Any other error: a real I/O failure - surface via io_ec_.
+  bool done_read = false;
   while (!buf.empty()) {
     io::Result<size_t> res = socket_->TryRecv(buf);
     if (!res) {
@@ -3555,44 +3569,148 @@ void Connection::ReadPendingInput() {
 
     last_interaction_ = time(nullptr);
     io_buf_.CommitWrite(commit_sz);
+    done_read = true;
     buf = io_buf_.AppendBuffer();
+  }
+
+  if (done_read) {
+    UpdateIoBufReadState();
   }
 }
 
-void Connection::CheckIoBufCapacity(bool reached_capacity, base::IoBuf* io_buf) {
-  size_t max_io_buf_len = GetFlag(FLAGS_max_client_iobuf_len);
+void Connection::MaybeAdjustIoBufCapacity(ParserStatus parse_status, bool reached_capacity) {
+  DCHECK_NE(parse_status, ERROR);
 
-  size_t capacity = io_buf->Capacity();
-  if (capacity < max_io_buf_len) {
-    size_t parser_hint = 0;
-    if (redis_parser_)
-      parser_hint = redis_parser_->parselen_hint();  // Could be done for MC as well.
-
-    // If we got a partial request and we managed to parse its
-    // length, make sure we have space to store it instead of
-    // increasing space incrementally.
-    // (Note: The buffer object is only working in power-of-2 sizes,
-    // so there's no danger of accidental O(n^2) behavior.)
-    if (parser_hint > capacity) {
-      ReadBufTracker tracker(*io_buf, id_);
-      io_buf->Reserve(std::min(max_io_buf_len, parser_hint));
-    }
-
-    // If we got a partial request because iobuf was full, grow it up to
-    // a reasonable limit to save on Recv() calls.
-    if (reached_capacity && capacity < max_io_buf_len / 2) {
-      // Last io used most of the io_buf to the end.
-      ReadBufTracker tracker(*io_buf, id_);
-      io_buf->Reserve(capacity * 2);  // Valid growth range.
-    }
-
-    if (io_buf->AppendLen() == 0U) {
-      // it can happen with memcached but not for RedisParser, because RedisParser fully
-      // consumes the passed buffer
-      LOG_EVERY_T(WARNING, 10) << CONN_ID << "Maximum io_buf length reached " << io_buf->Capacity()
-                               << ", consider to increase max_client_iobuf_len flag";
+  // A completed parse can reuse its existing allocation - only an incomplete request needs more
+  // input before it can make progress.
+  if (parse_status == NEED_MORE) {
+    const size_t capacity = io_buf_.Capacity();
+    if (capacity < max_client_iobuf_len_cached) {
+      size_t target_capacity = capacity;
+      if (redis_parser_) {
+        // Avoid incremental reallocations when the parser already knows the request size.
+        const size_t parser_hint = redis_parser_->parselen_hint();  // Could be done for MC as well.
+        if (parser_hint > capacity) {
+          target_capacity = std::min(max_client_iobuf_len_cached, parser_hint);
+        }
+      }
+      if (reached_capacity) {
+        // The preceding receive exhausted append space, so grow geometrically to reduce Recv()
+        // calls. min() allows the final doubling to reach the configured limit without exceeding
+        // it. Taking the maximum preserves a larger parser-hint target.
+        target_capacity =
+            std::max(target_capacity, std::min(max_client_iobuf_len_cached, capacity * 2));
+      }
+      if (target_capacity > capacity) {
+        {
+          ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonNeedMoreInput);
+          io_buf_.Reserve(target_capacity);
+        }
+        UpdateIoBufCapacityChange(capacity);
+        return;
+      }
     }
   }
+  // If we are here, we never grew the buffer, so we can consider shrinking it.
+  MaybeShrinkIoBufOnLowUsage();
+}
+
+void Connection::UpdateIoBufReadState() {
+  io_buf_last_read_time_ = time(nullptr);
+  io_buf_high_watermark_ = std::max(io_buf_high_watermark_, io_buf_.InputLen());
+}
+
+void Connection::ResetIoBufUsageWindow(time_t now) {
+  io_buf_high_watermark_ = io_buf_.InputLen();
+  iobuf_resize_allowed_time_ = now + iobuf_shrink_interval_sec_cached;
+  DVLOG(2) << CONN_ID << "io_buf usage window reset: next resize at " << iobuf_resize_allowed_time_
+           << ", high_watermark=" << io_buf_high_watermark_;
+}
+
+void Connection::UpdateIoBufCapacityChange(size_t previous_capacity) {
+  const size_t capacity = io_buf_.Capacity();
+  if (capacity == previous_capacity) {
+    return;
+  }
+
+  auto& conn_stats = GetLocalConnStats();
+  ++conn_stats.iobuf_capacity_change_cnt;
+
+  // A resized buffer starts a new usage window at its current occupancy.
+  ResetIoBufUsageWindow(time(nullptr));
+}
+
+bool Connection::CanShrinkIoBuf(time_t now) const {
+  return enable_iobuf_shrink_ && (now >= iobuf_resize_allowed_time_) &&
+         (io_buf_.Capacity() > kMinReadSize);
+}
+
+bool Connection::IsIoBufShrinkSafe() const {
+  // External shrinking is only safe while the V2 fiber is fully idle. Other park spots may retain
+  // parser state or have an active dispatch/reply that can receive input in the proactor callback.
+  DCHECK(ioloop_v2_);
+  return (fiber_park_spot_ == FiberParkSpot::kIdleAwait) && (io_buf_.InputLen() == 0) &&
+         !pending_input_ && (recv_buf_.res_len == 0);
+}
+
+bool Connection::ShrinkIoBufTo(size_t target_capacity, string_view capacity_change_reason) {
+  DCHECK(CanShrinkIoBuf(time(nullptr)));
+  DCHECK_LT(target_capacity, io_buf_.Capacity());
+
+  const size_t previous_capacity = io_buf_.Capacity();
+  {
+    ReadBufTracker tracker(io_buf_, id_, capacity_change_reason);
+    // Callers pass a smaller power-of-two target that preserves unread input; failure is a real
+    // bug, not an optional-shrink outcome, so retain this check in release builds.
+    CHECK(io_buf_.ShrinkTo(target_capacity));
+  }
+  UpdateIoBufCapacityChange(previous_capacity);
+  return true;
+}
+
+void Connection::MaybeShrinkIoBufOnLowUsage() {
+  if (!enable_iobuf_shrink_) {
+    return;
+  }
+
+  const time_t now = time(nullptr);
+  if (!CanShrinkIoBuf(now)) {
+    return;
+  }
+
+  size_t half_capacity = io_buf_.Capacity() / 2;
+  if (io_buf_high_watermark_ < half_capacity) {  // shrink
+    const size_t target_capacity =
+        std::max({half_capacity, absl::bit_ceil(io_buf_.InputLen()), kMinReadSize});
+    ShrinkIoBufTo(target_capacity, ReadBufTracker::kReasonLowUsage);
+    return;
+  }
+
+  // Start a new fixed observation window. An exact sliding window would need to retain enough
+  // timestamped observations to recover the next maximum after the old one expires. Keeping only
+  // the watermark avoids that state, so reset it after each evaluation.
+  ResetIoBufUsageWindow(now);
+}
+
+bool Connection::MaybeShrinkIoBufOnReceiveIdle() {
+  if (!ioloop_v2_ || !enable_iobuf_shrink_) {
+    return false;
+  }
+
+  const time_t now = time(nullptr);
+  // Shrink only if all are true:
+  // 1. Enough time has passed since the last read (that makes the connection receive-idle).
+  // 2. The V2 connection is safely parked for an external buffer resize. V1 does not expose an
+  //    externally observable receive-safe park point.
+  // 3. The resize interval elapsed and the buffer can still shrink.
+  time_t idle_for = std::max(now, io_buf_last_read_time_) - io_buf_last_read_time_;
+  if ((idle_for >= iobuf_shrink_min_idle_sec_cached) && IsIoBufShrinkSafe() &&
+      CanShrinkIoBuf(now)) {
+    return ShrinkIoBufTo(std::max(io_buf_.Capacity() / 2, kMinReadSize),
+                         ReadBufTracker::kReasonReceiveIdle);
+  }
+
+  return false;
 }
 
 void Connection::MaybeEnableRecvMultishot() {
@@ -3851,10 +3969,8 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       continue;
     }
 
-    if (parse_status == NEED_MORE) {
-      parse_status = OK;
-      CheckIoBufCapacity(reached_capacity, &io_buf_);
-    }
+    MaybeAdjustIoBufCapacity(parse_status, reached_capacity);
+    parse_status = OK;
   } while (peer->IsOpen());
 
   return parse_status;
@@ -3874,6 +3990,7 @@ void ResetStats() {
   cstats.io_read_bytes = 0;
   cstats.proactor_reads = 0;
   cstats.proactor_parse = 0;
+  cstats.iobuf_capacity_change_cnt = 0;
 
   tl_facade_stats->reply_stats = {};
   if (io_req_size_hist)

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -156,15 +156,8 @@ ABSL_FLAG(bool, enable_pipeline_squashing_v2, true,
           "Enable vectorized pipeline squashing for the V2 dispatch loop. Groups consecutive "
           "single-shard pipeline commands by shard and executes them in parallel.");
 
-ABSL_FLAG(bool, enable_iobuf_shrink, true,
-          "Enable gradual shrinking of underused client input buffers.");
-
-ABSL_FLAG(uint32_t, iobuf_shrink_min_idle_sec, 30,
-          "Minimum receive-idle time (in seconds) before a client input buffer may shrink.");
-
-ABSL_FLAG(uint32_t, iobuf_shrink_interval_sec, 30,
-          "Minimum time between client input-buffer shrink operations; growth restarts the "
-          "shrink interval.");
+ABSL_FLAG(uint32_t, iobuf_min_shrink_interval_sec, 30,
+          "Minimum time (in seconds) before a client input buffer may shrink; 0 disables.");
 
 ABSL_RETIRED_FLAG(bool, experimental_io_loop_v2, true, "retired.");
 
@@ -657,10 +650,8 @@ ConnectionStats& __attribute__((noinline)) GetLocalConnStats() {
 
 thread_local uint32_t max_busy_read_cycles_cached = UINT32_MAX;
 thread_local const size_t max_client_iobuf_len_cached = GetFlag(FLAGS_max_client_iobuf_len);
-thread_local const uint32_t iobuf_shrink_min_idle_sec_cached =
-    GetFlag(FLAGS_iobuf_shrink_min_idle_sec);
-thread_local const uint32_t iobuf_shrink_interval_sec_cached =
-    GetFlag(FLAGS_iobuf_shrink_interval_sec);
+thread_local const uint32_t iobuf_min_shrink_interval_sec_cached =
+    GetFlag(FLAGS_iobuf_min_shrink_interval_sec);
 thread_local bool always_flush_pipeline_cached = absl::GetFlag(FLAGS_always_flush_pipeline);
 thread_local uint32_t pipeline_squash_limit_cached = absl::GetFlag(FLAGS_pipeline_squash_limit);
 thread_local bool pipeline_prioritize_large_batches_cached =
@@ -907,8 +898,6 @@ Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener,
   }
 
   migration_enabled_ = GetFlag(FLAGS_migrate_connections);
-  enable_iobuf_shrink_ = GetFlag(FLAGS_enable_iobuf_shrink);
-
 #ifdef DFLY_USE_SSL
   // Increment reference counter so Listener won't free the context while we're
   // still using it.
@@ -3622,7 +3611,7 @@ void Connection::UpdateIoBufReadState() {
 
 void Connection::ResetIoBufUsageWindow(time_t now) {
   io_buf_high_watermark_ = io_buf_.InputLen();
-  iobuf_resize_allowed_time_ = now + iobuf_shrink_interval_sec_cached;
+  iobuf_resize_allowed_time_ = now + iobuf_min_shrink_interval_sec_cached;
   DVLOG(2) << CONN_ID << "io_buf usage window reset: next resize at " << iobuf_resize_allowed_time_
            << ", high_watermark=" << io_buf_high_watermark_;
 }
@@ -3641,7 +3630,7 @@ void Connection::UpdateIoBufCapacityChange(size_t previous_capacity) {
 }
 
 bool Connection::CanShrinkIoBuf(time_t now) const {
-  return enable_iobuf_shrink_ && (now >= iobuf_resize_allowed_time_) &&
+  return (iobuf_min_shrink_interval_sec_cached > 0) && (now >= iobuf_resize_allowed_time_) &&
          (io_buf_.Capacity() > kMinReadSize);
 }
 
@@ -3669,7 +3658,7 @@ bool Connection::ShrinkIoBufTo(size_t target_capacity, string_view capacity_chan
 }
 
 void Connection::MaybeShrinkIoBufOnLowUsage() {
-  if (!enable_iobuf_shrink_) {
+  if (iobuf_min_shrink_interval_sec_cached == 0) {
     return;
   }
 
@@ -3693,7 +3682,7 @@ void Connection::MaybeShrinkIoBufOnLowUsage() {
 }
 
 bool Connection::MaybeShrinkIoBufOnReceiveIdle() {
-  if (!ioloop_v2_ || !enable_iobuf_shrink_) {
+  if (!ioloop_v2_ || (iobuf_min_shrink_interval_sec_cached == 0)) {
     return false;
   }
 
@@ -3704,7 +3693,7 @@ bool Connection::MaybeShrinkIoBufOnReceiveIdle() {
   //    externally observable receive-safe park point.
   // 3. The resize interval elapsed and the buffer can still shrink.
   time_t idle_for = std::max(now, io_buf_last_read_time_) - io_buf_last_read_time_;
-  if ((idle_for >= iobuf_shrink_min_idle_sec_cached) && IsIoBufShrinkSafe() &&
+  if ((idle_for >= iobuf_min_shrink_interval_sec_cached) && IsIoBufShrinkSafe() &&
       CanShrinkIoBuf(now)) {
     return ShrinkIoBufTo(std::max(io_buf_.Capacity() / 2, kMinReadSize),
                          ReadBufTracker::kReasonReceiveIdle);

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -332,6 +332,11 @@ class Connection : public util::Connection {
 
   bool IsSending() const;
 
+  // Reclaims capacity for receive-idle connections when the V2 fiber is safely parked.
+  // A receive-idle connection has not received data for iobuf_shrink_min_idle_sec.
+  // Returns true if the buffer capacity changed.
+  bool MaybeShrinkIoBufOnReceiveIdle();
+
   void Notify() {
     io_event_.notify();
   }
@@ -385,7 +390,35 @@ class Connection : public util::Connection {
   // Drains currently available bytes from socket into io_buf_ using non-blocking reads.
   void ReadPendingInput();
 
-  void CheckIoBufCapacity(bool reached_capacity, base::IoBuf* buf);
+  // Grows the buffer when parsing needs more data, or evaluates low-usage shrinking otherwise.
+  // `parse_status` is the parser result; `reached_capacity` marks the preceding read filled it.
+  void MaybeAdjustIoBufCapacity(ParserStatus parse_status, bool reached_capacity);
+
+  // Halves the buffer when its peak unread input is below half capacity; otherwise starts a new
+  // observation window.
+  void MaybeShrinkIoBufOnLowUsage();
+
+  // Records the time of the latest received data and updates the peak unread input.
+  void UpdateIoBufReadState();
+
+  // Updates resize statistics and starts a new observation window when the capacity changed.
+  // `previous_capacity` is compared with the current capacity.
+  void UpdateIoBufCapacityChange(size_t previous_capacity);
+
+  // Starts a new observation window and initializes the peak with current unread input.
+  // `now` determines when the next resize is allowed.
+  void ResetIoBufUsageWindow(time_t now);
+
+  // Returns true when shrinking is enabled, the resize cooldown elapsed, and the buffer is larger
+  // than the minimum capacity. `now` is compared with the resize deadline.
+  bool CanShrinkIoBuf(time_t now) const;
+
+  // Returns true when the V2 fiber is idle and no pending input or receive result uses the buffer.
+  bool IsIoBufShrinkSafe() const;
+
+  // Shrinks the buffer and updates capacity accounting. `target_capacity` is the new capacity and
+  // `reason` identifies the resize in diagnostics. Returns true when the capacity changes.
+  bool ShrinkIoBufTo(size_t target_capacity, std::string_view reason);
 
   // Main loop reading client messages and passing requests to dispatch queue.
   std::variant<std::error_code, ParserStatus> IoLoopV2();
@@ -625,7 +658,13 @@ class Connection : public util::Connection {
   size_t request_consumed_bytes_ = 0;
 
   util::FiberSocketBase::ProvidedBuffer recv_buf_;
-  io::IoBuf io_buf_;  // used in io loop and parsers
+
+  // IO buffer for reading data from the socket, and parsing commands from it.
+  io::IoBuf io_buf_;
+  time_t io_buf_last_read_time_;
+  time_t iobuf_resize_allowed_time_;
+  size_t io_buf_high_watermark_ = 0;
+
   std::unique_ptr<RespSrvParser> redis_parser_;
   std::unique_ptr<MemcacheParser> memcache_parser_;
   ParsedCommand* parsed_cmd_ = nullptr;
@@ -776,6 +815,8 @@ class Connection : public util::Connection {
       bool proactor_parse_error_ : 1;
 
       bool request_shutdown_ : 1;  // set when the connection is requested to shutdown
+
+      bool enable_iobuf_shrink_ : 1;
     };
   };
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -333,7 +333,7 @@ class Connection : public util::Connection {
   bool IsSending() const;
 
   // Reclaims capacity for receive-idle connections when the V2 fiber is safely parked.
-  // A receive-idle connection has not received data for iobuf_shrink_min_idle_sec.
+  // A receive-idle connection has not received data for the configured minimum duration.
   // Returns true if the buffer capacity changed.
   bool MaybeShrinkIoBufOnReceiveIdle();
 
@@ -815,8 +815,6 @@ class Connection : public util::Connection {
       bool proactor_parse_error_ : 1;
 
       bool request_shutdown_ : 1;  // set when the connection is requested to shutdown
-
-      bool enable_iobuf_shrink_ : 1;
     };
   };
 

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -23,7 +23,7 @@ using namespace std;
 constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
-  static_assert(kSizeConnStats == 328);
+  static_assert(kSizeConnStats == 336);
 
   ADD(read_buf_capacity);
   ADD(connection_memory_bytes);
@@ -48,6 +48,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(num_read_yields);
   ADD(num_migrations);
   ADD(num_recv_provided_calls);
+  ADD(iobuf_capacity_change_cnt);
   ADD(pipeline_throttle_count);
   ADD(tls_accept_disconnects);
   ADD(handshakes_started);

--- a/src/facade/facade_stats.h
+++ b/src/facade/facade_stats.h
@@ -74,6 +74,7 @@ struct ConnectionStats {
   uint32_t num_read_yields = 0;
   uint64_t num_migrations = 0;
   uint64_t num_recv_provided_calls = 0;
+  uint64_t iobuf_capacity_change_cnt = 0;
 
   // Number of times the tls connection was closed by the time we started reading from it.
   uint64_t tls_accept_disconnects = 0;  // number of TLS socket disconnects during the handshake

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -315,6 +315,8 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
                             &resp->body());
   AppendMetricWithoutLabels("net_read_yields_total", "", conn_stats.num_read_yields,
                             MetricType::COUNTER, &resp->body());
+  AppendMetricWithoutLabels("iobuf_capacity_change_count", "", conn_stats.iobuf_capacity_change_cnt,
+                            MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("proactor_reads_total", "V2 OnRecv reads that actually drained bytes",
                             conn_stats.proactor_reads, MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("proactor_parse_total",

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -32,23 +32,21 @@ ABSL_FLAG(uint32_t, timeout, 0,
           "Close the connection after it is idle for N seconds (0 to disable)");
 ABSL_FLAG(uint32_t, send_timeout, 0,
           "Close the connection after it is stuck on send for N seconds (0 to disable)");
-
 ABSL_FLAG(double, rss_oom_deny_ratio, 1.25,
           "When the ratio between maxmemory and RSS memory exceeds this value, commands marked as "
           "DENYOOM will fail with OOM error and new connections to non-admin port will be "
           "rejected. Negative value disables this feature.");
-
 ABSL_FLAG(size_t, serialization_max_chunk_size, 64_KB,
           "Maximum size of a value that may be serialized at once during snapshotting or full "
           "sync. Values bigger than this threshold will be serialized using streaming "
           "serialization. 0 - to disable streaming mode");
 ABSL_FLAG(uint32_t, max_squashed_cmd_num, 100,
           "Max number of commands squashed in a single shard during squash optimizaiton");
-
 ABSL_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes, 0,
           "Per-shard-thread socket egress bandwidth budget in bytes/second. Each shard throttles "
           "its snapshot traversal loop to stay under this rate. Accepts human-readable sizes "
           "(e.g. 100mb, 1gb). 0 disables throttling.");
+ABSL_DECLARE_FLAG(bool, enable_iobuf_shrink);
 
 namespace dfly {
 
@@ -309,9 +307,10 @@ void ServerState::ConnectionsWatcherFb(util::ListenerInterface* main) {
 
     const uint32_t timeout = absl::GetFlag(FLAGS_timeout);
     const uint32_t send_timeout = absl::GetFlag(FLAGS_send_timeout);
+    const bool enable_iobuf_shrink = absl::GetFlag(FLAGS_enable_iobuf_shrink);
     VLOG(1) << "ConnectionsWatcherFb: timeout=" << timeout << ", send_timeout=" << send_timeout;
 
-    if (timeout == 0 && send_timeout == 0) {
+    if ((timeout == 0) && (send_timeout == 0) && !enable_iobuf_shrink) {
       continue;
     }
 
@@ -339,10 +338,13 @@ void ServerState::ConnectionsWatcherFb(util::ListenerInterface* main) {
       bool stuck_sending = send_timeout != 0 && !is_replica && dfly_conn->IsSending() &&
                            dfly_conn->GetSendWaitTimeSec() > send_timeout;
 
-      VLOG(2) << "Connection check: " << dfly_conn->GetClientInfo()
+      bool iobuf_shrunk = dfly_conn->MaybeShrinkIoBufOnReceiveIdle();
+
+      VLOG(2) << std::boolalpha << "Connection check: " << dfly_conn->GetClientInfo()
               << ", phase=" << static_cast<int>(phase) << ", idle_time=" << dfly_conn->idle_time()
               << ", is_replica=" << is_replica << ", is_sending=" << dfly_conn->IsSending()
-              << ", idle_read=" << idle_read << ", stuck_sending=" << stuck_sending;
+              << ", idle_read=" << idle_read << ", stuck_sending=" << stuck_sending
+              << ", iobuf_shrunk=" << iobuf_shrunk;
 
       if (idle_read || stuck_sending) {
         conn_refs.push_back(dfly_conn->Borrow());

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -46,7 +46,7 @@ ABSL_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes, 0,
           "Per-shard-thread socket egress bandwidth budget in bytes/second. Each shard throttles "
           "its snapshot traversal loop to stay under this rate. Accepts human-readable sizes "
           "(e.g. 100mb, 1gb). 0 disables throttling.");
-ABSL_DECLARE_FLAG(bool, enable_iobuf_shrink);
+ABSL_DECLARE_FLAG(uint32_t, iobuf_min_shrink_interval_sec);
 
 namespace dfly {
 
@@ -307,10 +307,11 @@ void ServerState::ConnectionsWatcherFb(util::ListenerInterface* main) {
 
     const uint32_t timeout = absl::GetFlag(FLAGS_timeout);
     const uint32_t send_timeout = absl::GetFlag(FLAGS_send_timeout);
-    const bool enable_iobuf_shrink = absl::GetFlag(FLAGS_enable_iobuf_shrink);
+    const uint32_t iobuf_min_shrink_interval_sec =
+        absl::GetFlag(FLAGS_iobuf_min_shrink_interval_sec);
     VLOG(1) << "ConnectionsWatcherFb: timeout=" << timeout << ", send_timeout=" << send_timeout;
 
-    if ((timeout == 0) && (send_timeout == 0) && !enable_iobuf_shrink) {
+    if ((timeout == 0) && (send_timeout == 0) && (iobuf_min_shrink_interval_sec == 0)) {
       continue;
     }
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2526,8 +2526,7 @@ async def test_pipeline_cache_size(df_server: DflyInstance):
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_min_idle_sec": 1,
-        "iobuf_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": 1,
     }
 )
 async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
@@ -2570,8 +2569,7 @@ async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_min_idle_sec": 1,
-        "iobuf_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": 1,
     }
 )
 async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
@@ -2607,10 +2605,8 @@ async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
-        "enable_iobuf_shrink": "false",
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_min_idle_sec": 1,
-        "iobuf_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": 0,
     }
 )
 async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
@@ -2638,7 +2634,7 @@ async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": 1,
     }
 )
 async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
@@ -2683,7 +2679,7 @@ async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": 1,
     }
 )
 async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
@@ -2714,7 +2710,7 @@ async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": 1,
     }
 )
 async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
@@ -2740,8 +2736,7 @@ async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
-        "iobuf_shrink_min_idle_sec": 1,
-        "iobuf_shrink_interval_sec": 3,
+        "iobuf_min_shrink_interval_sec": 3,
     }
 )
 async def test_iobuf_shrink_respects_cooldown(df_server: DflyInstance):

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2521,6 +2521,255 @@ async def test_pipeline_cache_size(df_server: DflyInstance):
     assert info["dispatch_queue_bytes"] == 0
 
 
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "enable_resp_io_loop_v2": "true",
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_min_idle_sec": 1,
+        "iobuf_shrink_interval_sec": 1,
+    }
+)
+async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
+    """V2 idle connections reclaim input-buffer capacity."""
+    if not is_resp_io_loop_v2(df_server):
+        pytest.skip("targets V2 receive-idle IoBuf shrinking")
+
+    observer = df_server.client()
+    client = df_server.client()
+    await observer.ping()
+
+    async def client_read_buffer_bytes():
+        metrics = await df_server.metrics()
+        return next(
+            sample.value
+            for sample in metrics["dragonfly_memory_by_class_bytes"].samples
+            if sample.labels["class"] == "client_read_buffer"
+        )
+
+    baseline = int((await observer.info("clients"))["client_read_buffer_bytes"])
+    await client.set("iobuf-shrink", "x" * 2048)
+
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+    metric_peak = await client_read_buffer_bytes()
+    assert peak > baseline
+
+    @assert_eventually(timeout=5)
+    async def wait_for_reclamation():
+        current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+        assert current < peak
+        assert await client_read_buffer_bytes() < metric_peak
+
+    await wait_for_reclamation()
+    await client.aclose()
+    await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "enable_resp_io_loop_v2": "true",
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_min_idle_sec": 1,
+        "iobuf_shrink_interval_sec": 1,
+    }
+)
+async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
+    """A V2 buffer that shrank while idle regrows and processes a later large command."""
+    if not is_resp_io_loop_v2(df_server):
+        pytest.skip("targets V2 receive-idle IoBuf shrinking")
+
+    observer = df_server.client()
+    client = df_server.client()
+    await observer.ping()
+
+    await client.set("iobuf-regrow-before", "x" * 2048)
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    @assert_eventually(timeout=5)
+    async def wait_for_shrink():
+        current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+        assert current < peak
+
+    await wait_for_shrink()
+    shrunk = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    value = "y" * 3072
+    assert await client.set("iobuf-regrow-after", value) is True
+    assert await client.get("iobuf-regrow-after") == value
+    assert int((await observer.info("clients"))["client_read_buffer_bytes"]) > shrunk
+
+    await client.aclose()
+    await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "enable_resp_io_loop_v2": "true",
+        "enable_iobuf_shrink": "false",
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_min_idle_sec": 1,
+        "iobuf_shrink_interval_sec": 1,
+    }
+)
+async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
+    """Disabling IoBuf shrinking retains capacity after a receive-idle interval."""
+    if not is_resp_io_loop_v2(df_server):
+        pytest.skip("targets V2 receive-idle IoBuf shrinking")
+
+    observer = df_server.client()
+    client = df_server.client()
+    await observer.ping()
+
+    await client.set("iobuf-shrink-disabled", "x" * 2048)
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    await asyncio.sleep(3)
+
+    current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+    assert current == peak
+
+    await client.aclose()
+    await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_interval_sec": 1,
+    }
+)
+async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
+    """Both loops self-shrink after low usage without corrupting a partial command."""
+    observer = df_server.client()
+    await observer.ping()
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+
+    value = b"x" * 2048
+    writer.write(b"*3\r\n$3\r\nSET\r\n$7\r\nprefill\r\n$2048\r\n" + value + b"\r\n")
+    await writer.drain()
+    assert await reader.readuntil(b"\r\n") == b"+OK\r\n"
+
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+    await asyncio.sleep(2)
+
+    partial_value = b"y" * 100
+    writer.write(b"*3\r\n$3\r\nSET\r\n$7\r\npartial\r\n$1024\r\n" + partial_value)
+    await writer.drain()
+    await asyncio.sleep(2)
+
+    writer.write(b"y")
+    await writer.drain()
+
+    @assert_eventually(timeout=5)
+    async def wait_for_reclamation():
+        current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+        assert current < peak
+
+    await wait_for_reclamation()
+
+    writer.write(b"y" * (1024 - len(partial_value) - 1) + b"\r\n")
+    await writer.drain()
+    assert await reader.readuntil(b"\r\n") == b"+OK\r\n"
+
+    writer.close()
+    await writer.wait_closed()
+    await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_interval_sec": 1,
+    }
+)
+async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
+    """Both loops restart the usage window before shrinking after low-use commands."""
+    observer = df_server.client()
+    client = df_server.client()
+    await observer.ping()
+
+    await client.set("iobuf-shrink-complete", "x" * 2048)
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    await asyncio.sleep(2)
+    await client.ping()
+    await asyncio.sleep(2)
+    await client.ping()
+
+    @assert_eventually(timeout=5)
+    async def wait_for_reclamation():
+        current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+        assert current < peak
+
+    await wait_for_reclamation()
+    await client.aclose()
+    await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_interval_sec": 1,
+    }
+)
+async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
+    """Both loops retain capacity when the usage window contains a large read."""
+    observer = df_server.client()
+    client = df_server.client()
+    await observer.ping()
+
+    await client.set("iobuf-shrink-high-usage", "x" * 2048)
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    await asyncio.sleep(2)
+    await client.ping()
+
+    assert int((await observer.info("clients"))["client_read_buffer_bytes"]) == peak
+
+    await client.aclose()
+    await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "enable_resp_io_loop_v2": "true",
+        "max_client_iobuf_len": 4096,
+        "iobuf_shrink_min_idle_sec": 1,
+        "iobuf_shrink_interval_sec": 3,
+    }
+)
+async def test_iobuf_shrink_respects_cooldown(df_server: DflyInstance):
+    """Receive-idle shrinking performs at most one resize during each cooldown interval."""
+    if not is_resp_io_loop_v2(df_server):
+        pytest.skip("targets V2 receive-idle IoBuf shrinking")
+
+    observer = df_server.client()
+    client = df_server.client()
+    await observer.ping()
+
+    await client.set("iobuf-shrink-cooldown", "x" * 2048)
+    peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
+
+    @assert_eventually(timeout=7)
+    async def wait_for_first_shrink():
+        current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+        assert current < peak
+
+    await wait_for_first_shrink()
+    after_first_shrink = int((await observer.info("clients"))["client_read_buffer_bytes"])
+    await asyncio.sleep(1)
+    assert int((await observer.info("clients"))["client_read_buffer_bytes"]) == after_first_shrink
+
+    await client.aclose()
+    await observer.aclose()
+
+
 @dfly_multi_test_args(
     {
         "proactor_threads": 4,


### PR DESCRIPTION
- Enable self-shrinking for both V1 and V2 after bounded low-use windows.
- Let ConnectionsWatcherFb perform external receive-idle shrinking only on V2, whose idle await point makes resizing safe; V1 can retain receive buffer views.
- Fix inconsistent buffer growth so parser hints and full reads use one target capacity calculation.
- Add enable_iobuf_shrink, iobuf_shrink_interval_sec, and iobuf_shrink_min_idle_sec configuration.
- Add capacity metrics and regression coverage for V1 and V2 shrinking, regrowth, cooldown, and high-use deferral.
- Lower max_client_iobuf_len from 64 KiB to 32 KiB to avoid OOM alerts from existing workloads; typical requests remain well below the limit, while larger input is parsed incrementally.

**Attention**:
- Temporarily pin Helio to the shrink_iobuff side branch; update the pin before merge after that branch merges into Helio.
