### PR TITLE
Fix/rdb finishload cross shard free

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2700,20 +2700,25 @@ void RdbLoader::DiscardChunkedValuesOnFinish() {
     now_chunked_.clear();
   }
 
+  size_t total = 0;
+  for (auto& values : by_shard)
+    total += values.size();
+  if (total > 0)
+    LOG(ERROR) << "unexpected " << total << " values found in chunk map on RDB load finish";
+
   BlockingCounter bc{0};
   for (ShardId sid = 0; sid < by_shard.size(); ++sid) {
     auto& values = by_shard[sid];
     if (values.empty())
       continue;
 
-    LOG(ERROR) << "unexpected " << values.size() << " values found in chunk map on RDB load finish";
     bc->Add(1);
     shard_set->Add(sid, [values = std::move(values), bc]() mutable {
       values.clear();
       bc->Dec();
     });
   }
-  bc->Wait();
+  bc->Wait();  // block until every shard has finished freeing its leftover values
 }
 
 void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2700,25 +2700,21 @@ void RdbLoader::DiscardChunkedValuesOnFinish() {
     now_chunked_.clear();
   }
 
-  size_t total = 0;
-  for (auto& values : by_shard)
-    total += values.size();
-  if (total > 0)
-    LOG(ERROR) << "unexpected " << total << " values found in chunk map on RDB load finish";
-
   BlockingCounter bc{0};
   for (ShardId sid = 0; sid < by_shard.size(); ++sid) {
     auto& values = by_shard[sid];
     if (values.empty())
       continue;
 
+    LOG(ERROR) << "unexpected " << values.size() << " values found in chunk map on RDB load finish";
     bc->Add(1);
     shard_set->Add(sid, [values = std::move(values), bc]() mutable {
       values.clear();
       bc->Dec();
     });
   }
-  bc->Wait();  // block until every shard has finished freeing its leftover values
+
+  bc->Wait();
 }
 
 void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
@@ -3150,13 +3146,22 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
   PrimeValue* pv_ptr = &pv;
   DbIndex db_ind = db_cntx.db_index;
 
+  LoadConfig config_copy = item->load_config;
+  ChunkedKey chunked_key{db_ind, item->key};
+
+  bool failed_should_cleanup = false;
+  absl::Cleanup maybe_remove_chunk_entry = [&] {
+    if (!failed_should_cleanup)
+      return;
+    std::unique_lock l{now_chunked_mu_};
+    now_chunked_.erase(chunked_key);
+  };
+
   auto error_msg = [](const auto* item, auto db_ind) {
     return absl::StrCat("Found empty key: ", item->key, " in DB ", db_ind, " rdb_type ",
                         item->val.rdb_type);
   };
 
