### PR TITLE
fix(cluster): journal FLUSHSLOTS from inside the flush transaction

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -516,15 +516,20 @@ void DeleteSlots(Transaction* trans, const SlotRanges& slots_ranges) {
 
   trans->Execute(
       [&slots_ranges, &args_view](Transaction* t, EngineShard* shard) {
+        namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
+
         // TODO: Break slot migration upon FLUSHSLOTS
         if (shard->journal()) {
           journal::RecordEntry(t->txid(), journal::Op::COMMAND, /* dbid= */ 0, nullopt,
                                Payload("DFLYCLUSTER", args_view));
         }
-        namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
         return OpStatus::OK;
       },
       true);
+
+  OpStatus status = *trans->LocalResultPtr();
+  LOG_IF(ERROR, status != OpStatus::OK)
+      << "Failed to flush slots " << slots_ranges.ToString() << ": " << status;
 
   auto deleted = SlotSet(slots_ranges);
   channel_store->UnsubscribeAfterClusterSlotMigration(deleted);

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -496,13 +496,31 @@ namespace {
 
 // FlushSlots calls RegisterOnChange which requires the shard lock to be held (see #7153).
 // Execute under a global transaction so the shard lock is acquired properly.
+//
+// The journal record must be emitted from inside that transaction, so that every shard uses the
+// transaction's txid. Replicas rendezvous all their flows on this record keyed by txid, so two
+// records sharing one txid make those flows wait for each other forever.
 void DeleteSlots(Transaction* trans, const SlotRanges& slots_ranges) {
   if (slots_ranges.Empty()) {
     return;
   }
 
+  vector<string> args;
+  args.reserve(slots_ranges.Size() * 2 + 1);
+  args.push_back("FLUSHSLOTS");
+  for (SlotRange range : slots_ranges) {
+    args.push_back(absl::StrCat(range.start));
+    args.push_back(absl::StrCat(range.end));
+  }
+  vector<string_view> args_view(args.begin(), args.end());
+
   trans->Execute(
-      [&slots_ranges](Transaction* t, EngineShard* shard) {
+      [&slots_ranges, &args_view](Transaction* t, EngineShard* shard) {
+        // TODO: Break slot migration upon FLUSHSLOTS
+        if (shard->journal()) {
+          journal::RecordEntry(t->txid(), journal::Op::COMMAND, /* dbid= */ 0, nullopt,
+                               Payload("DFLYCLUSTER", args_view));
+        }
         namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
         return OpStatus::OK;
       },
@@ -510,44 +528,6 @@ void DeleteSlots(Transaction* trans, const SlotRanges& slots_ranges) {
 
   auto deleted = SlotSet(slots_ranges);
   channel_store->UnsubscribeAfterClusterSlotMigration(deleted);
-}
-
-void WriteFlushSlotsToJournal(const SlotRanges& slot_ranges) {
-  if (slot_ranges.Empty()) {
-    return;
-  }
-
-  // Build args
-  vector<string> args;
-  args.reserve(slot_ranges.Size() + 1);
-  args.push_back("FLUSHSLOTS");
-  for (SlotRange range : slot_ranges) {
-    args.push_back(absl::StrCat(range.start));
-    args.push_back(absl::StrCat(range.end));
-  }
-
-  // Build view
-  vector<string_view> args_view(args.size());
-  for (size_t i = 0; i < args.size(); ++i) {
-    args_view[i] = args[i];
-  }
-
-  auto cb = [&](auto*) {
-    EngineShard* shard = EngineShard::tlocal();
-    if (shard == nullptr) {
-      return;
-    }
-
-    if (!shard->journal()) {
-      return;
-    }
-
-    // Send journal entry
-    // TODO: Break slot migration upon FLUSHSLOTS
-    journal::RecordEntry(/* txid= */ 0, journal::Op::COMMAND, /* dbid= */ 0, nullopt,
-                         Payload("DFLYCLUSTER", args_view));
-  };
-  shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }
 }  // namespace
 
@@ -634,7 +614,6 @@ void ClusterFamily::DflyClusterConfig(CmdArgParser parser, CommandContext* cmd_c
       DeleteSlots(cmd_cntx->tx(), deleted_slots);
       LOG_IF(INFO, !deleted_slots.Empty())
           << "Flushing newly unowned slots: " << deleted_slots.ToString();
-      WriteFlushSlotsToJournal(deleted_slots);
     }
 
     // Start new migrations only after stale data is flushed. This ensures DFLYMIGRATE FLOW
@@ -998,7 +977,6 @@ void ClusterFamily::InitMigration(CmdArgParser parser, CommandContext* cmd_cntx)
         new Transaction{server_family_->service().FindCmd("DFLYCLUSTER")});
     flush_tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
     DeleteSlots(flush_tx.get(), slots);
-    WriteFlushSlotsToJournal(slots);
   }
 
   if (migration->GetState() == MigrationState::C_FATAL) {

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3790,3 +3790,195 @@ async def test_slot_migration_oom_replica_rollback(df_factory):
     assert (
         replica_keys == 0
     ), f"target_replica has {replica_keys} keys but master has 0 — replica was not rolled back"
+
+
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "replication_timeout": 3000})
+async def test_repeated_flushslots_with_replica(df_factory: DflyInstanceFactory):
+    """
+    Back to back DFLYCLUSTER CONFIG pushes that drop slots must journal one FLUSHSLOTS record
+    per push, each with its own txid. Replicas rendezvous their flows on this record keyed by
+    txid, so a shared txid leaves them waiting for each other forever.
+    """
+    # replica=2 traces the rendezvous txid, the only place it is observable. logbuflevel=-1
+    # keeps those records out of the log buffer, which the SIGKILL below would discard.
+    master = df_factory.create(port=next(next_port), admin_port=next(next_port), logbuflevel=-1)
+    replica = df_factory.create(
+        port=next(next_port),
+        admin_port=next(next_port),
+        logbuflevel=-1,
+        vmodule="replica=2,cluster_family=1,db_slice=1,dflycmd=1",
+    )
+    df_factory.start_all([master, replica])
+
+    c_master, c_master_admin = master.client(), master.admin_client()
+    c_replica, c_replica_admin = replica.client(), replica.admin_client()
+    master_id = await get_node_id(c_master)
+    replica_id = await get_node_id(c_replica)
+
+    def make_config(start_slot):
+        # Slots below start_slot move to a placeholder owner, so the master has to flush them.
+        dropped = (
+            ""
+            if start_slot == 0
+            else f""",
+            {{
+              "slot_ranges": [{{ "start": 0, "end": {start_slot - 1} }}],
+              "master": {{ "id": "other-master", "ip": "localhost", "port": 9000 }},
+              "replicas": []
+            }}"""
+        )
+        return f"""
+          [
+            {{
+              "slot_ranges": [{{ "start": {start_slot}, "end": 16383 }}],
+              "master": {{ "id": "{master_id}", "ip": "localhost", "port": {master.port} }},
+              "replicas": [
+                {{ "id": "{replica_id}", "ip": "localhost", "port": {replica.port} }}
+              ]
+            }}{dropped}
+          ]
+        """
+
+    await push_config(make_config(0), [c_master_admin, c_replica_admin])
+    await c_master.execute_command("debug", "populate", "100000")
+    await c_replica.execute_command("REPLICAOF", "localhost", master.port)
+    await check_all_replicas_finished([c_replica], c_master)
+    assert await c_replica.execute_command("dbsize") == 100_000
+    logging.info("stable sync reached with %d keys", await c_master.execute_command("dbsize"))
+
+    stop = False
+
+    async def write_load():
+        # Keys land on slots that are never dropped, so they must survive every flush.
+        value = "v" * 4096
+        i = 0
+        async with master.client() as c:
+            while not stop:
+                pipe = c.pipeline(transaction=False)
+                for _ in range(50):
+                    pipe.set(f"{{a}}:{i}", value)
+                    i += 1
+                try:
+                    await pipe.execute()
+                except Exception as e:
+                    logging.warning("write load error: %s", e)
+                    await asyncio.sleep(0.05)
+
+    async def probe(name, client):
+        t0 = time.perf_counter()
+        try:
+            await asyncio.wait_for(client.execute_command("PING"), timeout=5)
+            logging.info("%s answers PING in %.1f ms", name, (time.perf_counter() - t0) * 1000)
+            return True
+        except Exception as e:
+            logging.warning("%s does not answer PING: %r", name, e)
+            return False
+
+    load = asyncio.create_task(write_load())
+    master_alive = replica_alive = False
+    converged = True
+    try:
+        # Stress knob only - whether two records actually collide is a race. The txid
+        # assertions at the end are the detector.
+        pushes, step = 15, 500
+        for start in range(step, step * pushes + 1, step):
+            await push_config(make_config(start), [c_master_admin, c_replica_admin])
+            logging.info("pushed config owning slots %d-16383", start)
+
+        stop = True
+        # Nothing else bounds this test, so do not wait on an in-flight pipeline forever.
+        try:
+            await asyncio.wait_for(load, timeout=30)
+        except asyncio.TimeoutError:
+            load.cancel()
+            await asyncio.gather(load, return_exceptions=True)
+
+        master_alive = await probe("master", c_master)
+        replica_alive = await probe("replica", c_replica)
+
+        for name, client in (("master", c_master), ("replica", c_replica)):
+            try:
+                info = await asyncio.wait_for(client.info("replication"), timeout=5)
+                keep = {
+                    k: v
+                    for k, v in info.items()
+                    if k
+                    in (
+                        "role",
+                        "master_link_status",
+                        "master_last_io_seconds_ago",
+                        "master_sync_in_progress",
+                        "connected_slaves",
+                        "slave0",
+                    )
+                }
+                logging.info("%s INFO replication: %s", name, keep)
+            except Exception as e:
+                logging.warning("%s INFO replication failed: %r", name, e)
+
+        try:
+            await asyncio.wait_for(
+                check_all_replicas_finished([c_replica], c_master, timeout=30), 45
+            )
+
+            # FlushSlots runs in a detached fiber, so an acked record does not mean the keys
+            # are gone, and dbsize equality alone can catch a value both sides pass through.
+            dropped = f"0-{step * pushes - 1}"
+            slotinfo = ("DFLYCLUSTER", "GETSLOTINFO", "SLOTS", dropped)
+
+            @assert_eventually(timeout=30)
+            async def dropped_slots_empty():
+                m_slots, r_slots, m, r = await asyncio.gather(
+                    c_master_admin.execute_command(*slotinfo),
+                    c_replica_admin.execute_command(*slotinfo),
+                    c_master.execute_command("dbsize"),
+                    c_replica.execute_command("dbsize"),
+                )
+                m_left = sum(row[2] for row in m_slots)
+                r_left = sum(row[2] for row in r_slots)
+                assert m_left == 0, f"master still holds {m_left} keys in slots {dropped}"
+                assert r_left == 0, f"replica still holds {r_left} keys in slots {dropped}"
+                assert m == r, f"master and replica diverged across repeated FLUSHSLOTS: {m} vs {r}"
+                logging.info("after the flush sequence: master dbsize=%d replica dbsize=%d", m, r)
+
+            await dropped_slots_empty()
+        except AssertionError:
+            raise
+        except Exception as e:
+            converged = False
+            logging.warning("replication never converged after the flush sequence: %r", e)
+    finally:
+        stop = True
+        load.cancel()
+        await asyncio.gather(load, return_exceptions=True)
+        # A wedged replica ignores SIGTERM and the fixture would burn ~125s per instance.
+        master.stop(kill=True)
+        replica.stop(kill=True)
+
+    def hits(inst, pat):
+        return sorted({l.strip() for l in inst.find_in_logs(pat)})
+
+    timeouts = hits(master, "Stream timed out")
+    disconnects = hits(master, "Disconnecting from replica")
+    logging.info("RESULT stream_timeouts=%d master_disconnects=%d", len(timeouts), len(disconnects))
+    for line in timeouts:
+        logging.info("  MASTER %s", line)
+    logging.info(
+        "RESULT master_alive=%s replica_alive=%s converged=%s",
+        master_alive,
+        replica_alive,
+        converged,
+    )
+
+    # Each flush must show up under exactly one non-zero txid.
+    txid_re = r"Execute txid: (\d+) waiting for data in all shards"
+    txids = [int(re.search(txid_re, l).group(1)) for l in hits(replica, txid_re)]
+    logging.info("RESULT flushslots_txids=%s", sorted(set(txids)))
+    assert txids, "replica logged no global-command rendezvous - is vmodule=replica=2 set?"
+    assert 0 not in txids, "FLUSHSLOTS was journaled with txid 0"
+    assert (
+        len(set(txids)) == pushes
+    ), f"expected one distinct txid per FLUSHSLOTS, got {sorted(set(txids))}"
+
+    assert not timeouts, "replication stalled past replication_timeout during repeated FLUSHSLOTS"
+    assert converged, "replication never converged after repeated FLUSHSLOTS"

--- a/tests/dragonfly/proxy.py
+++ b/tests/dragonfly/proxy.py
@@ -12,6 +12,9 @@ class Proxy:
         self.server = None
         self._handler_tasks = set()
         self._serve_task = None
+        self._forwarding = asyncio.Event()
+        self._forwarding.set()
+        self._conn_gates = []
 
     async def handle(self, reader, writer):
         task = asyncio.current_task()
@@ -30,8 +33,14 @@ class Proxy:
             writer.close()
             return
 
+        gate = asyncio.Event()
+        gate.set()
+        self._conn_gates.append(gate)
+
         async def forward(reader, writer):
             while True:
+                await self._forwarding.wait()
+                await gate.wait()
                 data = await reader.read(1024)
                 if not data:
                     break
@@ -47,6 +56,8 @@ class Proxy:
             task2.cancel()
             writer.close()
             remote_writer.close()
+            if gate in self._conn_gates:
+                self._conn_gates.remove(gate)
 
         self.stop_connections.append(cleanup)
 
@@ -84,6 +95,36 @@ class Proxy:
     async def __aexit__(self, exc_type, exc, tb):
         await self.close()
 
+    def pause(self):
+        """
+        Stop forwarding bytes without closing anything. Sockets stay ESTABLISHED on both
+        sides while data stops moving, which is what either a lost network path or a peer
+        that stopped reading looks like to the sender (as opposed to drop_connection, which
+        is an immediate reset).
+        """
+        self._forwarding.clear()
+
+    def pause_one(self, index=0):
+        """
+        Stall a single connection and leave the rest forwarding. With one replication
+        flow per shard, this freezes exactly one flow.
+        """
+        gates = list(self._conn_gates)
+        if not gates:
+            return False
+        gates[index % len(gates)].clear()
+        return True
+
+    def connection_count(self):
+        """Number of currently proxied connections."""
+        return len(self._conn_gates)
+
+    def resume(self):
+        """Undo pause()/pause_one(): resume forwarding on all connections."""
+        self._forwarding.set()
+        for gate in list(self._conn_gates):
+            gate.set()
+
     def drop_connection(self):
         """
         Randomly drop one connection
@@ -94,6 +135,10 @@ class Proxy:
             cb()
 
     async def close(self, task=None):
+        # A Proxy is reused across close()/start_serving() cycles (see test_partial_sync), so
+        # leave it forwarding: a paused proxy would silently stall every future connection.
+        self.resume()
+
         if task is None:
             task = self._serve_task
         if task is self._serve_task:


### PR DESCRIPTION
DFLYCLUSTER FLUSHSLOTS was journaled with a hardcoded txid of 0 by a separate pass over the proactors after the flush transaction. Replicas classify it as a global command and rendezvous all their flows on it through a map keyed by txid, so two records emitted close together aliased onto a single map entry. Every flow then decremented a counter that had already drained: debug builds abort on DCHECK_GT, release builds wrap the counter and the flow fibers block forever. Those fibers also read the replication sockets, so the replica silently stops draining them - with write traffic the master kills the session after replication_timeout, on an idle master both sides keep reporting a healthy link while the replica no longer applies.

The record is now emitted from inside the global transaction that performs the flush, using the transaction's own txid. Besides fixing the aliasing, this makes the emission atomic with respect to replica flow registration (DFLY SYNC / STARTSTABLE run under Transaction::Guard, itself a global transaction), so a replica can no longer receive the record on a subset of its flows. This is the same pattern FLUSHALL and FLUSHDB already use. The record is written before FlushSlots so an allocation failure inside the flush cannot leave one shard without a record.

The regression test asserts the invariant directly: with vmodule=replica=2 the replica logs each rendezvous txid, and the test requires one distinct non-zero txid per flush - catching both a revert to txid 0 and a move of the emission back outside the transaction. On the pre-fix binary it fails in under 30s on both build types.

Found while investigating https://github.com/dragonflydb/dataplane-private/issues/278. That incident reported the symptom (replication broke while a shard was being decommissioned); this defect has exactly that shape, but the retained logs cannot confirm it caused that specific alert - the discriminating lines are all at INFO level and are not collected.

Closes: https://github.com/dragonflydb/dataplane-private/issues/278