### PR TITLE
fix: wake  blocked XREADGROUP on FLUSHDB

### DIFF
--- a/src/server/blocking_controller.cc
+++ b/src/server/blocking_controller.cc
@@ -9,6 +9,7 @@
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
 #include "base/logging.h"
+#include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/namespaces.h"
 #include "server/transaction.h"
@@ -218,6 +219,30 @@ void BlockingController::Awaken(DbIndex db_index, string_view db_key) {
   if (wt.AddAwakeEvent(db_key)) {
     VLOG(1) << "Touch: db(" << db_index << ") " << db_key;
     awakened_indices_.insert(db_index);
+  }
+}
+
+void BlockingController::AwakenWatched(DbIndex db_index) {
+  const auto update_awakened = [&](DbWatchTable& wt, DbIndex index) {
+    for (const auto& [key, queue] : wt.queue_map) {
+      if (queue->state == WatchQueue::SUSPENDED) {
+        wt.awakened_keys.insert(key);
+      }
+    }
+
+    if (!wt.awakened_keys.empty()) {
+      awakened_indices_.insert(index);
+    }
+  };
+
+  if (db_index == DbSlice::kDbAll) {
+    for (const auto& [index, wt] : watched_dbs_) {
+      update_awakened(*wt, index);
+    }
+  } else {
+    if (auto it = watched_dbs_.find(db_index); it != watched_dbs_.end()) {
+      update_awakened(*it->second, db_index);
+    }
   }
 }
 

--- a/src/server/blocking_controller.h
+++ b/src/server/blocking_controller.h
@@ -45,6 +45,9 @@ class BlockingController {
   // Mark given key as awakened. Called by commands mutating this key.
   void Awaken(DbIndex db_index, std::string_view key);
 
+  // Mark all watched keys in a specific db as awakened.
+  void AwakenWatched(DbIndex db_index);
+
   // Notify transactions of awakened keys
   void NotifyPending();
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -53,6 +53,7 @@ extern "C" {
 #include "search/doc_index.h"
 #include "server/acl/acl_commands_def.h"
 #include "server/acl/user_registry.h"
+#include "server/blocking_controller.h"
 #include "server/command_registry.h"
 #include "server/conn_context.h"
 #include "server/debugcmd.h"
@@ -1917,6 +1918,9 @@ void ServerFamily::Drakarys(Transaction* transaction, DbIndex db_ind, bool wait)
   vector<fb2::Fiber> fibers(shard_set->size());
   transaction->Execute(
       [db_ind, &fibers](Transaction* t, EngineShard* shard) {
+        if (auto* bc = t->GetNamespace().GetBlockingController(shard->shard_id()); bc) {
+          bc->AwakenWatched(db_ind);
+        }
         fibers[shard->shard_id()] = t->GetDbSlice(shard->shard_id()).FlushDb(db_ind);
         return OpStatus::OK;
       },

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -579,6 +579,20 @@ TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnRetypedStream) {
   EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
 }
 
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnFlushDb) {
+  Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
+
+  RespExpr resp0;
+  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    resp0 = Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  Run({"FLUSHDB"});
+  fb0.Join();
+  EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockHonorsCount) {
   Run({"xgroup", "create", "foo", "group", "0", "MKSTREAM"});
 


### PR DESCRIPTION
Summary: Fixes blocked XREADGROUP clients not being woken up when FLUSHDB/FLUSHALL removes the underlying stream/consumer group.

Changes:

- Added BlockingController::AwakenWatched to mark all suspended watched keys in a DB (or all DBs) as awakened
- Invoked this from ServerFamily::Drakarys during the flush flow so blocked watchers revalidate after the flush
- Added a regression test asserting a blocked XREADGROUP returns the expected NOGROUP error after FLUSHDB

Technical Notes: Reuses the existing wake/notify path so the blocked reader rechecks stream/group existence instead of waiting until timeout.

