### PR TITLE
CI: install python3 in container before running script

### DIFF
--- a/.github/workflows/package-install.yml
+++ b/.github/workflows/package-install.yml
@@ -43,7 +43,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Wait for repo version
         if: github.event_name == 'workflow_run'
-        run: python3 tools/packaging/osrepos/scripts/wait_for_repo_version.py
+        run: |
+          apt update && apt install -y python3
+          python3 tools/packaging/osrepos/scripts/wait_for_repo_version.py
       - name: Install on ubuntu
         run: |
           apt update


### PR DESCRIPTION
A new script for package-install-tests needs python3 to run