### PR TITLE
feat: use OAHSet by default

### DIFF
--- a/src/server/collection_family_fallback.cc
+++ b/src/server/collection_family_fallback.cc
@@ -14,6 +14,9 @@ namespace dfly {
 
 using namespace std;
 
+void InitSetFamilyFlags() {
+}
+
 namespace {
 void Fail() {
   CHECK(false) << "Compiled without command support";

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -61,6 +61,7 @@ ABSL_DECLARE_FLAG(std::string, dir);
 #include "server/generic_family.h"
 #include "server/main_service.h"
 #include "server/server_family.h"
+#include "server/set_family.h"
 #include "server/version.h"
 #include "server/version_monitor.h"
 #include "strings/human_readable.h"
@@ -84,11 +85,6 @@ ABSL_DECLARE_FLAG(std::string, admin_bind);
 ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, maxmemory);
 ABSL_DECLARE_FLAG(uint32_t, proactor_threads);
 ABSL_DECLARE_FLAG(std::string, dbfilename);
-ABSL_FLAG(bool, use_oah_set, false, "If true, store SET values in OAHSet instead of StringSet.");
-
-namespace dfly {
-extern bool g_use_oah_set;  // defined in core/oah_set.h
-}
 
 #ifdef USE_ABSL_LOG
 ABSL_FLAG(bool, alsologtostderr, false, "also log messages to stderr in addition to logfiles");
@@ -1161,7 +1157,7 @@ Usage: dragonfly [FLAGS]
     LOG(WARNING) << "SWAP is enabled. Consider disabling it when running Dragonfly.";
 
   dfly::max_memory_limit = absl::GetFlag(FLAGS_maxmemory);
-  dfly::g_use_oah_set = absl::GetFlag(FLAGS_use_oah_set);
+  dfly::InitSetFamilyFlags();
 
   if (dfly::max_memory_limit == 0) {
     LOG(INFO) << "maxmemory has not been specified. Deciding myself....";

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -13,6 +13,7 @@ extern "C" {
 }
 
 #include "base/cycle_clock.h"
+#include "base/flags.h"
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "core/detail/listpack_wrap.h"
@@ -29,9 +30,15 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/transaction.h"
 
+ABSL_FLAG(bool, use_oah_set, true, "If true, store SET values in OAHSet instead of StringSet.");
+
 namespace rng = std::ranges;
 
 namespace dfly {
+
+void InitSetFamilyFlags() {
+  g_use_oah_set = absl::GetFlag(FLAGS_use_oah_set);
+}
 
 using namespace facade;
 

--- a/src/server/set_family.h
+++ b/src/server/set_family.h
@@ -14,6 +14,9 @@ namespace dfly {
 
 using facade::OpResult;
 
+// Captures the selected SET implementation after command-line flags have been parsed.
+void InitSetFamilyFlags();
+
 class StringSet;
 
 class SetFamily {

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -386,7 +386,9 @@ TEST_F(SetFamilyTest, SScan) {
   resp = Run({"sscan", "mystrset", "0", "match", "str-1*", "count", "3"});
   vec = StrArray(resp.GetVec()[1]);
   EXPECT_THAT(vec, IsSubsetOf({"str-1", "str-10", "str-11", "str-12", "str-13", "str-14"}));
-  EXPECT_EQ(vec.size(), 3);
+  // COUNT is a hint. OAHSet scans an entire bucket at a time, so a response can contain more
+  // than the requested number of matching members.
+  EXPECT_GE(vec.size(), 3);
 
   // nothing should match this
   resp = Run({"sscan", "mystrset", "0", "match", "1*"});

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -26,6 +26,7 @@ extern "C" {
 #include "facade/reply_builder.h"
 #include "io/file_util.h"
 #include "server/acl/acl_log.h"
+#include "server/set_family.h"
 #include "util/fibers/pool.h"
 
 using namespace std;
@@ -33,7 +34,6 @@ using namespace std;
 ABSL_DECLARE_FLAG(string, dbfilename);
 ABSL_DECLARE_FLAG(double, rss_oom_deny_ratio);
 ABSL_DECLARE_FLAG(uint32_t, num_shards);
-ABSL_FLAG(bool, use_oah_set, false, "If true, store SET values in OAHSet instead of StringSet.");
 ABSL_FLAG(bool, force_epoll, false, "If true, uses epoll api instead iouring to run tests");
 ABSL_DECLARE_FLAG(uint32_t, acllog_max_len);
 ABSL_DECLARE_FLAG(bool, enable_heartbeat_rss_eviction);
@@ -219,7 +219,7 @@ void BaseFamilyTest::SetUpTestSuite() {
 
 void BaseFamilyTest::SetUp() {
   max_memory_limit = INT_MAX;
-  g_use_oah_set = absl::GetFlag(FLAGS_use_oah_set);
+  InitSetFamilyFlags();
   ResetService();
 }
 

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -19,7 +19,9 @@ from .utility import assert_eventually, tmp_file_name
     "type, keys, val_size, elements",
     [
         ("JSON", 200_000, 100, 100),
-        ("SET", 280_000, 100, 100),
+        # OAHSet do ASCII encoding, so 32M values are required
+        # to keep this workload above the test's 3 GiB threshold.
+        ("SET", 320_000, 100, 100),
         ("HASH", 250_000, 100, 100),
         ("ZSET", 250_000, 100, 100),
         ("LIST", 300_000, 100, 100),


### PR DESCRIPTION
Summary: This PR makes OAHSet the default backing structure for SET values.

Changes: Flips the --use_oah_set flag default from false to true in both the main server and test binaries, so SETs will use OAHSet unless explicitly disabled.