### PR TITLE
fix(search): keep indexed hashes resident under experimental hash offloading

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -263,6 +263,37 @@ OpResult<DbSlice::ItAndUpdater> RdbRestoreValue::Add(string_view key, string_vie
   return true;
 }
 
+OpStatus MaterializeHashForDb0Search(DbIndex source_db, string_view key,
+                                     DbSlice::ItAndUpdater* entry, EngineShard* shard) {
+  if (!IsValid(entry->it)) {
+    entry->post_updater.Cancel();
+    return OpStatus::IO_ERROR;
+  }
+
+  if (entry->it->second.ObjType() != OBJ_HASH || !entry->it->second.IsExternal() ||
+      !shard->search_indices()->HasHashIndexes()) {
+    return OpStatus::OK;
+  }
+
+  auto future = shard->tiered_storage()->MaterializeForIndexing(source_db, key, &entry->it->second);
+  const bool fetched = future.Get();
+
+  // Cluster slot flushing can remove an entry while this fiber waits even though regular
+  // transactions retain their key locks. Never let the updater outlive a removed key.
+  if (!IsValid(entry->it)) {
+    entry->post_updater.Cancel();
+    return OpStatus::IO_ERROR;
+  }
+
+  // A successful tiered upload accounted resident bytes behind this updater's back. Resync on
+  // every surviving entry so an error or concurrent replacement cannot double-account it.
+  entry->post_updater.ResyncBaseline();
+  if (!fetched || entry->it->second.ObjType() != OBJ_HASH || entry->it->second.IsExternal())
+    return OpStatus::IO_ERROR;
+
+  return OpStatus::OK;
+}
+
 OpResult<string> DumpToString(string_view key, const PrimeValue& pv, const OpArgs& op_args) {
   string str_res;
 
@@ -299,10 +330,11 @@ class Renamer {
   ErrorReply Rename(bool destination_should_not_exist);
 
  private:
-  void FetchData();
+  void FetchData(bool materialize_destination);
   facade::OpStatus FinalizeRename();
 
   bool KeyExists(Transaction* t, EngineShard* shard, std::string_view key) const;
+  OpStatus PrepareDest(Transaction* t, EngineShard* shard);
   void SerializeSrc(Transaction* t, EngineShard* shard);
 
   OpStatus DelSrc(Transaction* t, EngineShard* shard);
@@ -325,12 +357,13 @@ class Renamer {
   bool src_found_ = false;
   bool dest_found_ = false;
   bool do_copy_ = false;
+  OpStatus dest_status_ = OpStatus::OK;
 
   OpResult<SerializedValue> serialized_value_;
 };
 
 ErrorReply Renamer::Rename(bool destination_should_not_exist) {
-  FetchData();
+  FetchData(!destination_should_not_exist);
 
   if (!src_found_) {
     transaction_->Conclude();
@@ -347,6 +380,11 @@ ErrorReply Renamer::Rename(bool destination_should_not_exist) {
     return ErrorReply{kInvalidDumpValueErr};
   }
 
+  if (dest_status_ != OpStatus::OK) {
+    transaction_->Conclude();
+    return dest_status_;
+  }
+
   if (dest_found_ && destination_should_not_exist) {
     transaction_->Conclude();
     return OpStatus::KEY_EXISTS;
@@ -355,8 +393,8 @@ ErrorReply Renamer::Rename(bool destination_should_not_exist) {
   return FinalizeRename();
 }
 
-void Renamer::FetchData() {
-  auto cb = [this](Transaction* t, EngineShard* shard) {
+void Renamer::FetchData(bool materialize_destination) {
+  auto cb = [this, materialize_destination](Transaction* t, EngineShard* shard) {
     auto args = t->GetShardArgs(shard->shard_id());
     DCHECK(1 == args.Size() || do_copy_);
 
@@ -367,7 +405,10 @@ void Renamer::FetchData() {
     }
 
     if (shard_id == dest_sid_) {
-      dest_found_ = KeyExists(t, shard, dest_key_);
+      if (materialize_destination)
+        dest_status_ = PrepareDest(t, shard);
+      else
+        dest_found_ = KeyExists(t, shard, dest_key_);
     }
 
     return OpStatus::OK;
@@ -406,6 +447,21 @@ bool Renamer::KeyExists(Transaction* t, EngineShard* shard, std::string_view key
   return IsValid(it);
 }
 
+OpStatus Renamer::PrepareDest(Transaction* t, EngineShard* shard) {
+  auto& db_slice = t->GetDbSlice(shard->shard_id());
+  auto it = db_slice.FindReadOnly(t->GetDbContext(), dest_key_);
+  dest_found_ = IsValid(it);
+
+  const bool materialize = dest_found_ && t->GetDbIndex() == 0 &&
+                           it->second.ObjType() == OBJ_HASH && it->second.IsExternal() &&
+                           shard->search_indices()->HasHashIndexes();
+  if (!materialize)
+    return OpStatus::OK;
+
+  auto res = db_slice.FindMutable(t->GetDbContext(), dest_key_);
+  return MaterializeHashForDb0Search(0, dest_key_, &res, shard);
+}
+
 void Renamer::SerializeSrc(Transaction* t, EngineShard* shard) {
   auto& db_slice = t->GetDbSlice(shard->shard_id());
   auto it = db_slice.FindReadOnly(t->GetDbContext(), src_key_);
@@ -415,14 +471,30 @@ void Renamer::SerializeSrc(Transaction* t, EngineShard* shard) {
     return;
   }
 
-  OpResult<string> res = DumpToString(src_key_, it->second, t->GetOpArgs(shard));
-  if (res.ok()) {
-    optional rdb_version = GetRdbVersion(*res);
-    int64_t exp_time = it->first.GetExpireTime();
-    serialized_value_ =
-        SerializedValue{std::move(*res), rdb_version, exp_time, it->first.IsSticky()};
+  auto serialize = [&](const auto& entry) {
+    OpResult<string> dump = DumpToString(src_key_, entry->second, t->GetOpArgs(shard));
+    if (dump.ok()) {
+      optional rdb_version = GetRdbVersion(*dump);
+      int64_t exp_time = entry->first.GetExpireTime();
+      serialized_value_ =
+          SerializedValue{std::move(*dump), rdb_version, exp_time, entry->first.IsSticky()};
+    } else {
+      serialized_value_ = dump.status();
+    }
+  };
+
+  const bool materialize = t->GetDbIndex() == 0 && it->second.ObjType() == OBJ_HASH &&
+                           it->second.IsExternal() && shard->search_indices()->HasHashIndexes();
+  if (materialize) {
+    auto res = db_slice.FindMutable(t->GetDbContext(), src_key_);
+    OpStatus status = MaterializeHashForDb0Search(0, src_key_, &res, shard);
+    if (status != OpStatus::OK) {
+      serialized_value_ = status;
+      return;
+    }
+    serialize(res.it);
   } else {
-    serialized_value_ = res.status();
+    serialize(it);
   }
 }
 
@@ -939,6 +1011,15 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   if (IsValid(to_res))
     return OpStatus::KEY_EXISTS;
 
+  // Existing DB 0 values may still be external during the initial sweep, and values entering
+  // DB 0 from another database were never covered by its resident gate.
+  if (op_args.db_cntx.db_index == 0 || target_db == 0) {
+    OpStatus status =
+        MaterializeHashForDb0Search(op_args.db_cntx.db_index, key, &from_res, op_args.shard);
+    if (status != OpStatus::OK)
+      return status;
+  }
+
   bool sticky = from_res.it->first.IsSticky();
   uint64_t exp_ts = from_res.it->first.GetExpireTime();
   RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, from_res.it->second, op_args.shard);
@@ -979,11 +1060,29 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
   if (from_key == to_key)
     return destination_should_not_exist ? OpStatus::KEY_EXISTS : OpStatus::OK;
 
+  if (destination_should_not_exist && IsValid(db_slice.FindReadOnly(op_args.db_cntx, to_key)))
+    return OpStatus::KEY_EXISTS;
+
+  if (op_args.db_cntx.db_index == 0) {
+    OpStatus status = MaterializeHashForDb0Search(0, from_key, &from_res, op_args.shard);
+    if (status != OpStatus::OK)
+      return status;
+  }
+
   bool is_prior_list = false;
   auto to_res = db_slice.FindMutable(op_args.db_cntx, to_key);
   if (IsValid(to_res.it)) {
-    if (destination_should_not_exist)
-      return OpStatus::KEY_EXISTS;
+    if (op_args.db_cntx.db_index == 0) {
+      OpStatus status = MaterializeHashForDb0Search(0, to_key, &to_res, op_args.shard);
+      // Destination materialization can suspend. Cluster slot flushing may remove the source
+      // despite the transaction lock, so do not retain its updater or dereference it afterward.
+      if (!IsValid(from_res.it)) {
+        from_res.post_updater.Cancel();
+        return OpStatus::IO_ERROR;
+      }
+      if (status != OpStatus::OK)
+        return status;
+    }
 
     RemoveKeyFromIndexesIfNeeded(to_key, op_args.db_cntx, to_res.it->second, op_args.shard);
     is_prior_list = (to_res.it->second.ObjType() == OBJ_LIST);
@@ -2332,7 +2431,7 @@ void GenericFamily::Move(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
       res = OpMove(op_args, key, target_db);
       // MOVE runs as global command but we want to write the
       // command to only one journal.
-      if (op_args.shard->journal()) {
+      if (res != OpStatus::IO_ERROR && op_args.shard->journal()) {
         RecordJournal(op_args, "MOVE"sv, ArgSlice{key, target_db_str});
       }
     }
@@ -2342,6 +2441,8 @@ void GenericFamily::Move(facade::CmdArgParser parser, CommandContext* cmd_cntx) 
   cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
   // Exactly one shard will call OpMove.
   DCHECK(res != OpStatus::SKIPPED);
+  if (res == OpStatus::IO_ERROR)
+    return cmd_cntx->SendError(res);
   cmd_cntx->SendLong(res == OpStatus::OK);
 }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -49,6 +49,26 @@ using IncrByParam = std::variant<double, int64_t>;
 using OptStr = std::optional<std::string>;
 enum GetAllMode : uint8_t { FIELDS = 1, VALUES = 2 };
 
+OpStatus MaterializeForHashIndex(const OpArgs& op_args, string_view key,
+                                 DbSlice::ItAndUpdater* entry) {
+  if (op_args.db_cntx.db_index != 0 || !entry->it->second.IsExternal() ||
+      !op_args.shard->search_indices()->HasHashIndexes()) {
+    return OpStatus::OK;
+  }
+
+  bool fetched =
+      op_args.shard->tiered_storage()->MaterializeForIndexing(0, key, &entry->it->second).Get();
+  if (!IsValid(entry->it)) {
+    entry->post_updater.Cancel();
+    return OpStatus::IO_ERROR;
+  }
+
+  entry->post_updater.ResyncBaseline();
+  return fetched && entry->it->second.ObjType() == OBJ_HASH && !entry->it->second.IsExternal()
+             ? OpStatus::OK
+             : OpStatus::IO_ERROR;
+}
+
 // FIELDS arg-count error for the hash field-TTL commands. HTTL/HPEXPIRETIME/HGETEX additionally
 // pass kInvalidNumFields for a non-positive numfields.
 constexpr char kNumFieldsMismatch[] =
@@ -269,6 +289,10 @@ auto ExecuteW(Transaction* tx, F&& f,
 
     auto it_res = op_args.GetDbSlice().FindMutable(op_args.db_cntx, key, OBJ_HASH);
     RETURN_ON_BAD_STATUS(it_res);
+    OpStatus materialized = MaterializeForHashIndex(op_args, key, &*it_res);
+    if (materialized != OpStatus::OK)
+      return materialized;
+
     auto& pv = it_res->it->second;
 
     // Enqueue read for future values
@@ -530,6 +554,10 @@ OpResult<CbVariant<uint32_t>> OpSet(const OpArgs& op_args, string_view key,
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_HASH);
   RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
+
+  OpStatus materialized = MaterializeForHashIndex(op_args, key, &add_res);
+  if (materialized != OpStatus::OK)
+    return materialized;
 
   uint8_t* lp = nullptr;
   auto& it = add_res.it;

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -479,6 +479,20 @@ void JsonAccessor::RemoveFieldFromCache(string_view field) {
 thread_local absl::flat_hash_map<std::string, std::unique_ptr<JsonAccessor::JsonPathContainer>>
     JsonAccessor::path_cache_;
 
+namespace {
+
+struct EmptyAccessor : public BaseAccessor {
+  std::optional<StringList> GetStrings(std::string_view /*active_field*/) const override {
+    return std::optional<StringList>{std::in_place};
+  }
+
+  SearchDocData Serialize(const search::Schema& /*schema*/) const override {
+    return {};
+  }
+};
+
+}  // namespace
+
 unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv,
                                      std::string_view cleanup_key) {
   DCHECK(pv.ObjType() == OBJ_HASH || pv.ObjType() == OBJ_JSON);
@@ -486,6 +500,13 @@ unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue&
   if (pv.ObjType() == OBJ_JSON) {
     DCHECK(pv.GetJson());
     return make_unique<JsonAccessor>(pv.GetJson());
+  }
+
+  // An external value stores a disk reference where its container pointer would normally be.
+  // The resident gate and index builder should make this unreachable.
+  if (pv.IsExternal()) {
+    LOG(DFATAL) << "Cannot access an offloaded HASH from a search index";
+    return make_unique<EmptyAccessor>();
   }
 
   if (pv.Encoding() == kEncodingListPack) {

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -402,8 +402,11 @@ bool DocIndex::Matches(string_view key, unsigned obj_code) const {
   return false;
 }
 
-ShardDocIndex::ShardDocIndex(shared_ptr<const DocIndex> index)
-    : base_{std::move(index)}, key_index_{} {
+ShardDocIndex::ShardDocIndex(shared_ptr<const DocIndex> index, unsigned* hash_index_count)
+    : base_{std::move(index)},
+      hash_index_lifetime_{base_->type == DocIndex::HASH ? hash_index_count : nullptr},
+      key_index_{} {
+  DCHECK(base_->type != DocIndex::HASH || hash_index_count);
 }
 
 ShardDocIndex::~ShardDocIndex() {
@@ -1287,7 +1290,7 @@ ShardDocIndex* ShardDocIndices::GetIndex(string_view name) {
 
 void ShardDocIndices::InitIndex(const OpArgs& op_args, std::string_view name,
                                 shared_ptr<const DocIndex> index_ptr, bool is_journal) {
-  auto shard_index = make_unique<ShardDocIndex>(std::move(index_ptr));
+  auto shard_index = make_unique<ShardDocIndex>(std::move(index_ptr), &hash_index_count_);
   auto [it, _] = indices_.emplace(name, std::move(shard_index));
 
   it->second->InitHnswShardIndices();

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/logging.h"
 #include "base/pmr/memory_resource.h"
 #include "core/mi_memory_resource.h"
 #include "core/search/base.h"
@@ -388,7 +389,7 @@ class ShardDocIndex {
     DocId last_id_ = 0;
   };
   // Index must be rebuilt at least once after intialization
-  explicit ShardDocIndex(std::shared_ptr<const DocIndex> index);
+  explicit ShardDocIndex(std::shared_ptr<const DocIndex> index, unsigned* hash_index_count);
 
   // Possibly blocking to stop indexing job
   ~ShardDocIndex();
@@ -537,6 +538,26 @@ class ShardDocIndex {
   size_t GetNonPmrMemoryUsage() const;
 
  private:
+  struct HashIndexLifetime {
+    explicit HashIndexLifetime(unsigned* count) : count_{count} {
+      if (count_)
+        ++*count_;
+    }
+
+    ~HashIndexLifetime() {
+      if (count_) {
+        DCHECK_GT(*count_, 0u);
+        --*count_;
+      }
+    }
+
+    HashIndexLifetime(const HashIndexLifetime&) = delete;
+    HashIndexLifetime& operator=(const HashIndexLifetime&) = delete;
+
+   private:
+    unsigned* count_;
+  };
+
   // Common doc-loading loop used by SearchForAggregator and LoadHnswRangeDocsForAggregator.
   // Loads, serializes, and (optionally) injects the YIELD_DISTANCE_AS alias for each doc.
   std::vector<SearchDocData> LoadDocEntriesWithScores(
@@ -566,6 +587,10 @@ class ShardDocIndex {
 
  private:
   std::shared_ptr<const DocIndex> base_;
+
+  // Declared before index resources so its destructor releases the resident gate last.
+  HashIndexLifetime hash_index_lifetime_;
+
   std::optional<search::FieldIndices> indices_;
   DocKeyIndex key_index_;
   Synonyms synonyms_;
@@ -614,6 +639,11 @@ class ShardDocIndices {
 
   std::vector<std::string> GetIndexNames() const;
 
+  // HASH values in database 0 stay resident while any HASH index exists on this shard.
+  bool HasHashIndexes() const {
+    return hash_index_count_ != 0;
+  }
+
   /* Use AddDoc and RemoveDoc only if pv object type is json or hset */
   void AddDoc(std::string_view key, const DbContext& db_cnt, PrimeValue* pv);
 
@@ -635,6 +665,7 @@ class ShardDocIndices {
 
  private:
   MiMemoryResource local_mr_;
+  unsigned hash_index_count_ = 0;
   absl::flat_hash_map<std::string, std::unique_ptr<ShardDocIndex>> indices_;
 
   std::string next_defrag_index_;

--- a/src/server/search/index_builder.cc
+++ b/src/server/search/index_builder.cc
@@ -4,14 +4,22 @@
 
 #include "server/search/index_builder.h"
 
+#include <algorithm>
 #include <ranges>
 
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/search/doc_accessors.h"
 #include "server/search/global_hnsw_index.h"
+#include "server/tiered_storage.h"
 
 namespace dfly::search {
+
+namespace {
+
+constexpr size_t kOffloadedBatchSize = 64;
+
+}  // namespace
 
 void IndexBuilder::Start(const OpArgs& op_args, bool is_restored,
                          std::function<void()> on_complete) {
@@ -55,42 +63,168 @@ void IndexBuilder::CursorLoop(dfly::DbTable* table, DbContext db_cntx) {
     PrimeValue& pv = it->second;
     std::string_view key = it->first.GetSlice(&scratch);
 
-    if (!index_->Matches(key, pv.ObjType()))
-      return;
+    const bool matches = index_->Matches(key, pv.ObjType());
+    const bool must_be_resident = matches && index_->base_->type == DocIndex::HASH &&
+                                  db_cntx.db_index == 0 && pv.ObjType() == OBJ_HASH;
 
-    // TODO: make it a parameter of SharDocIndex::AddDoc()
-    if (is_restored_) {
-      // Use existing DocIds from the restored key_index_ to keep them aligned with
-      // GlobalDocIds stored in the serialized HNSW graph. Only add to regular indices
-      // (text/tag/numeric); vector indices are handled separately by VectorLoop.
-      if (auto doc_id = index_->key_index().Find(key); doc_id) {
-        auto accessor = GetAccessor(db_cntx, pv);
-        if (!index_->indices_->Add(*doc_id, *accessor)) {
-          LOG(WARNING) << "Failed to restore index entry for key: " << key
-                       << ", removing from key index";
-          index_->key_index_.Remove(*doc_id);
-        }
-      } else {
-        // New document not in the restored key_index_ (added by journal events during
-        // full sync before the index was created). Use AddNew to allocate a fresh DocId
-        // that won't collide with serialized HNSW node ids from freed slots.
-        auto accessor = GetAccessor(db_cntx, pv);
-        DocId id = index_->key_index_.AddNew(key);
-        if (!index_->indices_->Add(id, *accessor)) {
-          index_->key_index_.Remove(id);
-        }
-      }
-    } else {
-      index_->AddDoc(key, db_cntx, pv);
+    // Existing non-matching HASH values can stay external. Generic key-moving commands
+    // materialize them before a new key can start matching an index prefix.
+    if (must_be_resident && pv.HasStashPending()) {
+      EngineShard::tlocal()->tiered_storage()->CancelStash(std::make_pair(db_cntx.db_index, key),
+                                                           &pv);
     }
+
+    // Reading from disk suspends, which is unsafe inside PrimeTable traversal. Defer the key and
+    // re-lookup it after traversal yields a stable cursor.
+    if (must_be_resident && pv.IsExternal()) {
+      offloaded_keys_.push_back(
+          {std::string(key), is_restored_ ? index_->key_index().Find(key) : std::nullopt});
+      return;
+    }
+
+    if (matches)
+      IndexEntry(key, db_cntx, pv);
   };
 
   PrimeTable::Cursor cursor;
   do {
     cursor = table->prime.Traverse(cursor, cb);
+    if (offloaded_keys_.size() >= kOffloadedBatchSize)
+      IndexOffloaded(table, db_cntx);
     if (base::CycleClock::ToUsec(util::ThisFiber::GetRunningTimeCycles()) > 500)
       util::ThisFiber::Yield();
   } while (cursor && state_.IsRunning());
+
+  IndexOffloaded(table, db_cntx);
+  offloaded_keys_ = {};
+}
+
+void IndexBuilder::IndexOffloaded(dfly::DbTable* table, DbContext db_cntx) {
+  TieredStorage* ts = EngineShard::tlocal()->tiered_storage();
+
+  // Issue a batch before waiting so reads from the same small-bin page are coalesced and reads
+  // from different pages can overlap.
+  struct PendingRead {
+    std::string_view key;
+    std::pair<size_t, size_t> segment;
+    std::optional<DocId> restored_id;
+    util::fb2::Future<bool> future;
+  };
+  std::vector<PendingRead> pending;
+  pending.reserve(offloaded_keys_.size());
+
+  auto cleanup_restored = [&](std::string_view key, std::optional<DocId> restored_id,
+                              bool remove_mapping) {
+    if (!restored_id)
+      return;
+
+    index_->RemoveFromAllHnswIndices(*restored_id);
+    const auto current_id = index_->key_index().Find(key);
+    const auto& indexed_docs = index_->indices_->GetAllDocs();
+    if (remove_mapping && current_id == restored_id &&
+        !std::binary_search(indexed_docs.begin(), indexed_docs.end(), *restored_id)) {
+      index_->key_index_.Remove(*restored_id);
+    }
+  };
+
+  for (const OffloadedKey& deferred : offloaded_keys_) {
+    if (!state_.IsRunning())
+      break;
+    const std::string& key = deferred.key;
+
+    auto it = table->prime.Find(key);
+    if (!IsValid(it) || !index_->Matches(key, it->second.ObjType())) {
+      cleanup_restored(key, deferred.restored_id, true);
+      continue;
+    }
+
+    // The key may have been materialized by another fiber since CursorLoop deferred it.
+    if (!it->second.IsExternal()) {
+      if (deferred.restored_id && index_->key_index().Find(key) != deferred.restored_id)
+        cleanup_restored(key, deferred.restored_id, false);
+      IndexEntry(key, db_cntx, it->second);
+      continue;
+    }
+
+    pending.push_back({key, it->second.GetExternalSlice(), deferred.restored_id,
+                       ts->MaterializeForIndexing(db_cntx.db_index, key, &it->second)});
+  }
+
+  for (auto& read : pending) {
+    if (!state_.IsRunning())
+      break;
+
+    // Waiting can move or replace the table entry, so never retain its old iterator/reference.
+    read.future.Get();
+
+    auto is_ready = [&](auto it) {
+      return IsValid(it) && !it->second.IsExternal() &&
+             index_->Matches(read.key, it->second.ObjType());
+    };
+    auto is_same_external_hash = [&](auto it) {
+      return IsValid(it) && it->second.ObjType() == OBJ_HASH && it->second.IsExternal() &&
+             it->second.GetExternalSlice() == read.segment;
+    };
+
+    auto it = table->prime.Find(read.key);
+    if (!is_ready(it) && is_same_external_hash(it)) {
+      // Retry once for a transient I/O failure. A persistent failure must not keep index
+      // construction alive indefinitely.
+      ts->MaterializeForIndexing(db_cntx.db_index, read.key, &it->second).Get();
+      it = table->prime.Find(read.key);
+    }
+
+    const bool ready = is_ready(it);
+    const auto current_id = is_restored_ ? index_->key_index().Find(read.key) : std::nullopt;
+
+    // A restored graph still contains the node captured before this read. If the document went
+    // away, could not be indexed, or now maps to a different id, remove that stale node. A
+    // concurrently added replacement is buffered while the index is restoring and will be added
+    // when pending vector updates are drained.
+    if (read.restored_id && (!ready || current_id != read.restored_id))
+      cleanup_restored(read.key, read.restored_id, !ready);
+
+    if (ready) {
+      IndexEntry(read.key, db_cntx, it->second);
+    } else {
+      LOG_IF(ERROR, is_same_external_hash(it))
+          << "Failed to materialize an indexed value for key: " << read.key;
+    }
+
+    if (base::CycleClock::ToUsec(util::ThisFiber::GetRunningTimeCycles()) > 500)
+      util::ThisFiber::Yield();
+  }
+
+  offloaded_keys_.clear();
+}
+
+// TODO: make restored handling a parameter of ShardDocIndex::AddDoc().
+void IndexBuilder::IndexEntry(std::string_view key, const DbContext& db_cntx,
+                              const PrimeValue& pv) {
+  if (!is_restored_) {
+    index_->AddDoc(key, db_cntx, pv);
+    return;
+  }
+
+  // Reuse restored DocIds so they stay aligned with ids serialized in the HNSW graph. Vector
+  // fields are populated later by VectorLoop.
+  auto accessor = GetAccessor(db_cntx, pv);
+  if (auto doc_id = index_->key_index().Find(key); doc_id) {
+    const auto& indexed_docs = index_->indices_->GetAllDocs();
+    if (std::binary_search(indexed_docs.begin(), indexed_docs.end(), *doc_id))
+      return;
+
+    if (!index_->indices_->Add(*doc_id, *accessor)) {
+      LOG(WARNING) << "Failed to restore index entry for key: " << key
+                   << ", removing from key index";
+      index_->RemoveFromAllHnswIndices(*doc_id);
+      index_->key_index_.Remove(*doc_id);
+    }
+  } else {
+    DocId id = index_->key_index_.AddNew(key);
+    if (!index_->indices_->Add(id, *accessor))
+      index_->key_index_.Remove(id);
+  }
 }
 
 void IndexBuilder::VectorLoop(dfly::DbTable* table, DbContext db_cntx) {

--- a/src/server/search/index_builder.h
+++ b/src/server/search/index_builder.h
@@ -5,12 +5,16 @@
 #pragma once
 
 #include <functional>
+#include <optional>
+#include <string>
+#include <vector>
 
+#include "core/search/base.h"
 #include "server/execution_state.h"
+#include "server/table.h"
 #include "server/tx_base.h"
 
 namespace dfly {
-struct DbTable;
 class ShardDocIndex;
 }  // namespace dfly
 
@@ -38,12 +42,24 @@ struct IndexBuilder {
   // Loop with cursor over table and add entries to regular index
   void CursorLoop(DbTable* table, DbContext db_cntx);
 
+  // Add one resident entry to the regular indices, reusing restored DocIds when needed.
+  void IndexEntry(std::string_view key, const DbContext& db_cntx, const PrimeValue& pv);
+
+  // Materialize and index values deferred by CursorLoop. Disk reads must happen outside table
+  // traversal because they suspend the builder fiber.
+  void IndexOffloaded(DbTable* table, DbContext db_cntx);
+
   // Loop with cursor over table and add entries to global HNSW vector indices
   void VectorLoop(DbTable* table, DbContext db_cntx);
 
   dfly::ExecutionState state_;
   ShardDocIndex* index_;
   bool is_restored_ = false;
+  struct OffloadedKey {
+    std::string key;
+    std::optional<DocId> restored_id;
+  };
+  std::vector<OffloadedKey> offloaded_keys_;
   util::fb2::Fiber fiber_;
 };
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -23,6 +23,7 @@
 #include "core/qlist.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
+#include "server/search/doc_index.h"
 #include "server/snapshot.h"
 #include "server/table.h"
 #include "server/tiering/common.h"
@@ -704,7 +705,8 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   string tmp;
   auto cb = [this, dbid, &tmp](PrimeIterator it) mutable {
     stats_.offloading_steps++;
-    auto blobs = ShouldStash(it->second, StashContext{.key_expire_ms = it->first.GetExpireTime()});
+    auto blobs = ShouldStash(
+        it->second, StashContext{.dbid = dbid, .key_expire_ms = it->first.GetExpireTime()});
     if (blobs) {
       if (it->second.WasTouched()) {
         it->second.SetTouched(false);
@@ -824,6 +826,14 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref,
   if (fragment_ref.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
     return nullopt;
 
+  // Prevent new database 0 HASH stashes while an index exists. The index builder materializes
+  // matching values that were already external when the index was created.
+  auto* search_indices = op_manager_->db_slice_.shard_owner()->search_indices();
+  if (stash_ctx.dbid == 0 && fragment_ref.ObjType() == OBJ_HASH && search_indices &&
+      search_indices->HasHashIndexes()) {
+    return nullopt;
+  }
+
   // For now, list node offloading is conditional
   if (fragment_ref.ObjType() == OBJ_LIST && !config_.experimental_list_offload)
     return nullopt;
@@ -881,6 +891,41 @@ PrimeValue TieredStorage::Warmup(DbIndex dbid, std::string_view key, PrimeValue:
   return hot;
 }
 
+util::fb2::Future<bool> TieredStorage::MaterializeForIndexing(DbIndex dbid, string_view key,
+                                                              PrimeValue* pv) {
+  util::fb2::Future<bool> fut;
+  if (!pv->IsExternal()) {
+    fut.Resolve(true);
+    return fut;
+  }
+
+  // A cool value still has its in-memory copy, so bringing it back does not suspend.
+  if (pv->IsCool()) {
+    *pv = Warmup(dbid, key, pv->GetCool());
+    fut.Resolve(true);
+    return fut;
+  }
+
+  // HASH is the only indexable type that can be offloaded.
+  if (pv->GetExternalRep() != CompactObj::ExternalRep::SERIALIZED_MAP) {
+    LOG(DFATAL) << "Unexpected representation for an indexed value";
+    fut.Resolve(false);
+    return fut;
+  }
+
+  // Taking a mutable copy marks the decoder as modified. The normal modified-read path then
+  // uploads the value and releases its disk segment regardless of the current upload budget.
+  Read(
+      KeyRef{dbid, key}, pv->GetExternalSlice(), tiering::ListpackMapDecoder{},
+      [fut](io::Result<tiering::ListpackMapDecoder*> res) mutable {
+        if (res)
+          (*res)->GetMutable();
+        fut.Resolve(res.has_value());
+      },
+      false /* read_only */);
+  return fut;
+}
+
 PrimeValue TieredStorage::DeleteCool(TieredCoolRecord* record) {
   auto it = CoolQueue::s_iterator_to(*record);
   cool_queue_.erase(it);
@@ -903,8 +948,8 @@ TieredCoolRecord* TieredStorage::PopCool() {
 
 void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, PrimeValue* pv,
                      TieredStorage* ts, BackPressureFuture* backpressure) {
-  if (auto blobs =
-          ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk.GetExpireTime()});
+  if (auto blobs = ts->ShouldStash(
+          *pv, TieredStorage::StashContext{.dbid = dbid, .key_expire_ms = pk.GetExpireTime()});
       blobs) {
     pv->SetStashPending(true);
     ts->StashPrimeValue(dbid, key, *blobs, backpressure);
@@ -913,7 +958,7 @@ void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, Pri
 
 bool StashListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts,
                    BackPressureFuture* backpressure) {
-  if (auto blobs = ts->ShouldStash(*node, {}); blobs) {
+  if (auto blobs = ts->ShouldStash(*node, {.dbid = dbid}); blobs) {
     // Increment before stashing; decremented on failure in `ClearStashPending`
     ql->AdjustOffloadNodeCount(1);
     node->io_pending = 1;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -43,6 +43,7 @@ struct TieredStorageBase {
   };
 
   struct StashContext {
+    DbIndex dbid = 0;
     uint64_t key_expire_ms = 0;  // 0 means no expiry
   };
 
@@ -114,6 +115,11 @@ class TieredStorage : public TieredStorageBase {
 
   // Returns the primary value, and deletes the cool item as well as its offloaded storage.
   PrimeValue Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item);
+
+  // Brings an offloaded HASH back into memory so a search index can read its fields. The returned
+  // future resolves to false if a disk-resident value could not be read.
+  util::fb2::Future<bool> MaterializeForIndexing(DbIndex dbid, std::string_view key,
+                                                 PrimeValue* pv);
 
   TieredStats GetStats() const;
 
@@ -331,6 +337,13 @@ class TieredStorage : public TieredStorageBase {
 
   PrimeValue Warmup(DbIndex dbid, std::string_view key, PrimeValue::CoolItem item) {
     return PrimeValue{};
+  }
+
+  util::fb2::Future<bool> MaterializeForIndexing(DbIndex dbid, std::string_view key,
+                                                 PrimeValue* pv) {
+    util::fb2::Future<bool> fut;
+    fut.Resolve(true);
+    return fut;
   }
 
   bool IsClosed() const {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -13,7 +13,12 @@
 #include "base/flags.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
+#include "server/db_slice.h"
 #include "server/engine_shard_set.h"
+#include "server/namespaces.h"
+#ifdef WITH_SEARCH
+#include "server/search/doc_index.h"
+#endif
 #include "server/test_utils.h"
 #include "strings/human_readable.h"
 #include "util/fibers/fibers.h"
@@ -1960,5 +1965,238 @@ TEST_F(TieredStorageTest, CoolHashDeleteDoesNotAbort) {
   EXPECT_EQ(Run({"PING"}), "PONG");
   EXPECT_EQ(GetMetrics().db_stats[0].obj_memory_usage, 0u);
 }
+
+#ifdef WITH_SEARCH
+
+class IndexedHashTieringTest : public TieredStorageTest, public testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+    SetFlag(&FLAGS_tiered_upload_threshold, 0.0f);
+    SetFlag(&FLAGS_tiered_experimental_cooling, GetParam());
+    SetFlag(&FLAGS_tiered_experimental_hash_support, true);
+    TieredStorageTest::SetUp();
+  }
+
+  static constexpr int kNumHashes = 150;
+
+  struct HashState {
+    size_t external = 0;
+    size_t pending = 0;
+  };
+
+  void FillHashes(string_view prefix, DbIndex dbid = 0) {
+    Run({"SELECT", absl::StrCat(dbid)});
+    for (int i = 0; i < kNumHashes; ++i) {
+      Run({"HSET", absl::StrCat(prefix, i), "f1", BuildString(48, 'v'), "f2",
+           absl::StrCat("s", i)});
+    }
+    Run({"SELECT", "0"});
+  }
+
+  void FillLargeHash(string_view key, char fill, DbIndex dbid = 0) {
+    Run({"SELECT", absl::StrCat(dbid)});
+    Run({"HSET", key, "f1", BuildString(3000, fill)});
+    Run({"SELECT", "0"});
+  }
+
+  void CreateIndex(string_view name = "idx", string_view prefix = "h") {
+    EXPECT_EQ(Run({"FT.CREATE", name, "ON", "HASH", "PREFIX", "1", prefix, "SCHEMA", "f1", "TEXT"}),
+              "OK");
+    WaitIndexBuilt();
+  }
+
+  void ExpectIndexed(int64_t count, string_view name = "idx") {
+    EXPECT_THAT(Run({"FT.SEARCH", name, "*", "LIMIT", "0", "0"}),
+                RespArray(ElementsAre(IntArg(count))));
+  }
+
+  void WaitIndexBuilt() {
+    pp_->at(0)->Await([] { EngineShard::tlocal()->search_indices()->BlockUntilConstructionEnd(); });
+  }
+
+  HashState GetHashState(string_view prefix, DbIndex dbid = 0) {
+    HashState state;
+    pp_->at(0)->AwaitBrief([&] {
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      DbTable* table = db.GetDBTable(dbid);
+      for (int i = 0; i < kNumHashes; ++i) {
+        auto it = table->prime.Find(absl::StrCat(prefix, i));
+        if (!IsValid(it))
+          continue;
+        state.external += it->second.IsExternal();
+        state.pending += it->second.HasStashPending();
+      }
+    });
+    return state;
+  }
+
+  bool IsHashExternal(string_view key, DbIndex dbid = 0) {
+    bool external = false;
+    pp_->at(0)->AwaitBrief([&] {
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      auto it = db.GetDBTable(dbid)->prime.Find(key);
+      external = IsValid(it) && it->second.ObjType() == OBJ_HASH && it->second.IsExternal();
+    });
+    return external;
+  }
+
+ private:
+  absl::FlagSaver flag_saver_;
+};
+
+INSTANTIATE_TEST_SUITE_P(Cooling, IndexedHashTieringTest, testing::Values(false, true));
+
+TEST_P(IndexedHashTieringTest, HashIndexKeepsDbZeroHashesResident) {
+  CreateIndex();
+  CreateIndex("other_idx", "z");
+  FillHashes("h");
+  FillLargeHash("plain", 'p');
+  FillLargeHash("h_db1_move", 'm', 1);
+
+  ExpectConditionWithinTimeout([&] { return IsHashExternal("h_db1_move", 1); });
+  ASSERT_TRUE(IsHashExternal("h_db1_move", 1));
+
+  HashState db0_h = GetHashState("h");
+  EXPECT_EQ(db0_h.external, 0u);
+  EXPECT_EQ(db0_h.pending, 0u);
+  EXPECT_FALSE(IsHashExternal("plain"));
+  ExpectIndexed(kNumHashes);
+
+  Run({"SELECT", "1"});
+  EXPECT_THAT(Run({"MOVE", "h_db1_move", "0"}), IntArg(1));
+  Run({"SELECT", "0"});
+  EXPECT_FALSE(IsHashExternal("h_db1_move"));
+  EXPECT_EQ(Run({"HGET", "h_db1_move", "f1"}), BuildString(3000, 'm'));
+  ExpectIndexed(kNumHashes + 1);
+
+  EXPECT_EQ(Run({"FT.DROPINDEX", "idx"}), "OK");
+  FillLargeHash("still_pinned", 's');
+  FillLargeHash("drop_probe", 'd', 1);
+  ExpectConditionWithinTimeout([&] { return IsHashExternal("drop_probe", 1); });
+  EXPECT_FALSE(IsHashExternal("still_pinned"));
+  EXPECT_EQ(Run({"FT.DROPINDEX", "other_idx"}), "OK");
+  FillLargeHash("post", 'x');
+  ExpectConditionWithinTimeout([&] { return IsHashExternal("post"); });
+}
+
+TEST_P(IndexedHashTieringTest, BuildMaterializesMatchingHashes) {
+  FillHashes("h");
+  FillLargeHash("plain_source", 's');
+  FillLargeHash("plain_destination", 'd');
+  ExpectConditionWithinTimeout([&] {
+    return GetHashState("h").external > 0 && IsHashExternal("plain_source") &&
+           IsHashExternal("plain_destination");
+  });
+
+  CreateIndex();
+
+  HashState state = GetHashState("h");
+  EXPECT_EQ(state.external, 0u);
+  EXPECT_EQ(state.pending, 0u);
+  EXPECT_TRUE(IsHashExternal("plain_source"));
+  EXPECT_TRUE(IsHashExternal("plain_destination"));
+  ExpectIndexed(kNumHashes);
+  EXPECT_EQ(Run({"HGET", "h5", "f1"}), BuildString(48, 'v'));
+
+  EXPECT_EQ(Run({"RENAME", "plain_source", "h_renamed"}), "OK");
+  EXPECT_FALSE(IsHashExternal("h_renamed"));
+  ExpectIndexed(kNumHashes + 1);
+
+  EXPECT_EQ(Run({"RENAME", "h0", "plain_destination"}), "OK");
+  EXPECT_FALSE(IsHashExternal("plain_destination"));
+  ExpectIndexed(kNumHashes);
+}
+
+TEST_P(IndexedHashTieringTest, CopyMaterializesExternalSourceAndDestination) {
+  const string source0 = "copy_src:0";
+  const string source1 = "copy_src:1";
+  const string destination = "copy_old:0";
+  FillLargeHash(source0, 'a');
+  FillLargeHash(source1, 'b');
+  FillLargeHash(destination, 'c');
+  ExpectConditionWithinTimeout([&] {
+    return IsHashExternal(source0) && IsHashExternal(source1) && IsHashExternal(destination);
+  });
+
+  CreateIndex("copy_idx", "copy_indexed:");
+  ASSERT_TRUE(IsHashExternal(source0));
+  ASSERT_TRUE(IsHashExternal(source1));
+  ASSERT_TRUE(IsHashExternal(destination));
+
+  EXPECT_THAT(Run({"COPY", source0, destination, "REPLACE"}), IntArg(1));
+  EXPECT_FALSE(IsHashExternal(source0));
+  EXPECT_FALSE(IsHashExternal(destination));
+  EXPECT_EQ(Run({"HGET", destination, "f1"}), BuildString(3000, 'a'));
+
+  EXPECT_THAT(Run({"COPY", source1, "copy_indexed:0"}), IntArg(1));
+  EXPECT_FALSE(IsHashExternal(source1));
+  EXPECT_FALSE(IsHashExternal("copy_indexed:0"));
+  ExpectIndexed(1, "copy_idx");
+}
+
+TEST_P(IndexedHashTieringTest, CancelledMaterializationLeavesHashExternal) {
+  if (GetParam())
+    GTEST_SKIP() << "cool values warm synchronously without a cancellable disk read";
+
+  SetFlag(&FLAGS_tiered_upload_threshold, 1.0f);
+  UpdateFromFlags();
+  const string key = "cancelled";
+  FillLargeHash(key, 'c');
+  ExpectConditionWithinTimeout([&] { return IsHashExternal(key); });
+
+  pp_->at(0)->Await([&] {
+    auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+    auto it = db.GetDBTable(0)->prime.Find(key);
+    ASSERT_TRUE(IsValid(it));
+    ASSERT_TRUE(it->second.IsExternal());
+
+    auto* ts = EngineShard::tlocal()->tiered_storage();
+    tiering::DiskSegment segment = it->second.GetExternalSlice();
+    auto future = ts->MaterializeForIndexing(0, key, &it->second);
+    ASSERT_TRUE(ts->HasModificationPending(segment));
+    ts->CancelLoad(segment);
+    EXPECT_FALSE(future.Get());
+  });
+  ExpectConditionWithinTimeout([&] { return GetMetrics().tiered_stats.pending_read_cnt == 0; });
+  EXPECT_TRUE(IsHashExternal(key));
+}
+
+TEST_P(IndexedHashTieringTest, BorrowedHnswVectorsStayResident) {
+  constexpr int kDim = 512;  // 2 KiB: HNSW borrows the keyspace bytes instead of copying them.
+  auto vector_blob = [=](float value) {
+    vector<float> values(kDim, value);
+    return string(reinterpret_cast<const char*>(values.data()), values.size() * sizeof(float));
+  };
+
+  for (int i = 0; i < 3; ++i)
+    Run({"HSET", absl::StrCat("vec:", i), "v", vector_blob(i + 1)});
+  ExpectConditionWithinTimeout([&] { return GetHashState("vec:").external == 3; });
+
+  EXPECT_EQ(
+      Run({"FT.CREATE", "vec_idx", "ON", "HASH", "PREFIX", "1", "vec:", "SCHEMA", "v", "VECTOR",
+           "HNSW", "6", "TYPE", "FLOAT32", "DIM", absl::StrCat(kDim), "DISTANCE_METRIC", "L2"}),
+      "OK");
+  WaitIndexBuilt();
+
+  HashState state = GetHashState("vec:");
+  EXPECT_EQ(state.external, 0u);
+  EXPECT_EQ(state.pending, 0u);
+  ExpectIndexed(3, "vec_idx");
+
+  string query = vector_blob(1.0f);
+  auto response =
+      Run({"FT.SEARCH", "vec_idx", "*=>[KNN 1 @v $q]", "PARAMS", "2", "q", query, "DIALECT", "2"});
+  ASSERT_EQ(response.type, RespExpr::ARRAY);
+  ASSERT_GE(response.GetVec().size(), 2u);
+  EXPECT_THAT(response.GetVec()[0], IntArg(1));
+  EXPECT_EQ(response.GetVec()[1], "vec:0");
+
+  FillLargeHash("pressure", 'p', 1);
+  ExpectConditionWithinTimeout([&] { return IsHashExternal("pressure", 1); });
+  EXPECT_EQ(GetHashState("vec:").external, 0u);
+}
+
+#endif  // WITH_SEARCH
 
 }  // namespace dfly


### PR DESCRIPTION
Search accessors borrow HASH container memory, while hash offloading replaces the resident container with a disk reference. Keep DB 0 HASH values resident while any HASH search index exists and safely materialize values that were already external.

Changes:
- Track HASH index lifetime per shard and prevent new DB 0 HASH stashes while the resident gate is active.
- Defer matching external hashes during index construction and materialize them in bounded batches outside PrimeTable traversal, with one retry for transient failures.
- Add `TieredStorage::MaterializeForIndexing` using the existing modified-read upload path.
- Conservatively materialize external DB 0 hashes in HASH write and key-moving paths while the resident gate is active.
- Revalidate mutable entries before dereferencing them and after suspension points; return `IO_ERROR` without mutating or journaling when materialization cannot complete safely.
- Make `GetAccessor` fail safely on an unexpected external HASH instead of interpreting its disk reference as a container pointer.

Tests:
- Cover resident-gate lifetime, matching index backfill, MOVE/RENAME/COPY paths, canceled materialization, and borrowed HNSW vector residency with cooling enabled and disabled.
- Exercise cancellation through the existing tiered-storage API without production test-only hooks.

Fixes #7975