### PR TITLE
fix(qlist): release compression stats when DelNode drops a compressed node

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1205,7 +1205,16 @@ void QList::DelNode(Node* node) {
     // compressed payload length to malloc_size_. Subtracting node->sz here would over-subtract
     // and drive the counter negative. Erase() reaches this with a still-compressed node when it
     // drops whole interior nodes.
-    malloc_size_ -= node->IsCompressed() ? GetLzf(node)->sz : node->sz;
+    if (node->IsCompressed()) {
+      // Dropping a compressed node also retires its share of the compression stats, the same way
+      // Clear() does. Without this the counters keep accounting for bytes that no longer exist.
+      size_t compressed_sz = GetLzf(node)->sz;
+      malloc_size_ -= compressed_sz;
+      stats.compressed_bytes -= compressed_sz;
+      stats.raw_compressed_bytes -= node->sz;
+    } else {
+      malloc_size_ -= node->sz;
+    }
   }
 
   if (tiering_enabled_ && (node->offloaded || node->io_pending)) {

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -1617,6 +1617,41 @@ TEST_F(QListZstdTest, MallocUsedTracksSteadyStateCompression) {
 // Erase() drops whole interior nodes without decompressing them first, so DelNode() used to
 // subtract the uncompressed node->sz for a node that had only contributed its compressed length
 // to malloc_size_. The counter is unsigned, so the over-subtraction wrapped it around.
+TEST_F(QListZstdTest, DelNodeReleasesCompressionStats) {
+  // Sums the compressed payload the list currently holds, i.e. what compressed_bytes should be
+  // accounting for.
+  auto live_compressed = [](const QList& ql) {
+    ssize_t total = 0;
+    for (const QList::Node* node = ql.Head(); node; node = node->next) {
+      if (node->IsCompressed()) {
+        void* data = nullptr;
+        total += node->GetLZF(&data);
+      }
+    }
+    return total;
+  };
+
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+  ASSERT_GT(ql.node_count(), 10u);
+
+  const ssize_t live_before = live_compressed(ql);
+  const ssize_t stats_before = QList::stats.compressed_bytes;
+  const ssize_t raw_before = QList::stats.raw_compressed_bytes;
+  ASSERT_GT(live_before, 0);
+
+  // Drops whole compressed interior nodes through DelNode().
+  ql.Erase(100, 200);
+  ASSERT_EQ(ql.Size(), 300u);
+
+  // Whatever left the list must have left the counters as well. Compared as deltas because the
+  // stats are thread-local and accumulate across tests in this binary.
+  EXPECT_EQ(stats_before - ssize_t(QList::stats.compressed_bytes),
+            live_before - live_compressed(ql));
+  EXPECT_GT(raw_before - ssize_t(QList::stats.raw_compressed_bytes), 0);
+}
+
 TEST_F(QListZstdTest, EraseWholeCompressedNodesKeepsMallocSize) {
   QList ql(-1, 0);
   ql.set_compr_threshold(1);


### PR DESCRIPTION
## Summary

`DelNode()` subtracted the compressed payload from `malloc_size_` but left
`stats.compressed_bytes` / `stats.raw_compressed_bytes` untouched, so the counters keep
accounting for bytes that no longer exist. `Erase()` reaches `DelNode()` with
still-compressed interior nodes, which makes the drift permanent and understates the
reported compression savings.

`Clear()` already retires the stats the same way — this brings `DelNode()` in line with it.

## Test

`QListZstdTest.DelNodeReleasesCompressionStats` compares the delta in `compressed_bytes`
against a walk of the compressed payload actually left in the list. It fails on `main`
(4380 bytes of drift) and passes with the fix.

Split out of #8008 so it can land independently.