-  LoadConfig config_copy = item->load_config;
-  ChunkedKey chunked_key{db_ind, item->key};
   if (item->load_config.chunked && item->load_config.append) {
     std::unique_lock lk{now_chunked_mu_};
     if (auto it = now_chunked_.find(chunked_key); it != now_chunked_.end()) {
@@ -3176,6 +3181,7 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
   }
 
   if (auto ec = FromOpaque(item->val, config_copy, pv_ptr); ec) {
+    failed_should_cleanup = item->load_config.chunked;
     if (ec.value() == errc::value_expired) {
       // hmap and sset values can expire and we ok with it,
       // so we don't set ec_ in this case

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2690,6 +2690,32 @@ error_code RdbLoader::Load(io::Source* src) {
   return kOk;
 }
 
+void RdbLoader::DiscardChunkedValuesOnFinish() {
+  using Values = std::vector<std::unique_ptr<PrimeValue>>;
+  std::vector<Values> by_shard(shard_set->size());
+  {
+    std::unique_lock l{now_chunked_mu_};
+    for (auto& [key, pv] : now_chunked_)
+      by_shard[Shard(key.second, shard_set->size())].push_back(std::move(pv));
+    now_chunked_.clear();
+  }
+
+  BlockingCounter bc{0};
+  for (ShardId sid = 0; sid < by_shard.size(); ++sid) {
+    auto& values = by_shard[sid];
+    if (values.empty())
+      continue;
+
+    LOG(ERROR) << "unexpected " << values.size() << " values found in chunk map on RDB load finish";
+    bc->Add(1);
+    shard_set->Add(sid, [values = std::move(values), bc]() mutable {
+      values.clear();
+      bc->Dec();
+    });
+  }
+  bc->Wait();
+}
+
 void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
   BlockingCounter bc(shard_set->size());
   for (unsigned i = 0; i < shard_set->size(); ++i) {
@@ -2705,7 +2731,7 @@ void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
     GetCurrentDbSlice().DecrLoadInProgress();
   }
 
-  now_chunked_.clear();
+  DiscardChunkedValuesOnFinish();
 
   absl::Duration dur = absl::Now() - start_time;
   load_time_ = double(absl::ToInt64Milliseconds(dur)) / 1000;

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -413,6 +413,7 @@ class RdbLoader : protected RdbLoaderBase {
 
   std::error_code VerifyChecksum();
 
+  void DiscardChunkedValuesOnFinish();
   void FinishLoad(absl::Time start_time, size_t* keys_loaded);
 
   void FlushShardAsync(ShardId sid);

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -2294,4 +2294,38 @@ TEST_F(RdbTest, SnapshotEgressThrottle) {
   EXPECT_GT(t_lim, t_base * 3);
 }
 
+TEST_F(RdbTest, EofWithRemoteShardChunksPending) {
+  // This test creates a key whose RDB chunk is dispatched to a remote shard (not the shard
+  // driving the load), and simulates the source stream ending (EOF) before all of that chunk's
+  // promised elements arrive. This exercises the case where a remote-shard chunk is left
+  // incomplete/pending when EOF is hit, verifying the loader neither errors out nor leaves a
+  // partially-built key behind.
+  ASSERT_GT(shard_set->size(), 1);  // need >1 shard so we can pick a key on a non-zero shard
+
+  std::string key;
+  ShardId sid = 0;
+
+  for (auto i = 0; i < 1000; ++i) {
+    key = absl::StrCat("uc-", i);
+    sid = Shard(key, shard_set->size());
+    if (sid > 0)
+      break;
+  }
+  ASSERT_GT(sid, 0);
+
+  std::string chunk;
+  chunk.push_back(RDB_TYPE_HASH);
+  AppendString(&chunk, key);
+  AppendLen(&chunk, 2);  // promise 2 fields, only 1 will follow
+  AddKV(&chunk, "field", "v1");
+
+  const std::string body = MakeTaggedChunk(1, chunk);
+
+  const auto ec = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body)); });
+  ASSERT_FALSE(ec) << ec.message();  // EOF with pending remote chunk must not surface as an error
+
+  // Key was never fully loaded before EOF, so it must not exist.
+  EXPECT_EQ(Run({"EXISTS", key}), 0);
+}
+
 }  // namespace dfly


### PR DESCRIPTION
RdbLoader stores partially-loaded chunked values (hash/set entries split
across multiple RDB chunks) in now_chunked_ until the chunk is finalized.
These values are created on their owning shard's thread via
Shard(key, shard_num), so they're allocated on that shard's mimalloc heap.

Two places were freeing them from the wrong thread:

- FinishLoad() cleared now_chunked_ directly on the loader thread instead
  of dispatching to each entry's owning shard. This crashes
  (mi_heap_contains_block check failure) when a leftover entry's shard
  differs from the loader thread — e.g. when EOF hits mid-chunk.

- CreateObjectOnShard() left a now_chunked_ entry behind on any parse
  failure (e.g. value_expired) without removing it, so it lingered until
  FinishLoad() eventually swept it up.

Fix:
- FinishLoad() now groups leftover entries by owning shard and dispatches
  destruction to each shard via shard_set->Add(), same pattern already
  used for FlushShardAsync in the same function.
- CreateObjectOnShard() removes its now_chunked_ entry immediately on
  failure, on the same shard thread, via absl::Cleanup.

Root cause investigated together with @abhijat, based on his draft #7877.
This PR follows the same approach with a couple of small readability
changes.