### PR TITLE
fix(geo): avoid replica crash on cross-shard GEORADIUS/GEORADIUSBYMEM…

### DIFF
--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -651,6 +651,7 @@ void GeoSearchStoreGeneric(Transaction* tx, facade::SinkReplyBuilder* builder,
       if (shard->shard_id() == dest_shard) {
         ZSetFamily::ZParams zparams;
         zparams.override = true;
+        zparams.journal_update = true;
         add_result = ZSetFamily::OpAdd(t->GetOpArgs(shard), zparams, geo_ops.store_key,
                                        ScoredMemberSpan{smvec})
                          .value();
@@ -769,16 +770,18 @@ void CmdGeoRadiusRO(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void RegisterGeoFamily(CommandRegistry* registry) {
   registry->StartFamily(acl::GEO);
-  *registry << CI{"GEOADD", CO::JOURNALED | CO::DENYOOM, -5, 1, 1}.HFUNC(GeoAdd)
-            << CI{"GEOHASH", CO::READONLY, -2, 1, 1}.HFUNC(GeoHash)
-            << CI{"GEOPOS", CO::READONLY, -2, 1, 1}.HFUNC(GeoPos)
-            << CI{"GEODIST", CO::READONLY, -4, 1, 1}.HFUNC(GeoDist)
-            << CI{"GEOSEARCH", CO::READONLY, -7, 1, 1}.HFUNC(GeoSearch)
-            << CI{"GEORADIUSBYMEMBER", CO::JOURNALED | CO::STORE_LAST_KEY, -5, 1, 1}.HFUNC(
-                   GeoRadiusByMember)
-            << CI{"GEORADIUSBYMEMBER_RO", CO::READONLY, -5, 1, 1}.HFUNC(GeoRadiusByMemberRO)
-            << CI{"GEORADIUS", CO::JOURNALED | CO::STORE_LAST_KEY, -6, 1, 1}.HFUNC(GeoRadius)
-            << CI{"GEORADIUS_RO", CO::READONLY, -6, 1, 1}.HFUNC(GeoRadiusRO);
+  *registry
+      << CI{"GEOADD", CO::JOURNALED | CO::DENYOOM, -5, 1, 1}.HFUNC(GeoAdd)
+      << CI{"GEOHASH", CO::READONLY, -2, 1, 1}.HFUNC(GeoHash)
+      << CI{"GEOPOS", CO::READONLY, -2, 1, 1}.HFUNC(GeoPos)
+      << CI{"GEODIST", CO::READONLY, -4, 1, 1}.HFUNC(GeoDist)
+      << CI{"GEOSEARCH", CO::READONLY, -7, 1, 1}.HFUNC(GeoSearch)
+      << CI{"GEORADIUSBYMEMBER", CO::JOURNALED | CO::STORE_LAST_KEY | CO::NO_AUTOJOURNAL, -5, 1, 1}
+             .HFUNC(GeoRadiusByMember)
+      << CI{"GEORADIUSBYMEMBER_RO", CO::READONLY, -5, 1, 1}.HFUNC(GeoRadiusByMemberRO)
+      << CI{"GEORADIUS", CO::JOURNALED | CO::STORE_LAST_KEY | CO::NO_AUTOJOURNAL, -6, 1, 1}.HFUNC(
+             GeoRadius)
+      << CI{"GEORADIUS_RO", CO::READONLY, -6, 1, 1}.HFUNC(GeoRadiusRO);
 }
 
 }  // namespace dfly

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2046,8 +2046,12 @@ OpResult<ZSetFamily::AddResult> ZSetFamily::OpAdd(const OpArgs& op_args,
     scores.reserve(members.size());
     mapped.reserve(members.size() * 2 + 1);
     mapped.push_back(key);
+    char buf[128];
     for (const auto& [score, member] : members) {
-      scores.push_back(absl::StrCat(score));
+      // absl::StrCat truncates to ~6 significant digits; scores must round-trip exactly
+      // (e.g. geohash-derived scores from GEORADIUS/GEORADIUSBYMEMBER STORE) since this is
+      // the only replay path for callers using NO_AUTOJOURNAL.
+      scores.push_back(RedisReplyBuilder::FormatDouble(score, buf, sizeof(buf)));
       mapped.push_back(scores.back());
       mapped.push_back(member);
     }

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -340,6 +340,31 @@ async def test_rewrites(replication):
         assert abs(ttl1 - ttl2) <= 1
 
     async with m_replica:
+        # Pick GEORADIUS/GEORADIUSBYMEMBER STORE dest keys that are deliberately on a different
+        # shard than the source (gh #7996 — the crash this guards against only reproduces when
+        # source and destination land on different shards). Each probe SET/DEL is journaled, so
+        # it must be skip_cmd()'d like any other setup write in this monitor block.
+        async def get_shard(key):
+            await c_master.execute_command(f"SET {key} v")
+            await skip_cmd()
+            debug_key_info = await c_master.execute_command(f"DEBUG OBJECT {key}")
+            shard_id = int(dict(map(lambda s: s.split(":"), debug_key_info.split()))["shard"])
+            await c_master.execute_command(f"DEL {key}")
+            await skip_cmd()
+            return shard_id
+
+        async def cross_shard_key(prefix, other_shard):
+            i = 0
+            while True:
+                candidate = f"{prefix}{i}"
+                if await get_shard(candidate) != other_shard:
+                    return candidate
+                i += 1
+
+        src_shard = await get_shard("geo-src")
+        geo_dst = await cross_shard_key("geo-dst", src_shard)
+        geo_dst2 = await cross_shard_key("geo-dst2", src_shard)
+
         # CHECK EXPIRE, PEXPIRE, PEXPIRE turn into EXPIREAT
         await c_master.set("k-exp", "v")
         await skip_cmd()
@@ -415,6 +440,24 @@ async def test_rewrites(replication):
 
         # Check ZUNIONSTORE turns into DEL and ZADD
         await check_list_ooo("ZUNIONSTORE k 2 zet1 zet2", [r"DEL k", r"ZADD k (.*?)"])
+
+        # Check GEORADIUS/GEORADIUSBYMEMBER with STORE turn into DEL and ZADD (gh #7996 — a
+        # raw-command replay is invalid when the source and destination keys land on different
+        # shards; geo_dst/geo_dst2 were pre-selected above to be cross-shard from geo-src).
+        await c_master.execute_command(
+            "GEOADD geo-src 13.361389 38.115556 Palermo 15.087269 37.502669 Catania"
+        )
+        await skip_cmd()
+        await check_list_ooo(
+            f"GEORADIUS geo-src 15 37 200 km STORE {geo_dst}",
+            [rf"DEL {geo_dst}", rf"ZADD {geo_dst} (.*?)"],
+        )
+
+        # Check GEORADIUSBYMEMBER with STORE turns into DEL and ZADD
+        await check_list_ooo(
+            f"GEORADIUSBYMEMBER geo-src Palermo 200 km STORE {geo_dst2}",
+            [rf"DEL {geo_dst2}", rf"ZADD {geo_dst2} (.*?)"],
+        )
 
         await c_master.set("k1", "1000")
         await c_master.set("k2", "1100")
@@ -535,6 +578,53 @@ async def test_rewrites(replication):
         )
         # With NOACK, only XGROUP SETID should be journaled (no XCLAIM)
         assert await is_match_rsp(r"XGROUP SETID mystream mygroup (.*?) ENTRIESREAD 2")
+
+
+@pytest.mark.replication(master_args={"proactor_threads": 4}, replica_args={"proactor_threads": 2})
+async def test_georadius_store_cross_shard_precision(replication):
+    """
+    Regression test for gh #7996 follow-up: GEORADIUS/GEORADIUSBYMEMBER STORE journal their
+    destination via ZSetFamily::OpAdd's explicit DEL+ZADD path (CO::NO_AUTOJOURNAL), which used
+    to serialize scores with absl::StrCat (~6 significant digits). Geohash-derived scores are
+    huge 52-bit-precision doubles, so that silently corrupted the replica's data. Verify master
+    and replica end up with identical ZRANGE ... WITHSCORES results after a cross-shard STORE.
+    """
+    _, _, c_master, [c_replica] = replication
+
+    async def get_shard(key):
+        await c_master.execute_command(f"SET {key} v")
+        debug_key_info = await c_master.execute_command(f"DEBUG OBJECT {key}")
+        shard_id = int(dict(map(lambda s: s.split(":"), debug_key_info.split()))["shard"])
+        await c_master.execute_command(f"DEL {key}")
+        return shard_id
+
+    async def cross_shard_key(prefix, other_shard):
+        i = 0
+        while True:
+            candidate = f"{prefix}{i}"
+            if await get_shard(candidate) != other_shard:
+                return candidate
+            i += 1
+
+    src_shard = await get_shard("geo-src-precision")
+    geo_dst = await cross_shard_key("geo-dst-precision", src_shard)
+    geo_dst2 = await cross_shard_key("geo-dst2-precision", src_shard)
+
+    await c_master.execute_command(
+        "GEOADD geo-src-precision 13.361389 38.115556 Palermo 15.087269 37.502669 Catania"
+    )
+    await c_master.execute_command(f"GEORADIUS geo-src-precision 15 37 200 km STORE {geo_dst}")
+    await c_master.execute_command(
+        f"GEORADIUSBYMEMBER geo-src-precision Palermo 200 km STORE {geo_dst2}"
+    )
+
+    await check_all_replicas_finished([c_replica], c_master)
+
+    for key in (geo_dst, geo_dst2):
+        master_scores = await c_master.zrange(key, 0, -1, withscores=True)
+        replica_scores = await c_replica.zrange(key, 0, -1, withscores=True)
+        assert len(master_scores) == 2
+        assert master_scores == replica_scores
 
 
 """


### PR DESCRIPTION
## Summary

- `GEORADIUS ... STORE` / `GEORADIUSBYMEMBER ... STORE` can place the source key and the destination key on different shards. Both commands were registered with `CO::JOURNALED` but no `CO::NO_AUTOJOURNAL`, so the auto-journal path logged only the shard-local key args of the command instead of the full invocation.
- On stable-sync replay, the replica receives one of these partial fragments (e.g. `GEORADIUS dest0` with no search args, or `GEORADIUS src0` with no `STORE dest0`), fails to parse it, and crashes (`FATAL`/exit 134).
- Same bug class as `GEOSEARCHSTORE`/`ZRANGESTORE`/`ZUNIONSTORE`, which avoid it by disabling auto-journal and instead journaling the store explicitly.
- Fix: add `CO::NO_AUTOJOURNAL` to both commands, and set `journal_update = true` on the `ZParams` used for the destination `ZSetFamily::OpAdd` call. This makes the shard holding the destination key emit an explicit `DEL dest` + `ZADD dest ...` (or just `DEL dest` when there are no matches), which is always replica-safe regardless of shard placement — matching the existing `ZRANGESTORE`/`ZUNIONSTORE` pattern in `zset_family.cc`.

## Test plan

- [x] All 12 existing `GeoFamilyTest` cases in `geo_family_test.cc` pass with identical output (no behavior change for non-STORE and same-shard STORE cases)
- [x] Added `GEORADIUS ... STORE` and `GEORADIUSBYMEMBER ... STORE` assertions to `replication_test.py::test_rewrites`, confirming both now replicate as `DEL <dest>` followed by `ZADD <dest> ...` instead of the raw command
- [x] Full `test_rewrites` (63 rewrite assertions across all families) passes

Fixes #7996
