### PR TITLE
fix: wake blocked XREADGROUP when its stream is deleted

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -21,12 +21,14 @@ extern "C" {
 #include "core/top_keys.h"
 #include "facade/dragonfly_connection.h"
 #include "search/doc_index.h"
+#include "server/blocking_controller.h"
 #include "server/channel_store.h"
 #include "server/cluster/slot_set.h"
 #include "server/conn_context.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
 #include "server/journal/journal.h"
+#include "server/namespaces.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
 #include "strings/human_readable.h"
@@ -456,11 +458,13 @@ class DbSlice::PrimeBumpPolicy {
   }
 };
 
-DbSlice::DbSlice(uint32_t index, bool cache_mode, EngineShard* owner)
+DbSlice::DbSlice(uint32_t index, bool cache_mode, EngineShard* owner, Namespace* ns)
     : shard_id_(index),
       cache_mode_(cache_mode),
       owner_(owner),
+      ns_(ns),
       client_tracking_map_(owner->memory_resource()) {
+  CHECK(ns_ != nullptr);
   db_arr_.emplace_back();
   CreateDb(0);
   std::string keyspace_events = GetFlag(FLAGS_notify_keyspace_events);
@@ -904,7 +908,16 @@ void DbSlice::Del(Context cntx, Iterator it, DbTable* db_table, bool async) {
   DbTable* table = db_table ? db_table : db_arr_[cntx.db_index].get();
   auto obj_type = it->second.ObjType();
 
-  if (doc_del_cb_ && (obj_type == OBJ_JSON || obj_type == OBJ_HASH)) {
+  if (obj_type == OBJ_STREAM) {
+    // A blocked XREADGROUP watches a key that can never become ready again once the stream is
+    // gone. Mark it awakened so that the readiness check re-evaluates it and the reader learns
+    // that its consumer group disappeared. The awakened keys are dispatched by the transaction
+    // that performs this deletion when it concludes.
+    if (auto* bc = ns_->GetBlockingController(owner_->shard_id()); bc) {
+      string tmp;
+      bc->Awaken(table->index, it->first.GetSlice(&tmp));
+    }
+  } else if (doc_del_cb_ && (obj_type == OBJ_JSON || obj_type == OBJ_HASH)) {
     string tmp;
     string_view key = it->first.GetSlice(&tmp);
     doc_del_cb_(key, cntx, it->second);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -29,6 +29,8 @@ class SlotRanges;
 class SlotSet;
 }  // namespace cluster
 
+class BlockingController;
+
 using facade::OpResult;
 
 // Applies a delta to the per-db/per-type counters and to the owning slot's memory_bytes.
@@ -255,7 +257,7 @@ class DbSlice {
     int32_t expire_options = 0;  // ExpireFlags
   };
 
-  DbSlice(uint32_t index, bool cache_mode, EngineShard* owner);
+  DbSlice(uint32_t index, bool cache_mode, EngineShard* owner, Namespace* ns);
   ~DbSlice();
 
   // Returns statistics for the whole db slice. A bit heavy operation.
@@ -620,6 +622,9 @@ class DbSlice {
   uint8_t cache_mode_ : 1;
 
   EngineShard* owner_;
+
+  // The namespace owning this slice. Never null and never changes.
+  Namespace* ns_;
 
   bool expire_allowed_ = true;
 

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -22,7 +22,7 @@ Namespace::Namespace() {
   shard_set->RunBriefInParallel([&](EngineShard* es) {
     CHECK(es != nullptr);
     ShardId sid = es->shard_id();
-    shard_db_slices_[sid] = make_unique<DbSlice>(sid, absl::GetFlag(FLAGS_cache_mode), es);
+    shard_db_slices_[sid] = make_unique<DbSlice>(sid, absl::GetFlag(FLAGS_cache_mode), es, this);
   });
 }
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3029,9 +3029,14 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
                                   std::string_view key) -> KeyReadyResult {
     auto& db_slice = context.GetDbSlice(owner->shard_id());
     auto res_it = db_slice.FindReadOnly(context, key, OBJ_STREAM);
-    if (!res_it.ok())
-      return res_it.status() == OpStatus::WRONG_TYPE ? KeyReadyResult::kNotReady
-                                                     : KeyReadyResult::kKeyNotFound;
+    if (!res_it.ok()) {
+      // A blocked XREADGROUP must revalidate when its key is no longer a stream. The wake path
+      // distinguishes a missing stream (NOGROUP) from a non-stream value (WRONGTYPE). A plain
+      // XREAD keeps waiting for the stream to be recreated.
+      // TODO: Make kKeyNotFound a per-waiter result in BlockingController. It currently
+      // short-circuits the whole queue, so a blocked XREAD would hide an XREADGROUP behind it.
+      return opts->read_group ? KeyReadyResult::kReady : KeyReadyResult::kNotReady;
+    }
 
     StreamIDsItem& sitem = opts->stream_ids.at(key);
     const CompactObj& cobj = (*res_it)->second;
@@ -3086,10 +3091,24 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
       StreamIDsItem& sitem = opts->stream_ids.at(*wake_key);
       range_opts.start = sitem.id;
 
-      // Expect group to exist? No guarantees from transactional framework
-      if (opts->read_group && !sitem.group) {
-        result = OpStatus::INVALID_VALUE;
-        return OpStatus::OK;
+      // sitem.group was resolved before we blocked and the stream may have been deleted or
+      // retyped since. Re-resolve it against the current table instead of dereferencing a stale
+      // pointer, preserving WRONGTYPE when a non-stream replaced the key.
+      if (opts->read_group) {
+        auto op_args = t->GetOpArgs(shard);
+        auto res_it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, *wake_key, OBJ_STREAM);
+        if (!res_it.ok()) {
+          result = res_it.status() == OpStatus::WRONG_TYPE ? OpStatus::WRONG_TYPE
+                                                           : OpStatus::INVALID_VALUE;
+          return OpStatus::OK;
+        }
+
+        sitem.group =
+            StreamLookupCG(GetReadOnlyStream((*res_it)->second), WrapSds(opts->group_name));
+        if (!sitem.group) {
+          result = OpStatus::INVALID_VALUE;
+          return OpStatus::OK;
+        }
       }
 
       // '>' is encoded as UINT64_MAX-UINT64_MAX and is only accepted for XREADGROUP, so the start
@@ -3158,6 +3177,8 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     return StreamReplies{rb}.SendStreamRecords(key, *result);
   } else if (result.status() == OpStatus::INVALID_VALUE) {
     return rb->SendError("-NOGROUP the consumer group this client was blocked on no longer exists");
+  } else if (result.status() == OpStatus::WRONG_TYPE) {
+    return rb->SendError(result.status());
   }
   return rb->SendNullArray();
 }

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -527,6 +527,58 @@ TEST_F(StreamFamilyTest, XReadBlockOnMaxMsId) {
               ElementsAre("18446744073709551615-2", ArrLen(2)));
 }
 
+// A blocked XREADGROUP watches a key that can never become ready once the stream is deleted, so
+// it must be told that its consumer group is gone instead of sleeping forever.
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnDeletedStream) {
+  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  pp_->at(1)->Await([&] { return Run({"del", "foo"}); });
+  reader.Join();
+  EXPECT_THAT(resp, ErrArg("consumer group this client was blocked on no longer exists"));
+}
+
+// Deleting the stream must not wake a plain XREAD: it is waiting for entries that a recreated
+// stream can still deliver.
+TEST_F(StreamFamilyTest, XReadBlockStaysBlockedOnDeletedStream) {
+  Run({"xadd", "foo", "1-0", "k", "v"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xread", "block", "0", "streams", "foo", "1-1"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  pp_->at(1)->Await([&] { return Run({"del", "foo"}); });
+  EXPECT_FALSE(WaitUntilCondition([&] { return !IsConnBlocked("IO0"); }, 100ms))
+      << "XREAD woke up although the stream can still be recreated";
+
+  pp_->at(1)->Await([&] { return Run({"xadd", "foo", "2-0", "k", "v"}); });
+  reader.Join();
+  const auto& stream_resp = resp.GetVec()[0].GetVec();
+  EXPECT_THAT(stream_resp, ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(stream_resp[1].GetVec()[0].GetVec(), ElementsAre("2-0", ArrLen(2)));
+}
+
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnRetypedStream) {
+  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  pp_->at(1)->Await([&] { return Run({"set", "foo", "value"}); });
+  reader.Join();
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockHonorsCount) {
   Run({"xgroup", "create", "foo", "group", "0", "MKSTREAM"});
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -22,6 +22,7 @@
 #include "facade/reply_capture.h"
 #include "redis/redis_aux.h"
 #include "server/acl/acl_commands_def.h"
+#include "server/blocking_controller.h"
 #include "server/cmd_support.h"
 #include "server/command_families.h"
 #include "server/command_registry.h"
@@ -33,6 +34,7 @@
 #include "server/family_utils.h"
 #include "server/generic_family.h"
 #include "server/journal/journal.h"
+#include "server/namespaces.h"
 #include "server/search/doc_index.h"
 #include "server/table.h"
 #include "server/tiered_storage.h"
@@ -969,6 +971,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
   }
 
   bool has_expire = key.HasExpire();
+  const bool was_stream = prime_value.ObjType() == OBJ_STREAM;
 
   it_upd->post_updater.ReduceHeapUsage();
 
@@ -987,6 +990,12 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
 
   // overwrite existing entry.
   prime_value.SetString(value);
+
+  if (was_stream) {
+    if (auto* bc = op_args_.db_cntx.ns->GetBlockingController(shard->shard_id()); bc) {
+      bc->Awaken(op_args_.db_cntx.db_index, it_upd->it.key());
+    }
+  }
 
   DCHECK_EQ(has_expire, key.HasExpire());
 


### PR DESCRIPTION
related to: #7903
A client blocked on XREADGROUP GROUP g c BLOCK 0 STREAMS s > watches a key that can never become ready again once the stream is deleted, so it slept until its timeout expired (forever with BLOCK 0).

DbSlice::Del now marks a deleted stream key as awakened; the transaction performing the deletion dispatches the event when it concludes. The readiness check reports a missing key as ready for XREADGROUP so the reader resumes and replies NOGROUP, while a plain XREAD keeps waiting since a recreated stream can still serve it.

The wake path also re-resolves the consumer group instead of dereferencing the streamCG* cached before blocking, which the deletion has already freed.

