### PR TITLE
fix: unblock stream if flush  slots

### DIFF
--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -1127,6 +1127,25 @@ TEST_F(ClusterFamilyTest, FlushSlots) {
                                                   _, "total_writes", _, "memory_bytes", _)))));
 }
 
+TEST_F(ClusterFamilyTest, FlushSlotsWakesBlockedXReadGroup) {
+  ConfigSingleNodeCluster(GetMyId());
+  EXPECT_EQ(Run({"XGROUP", "CREATE", "s", "group", "0", "MKSTREAM"}), "OK");
+
+  RespExpr blocked_resp;
+  auto reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    blocked_resp =
+        Run({"XREADGROUP", "GROUP", "group", "consumer", "BLOCK", "2000", "STREAMS", "s", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  const string slot = absl::StrCat(CheckedInt({"CLUSTER", "KEYSLOT", "s"}));
+  EXPECT_EQ(RunPrivileged({"DFLYCLUSTER", "FLUSHSLOTS", slot, slot}), "OK");
+
+  reader.Join();
+  EXPECT_THAT(blocked_resp, ErrArg("consumer group this client was blocked on no longer exists"));
+  EXPECT_THAT(Run({"EXISTS", "s"}), IntArg(0));
+}
+
 TEST_F(ClusterFamilyTest, FlushSlotsOutOfBounds) {
   EXPECT_THAT(RunPrivileged({"dflycluster", "flushslots", "0", "16384"}),
               ErrArg("value is not an integer or out of range"));

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -973,6 +973,14 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids, uint64_t next_versi
     PrimeTable::Cursor next = pt->TraverseBuckets(cursor, iterate_bucket);
     cursor = next;
     ThisFiber::Yield();
+
+    // Del above only marks the watchers of a deleted stream as awakened; normally the deleting
+    // transaction dispatches them when it concludes. This fiber has no such transaction, so
+    // dispatch here - between bucket traversals, where preempting in a readiness check is safe.
+    if (auto* bc = ns_->GetBlockingController(owner_->shard_id());
+        bc && owner_->GetContTx() == nullptr) {
+      bc->NotifyPending();
+    }
   } while (cursor && etl.gstate() != GlobalState::SHUTTING_DOWN);
 
   VLOG(1) << "FlushSlotsFb del count is: " << del_count;


### PR DESCRIPTION
Summary: Ensures detached cluster slot-flush fibers dispatch pending wake events after deleting streams, so blocked XREADGROUP calls re-evaluate missing consumer groups.
Changes: Adds a regression test that blocks an XREADGROUP, flushes its stream’s slot, and verifies the expected group-removal error and key deletion.