### PR TITLE
fix(test): cover V2 idle IoBuf reclamation

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2521,12 +2521,17 @@ async def test_pipeline_cache_size(df_server: DflyInstance):
     assert info["dispatch_queue_bytes"] == 0
 
 
+IOBUF_MIN_SHRINK_INTERVAL_SEC = 1
+IOBUF_SHRINK_WAIT_SEC = IOBUF_MIN_SHRINK_INTERVAL_SEC + 1
+IOBUF_COOLDOWN_SEC = 3
+
+
 @dfly_args(
     {
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
-        "iobuf_min_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
 )
 async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
@@ -2553,7 +2558,7 @@ async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
     metric_peak = await client_read_buffer_bytes()
     assert peak > baseline
 
-    @assert_eventually(timeout=5)
+    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
     async def wait_for_reclamation():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2569,7 +2574,7 @@ async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
-        "iobuf_min_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
 )
 async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
@@ -2584,7 +2589,7 @@ async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
     await client.set("iobuf-regrow-before", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    @assert_eventually(timeout=5)
+    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
     async def wait_for_shrink():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2621,7 +2626,7 @@ async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
     await client.set("iobuf-shrink-disabled", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    await asyncio.sleep(3)
+    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
 
     current = int((await observer.info("clients"))["client_read_buffer_bytes"])
     assert current == peak
@@ -2634,7 +2639,7 @@ async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "max_client_iobuf_len": 4096,
-        "iobuf_min_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
 )
 async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
@@ -2649,17 +2654,17 @@ async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
     assert await reader.readuntil(b"\r\n") == b"+OK\r\n"
 
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
-    await asyncio.sleep(2)
+    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
 
     partial_value = b"y" * 100
     writer.write(b"*3\r\n$3\r\nSET\r\n$7\r\npartial\r\n$1024\r\n" + partial_value)
     await writer.drain()
-    await asyncio.sleep(2)
+    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
 
     writer.write(b"y")
     await writer.drain()
 
-    @assert_eventually(timeout=5)
+    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
     async def wait_for_reclamation():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2679,7 +2684,7 @@ async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "max_client_iobuf_len": 4096,
-        "iobuf_min_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
 )
 async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
@@ -2691,12 +2696,12 @@ async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
     await client.set("iobuf-shrink-complete", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
     await client.ping()
-    await asyncio.sleep(2)
+    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
     await client.ping()
 
-    @assert_eventually(timeout=5)
+    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
     async def wait_for_reclamation():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2710,22 +2715,35 @@ async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "max_client_iobuf_len": 4096,
-        "iobuf_min_shrink_interval_sec": 1,
+        "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
 )
 async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
-    """Both loops retain capacity when the usage window contains a large read."""
+    """V1 retains a high-use buffer, while V2 reclaims it once receive-idle."""
+
     observer = df_server.client()
     client = df_server.client()
     await observer.ping()
 
+    observer_size = int((await observer.info("clients"))["client_read_buffer_bytes"])
     await client.set("iobuf-shrink-high-usage", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
     await client.ping()
 
-    assert int((await observer.info("clients"))["client_read_buffer_bytes"]) == peak
+    if is_resp_io_loop_v2(df_server):
+        # Keep client receive-idle while the observer polls aggregate client-buffer memory.
+        @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
+        async def wait_for_receive_idle_shrink():
+            current = int((await observer.info("clients"))["client_read_buffer_bytes"])
+            assert current <= observer_size + (peak - observer_size) // 2
+
+        await wait_for_receive_idle_shrink()
+    else:
+        # V1 only shrinks in its active path, so it cannot self-shrink while receive-idle.
+        await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+        assert int((await observer.info("clients"))["client_read_buffer_bytes"]) == peak
 
     await client.aclose()
     await observer.aclose()
@@ -2736,7 +2754,7 @@ async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
-        "iobuf_min_shrink_interval_sec": 3,
+        "iobuf_min_shrink_interval_sec": IOBUF_COOLDOWN_SEC,
     }
 )
 async def test_iobuf_shrink_respects_cooldown(df_server: DflyInstance):
