### PR TITLE
fix(tiering): small-bins defrag livelock on underfilled bins

### DIFF
--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -157,7 +157,7 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
       return {full_segment, false /* fragmented */, true /* empty */};
     }
 
-    bool fragmented = bin.bytes < bin.orig_bytes / 2;
+    bool fragmented = bin.bytes * 2 < bin.orig_bytes;
     return {full_segment, fragmented, false /* empty */};
   }
 
@@ -166,14 +166,14 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
 
 bool SmallBins::IsFragmented(size_t offset) {
   if (auto it = stashed_bins_.Find(offset); it != stashed_bins_.end())
-    return it->second.bytes < it->second.orig_bytes / 2;
+    return it->second.bytes * 2 < it->second.orig_bytes;
   return false;
 }
 
 ::dfly::detail::DashCursor SmallBins::TraverseFragmented(::dfly::detail::DashCursor cursor,
                                                          absl::FunctionRef<void(size_t)> f) {
   return stashed_bins_.Traverse(cursor, [f](Dash::iterator it) {
-    if (it->second.bytes < it->second.orig_bytes / 2)
+    if (it->second.bytes * 2 < it->second.orig_bytes)
       f(it->first);
   });
 }

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -108,7 +108,7 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
   }
 
   stats_.stashed_entries_cnt += list.size();
-  stashed_bins_.InsertNew(segment.offset, StashInfo{uint8_t(list.size()), bytes});
+  stashed_bins_.InsertNew(segment.offset, StashInfo{uint8_t(list.size()), bytes, bytes});
 
   return list;
 }
@@ -157,9 +157,8 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
       return {full_segment, false /* fragmented */, true /* empty */};
     }
 
-    if (bin.bytes < kPageSize / 2) {
-      return {full_segment, true /* fragmented */, false /* empty */};
-    }
+    bool fragmented = bin.bytes < bin.orig_bytes / 2;
+    return {full_segment, fragmented, false /* empty */};
   }
 
   return {segment};
@@ -167,14 +166,14 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
 
 bool SmallBins::IsFragmented(size_t offset) {
   if (auto it = stashed_bins_.Find(offset); it != stashed_bins_.end())
-    return it->second.bytes < kPageSize / 2;
+    return it->second.bytes < it->second.orig_bytes / 2;
   return false;
 }
 
 ::dfly::detail::DashCursor SmallBins::TraverseFragmented(::dfly::detail::DashCursor cursor,
                                                          absl::FunctionRef<void(size_t)> f) {
   return stashed_bins_.Traverse(cursor, [f](Dash::iterator it) {
-    if (it->second.bytes < kPageSize / 2)
+    if (it->second.bytes < it->second.orig_bytes / 2)
       f(it->first);
   });
 }

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -98,9 +98,13 @@ class SmallBins {
  private:
   struct StashInfo {
     uint8_t entries = 0;
+    // Live bytes still occupied by non-deleted entries.
     uint16_t bytes = 0;
+    // Bytes at stash time; used to detect real fragmentation from deletes rather than
+    // flagging bins that were simply packed small.
+    uint16_t orig_bytes = 0;
   };
-  static_assert(sizeof(StashInfo) == sizeof(unsigned));
+  static_assert(sizeof(StashInfo) == 6);
 
   BinId last_bin_id_ = 0;
   FilledBin current_bin_{last_bin_id_};

--- a/src/server/tiering/small_bins_test.cc
+++ b/src/server/tiering/small_bins_test.cc
@@ -93,10 +93,17 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
     EXPECT_EQ(key, "k"s + data.substr(segment.offset, segment.length).substr(1));
   }
 
-  // Delete all stashed values
+  // Delete all stashed values, tracking live bytes to know when we've crossed the
+  // "more than half of this bin's live content was deleted" fragmentation threshold.
+  size_t orig_bytes = 0;
+  for (auto& [dbid, key, segment] : segments)
+    orig_bytes += segment.length;
+
+  size_t deleted_bytes = 0;
   while (!segments.empty()) {
     auto segment = std::get<2>(segments.back());
     segments.pop_back();
+    deleted_bytes += segment.length;
     auto bin = bins_.Delete(segment);
 
     EXPECT_EQ(bin.segment.offset, 0u);
@@ -104,8 +111,10 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
 
     if (segments.empty()) {
       EXPECT_TRUE(bin.empty);
+    } else if (deleted_bytes * 2 > orig_bytes) {
+      EXPECT_TRUE(bin.fragmented);  // more than half of the bin's live bytes were deleted
     } else {
-      EXPECT_TRUE(bin.fragmented);  // half of the values were deleted
+      EXPECT_FALSE(bin.fragmented);
     }
   }
 }


### PR DESCRIPTION
# The livelock

1. Heartbeat loads an underutilized disk segment (page) and reads it back then freeing the old page.
2. Later in RunOffloading picks the in memory value and pushes it into a new bin
3. Heartbeat finds again the new page (same size as before) and the cycle never ends. The test is forever blocked waiting for `total_stashes` to stabilize which it never does.

The issue is that the defragmentation algorithm blindly assumes that a half filled page *needs defragmentation*. This is not true however because it may well be that page is half full anyway.

The fix is to allow the algorithm decide if the page had actually shrung since it was last written (because of deletions). If it hasn't then this page should not be a candidate for defragmentation

Fixes: #8012