### PR TITLE
fix(core): make QList read paths footprint-neutral

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -695,13 +695,13 @@ void QList::Iterate(IterateFunc cb, long start, long end) const {
 
   if (end < 0 || end >= long(Size()))
     end = Size() - 1;
-  Iterator it = GetIterator(start);
-  if (it.Valid()) {
+  ReadCursor cur = GetReadCursor(start);
+  if (cur.Valid()) {
     do {
-      if (start > end || !cb(it.Get()))
+      if (start > end || !cb(cur.Get()))
         break;
       start++;
-    } while (it.Next());
+    } while (cur.Next());
   }
 }
 
@@ -1364,6 +1364,14 @@ auto QList::GetIterator(long idx) const -> Iterator {
   InitIteratorEntry(&iter);
 
   return iter;
+}
+
+void QList::EndRead(const Iterator& it) const {
+  if (it.current_ == nullptr)
+    return;
+
+  QList* self = const_cast<QList*>(this);
+  self->RecompressNode(it.current_);
 }
 
 auto QList::Erase(Iterator it) -> Iterator {

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -124,6 +124,38 @@ class QList {
     friend class QList;
   };
 
+  // A read-only cursor that recompresses its final node on destruction.
+  class ReadCursor {
+   public:
+    ~ReadCursor() {
+      owner_->EndRead(it_);
+    }
+
+    ReadCursor(const ReadCursor&) = delete;
+    ReadCursor& operator=(const ReadCursor&) = delete;
+
+    bool Valid() const {
+      return it_.Valid();
+    }
+
+    Entry Get() const {
+      return it_.Get();
+    }
+
+    bool Next() {
+      return it_.Next();
+    }
+
+   private:
+    ReadCursor(const QList* owner, Iterator it) : owner_(owner), it_(it) {
+    }
+
+    const QList* owner_;
+    Iterator it_;
+
+    friend class QList;
+  };
+
   using IterateFunc = absl::FunctionRef<bool(Entry)>;
   enum InsertOpt : uint8_t { BEFORE, AFTER };
 
@@ -225,6 +257,15 @@ class QList {
   // negative index - means counting from the tail.
   // result.Valid() is true if the index is within range.
   Iterator GetIterator(long idx) const;
+
+  // Returns a read-only cursor that restores the list's footprint on destruction.
+  ReadCursor GetReadCursor(Where where) const {
+    return ReadCursor{this, GetIterator(where)};
+  }
+
+  ReadCursor GetReadCursor(long idx) const {
+    return ReadCursor{this, GetIterator(idx)};
+  }
 
   uint32_t node_count() const {
     return len_;
@@ -380,6 +421,8 @@ class QList {
 
   // Prepares the node for read access.
   void AccessForReads(bool recompress, Node* node);
+
+  void EndRead(const Iterator& it) const;
 
   Node* MergeNodes(Node* node);
 

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -353,6 +353,61 @@ TEST_F(QListTest, CompressionPlain) {
   EXPECT_EQ(500, i);
 }
 
+// A read decompresses the node it touches and marks it for recompression. Recompression used to
+// happen only when the iterator advanced off the node or on a subsequent write, so a read that
+// stopped early (partial LRANGE, LINDEX) left the node decompressed and grew MallocUsed().
+// DbSlice only re-accounts obj_memory_usage around writes, so the tracked total fell behind and
+// the next write tripped its DCHECK_GE.
+TEST_F(QListTest, PartialReadIsFootprintNeutral) {
+  ql_ = QList(-1, 1);  // 4KB nodes, compress depth 1: interior nodes are LZF compressed.
+
+  // Repetitive payloads so that interior nodes compress well past MIN_COMPRESS_IMPROVE.
+  for (unsigned i = 0; i < 300; ++i) {
+    ql_.Push(StrCat("value-", i, "-", string(200, 'x')), QList::TAIL);
+  }
+  ASSERT_GT(ql_.node_count(), 4u);
+
+  const QList::Node* interior = ql_.Head()->next;
+  ASSERT_TRUE(interior->IsCompressed());
+
+  const size_t tracked = ql_.MallocUsed(false);
+  const size_t actual = ql_.MallocUsed(true);
+
+  // A partial range read (LRANGE q 100 150) stops in the middle of an interior node.
+  unsigned count = 0;
+  ql_.Iterate(
+      [&](const QList::Entry& e) {
+        ++count;
+        return true;
+      },
+      100, 150);
+  ASSERT_EQ(51u, count);
+  EXPECT_EQ(tracked, ql_.MallocUsed(false));
+  EXPECT_LE(ql_.MallocUsed(true), actual);
+
+  // A callback that stops early is a partial read as well (LPOS with COUNT).
+  count = 0;
+  ql_.Iterate([&](const QList::Entry& e) { return ++count < 120; }, 0, -1);
+  ASSERT_EQ(120u, count);
+  EXPECT_EQ(tracked, ql_.MallocUsed(false));
+  EXPECT_LE(ql_.MallocUsed(true), actual);
+
+  // A single element read (LINDEX q 150): the cursor restores the node when it goes out of scope.
+  {
+    auto cur = ql_.GetReadCursor(150);
+    ASSERT_TRUE(cur.Valid());
+    EXPECT_FALSE(cur.Get().view().empty());
+  }
+  EXPECT_EQ(tracked, ql_.MallocUsed(false));
+  EXPECT_LE(ql_.MallocUsed(true), actual);
+  EXPECT_TRUE(interior->IsCompressed());
+
+  // The list is still intact and writable after the reads.
+  EXPECT_EQ(300u, ql_.Size());
+  ql_.Pop(QList::HEAD);
+  EXPECT_EQ(299u, ql_.Size());
+}
+
 TEST_F(QListTest, LargeValues) {
   string val(100000, 'a');
   ql_.Push(val, QList::HEAD);
@@ -1457,6 +1512,43 @@ TEST_F(QListZstdTest, IndexAccess) {
   ASSERT_TRUE(it.Valid());
   entry = it.Get();
   EXPECT_NE(entry.data(), nullptr);
+}
+
+// Same read-side accounting leak as QListTest.PartialReadIsFootprintNeutral, but in ZSTD
+// dictionary mode (list_compress_dict_threshold instead of list_compress_depth).
+TEST_F(QListZstdTest, PartialReadIsFootprintNeutral) {
+  QList ql(-1, 0);  // compress=0 so the ZSTD dict path is active (LZF disabled)
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+  ASSERT_GT(ql.node_count(), 4u);
+
+  const QList::Node* interior = ql.Head()->next;
+  ASSERT_TRUE(interior->IsCompressed());
+
+  const size_t tracked = ql.MallocUsed(false);
+  const size_t actual = ql.MallocUsed(true);
+
+  // Partial range read (LRANGE q 100 150).
+  unsigned count = 0;
+  ql.Iterate(
+      [&](const QList::Entry& e) {
+        ++count;
+        return true;
+      },
+      100, 150);
+  ASSERT_EQ(51u, count);
+  EXPECT_EQ(tracked, ql.MallocUsed(false));
+  EXPECT_LE(ql.MallocUsed(true), actual);
+
+  // Single element read (LINDEX q 150): the cursor restores the node when it goes out of scope.
+  {
+    auto cur = ql.GetReadCursor(150);
+    ASSERT_TRUE(cur.Valid());
+    EXPECT_FALSE(cur.Get().view().empty());
+  }
+  EXPECT_EQ(tracked, ql.MallocUsed(false));
+  EXPECT_LE(ql.MallocUsed(true), actual);
+  EXPECT_TRUE(interior->IsCompressed());
 }
 
 TEST_F(QListZstdTest, IncrementalCompression) {

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -276,9 +276,9 @@ class ListWrapper {
 
   string First(QList::Where where) const {
     return visit(Overload{[&](QList* ql) {
-                            auto it = ql->GetIterator(where);
-                            CHECK(it.Valid());
-                            return it.Get().to_string();
+                            auto cur = ql->GetReadCursor(where);
+                            CHECK(cur.Valid());
+                            return cur.Get().to_string();
                           },
                           [&](const LP& lp) { return lp.First(where); }},
                  impl_);
@@ -286,10 +286,10 @@ class ListWrapper {
 
   std::optional<string> At(long index) const {
     return visit(Overload{[&](QList* ql) -> optional<string> {
-                            auto it = ql->GetIterator(index);
-                            if (!it.Valid())
+                            auto cur = ql->GetReadCursor(index);
+                            if (!cur.Valid())
                               return nullopt;
-                            return it.Get().to_string();
+                            return cur.Get().to_string();
                           },
                           [&](const LP& lp) { return lp.At(index); }},
                  impl_);
@@ -335,7 +335,7 @@ vector<uint32_t> ListWrapper::Pos(string_view element, uint32_t rank, uint32_t c
   vector<uint32_t> matches;
 
   auto* ql = std::get<QList*>(impl_);
-  auto it = ql->GetIterator(where);
+  auto it = ql->GetReadCursor(where);
   if (!it.Valid())
     return matches;
 

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -2,10 +2,12 @@
 // See LICENSE for licensing terms.
 //
 
+#include <absl/flags/reflection.h>
 #include <absl/strings/match.h>
 
 #include <random>
 
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/error.h"
@@ -20,7 +22,11 @@
 using namespace testing;
 using namespace std;
 using namespace util;
+using absl::SetFlag;
 using absl::StrCat;
+
+ABSL_DECLARE_FLAG(int32_t, list_compress_depth);
+ABSL_DECLARE_FLAG(int32_t, list_max_listpack_size);
 
 namespace dfly {
 
@@ -516,6 +522,38 @@ TEST_F(ListFamilyTest, LRange) {
 
   ASSERT_THAT(resp, ArrLen(2));
   ASSERT_THAT(resp.GetVec(), ElementsAre("1", "2"));
+}
+
+// LRANGE/LINDEX decompress the node they touch. Recompression used to be deferred to the moment
+// the iterator advanced off the node or to the next write, so a read that stopped early left the
+// node decompressed and grew the object's MallocUsed(). DbSlice re-accounts obj_memory_usage only
+// around writes, so its tracked total fell behind and the following LPOP hit
+//   DCHECK_GE(obj_memory_usage, MallocUsed())
+// in DbSlice::FindMutableInternal.
+TEST_F(ListFamilyTest, PartialReadMemoryAccounting) {
+  absl::FlagSaver fs;
+  SetFlag(&FLAGS_list_compress_depth, 1);
+  SetFlag(&FLAGS_list_max_listpack_size, -1);  // 4KB nodes, so we get many of them.
+
+  // Celery-like payloads: ~200 compressible bytes each, enough entries for several nodes.
+  vector<string> push_args = {"rpush", kKey1};
+  for (unsigned i = 0; i < 3000; ++i) {
+    push_args.push_back(StrCat("{\"id\": \"b3e4b923-8a77-4053-aff0-", 100000 + i,
+                               "\", \"task\": \"process_job\", \"args\": [", i, "], ",
+                               "\"kwargs\": {}, \"retries\": 0, \"eta\": null, ",
+                               "\"expires\": null, \"origin\": \"gen917779@hut\"}"));
+  }
+  ASSERT_THAT(Run(push_args), IntArg(3000));
+
+  // A partial range read stops inside an interior, compressed node.
+  ASSERT_THAT(Run({"lrange", kKey1, "100", "200"}), ArrLen(101));
+
+  // A single element read does the same.
+  EXPECT_THAT(Run({"lindex", kKey1, "150"}), ArgType(RespExpr::STRING));
+
+  // The write triggers FindMutable → DCHECK. Must not crash.
+  EXPECT_THAT(Run({"lpop", kKey1}), ArgType(RespExpr::STRING));
+  EXPECT_EQ(2999, CheckedInt({"llen", kKey1}));
 }
 
 TEST_F(ListFamilyTest, Lset) {


### PR DESCRIPTION
## Summary

A read-only list command could grow a compressed list's `MallocUsed()` without `DbSlice` noticing, so the next write tripped `DCHECK_GE(obj_memory_usage, MallocUsed())` in `db_slice.cc`.

`QList` marks a node `recompress = 1` when a read decompresses it temporarily (`AccessForReads` -> `TryDecompressInternal`). Recompression only happened when the iterator advanced off that node (`Iterator::Next` -> `CompressByDepth`) or on a write path (`RecompressNode`). When a read stopped early - a partial `LRANGE`, or a single element read such as `LINDEX` via `GetIterator(long)` - the last touched node stayed decompressed with `recompress = 1` forever. In release builds there is no crash, but `used_memory` under-reports the list, which also skews eviction heuristics.

Reproducer on main (debug build):

```
./build-dbg/dragonfly --port 7020 --dir /tmp/dfbug --list_compress_depth=1 \
    --list_max_listpack_size=-1 --logtostderr
# RPUSH ~3000 celery-like JSON entries (~200 bytes each), LRANGE q 100 200, LPOP q
# => F ... db_slice.cc:624] Check failed:
#    db_arr_[cntx.db_index]->stats.obj_memory_usage >= (*res)->second.MallocUsed()
```

Both compression modes are affected: `--list_compress_depth` (LZF) and `--list_compress_dict_threshold` (ZSTD dict).

## Changes

- Add `QList::ReadCursor`: a move-only, read-only cursor that restores the footprint of the node it stopped on when it goes out of scope. `EndRead()` is a private implementation detail behind it, so no caller can forget to release the node.
- Use it in `QList::Iterate()`, covering partial ranges and callbacks that stop early.
- Use it in the `list_family` read paths: `First` (`LPOS`/`LMPOP` peeks), `At` (`LINDEX`), `Pos` (`LPOS` with `COUNT`/`RANK`).
- Regression tests: `QListTest.PartialReadIsFootprintNeutral`, `QListZstdTest.PartialReadIsFootprintNeutral`, `ListFamilyTest.PartialReadMemoryAccounting` (run with `list_compress_depth=1`).

### Why a separate cursor type rather than `Iterator`'s destructor

Releasing the node from `Iterator::~Iterator` would be a use-after-free. `QList::Erase(Iterator it)` takes its iterator **by value** and calls `InitIteratorEntry(&it)` to re-decompress the landing node before returning a copy. In `it = ql->Erase(it)` the parameter copy is destroyed after the assignment, so its destructor would recompress - freeing the raw buffer of - the very node the caller's iterator now points into. `ListWrapper::Remove` does exactly that in a loop. `QList::Insert(Iterator, ...)` is by-value too, and `QList::Erase(long, unsigned)` holds a live `Iterator` while its loop deletes nodes underneath it.

`ReadCursor` is move-only and cannot be converted to an `Iterator`, so it cannot reach a mutating method. Mutating methods keep taking a plain `Iterator` and recompress the node themselves.

## Notes

This unblocks the `edge_depth=0` setting of the upcoming `--list_compress_policy` work (compress every node, including the edges), where the bug becomes trivially reachable - any read touching the head or tail followed by a write would hit it.

Verified: all three new tests fail before the fix (the server-level one reproduces the exact `db_slice.cc:624` check failure); the original manual reproducer now leaves `MEMORY USAGE` byte-identical across the read in both compression modes; `ctest -L DFLY` is 85/85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)