@@ -2751,7 +2769,7 @@ async def test_iobuf_shrink_respects_cooldown(df_server: DflyInstance):
     await client.set("iobuf-shrink-cooldown", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    @assert_eventually(timeout=7)
+    @assert_eventually(timeout=IOBUF_COOLDOWN_SEC + 1)
     async def wait_for_first_shrink():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2522,9 +2522,11 @@ async def test_pipeline_cache_size(df_server: DflyInstance):
 
 
 IOBUF_MIN_SHRINK_INTERVAL_SEC = 1
-IOBUF_SHRINK_WAIT_SEC = IOBUF_MIN_SHRINK_INTERVAL_SEC + 1
 IOBUF_COOLDOWN_SEC = 3
-IOBUF_COOLDOWN_WAIT_SEC = IOBUF_COOLDOWN_SEC + 3
+IOBUF_WAIT_SEC = 2
+# We simplify the different timeout required by each test by using a single
+# maximum timeout for all.
+IOBUF_WAIT_TIMEOUT_SEC = 6
 
 
 @dfly_args(
@@ -2559,7 +2561,7 @@ async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
     metric_peak = await client_read_buffer_bytes()
     assert peak > baseline
 
-    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
+    @assert_eventually(timeout=IOBUF_WAIT_TIMEOUT_SEC)
     async def wait_for_reclamation():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2590,7 +2592,7 @@ async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
     await client.set("iobuf-regrow-before", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
+    @assert_eventually(timeout=IOBUF_WAIT_TIMEOUT_SEC)
     async def wait_for_shrink():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2627,7 +2629,7 @@ async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
     await client.set("iobuf-shrink-disabled", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
 
     current = int((await observer.info("clients"))["client_read_buffer_bytes"])
     assert current == peak
@@ -2655,17 +2657,17 @@ async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
     assert await reader.readuntil(b"\r\n") == b"+OK\r\n"
 
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
-    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
 
     partial_value = b"y" * 100
     writer.write(b"*3\r\n$3\r\nSET\r\n$7\r\npartial\r\n$1024\r\n" + partial_value)
     await writer.drain()
-    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
 
     writer.write(b"y")
     await writer.drain()
 
-    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
+    @assert_eventually(timeout=IOBUF_WAIT_TIMEOUT_SEC)
     async def wait_for_reclamation():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2697,12 +2699,12 @@ async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
     await client.set("iobuf-shrink-complete", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
     await client.ping()
-    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
     await client.ping()
 
-    @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
+    @assert_eventually(timeout=IOBUF_WAIT_TIMEOUT_SEC)
     async def wait_for_reclamation():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
@@ -2730,12 +2732,12 @@ async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
     await client.set("iobuf-shrink-high-usage", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
     await client.ping()
 
     if is_resp_io_loop_v2(df_server):
         # Keep client receive-idle while the observer polls aggregate client-buffer memory.
-        @assert_eventually(timeout=IOBUF_SHRINK_WAIT_SEC)
+        @assert_eventually(timeout=IOBUF_WAIT_TIMEOUT_SEC)
         async def wait_for_receive_idle_shrink():
             current = int((await observer.info("clients"))["client_read_buffer_bytes"])
             assert current <= observer_size + (peak - observer_size) // 2
@@ -2743,7 +2745,7 @@ async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
         await wait_for_receive_idle_shrink()
     else:
         # V1 only shrinks in its active path, so it cannot self-shrink while receive-idle.
-        await asyncio.sleep(IOBUF_SHRINK_WAIT_SEC)
+        await asyncio.sleep(IOBUF_WAIT_SEC)
         assert int((await observer.info("clients"))["client_read_buffer_bytes"]) == peak
 
     await client.aclose()
@@ -2755,6 +2757,8 @@ async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
         "max_client_iobuf_len": 4096,
+        # Needs a longer configured shrink interval so it can prove that after the first shrink
+        # a second shrink does not occur during the cooldown window.
         "iobuf_min_shrink_interval_sec": IOBUF_COOLDOWN_SEC,
     }
 )
@@ -2770,14 +2774,14 @@ async def test_iobuf_shrink_respects_cooldown(df_server: DflyInstance):
     await client.set("iobuf-shrink-cooldown", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    @assert_eventually(timeout=IOBUF_COOLDOWN_WAIT_SEC)
+    @assert_eventually(timeout=IOBUF_WAIT_TIMEOUT_SEC)
     async def wait_for_first_shrink():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak
 
     await wait_for_first_shrink()
     after_first_shrink = int((await observer.info("clients"))["client_read_buffer_bytes"])
-    await asyncio.sleep(1)
+    await asyncio.sleep(IOBUF_WAIT_SEC)
     assert int((await observer.info("clients"))["client_read_buffer_bytes"]) == after_first_shrink
 
     await client.aclose()

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2524,6 +2524,7 @@ async def test_pipeline_cache_size(df_server: DflyInstance):
 IOBUF_MIN_SHRINK_INTERVAL_SEC = 1
 IOBUF_SHRINK_WAIT_SEC = IOBUF_MIN_SHRINK_INTERVAL_SEC + 1
 IOBUF_COOLDOWN_SEC = 3
+IOBUF_COOLDOWN_WAIT_SEC = IOBUF_COOLDOWN_SEC + 3
 
 
 @dfly_args(
@@ -2769,7 +2770,7 @@ async def test_iobuf_shrink_respects_cooldown(df_server: DflyInstance):
     await client.set("iobuf-shrink-cooldown", "x" * 2048)
     peak = int((await observer.info("clients"))["client_read_buffer_bytes"])
 
-    @assert_eventually(timeout=IOBUF_COOLDOWN_SEC + 1)
+    @assert_eventually(timeout=IOBUF_COOLDOWN_WAIT_SEC)
     async def wait_for_first_shrink():
         current = int((await observer.info("clients"))["client_read_buffer_bytes"])
         assert current < peak


### PR DESCRIPTION
1) Fixes test_iobuf_high_usage_defers_active_shrink.
Update the high-usage test to distinguish the response I/O loop behavior: V1 retains capacity until activity, while V2 reclaims it through its receive-idle watcher. Use a single client so INFO CLIENTS directly reflects the connection
under test.

2) Add shared interval, wait, and cooldown constants across the IoBuf shrink tests and reduce redundant fixed waits.
