### PR TITLE
feat(tiering): Tiered bin-bucket defragmentation

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -847,15 +847,8 @@ void EngineShard::Heartbeat() {
     RetireExpiredAndEvict();
   }
 
-  if (tiered_storage_ && tiered_storage_->ShouldOffload()) {
-    VLOG(1) << "Running Offloading, memory=" << db_slice.memory_budget()
-            << ", cool memory: " << tiered_storage_->CoolMemoryUsage();
-
-    for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
-      if (!db_slice.IsDbValid(i))
-        continue;
-      tiered_storage_->RunOffloading(i);
-    }
+  if (tiered_storage_) {
+    tiered_storage_->Heartbeat();
   }
 }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2837,6 +2837,8 @@ string ServerFamily::FormatInfoMetrics(
     append("tiered_total_deletes", m.tiered_stats.total_deletes);
     append("tiered_total_uploads", m.tiered_stats.total_uploads);
     append("tiered_total_defrags", m.tiered_stats.total_defrags);
+    append("tiered_total_repacks", m.tiered_stats.total_buckets_repacked);
+
     append("tiered_total_stash_overflows", m.tiered_stats.total_stash_overflows);
     append("tiered_heap_buf_allocations", m.tiered_stats.total_heap_buf_allocs);
     append("tiered_registered_buf_allocations", m.tiered_stats.total_registered_buf_allocs);
@@ -2851,9 +2853,13 @@ string ServerFamily::FormatInfoMetrics(
     append("tiered_small_bins_cnt", m.tiered_stats.small_bins_cnt);
     append("tiered_small_bins_entries_cnt", m.tiered_stats.small_bins_entries_cnt);
     append("tiered_small_bins_filling_bytes", m.tiered_stats.small_bins_filling_bytes);
+    append("tiered_small_bins_estimated_bucket_fragmentation",
+           m.tiered_stats.estimated_bin_bucket_fragmentation);
+
     append("tiered_cold_storage_bytes", m.tiered_stats.cold_storage_bytes);
     append("tiered_offloading_steps", m.tiered_stats.total_offloading_steps);
     append("tiered_offloading_stashes", m.tiered_stats.total_offloading_stashes);
+    append("tiered_repack_values", m.tiered_stats.total_buckets_repacked);
     append("tiered_ram_hits", m.events.ram_hits);
     append("tiered_ram_cool_hits", m.events.ram_cool_hits);
     append("tiered_ram_misses", m.events.ram_misses);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2872,6 +2872,8 @@ string ServerFamily::FormatInfoMetrics(
     append("tiered_total_deletes", m.tiered_stats.total_deletes);
     append("tiered_total_uploads", m.tiered_stats.total_uploads);
     append("tiered_total_defrags", m.tiered_stats.total_defrags);
+    append("tiered_total_repacks", m.tiered_stats.total_repacks);
+
     append("tiered_total_stash_overflows", m.tiered_stats.total_stash_overflows);
     append("tiered_heap_buf_allocations", m.tiered_stats.total_heap_buf_allocs);
     append("tiered_registered_buf_allocations", m.tiered_stats.total_registered_buf_allocs);
@@ -2886,9 +2888,13 @@ string ServerFamily::FormatInfoMetrics(
     append("tiered_small_bins_cnt", m.tiered_stats.small_bins_cnt);
     append("tiered_small_bins_entries_cnt", m.tiered_stats.small_bins_entries_cnt);
     append("tiered_small_bins_filling_bytes", m.tiered_stats.small_bins_filling_bytes);
+    append("tiered_small_bins_estimated_bucket_fragmentation",
+           m.tiered_stats.estimated_bin_bucket_fragmentation);
+
     append("tiered_cold_storage_bytes", m.tiered_stats.cold_storage_bytes);
     append("tiered_offloading_steps", m.tiered_stats.total_offloading_steps);
     append("tiered_offloading_stashes", m.tiered_stats.total_offloading_stashes);
+    append("tiered_repack_usec", m.tiered_stats.total_repack_usec);
     append("tiered_ram_hits", m.events.ram_hits);
     append("tiered_ram_cool_hits", m.events.ram_cool_hits);
     append("tiered_ram_misses", m.events.ram_misses);

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -9,9 +9,10 @@
 namespace dfly {
 
 #define ADD(x) (x) += o.x
+#define UMAX(x) (x) = std::max((x), o.x)
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 176);
+  static_assert(sizeof(TieredStats) == 200);
 
   ADD(total_stashes);
   ADD(total_fetches);
@@ -38,6 +39,10 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
   ADD(pending_stash_bytes);
   ADD(total_offloading_steps);
   ADD(total_offloading_stashes);
+  ADD(total_repacks);
+  ADD(total_repack_usec);
+
+  UMAX(estimated_bin_bucket_fragmentation);
 
   ADD(clients_throttled);
   ADD(total_clients_throttled);
@@ -57,5 +62,6 @@ SearchStats& SearchStats::operator+=(const SearchStats& o) {
 }
 
 #undef ADD
+#undef UMAX
 
 }  // namespace dfly

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -9,9 +9,10 @@
 namespace dfly {
 
 #define ADD(x) (x) += o.x
+#define UMAX(x) (x) = std::max((x), o.x)
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 176);
+  static_assert(sizeof(TieredStats) == 192);
 
   ADD(total_stashes);
   ADD(total_fetches);
@@ -38,6 +39,9 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
   ADD(pending_stash_bytes);
   ADD(total_offloading_steps);
   ADD(total_offloading_stashes);
+  ADD(total_buckets_repacked);
+
+  UMAX(estimated_bin_bucket_fragmentation);
 
   ADD(clients_throttled);
   ADD(total_clients_throttled);
@@ -57,5 +61,6 @@ SearchStats& SearchStats::operator+=(const SearchStats& o) {
 }
 
 #undef ADD
+#undef UMAX
 
 }  // namespace dfly

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -45,6 +45,17 @@ struct TieredStats {
   // Values stashed during background offloading scans (subset of total_stashes).
   uint64_t total_offloading_stashes = 0;
 
+  // Fragmented bin buckets re-uploaded by the background repack scan to regroup small values
+  // scattered across disk pages.
+  uint64_t total_repacks = 0;
+
+  // Cumulative time in microseconds spent in background bin-bucket repack scans.
+  uint64_t total_repack_usec = 0;
+
+  // Average number of disk pages a fragmented bin bucket spreads across, estimated by the last
+  // completed repack scan pass (1.0 == perfectly packed).
+  float estimated_bin_bucket_fragmentation = 0;
+
   // Disk space currently in use (tracked by ExternalAllocator).
   size_t allocated_bytes = 0;
 

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -45,6 +45,13 @@ struct TieredStats {
   // Values stashed during background offloading scans (subset of total_stashes).
   uint64_t total_offloading_stashes = 0;
 
+  // Values re-offloaded by the background repack scan to re-group scattered buckets.
+  uint64_t total_buckets_repacked = 0;
+
+  // Buckets the background repack scan found fragmented (small tiered values spread over enough
+  // distinct disk pages to exceed the repack threshold).
+  float estimated_bin_bucket_fragmentation = 0;
+
   // Disk space currently in use (tracked by ExternalAllocator).
   size_t allocated_bytes = 0;
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -60,6 +60,10 @@ ABSL_FLAG(float, tiered_offload_threshold, 0.5,
 ABSL_FLAG(float, tiered_upload_threshold, 0.1,
           "Ratio of free memory (free/max memory) below which uploading stops");
 
+ABSL_FLAG(uint32_t, tiered_experimental_repack_limit, 0,
+          "Experimental bin-bucket deframentation. Limit for number of concurrent page reads "
+          "issued, 0 means disabled");
+
 ABSL_FLAG(bool, tiered_experimental_hash_support, false, "Experimental hash datatype offloading");
 
 ABSL_FLAG(bool, tiered_experimental_list_support, false, "Experimental list node offloading");
@@ -636,6 +640,8 @@ TieredStats TieredStorage::GetStats() const {
     stats.cold_storage_bytes = stats_.cool_memory_used;
     stats.total_offloading_steps = stats_.offloading_steps;
     stats.total_offloading_stashes = stats_.offloading_stashes;
+    stats.total_buckets_repacked = stats_.total_buckets_repacked;
+    stats.estimated_bin_bucket_fragmentation = stats_.estimated_bin_bucket_fragmentation;
     stats.clients_throttled = stash_backpressure_.size();
     stats.total_clients_throttled = stats_.total_clients_throttled;
   }
@@ -656,6 +662,7 @@ void TieredStorage::UpdateFromFlags() {
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
       .experimental_list_offload = absl::GetFlag(FLAGS_tiered_experimental_list_support),
+      .experimental_repack_limit = absl::GetFlag(FLAGS_tiered_experimental_repack_limit),
       .min_ttl_to_offload_ms = absl::GetFlag(FLAGS_tiered_min_ttl_to_offload_ms),
   };
 
@@ -669,6 +676,7 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
                             FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
                             FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
                             FLAGS_tiered_experimental_list_support,
+                            FLAGS_tiered_experimental_repack_limit,
                             FLAGS_tiered_min_ttl_to_offload_ms);
 }
 
@@ -684,6 +692,28 @@ int64_t TieredStorage::UploadBudget() const {
   int64_t free_memory = op_manager_->db_slice_.memory_budget();
   int64_t per_shard = max_memory_limit.load(memory_order_relaxed) / shard_set->size();
   return free_memory - double(config_.upload_threshold) * per_shard;
+}
+
+void TieredStorage::Heartbeat() {
+  DbSlice& db_slice = op_manager_->db_slice_;
+
+  if (config_.experimental_repack_limit) {
+    for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
+      if (db_slice.IsDbValid(i))
+        RunRepackScan(i);
+    }
+  }
+
+  if (!ShouldOffload())
+    return;
+
+  VLOG(1) << "Running offloading, memory=" << db_slice.memory_budget()
+          << ", cool memory: " << CoolMemoryUsage();
+
+  for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
+    if (db_slice.IsDbValid(i))
+      RunOffloading(i);
+  }
 }
 
 void TieredStorage::RunOffloading(DbIndex dbid) {
@@ -773,6 +803,94 @@ void TieredStorage::RunDefragScan() {
   } while (defrag_cursor_);
 
   last_defrag_scan_hits_ = hits;
+}
+
+void TieredStorage::RunRepackScan(DbIndex dbid) {
+  constexpr uint64_t kMaxScanUs = 100;
+
+  // How many more pages we can have than the theoretical minimal amount
+  const size_t kAcceptableWaste = 2;
+
+  PrimeTable& table = op_manager_->db_slice_.GetDBTable(dbid)->prime;
+  const auto start_cycles = base::CycleClock::Now();
+
+  size_t issued_reads = 0;
+
+  // With negative budget we just recalculate the stats
+  if (UploadBudget() < 0)
+    issued_reads = config_.experimental_repack_limit + 1;
+
+  auto cb = [&](PrimeTable::bucket_iterator it) {
+    size_t total_size = 0;
+    std::vector<size_t> pages;
+
+    auto it2 = it;
+    for (it2.AdvanceIfNotOccupied(); !it2.is_done(); ++it2) {
+      PrimeValue& pv = it2->second;
+      if (!pv.IsExternal() || pv.IsCool())
+        continue;
+
+      tiering::DiskSegment segment{pv.GetExternalSlice()};
+      if (OccupiesWholePages(segment.length))
+        continue;
+
+      total_size += segment.length;
+      size_t page = segment.ContainingPages().offset;
+      if (std::find(pages.begin(), pages.end(), page) == pages.end())
+        pages.push_back(page);
+    }
+
+    if (pages.empty())
+      return;
+
+    repack_state_.cycle_buckets++;
+    repack_state_.cycle_pages += pages.size();
+
+    // Check if we are in optimality bounds
+    size_t min_required = total_size / tiering::kPageSize + 1;
+    if (pages.size() + kAcceptableWaste <= min_required)
+      return;
+
+    if (issued_reads > config_.experimental_repack_limit)
+      return;
+
+    stats_.total_buckets_repacked++;
+
+    std::string scratch;
+    for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
+      PrimeValue& pv = it->second;
+      if (!pv.IsExternal() || pv.IsCool())
+        continue;
+      tiering::DiskSegment segment{pv.GetExternalSlice()};
+      if (OccupiesWholePages(segment.length))
+        continue;
+
+      if (op_manager_->HasModificationPending(segment))
+        continue;
+
+      pv.SetTouched(true);
+      string_view key = it->first.GetSlice(&scratch);
+      Read(
+          tiering::KeyRef{dbid, key}, segment, tiering::StringDecoder{pv},
+          [](io::Result<tiering::StringDecoder*>) {}, /*read_only=*/true);
+    }
+    issued_reads += pages.size();
+  };
+
+  do {
+    if (base::CycleClock::ToUsec(base::CycleClock::Now() - start_cycles) >= kMaxScanUs)
+      break;
+    repack_state_.cursor = table.TraverseBuckets(repack_state_.cursor, cb);
+  } while (repack_state_.cursor);
+
+  if (!repack_state_.cursor /* we made a loop */) {
+    if (repack_state_.cycle_buckets > 0) {
+      stats_.estimated_bin_bucket_fragmentation =
+          float(repack_state_.cycle_pages) / float(repack_state_.cycle_buckets);
+    }
+    repack_state_.cycle_buckets = 0;
+    repack_state_.cycle_pages = 0;
+  }
 }
 
 size_t TieredStorage::ReclaimMemory(size_t goal) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -61,6 +61,18 @@ ABSL_FLAG(float, tiered_offload_threshold, 0.5,
 ABSL_FLAG(float, tiered_upload_threshold, 0.1,
           "Ratio of free memory (free/max memory) below which uploading stops");
 
+ABSL_FLAG(uint32_t, tiered_repack_scan_budget_us, 0,
+          "Base cpu time-slice in microseconds granted to a single background bin-bucket repack "
+          "scan, which regroups small offloaded values scattered across disk pages. Set to 0 "
+          "(default) to disable repack scans");
+
+ABSL_FLAG(uint32_t, tiered_repack_max_reads, 10,
+          "Maximum number of concurrent page reads a single repack scan may issue");
+
+ABSL_FLAG(uint32_t, tiered_repack_acceptable_waste, 2,
+          "How many more disk pages than the theoretical minimum a bucket may spread its small "
+          "values over before the repack scan regroups it");
+
 ABSL_FLAG(bool, tiered_experimental_hash_support, false, "Experimental hash datatype offloading");
 
 ABSL_FLAG(bool, tiered_experimental_list_support, false, "Experimental list node offloading");
@@ -642,6 +654,9 @@ TieredStats TieredStorage::GetStats() const {
     stats.cold_storage_bytes = stats_.cool_memory_used;
     stats.total_offloading_steps = stats_.offloading_steps;
     stats.total_offloading_stashes = stats_.offloading_stashes;
+    stats.total_repacks = stats_.total_repacks;
+    stats.total_repack_usec = stats_.repack_usec;
+    stats.estimated_bin_bucket_fragmentation = stats_.estimated_bin_bucket_fragmentation;
     stats.clients_throttled = stash_backpressure_.size();
     stats.total_clients_throttled = stats_.total_clients_throttled;
   }
@@ -662,6 +677,9 @@ void TieredStorage::UpdateFromFlags() {
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
       .experimental_list_offload = absl::GetFlag(FLAGS_tiered_experimental_list_support),
+      .repack_scan_budget_us = absl::GetFlag(FLAGS_tiered_repack_scan_budget_us),
+      .repack_max_reads = absl::GetFlag(FLAGS_tiered_repack_max_reads),
+      .repack_acceptable_waste = absl::GetFlag(FLAGS_tiered_repack_acceptable_waste),
       .min_ttl_to_offload_ms = absl::GetFlag(FLAGS_tiered_min_ttl_to_offload_ms),
   };
 
@@ -675,6 +693,8 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
                             FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
                             FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
                             FLAGS_tiered_experimental_list_support,
+                            FLAGS_tiered_repack_scan_budget_us, FLAGS_tiered_repack_max_reads,
+                            FLAGS_tiered_repack_acceptable_waste,
                             FLAGS_tiered_min_ttl_to_offload_ms);
 }
 
