### PR TITLE
fix(test_client_kill): wait for client kill cleanup

### DIFF
--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -105,7 +105,13 @@ async def test_client_kill(df_factory):
 
             assert len(await admin_client.execute_command("CLIENT LIST")) == 2
             await admin_client.execute_command("CLIENT KILL LADDR 127.0.0.1:1111")
-            assert len(await admin_client.execute_command("CLIENT LIST")) == 1
+
+            # Shutdown is asynchronous, so wait for the listener to remove the connection.
+            @assert_eventually(timeout=10)
+            async def assert_client_is_killed():
+                assert len(await admin_client.execute_command("CLIENT LIST")) == 1
+
+            await assert_client_is_killed()
             with pytest.raises(redis.exceptions.ConnectionError):
                 await client_conn.ping()
 


### PR DESCRIPTION
Poll CLIENT LIST until the asynchronously shut down client is removed from the listener before asserting that only the admin connection remains.

Retain the connection error check to verify that CLIENT KILL still closes the target client. This covers the intermittent test race reproduced with the iouring RESP I/O loop.

Tested by reproducing locally, and then with the fix passed 1000 iterations.
