### PR TITLE
chore(server): Prefetch + cid caching for speedup

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -345,9 +345,11 @@ std::pair<const CommandId*, ParsedArgs> CommandRegistry::FindExtended(ParsedArgs
     return {nullptr, {}};
 
   // A workaround for XGROUP HELP that does not fit our static taxonomy of commands.
+  // Consume the HELP token so the tail is empty: _XGROUP_HELP takes no arguments, and keeping
+  // HELP in the tail would let CommandCache memoize _XGROUP_HELP under the "XGROUP" verb.
   if (tail_args.size() == 1 && res->name() == "XGROUP") {
     if (absl::EqualsIgnoreCase(tail_args.Front(), "HELP")) {
-      res = Find("_XGROUP_HELP");
+      return {Find("_XGROUP_HELP"), tail_args.Tail()};
     }
   }
   return {res, tail_args};

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -957,6 +957,34 @@ string_view McTypeToCmdName(MemcacheParser::CmdType type) {
   }
 }
 
+// Memoizes last command lookup to avoid hashmap access + ascii upper casting
+class CommandCache {
+ public:
+  explicit CommandCache(const CommandRegistry& registry) : registry_(registry) {
+  }
+
+  std::pair<const CommandId*, facade::ParsedArgs> Resolve(const facade::ParsedArgs& args) {
+    std::string_view verb = args.Front();
+    if (last_cid_ && verb == last_verb_)
+      return {last_cid_, args.Tail()};
+
+    auto [cid, tail] = registry_.FindExtended(args);
+
+    // Cache if it was a single verb command
+    last_cid_ = nullptr;
+    if (cid && tail.size() + 1 == args.size()) {
+      last_verb_.assign(verb);
+      last_cid_ = cid;
+    }
+    return {cid, tail};
+  }
+
+ private:
+  const CommandRegistry& registry_;
+  std::string last_verb_;
+  const CommandId* last_cid_ = nullptr;
+};
+
 }  // namespace
 
 Service::Service(ProactorPool* pp)
@@ -1785,12 +1813,15 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
     }
   };
 
+  // Skip FindExtended for repeated verbs (the common case in pipelines).
+  CommandCache cmd_cache{registry_};
+
   auto* cmd = first;
   for (unsigned i = 0; i < count && cmd; i++) {
     auto* cmd_cntx = static_cast<CommandContext*>(cmd);
 
     ParsedArgs args{*cmd_cntx};
-    const auto [cid, tail_args] = registry_.FindExtended(args);
+    const auto [cid, tail_args] = cmd_cache.Resolve(args);
 
     // Stop the batch at the first command that can't join it;
     // the connection's regular dispatch path then handles exceptions

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -15,6 +15,7 @@
 #include "server/command_registry.h"
 #include "server/conn_context.h"
 #include "server/engine_shard_set.h"
+#include "server/namespaces.h"
 #include "server/transaction.h"
 #include "server/tx_base.h"
 
@@ -220,18 +221,24 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     sinfo.reply_size_total_ptr->fetch_add(sz, std::memory_order_relaxed);
   };
 
+  constexpr size_t kPrefetchBatch = 8;
   const size_t dispatched_sz = sinfo.dispatched.size();
-  for (size_t batch_start = 0; batch_start < dispatched_sz; batch_start += 8) {
-    size_t batch_end = batch_start + 8;
-    if (batch_end > dispatched_sz)
-      batch_end = dispatched_sz;
 
-    // We are in the context of a shard thread, so prefetching allows faster access
-    // to the command arguments.
-    for (size_t i = batch_start; i < batch_end; ++i) {
-      auto& dispatched = sinfo.dispatched[i];
-      if (dispatched.cmd_cntx) {
-        __builtin_prefetch(dispatched.cmd_cntx, 0, 3);
+  PrimeTable* prime = nullptr;
+  if (DbTable* t = namespaces->GetDefaultNamespace()
+                       .GetDbSlice(es->shard_id())
+                       .GetDBTable(cntx_->conn_state.db_index))
+    prime = &t->prime;
+
+  for (size_t batch_start = 0; batch_start < dispatched_sz; batch_start += kPrefetchBatch) {
+    const size_t batch_end = std::min(batch_start + kPrefetchBatch, dispatched_sz);
+
+    // Prefetch prime table buckets for all commands to avoid stalling on dashtable memory access
+    // See git-blame source PR for different prefetch comparisons
+    if (prime) {
+      for (size_t i = batch_start; i < batch_end; ++i) {
+        const auto& dispatched = sinfo.dispatched[i];
+        prime->Prefetch(dispatched.args[dispatched.key_index.start]);
       }
     }
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -4220,7 +4220,7 @@ void StreamFamily::Register(CommandRegistry* registry) {
       << CI{"XSETID", CO::JOURNALED, 3, 1, 1, acl::kXSetId}.HFUNC(XSetId)
       << CI{"XTRIM", CO::JOURNALED | CO::FAST | CO::NO_AUTOJOURNAL, -4, 1, 1, acl::kXTrim}.HFUNC(
              XTrim)
-      << CI{"_XGROUP_HELP", CO::NOSCRIPT | CO::HIDDEN, 2, 0, 0, acl::kXGroupHelp}.SetHandler(
+      << CI{"_XGROUP_HELP", CO::NOSCRIPT | CO::HIDDEN, 1, 0, 0, acl::kXGroupHelp}.SetHandler(
              XGroupHelp)
       << CI{"XACK", CO::JOURNALED | CO::FAST, -4, 1, 1, acl::kXAck}.HFUNC(XAck)
       << CI{"XAUTOCLAIM", CO::JOURNALED | CO::FAST, -6, 1, 1, acl::kXAutoClaim}.HFUNC(XAutoClaim);

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -646,6 +646,20 @@ TEST_F(StreamFamilyTest, Issue854) {
   EXPECT_THAT(resp, ErrArg("is not allowed"));
 }
 
+TEST_F(StreamFamilyTest, XGroupHelpBatchCacheCollision) {
+  // Regression: within a squashed pipeline batch, XGROUP HELP resolves to the hidden _XGROUP_HELP
+  // command. It must not poison the per-verb command cache, otherwise a following XGROUP CREATE
+  // would run the help handler instead of creating the group.
+  RunMany({{"xgroup", "help"}, {"xgroup", "create", "foo", "group", "$", "MKSTREAM"}});
+
+  auto resp = Run({"xinfo", "stream", "foo"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto vec = resp.GetVec();
+  // The "groups" field must report a single created consumer group.
+  EXPECT_THAT(vec[14], "groups");
+  EXPECT_THAT(vec[15], IntArg(1));
+}
+
 TEST_F(StreamFamilyTest, XGroupConsumer) {
   Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
   auto resp = Run({"xgroup", "createconsumer", "foo", "group", "bob"});


### PR DESCRIPTION
1. Prefetching bucket data

It requires really large pipelines to reach large differences

<img width="1650" height="660" alt="image" src="https://github.com/user-attachments/assets/5b675ef9-35f4-4a82-b157-941f9a6a22ef" />

2. Caching last command id

Helps avoiding absl::AsciiStrToUpper + hashtable lookup + ifs for simple cases like all GET pipeline. Adds additionally around +1.5%