### PR TITLE
fix(qlist): fix malloc_size_ accounting for compressed nodes

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -814,7 +814,7 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
     uint8_t* new_entry = LP_Insert(node->entry, elem, it.zi_, after ? LP_AFTER : LP_BEFORE);
     malloc_size_ += NodeSetEntry(node, new_entry);
     node->count++;
-    malloc_size_ += RecompressNode(node);
+    RecompressNode(node);
   } else {
     bool insert_tail = at_tail && after;
     bool insert_head = at_head && !after;
@@ -825,8 +825,8 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
       AccessForReads(true, new_node);
       malloc_size_ += NodeSetEntry(new_node, LP_Prepend(new_node->entry, elem));
       new_node->count++;
-      malloc_size_ += RecompressNode(new_node);
-      malloc_size_ += RecompressNode(node);
+      RecompressNode(new_node);
+      RecompressNode(node);
     } else if (insert_head && avail_prev) {
       /* If we are: at head, previous has free space, and inserting before:
        *   - insert entry at tail of previous node. */
@@ -834,8 +834,8 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
       AccessForReads(true, new_node);
       malloc_size_ += NodeSetEntry(new_node, LP_Append(new_node->entry, elem));
       new_node->count++;
-      malloc_size_ += RecompressNode(new_node);
-      malloc_size_ += RecompressNode(node);
+      RecompressNode(new_node);
+      RecompressNode(node);
     } else if (insert_tail || insert_head) {
       /* If we are: full, and our prev/next has no available space, then:
        *   - create new node and attach to qlist */
@@ -1005,11 +1005,9 @@ void QList::CompressByDepth(Node* node) {
   // Handle the recompress flag via dict and return.
   if (IsZstdDictMode()) {
     if (node && node->recompress && tl_zstd_dict && CanCompressWithZstdDict(node)) {
-      size_t sz = node->sz;
-      if (CompressNodeWithDict(node)) {
+      // CompressNodeWithDict updates malloc_size_ itself.
+      if (CompressNodeWithDict(node))
         node->recompress = 0;
-        malloc_size_ += ssize_t(((quicklistLZF*)node->entry)->sz) - sz;
-      }
     }
     return;
   }
@@ -1203,7 +1201,11 @@ void QList::DelNode(Node* node) {
 
   // Offloaded nodes don't have entry data, so we only update malloc_size_ for non-offloaded nodes.
   if (!node->offloaded) {
-    malloc_size_ -= node->sz;
+    // node->sz keeps the uncompressed length, but a compressed node only ever contributed its
+    // compressed payload length to malloc_size_. Subtracting node->sz here would over-subtract
+    // and drive the counter negative. Erase() reaches this with a still-compressed node when it
+    // drops whole interior nodes.
+    malloc_size_ -= node->IsCompressed() ? GetLzf(node)->sz : node->sz;
   }
 
   if (tiering_enabled_ && (node->offloaded || node->io_pending)) {
@@ -1477,7 +1479,7 @@ bool QList::Erase(const long start, unsigned count) {
       if (node->count == 0) {
         DelNode(node);
       } else {
-        malloc_size_ += RecompressNode(node);
+        RecompressNode(node);
       }
     }
 
@@ -1630,11 +1632,9 @@ void QList::BackfillCompressWithZstdDict() {
       break;
     if (node->sz >= MIN_COMPRESS_BYTES)
       any_attempted = true;
-    size_t prev_size = zmalloc_usable_size(node->entry);
-    if (CompressNodeWithDict(node)) {
+    // CompressNodeWithDict updates malloc_size_ itself.
+    if (CompressNodeWithDict(node))
       any_compressed = true;
-      malloc_size_ += zmalloc_usable_size(node->entry) - prev_size;
-    }
   }
 
   // Avoid full scan again by setting either of flags.
@@ -1699,22 +1699,24 @@ bool QList::CompressNodeWithDict(Node* node) {
   zfree(node->entry);
   node->entry = (unsigned char*)dest;
   node->encoding = QLIST_NODE_ENCODING_ZSTD;
+
+  // node->sz keeps holding the *uncompressed* length, while the payload now takes csz bytes.
+  // Account for the difference here so that no caller can forget to do it. Uses the same
+  // convention as TryCompress/TryDecompressInternal, i.e. the quicklistLZF header is ignored.
+  malloc_size_ += ssize_t(csz) - ssize_t(node->sz);
   return true;
 }
 
-ssize_t QList::RecompressNode(Node* node) {
+void QList::RecompressNode(Node* node) {
   if (!node->recompress || node->dont_compress)
-    return 0;
+    return;
   if (IsZstdDictMode() && tl_zstd_dict && CanCompressWithZstdDict(node)) {
-    size_t sz = node->sz;
-    if (CompressNodeWithDict(node)) {
+    // CompressNodeWithDict updates malloc_size_ itself.
+    if (CompressNodeWithDict(node))
       node->recompress = 0;
-      return ssize_t(((quicklistLZF*)node->entry)->sz) - sz;
-    }
   } else if (CompressRaw(node)) {
-    return ssize_t(GetLzf(node)->sz) - node->sz;
+    malloc_size_ += ssize_t(GetLzf(node)->sz) - ssize_t(node->sz);
   }
-  return 0;
 }
 
 bool QList::DecompressZstdNode(const Node* node, std::string* dest) {

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -357,8 +357,8 @@ class QList {
   void CoolOff(Node* node, uint32_t node_id);
 
   // Like the RecompressOnly free function, but also handles ZSTD dict mode.
-  // Returns the size delta (negative means compression reduced memory usage).
-  ssize_t RecompressNode(Node* node);
+  // Updates malloc_size_ with the resulting size delta.
+  void RecompressNode(Node* node);
 
   void Replace(Iterator it, std::string_view elem);
   void CompressByDepth(Node* node);
@@ -375,6 +375,7 @@ class QList {
   void BackfillCompressWithZstdDict();
 
   // Compresses a single node using the thread-local ZSTD dictionary.
+  // On success updates malloc_size_ with the size delta, so callers must not account for it.
   bool CompressNodeWithDict(Node* node);
 
   // Prepares the node for read access.

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -1498,6 +1498,65 @@ TEST_F(QListZstdTest, IncrementalCompression) {
   EXPECT_EQ(count, ql.Size());
 }
 
+TEST_F(QListZstdTest, MallocUsedTracksSteadyStateCompression) {
+  // Most of the nodes below are compressed by the steady-state branch of CoolOff(), which used
+  // to skip the malloc_size_ update and left the tracked size at the uncompressed value.
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+
+  size_t compressed_nodes = 0;
+  for (const QList::Node* node = ql.Head(); node; node = node->next) {
+    compressed_nodes += node->IsCompressed();
+  }
+  ASSERT_GT(compressed_nodes, 10u);
+
+  const size_t tracked = ql.MallocUsed(false);
+  const size_t actual = ql.MallocUsed(true);
+  LOG(INFO) << "tracked: " << tracked << ", actual: " << actual;
+
+  // The two never match exactly: MallocUsed(true) sums zmalloc_usable_size() while the tracked
+  // deltas use the compressed payload length, ignoring the quicklistLZF header. So the tracked
+  // size must stay slightly below the real one, not an order of magnitude above it.
+  EXPECT_LE(tracked, actual);
+  EXPECT_GT(tracked, actual * 0.8);
+}
+
+// Erase() drops whole interior nodes without decompressing them first, so DelNode() used to
+// subtract the uncompressed node->sz for a node that had only contributed its compressed length
+// to malloc_size_. The counter is unsigned, so the over-subtraction wrapped it around.
+TEST_F(QListZstdTest, EraseWholeCompressedNodesKeepsMallocSize) {
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+  ASSERT_GT(ql.node_count(), 10u);
+
+  ql.Erase(100, 200);
+  ASSERT_EQ(ql.Size(), 300u);
+
+  const size_t tracked = ql.MallocUsed(false);
+  const size_t actual = ql.MallocUsed(true);
+  LOG(INFO) << "tracked: " << ssize_t(tracked) << ", actual: " << actual;
+  EXPECT_LE(tracked, actual);
+  EXPECT_GT(tracked, actual * 0.8);
+}
+
+// Same accounting bug on the LZF depth-compression path, which is independent of the ZSTD dict.
+TEST_F(QListZstdTest, EraseWholeLzfNodesKeepsMallocSize) {
+  QList ql(-1, 1);  // compress=1 enables LZF depth compression and disables the ZSTD dict path
+  PopulateWithCeleryData(ql, 500);
+  ASSERT_GT(ql.node_count(), 10u);
+
+  ql.Erase(100, 200);
+  ASSERT_EQ(ql.Size(), 300u);
+
+  const size_t tracked = ql.MallocUsed(false);
+  const size_t actual = ql.MallocUsed(true);
+  LOG(INFO) << "tracked: " << ssize_t(tracked) << ", actual: " << actual;
+  EXPECT_LE(tracked, actual);
+  EXPECT_GT(tracked, actual * 0.8);
+}
+
 TEST_F(QListZstdTest, IncompressibleDataNotCompressed) {
   // Train a dictionary with compressible Celery data.
   QList ql_train(-1, 0);


### PR DESCRIPTION
## Summary

Two bugs made `MallocUsed(false)` — which backs `obj_memory_usage`/`used_memory`, the eviction and OOM-rejection heuristics, and disagrees with `MEMORY USAGE` (`MallocUsed(true)`) — diverge from reality for compressed lists.

### 1. Steady-state ZSTD dict compression never updated `malloc_size_`

`CoolOff()`'s steady-state branch compressed interior nodes but left the tracked size at the *uncompressed* value forever. On a 500-entry Celery-like list: 290418 bytes tracked vs 21968 actually allocated, a ~13x over-report. The drift is upward, so it never tripped `DCHECK_GE(obj_memory_usage, MallocUsed())` — it was silent.

- The `malloc_size_` update now lives inside `CompressNodeWithDict()`, so no call site can forget it. The duplicate updates in `CompressByDepth()`, `BackfillCompressWithZstdDict()` and `RecompressNode()` are removed.
- Backfill switches from the `zmalloc_usable_size()` convention to the compressed-payload-length convention already used by `TryCompress`/`TryDecompressInternal`, so compress and decompress deltas are symmetric and repeated read/recompress cycles no longer drift.
- `RecompressNode()` returns `void` and updates `malloc_size_` directly.

### 2. `DelNode()` over-subtracted for compressed nodes

`DelNode()` subtracted `node->sz` — the uncompressed length — for a node that had only ever contributed its compressed payload length. `Erase()` drops whole interior nodes without decompressing them first, so `LTRIM`/`LREM` spanning compressed nodes over-subtracted and wrapped the unsigned counter negative (~1.8e19).

This is independent of the ZSTD dict and hits LZF identically, so it predates it. Fixing (1) removed the accidental cancellation that had been keeping the ZSTD path positive-but-wrong, which is why it is fixed here rather than separately.

`Erase(100, 200)` on a 500-entry list, tracked vs actual:

| | before | after |
|---|---:|---:|
| LZF (`compress=1`) | −63155 (actual 35000) | 31771 |
| ZSTD steady-state | 179011 (actual 15624) | 14259 |

## Tests

Three regression tests in `qlist_test.cc`, each verified to fail without its fix:

- `MallocUsedTracksSteadyStateCompression` — 290418 → 19719 against 21968 actual.
- `EraseWholeCompressedNodesKeepsMallocSize` — ZSTD path, −91688 → 14259.
- `EraseWholeLzfNodesKeepsMallocSize` — LZF path, −63155 → 31771.

The tracked size stays slightly *below* `MallocUsed(true)` rather than matching it: the slow path sums `zmalloc_usable_size()` while the incremental deltas count logical payload bytes, ignoring the `quicklistLZF` header and allocator rounding. The tests assert that band (ratio > 0.8) rather than equality.

`qlist_test` (2624), `list_family_test` (52 passed, 2 pre-existing skips) and `compact_object_test` (40) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)