### PR TITLE
fix(qlist): copy only the compressed blob when defragmenting a compressed node

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -459,8 +459,14 @@ size_t QList::DefragIfNeeded(PageUsage* page_usage) {
     // of their constant (and relatively small, ~40 bytes per object) size. Defragmentation fixes
     // fragmented memory allocation, which usually happens when variable-sized blocks of data are
     // allocated and deallocated, which is not expected with nodes.
-    uint8_t* new_entry = static_cast<uint8_t*>(zmalloc(curr->sz));
-    memcpy(new_entry, curr->entry, curr->sz);
+    //
+    // For compressed nodes curr->sz holds the *uncompressed* size, while curr->entry points to a
+    // quicklistLZF allocated with sizeof(quicklistLZF) + lzf->sz bytes, which is strictly smaller.
+    // Using curr->sz there would over-read the source buffer and over-allocate the new one.
+    const size_t entry_sz =
+        curr->IsCompressed() ? sizeof(quicklistLZF) + GetLzf(curr)->sz : curr->sz;
+    uint8_t* new_entry = static_cast<uint8_t*>(zmalloc(entry_sz));
+    memcpy(new_entry, curr->entry, entry_sz);
 
     uint8_t* old_entry = curr->entry;
     curr->entry = new_entry;

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -425,6 +425,50 @@ TEST_F(QListTest, DefragmentListpackCompressed) {
   ASSERT_EQ(i, total_items);
 }
 
+// Defragmenting a compressed node must copy only sizeof(quicklistLZF) + lzf->sz bytes,
+// not node->sz (which holds the *uncompressed* size). Copying node->sz over-reads the
+// source allocation (ASAN) and over-allocates the destination, inflating the real
+// footprint above the tracked malloc_size_.
+TEST_F(QListTest, DefragCompressedEntrySize) {
+  PageUsage page_usage{CollectPageStats::YES, 100.0};
+  page_usage.SetForceReallocate(true);
+
+  ql_ = QList{-1, 1};  // 4kb nodes, head/tail uncompressed, interior nodes LZF-compressed.
+
+  // Highly compressible payloads so that lzf->sz is much smaller than node->sz.
+  constexpr int kItems = 100;
+  const string payload(300, 'a');
+  for (int i = 0; i < kItems; ++i) {
+    ql_.Push(StrCat(payload, i), QList::TAIL);
+  }
+
+  ASSERT_GT(ql_.node_count(), 2u);
+  unsigned compressed = 0;
+  for (const auto* node = ql_.Head(); node; node = node->next) {
+    compressed += node->IsCompressed();
+  }
+  ASSERT_GT(compressed, 0u) << "test requires compressed interior nodes";
+
+  const size_t before_fast = ql_.MallocUsed(false);
+  const size_t before_slow = ql_.MallocUsed(true);
+
+  ASSERT_EQ(ql_.node_count(), ql_.DefragIfNeeded(&page_usage));
+
+  // Reallocating with the same sizes must not change either the tracked or the real footprint.
+  EXPECT_EQ(before_fast, ql_.MallocUsed(false));
+  EXPECT_EQ(before_slow, ql_.MallocUsed(true));
+
+  // Entries are still readable (decompression of the moved nodes succeeds).
+  int i = 0;
+  auto it = ql_.GetIterator(QList::HEAD);
+  ASSERT_TRUE(it.Valid());
+  do {
+    ASSERT_EQ(StrCat(payload, i), it.Get().to_string());
+    ++i;
+  } while (it.Next());
+  ASSERT_EQ(kItems, i);
+}
+
 // MergeNodes must not follow the head_->prev circular link when looking for
 // adjacent nodes to merge.  Splitting a full head node and calling MergeNodes
 // on the right half used to traverse new_head->prev (= tail), merging two


### PR DESCRIPTION
## Summary

`QList::DefragIfNeeded()` used `curr->sz` as both the `memcpy` length and the `zmalloc` size when moving a node's entry off an under-utilized page. For a *compressed* node (LZF or ZSTD) `curr->sz` is the **uncompressed** size, while `curr->entry` points at a `quicklistLZF` allocated with only `sizeof(quicklistLZF) + lzf->sz` bytes — strictly smaller, since `CompressLZF` keeps the result only when `lzf->sz + MIN_COMPRESS_IMPROVE <= node->sz`.

Two consequences:

1. The `memcpy` over-read the source allocation by roughly `curr->sz - 8 - lzf->sz` bytes.
2. The new buffer was over-allocated (`curr->sz` instead of `sizeof(quicklistLZF) + lzf->sz`) without adjusting `malloc_size_`, so the tracked footprint drifted below the real one — the same class of accounting drift recently fixed on the read paths.

## Changes

- `DefragIfNeeded()` sizes the copy by the real entry allocation: `sizeof(quicklistLZF) + GetLzf(curr)->sz` for compressed nodes, `curr->sz` for RAW/PLAIN. The replacement allocation now requests exactly as many bytes as the one it frees, so `malloc_size_` needs no adjustment.
- New `QListTest.DefragCompressedEntrySize`: defragments a `QList(-1, 1)` holding compressible payloads (so interior nodes are LZF-compressed), then asserts both `MallocUsed(false)` and `MallocUsed(true)` are unchanged by the pass and that every entry still decompresses to its original value.

The test fails on the old code with `MallocUsed(true)` = 32112 against a tracked 8496, and passes with the fix. Note that ASAN alone does not flag the over-read: mimalloc is built without `MI_TRACK_ASAN`, so `zmalloc` blocks have no redzones — the accounting assertion is what catches it. The full `qlist_test` suite (2621 tests) is green in both the plain debug and `-DWITH_ASAN=ON` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)