@@ -690,6 +710,28 @@ int64_t TieredStorage::UploadBudget() const {
   int64_t free_memory = op_manager_->db_slice_.memory_budget();
   int64_t per_shard = max_memory_limit.load(memory_order_relaxed) / shard_set->size();
   return free_memory - double(config_.upload_threshold) * per_shard;
+}
+
+void TieredStorage::Heartbeat() {
+  DbSlice& db_slice = op_manager_->db_slice_;
+
+  if (config_.repack_scan_budget_us) {
+    for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
+      if (db_slice.IsDbValid(i))
+        RunRepackScan(i);
+    }
+  }
+
+  if (!ShouldOffload())
+    return;
+
+  VLOG(1) << "Running offloading, memory=" << db_slice.memory_budget()
+          << ", cool memory: " << CoolMemoryUsage();
+
+  for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
+    if (db_slice.IsDbValid(i))
+      RunOffloading(i);
+  }
 }
 
 void TieredStorage::RunOffloading(DbIndex dbid) {
@@ -780,6 +822,103 @@ void TieredStorage::RunDefragScan() {
   } while (defrag_cursor_);
 
   last_defrag_scan_hits_ = hits;
+}
+
+void TieredStorage::RunRepackScan(DbIndex dbid) {
+  // Only run when explicitly enabled and there are small values stashed on disk to regroup.
+  if (config_.repack_scan_budget_us == 0 || bins_->GetStats().stashed_bins_cnt == 0)
+    return;
+
+  if (SliceSnapshot::IsSnaphotInProgress())
+    return;
+
+  PrimeTable& table = op_manager_->db_slice_.GetDBTable(dbid)->prime;
+  const auto start_cycles = base::CycleClock::Now();
+
+  size_t issued_reads = 0;
+
+  // With negative upload budget we only recalculate the fragmentation estimate and issue no reads.
+  if (UploadBudget() < 0)
+    issued_reads = config_.repack_max_reads + 1;
+
+  auto cb = [&](PrimeTable::bucket_iterator it) {
+    size_t total_size = 0;
+    std::vector<size_t> pages;
+
+    auto it2 = it;
+    for (it2.AdvanceIfNotOccupied(); !it2.is_done(); ++it2) {
+      PrimeValue& pv = it2->second;
+      if (!pv.IsExternal() || pv.IsCool())
+        continue;
+
+      tiering::DiskSegment segment{pv.GetExternalSlice()};
+      if (OccupiesWholePages(segment.length))
+        continue;
+
+      total_size += segment.length;
+      size_t page = segment.ContainingPages().offset;
+      if (std::find(pages.begin(), pages.end(), page) == pages.end())
+        pages.push_back(page);
+    }
+
+    if (pages.empty())
+      return;
+
+    repack_state_.cycle_buckets++;
+    repack_state_.cycle_pages += pages.size();
+
+    // Skip buckets already within the acceptable page-waste bound above the theoretical minimum.
+    size_t min_required = total_size / tiering::kPageSize + 1;
+    if (pages.size() <= min_required + config_.repack_acceptable_waste)
+      return;
+
+    if (issued_reads >= config_.repack_max_reads)
+      return;
+
+    stats_.total_repacks++;
+
+    std::string scratch;
+    for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
+      PrimeValue& pv = it->second;
+      if (!pv.IsExternal() || pv.IsCool())
+        continue;
+      tiering::DiskSegment segment{pv.GetExternalSlice()};
+      if (OccupiesWholePages(segment.length))
+        continue;
+
+      if (op_manager_->HasModificationPending(segment))
+        continue;
+
+      pv.SetTouched(true);
+      string_view key = it->first.GetSlice(&scratch);
+      Read(
+          tiering::KeyRef{dbid, key}, segment, tiering::StringDecoder{pv},
+          [](io::Result<tiering::StringDecoder*>) {}, tiering::ReadOptions{.read_only = true});
+    }
+    issued_reads += pages.size();
+  };
+
+  // TraverseBuckets advances the cursor monotonically each call (visiting a bounded number of
+  // buckets and returning an end-cursor once the whole table is covered), so the clock budget
+  // alone bounds the scan.
+  uint64_t cycles = 0;
+  do {
+    repack_state_.cursor = table.TraverseBuckets(repack_state_.cursor, cb);
+    cycles = base::CycleClock::Now() - start_cycles;
+    if (base::CycleClock::ToUsec(cycles) >= config_.repack_scan_budget_us)
+      break;
+  } while (repack_state_.cursor);
+
+  stats_.repack_usec += base::CycleClock::ToUsec(cycles);
+
+  if (!repack_state_.cursor) {  // completed a full pass over the table
+    if (repack_state_.cycle_buckets > 0) {
+      stats_.estimated_bin_bucket_fragmentation =
+          float(repack_state_.cycle_pages) / float(repack_state_.cycle_buckets);
+    }
+    repack_state_.cycle_buckets = 0;
+    repack_state_.cycle_pages = 0;
+  }
 }
 
 size_t TieredStorage::ReclaimMemory(size_t goal) {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -107,7 +107,7 @@ class TieredStorage : public TieredStorageBase {
   void CancelLoad(tiering::DiskSegment segment);
 
   // Run offloading loop until i/o device is loaded or all entries were traversed
-  void RunOffloading(DbIndex dbid);
+  void Heartbeat();
 
   // Prune cool entries to reach the set memory goal with freed memory
   size_t ReclaimMemory(size_t goal);
@@ -145,11 +145,25 @@ class TieredStorage : public TieredStorageBase {
   // Scan small bins for fragmented ones and enqueue for defrag
   void RunDefragScan();
 
+  // Runs offloading and background scans for a single db. Called from Heartbeat per valid db.
+  void RunOffloading(DbIndex dbid);
+
+  // Scan prime table buckets for offloaded small values scattered across many disk pages.
+  // Compute stimated fragmentation score. Upload all values from a fragmented bucket.
+  void RunRepackScan(DbIndex dbid);
+
   PrimeValue DeleteCool(tiering::TieredCoolRecord* record);
   tiering::TieredCoolRecord* PopCool();
 
   detail::DashCursor offloading_cursor_;  // where RunOffloading left off
   detail::DashCursor defrag_cursor_;      // where defrag left off
+
+  struct {
+    detail::DashCursor cursor;
+
+    size_t cycle_buckets = 0;
+    size_t cycle_pages = 0;
+  } repack_state_;
 
   // Number of bins the previous defrag scan enqueued. Used to scale the next scan's cpu time-slice.
   unsigned last_defrag_scan_hits_ = 0;
@@ -173,6 +187,7 @@ class TieredStorage : public TieredStorageBase {
     float upload_threshold;
     bool experimental_hash_offload;
     bool experimental_list_offload;
+    uint32_t experimental_repack_limit;
     uint32_t min_ttl_to_offload_ms;
   } config_;
 
@@ -183,6 +198,9 @@ class TieredStorage : public TieredStorageBase {
     uint64_t offloading_stashes = 0;
     uint64_t total_clients_throttled = 0;
     size_t cool_memory_used = 0;
+
+    uint64_t total_buckets_repacked = 0;
+    float estimated_bin_bucket_fragmentation = 0;
   } stats_;
 };
 
@@ -311,7 +329,7 @@ class TieredStorage : public TieredStorageBase {
     return {};
   }
 
-  void RunOffloading(DbIndex dbid) {
+  void Heartbeat() {
   }
 
   void UpdateFromFlags() {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -113,7 +113,7 @@ class TieredStorage : public TieredStorageBase {
   void CancelLoad(tiering::DiskSegment segment);
 
   // Run offloading loop until i/o device is loaded or all entries were traversed
-  void RunOffloading(DbIndex dbid);
+  void Heartbeat();
 
   // Prune cool entries to reach the set memory goal with freed memory
   size_t ReclaimMemory(size_t goal);
@@ -157,11 +157,26 @@ class TieredStorage : public TieredStorageBase {
   // Scan small bins for fragmented ones and enqueue for defrag
   void RunDefragScan();
 
+  // Runs offloading and background scans for a single db. Called from Heartbeat per valid db.
+  void RunOffloading(DbIndex dbid);
+
+  // Scan prime table buckets for small offloaded values scattered across many disk pages and
+  // re-upload fragmented buckets so their values can be re-grouped. Bounded per call by
+  // tiered_repack_scan_budget_us. Disabled by default.
+  void RunRepackScan(DbIndex dbid);
+
   PrimeValue DeleteCool(tiering::TieredCoolRecord* record);
   tiering::TieredCoolRecord* PopCool();
 
   detail::DashCursor offloading_cursor_;  // where RunOffloading left off
   detail::DashCursor defrag_cursor_;      // where defrag left off
+
+  // Progress and per-pass accumulators for the background repack scan.
+  struct {
+    detail::DashCursor cursor;  // where the repack scan left off
+    size_t cycle_buckets = 0;   // fragmented buckets seen in the current pass
+    size_t cycle_pages = 0;     // disk pages those buckets spread across in the current pass
+  } repack_state_;
 
   // Number of bins the previous defrag scan enqueued. Used to scale the next scan's cpu time-slice.
   unsigned last_defrag_scan_hits_ = 0;
@@ -185,6 +200,9 @@ class TieredStorage : public TieredStorageBase {
     float upload_threshold;
     bool experimental_hash_offload;
     bool experimental_list_offload;
+    uint32_t repack_scan_budget_us;
+    uint32_t repack_max_reads;
+    uint32_t repack_acceptable_waste;
     uint32_t min_ttl_to_offload_ms;
   } config_;
 
@@ -195,6 +213,10 @@ class TieredStorage : public TieredStorageBase {
     uint64_t offloading_stashes = 0;
     uint64_t total_clients_throttled = 0;
     size_t cool_memory_used = 0;
+
+    uint64_t total_repacks = 0;
+    uint64_t repack_usec = 0;
+    float estimated_bin_bucket_fragmentation = 0;
   } stats_;
 };
 
@@ -332,7 +354,7 @@ class TieredStorage : public TieredStorageBase {
     return {};
   }
 
-  void RunOffloading(DbIndex dbid) {
+  void Heartbeat() {
   }
 
   void UpdateFromFlags() {


### PR DESCRIPTION
Bin-bucket defragmentation algorithm for measuring and reducing bin fragmentation - the number of small pages a bucket has on average. Using a more compact distribution brings the read amplification factor down for scenarios that read the whole bucket -  like serialization

Manually controllable flag (disabled by default) that:

* Creates a cursor loop over buckets that computes the number of small-bin pages per bucket, exports that metric as `tiered_small_bins_estimated_bucket_fragmentation`
* If the optimal number of pages is lower than some `kAcceptableWaste` threshold, we upload all its values