### PR TITLE
fix: wake blocked XREADGROUP when its stream expires

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1467,13 +1467,8 @@ PrimeIterator DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterator it,
     }
   }
 
-  auto obj_type = it->second.ObjType();
-  if (doc_del_cb_ && (obj_type == OBJ_JSON || obj_type == OBJ_HASH)) {
-    doc_del_cb_(key, cntx, it->second);
-  }
-
-  const_cast<DbSlice*>(this)->PerformDeletionAtomic(Iterator(it, StringOrView::FromView(key)),
-                                                    db.get());
+  // Route through Del so that expiry runs the same per-type hooks as an explicit DEL.
+  const_cast<DbSlice*>(this)->Del(cntx, Iterator(it, StringOrView::FromView(key)), db.get());
 
   ++events_.expired_keys;
   db->stats.events.expired_keys++;
@@ -1589,15 +1584,22 @@ auto DbSlice::DeleteExpiredStep(const Context& cntx, unsigned count) -> DeleteEx
     checked++;
 
     string_view key = it->first.GetSlice(&stash);
-    if (!CheckLock(IntentLock::EXCLUSIVE, cntx.db_index, key))
-      return;
 
     int64_t ttl = it->first.GetExpireTime() - cntx.time_now_ms;
-    if (ttl <= 0) {
-      result.deleted_bytes += it->first.MallocUsed() + it->second.MallocUsed();
-      ExpireIfNeeded(cntx, it, &result.key_events);
-      ++result.deleted;
+    if (ttl > 0)
+      return;
+
+    if (!CheckLock(IntentLock::EXCLUSIVE, cntx.db_index, key)) {
+      // A client blocked on this key holds the lock itself, so we can never expire it here.
+      // Wake it instead: its readiness check lazily expires the key.
+      if (auto* bc = ns_->GetBlockingController(owner_->shard_id()); bc)
+        bc->Awaken(cntx.db_index, key);
+      return;
     }
+
+    result.deleted_bytes += it->first.MallocUsed() + it->second.MallocUsed();
+    ExpireIfNeeded(cntx, it, &result.key_events);
+    ++result.deleted;
   };
 
   unsigned i = 0;

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -955,6 +955,13 @@ void EngineShard::RetireExpiredAndEvict() {
   if (eviction_state_.track_deleted_bytes) {
     eviction_state_.deleted_bytes_at_prev_eviction = deleted_bytes;
   }
+
+  // Expiry/eviction above only marks watchers as awakened. Dispatch here, outside the atomic
+  // section, because readiness checks read the db slice and may preempt.
+  if (auto* bc = namespaces->GetDefaultNamespace().GetBlockingController(shard_id());
+      bc && GetContTx() == nullptr) {
+    bc->NotifyPending();
+  }
 }
 
 // Adjust deleted bytes w.r.t shard used memory. If we increase shard used

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -565,6 +565,55 @@ TEST_F(StreamFamilyTest, XReadBlockStaysBlockedOnDeletedStream) {
   EXPECT_THAT(stream_resp[1].GetVec()[0].GetVec(), ElementsAre("2-0", ArrLen(2)));
 }
 
+// A blocked XREADGROUP must be woken when its stream expires, not only when it is deleted.
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnExpiredStream) {
+  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
+  Run({"pexpire", "foo", "10"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  // Touching the key lazily expires it, dropping the stream and its consumer group.
+  AdvanceTime(100);
+  pp_->at(1)->Await([&] { return Run({"exists", "foo"}); });
+
+  bool woken = WaitUntilCondition([&] { return !IsConnBlocked("IO0"); }, 2000ms);
+  if (!woken) {
+    // Release the reader so that the test fails cleanly instead of hanging on Join().
+    pp_->at(1)->Await([&] { return Run({"xadd", "foo", "1-0", "k", "v"}); });
+  }
+  reader.Join();
+  ASSERT_TRUE(woken) << "XREADGROUP stayed blocked although its stream expired";
+  EXPECT_THAT(resp, ErrArg("consumer group this client was blocked on no longer exists"));
+}
+
+// Active expiry cannot reclaim a key that a blocked client locks, so the heartbeat must still
+// wake the reader.
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnActivelyExpiredStream) {
+  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
+  Run({"pexpire", "foo", "10"});
+
+  RespExpr resp;
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+
+  // No client touches the key afterwards: only the heartbeat can unblock the reader.
+  AdvanceTime(100);
+  bool woken = WaitUntilCondition([&] { return !IsConnBlocked("IO0"); }, 3000ms);
+  if (!woken) {
+    // Release the reader so that the test fails cleanly instead of hanging on Join().
+    pp_->at(1)->Await([&] { return Run({"del", "foo"}); });
+  }
+  reader.Join();
+  ASSERT_TRUE(woken) << "XREADGROUP stayed blocked although its stream expired";
+  EXPECT_THAT(resp, ErrArg("consumer group this client was blocked on no longer exists"));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnRetypedStream) {
   Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
 


### PR DESCRIPTION
A blocked `XREADGROUP` never woke when its stream expired — it slept forever on a
consumer group that no longer existed. Two independent gaps caused this:

**Lazy expiry** — `ExpireIfNeeded` deleted the key via `PerformDeletionAtomic`,
bypassing `DbSlice::Del` and its `OBJ_STREAM` wake hook. It now routes through
`Del`, which also removes a duplicated `doc_del_cb_` block so expiry and explicit
`DEL` share one path.

**Active expiry** — the heartbeat reaches the key every cycle but skips it at
`CheckLock(EXCLUSIVE)`, because the blocked reader holds that lock itself. So the
stream could never be reclaimed and the reader was never woken. Expired-but-locked
keys are now marked awakened, and `RetireExpiredAndEvict` dispatches them outside
the atomic section.
