### PR TITLE
feat: add time limitation for replication backlog

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -39,7 +39,6 @@ using namespace std;
 
 ABSL_DECLARE_FLAG(bool, info_replication_valkey_compatible);
 ABSL_DECLARE_FLAG(uint32_t, replication_timeout);
-ABSL_DECLARE_FLAG(uint32_t, shard_repl_backlog_len);
 ABSL_DECLARE_FLAG(bool, experimental_cascaded_partial_sync);
 
 namespace dfly {
@@ -490,8 +489,8 @@ bool DflyCmd::IsLSNInPartialSyncBuffer(LSN lsn) const {
     LOG(INFO) << "Partial sync requested from stale LSN=" << lsn
               << " that the replication buffer doesn't contain this anymore (current_lsn="
               << journal::GetLsn() << "). Will perform a full sync of the data.";
-    LOG(INFO) << "If this happens often you can control the replication buffer's size with the "
-                 "--shard_repl_backlog_len option";
+    LOG(INFO) << "If this happens often, increase --shard_repl_backlog_time_ms or "
+                 "--shard_repl_backlog_max_bytes.";
   }
   return exists;
 }

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -25,8 +25,8 @@ ABSL_RETIRED_FLAG(uint32_t, shard_repl_backlog_len, 0,
                   "--shard_repl_backlog_max_bytes instead.");
 ABSL_FLAG(uint32_t, shard_repl_backlog_time_ms, 5000,
           "Target retention age in milliseconds of entries in the per-shard replication backlog. "
-          "Entries are evicted in one-second buckets and can be retained for up to one extra "
-          "second. 0 disables time-based eviction.");
+          "Entries older than this are evicted on later journal writes. 0 disables time-based "
+          "eviction.");
 ABSL_FLAG(strings::MemoryBytesFlag, shard_repl_backlog_max_bytes, 0,
           "Total bytes retained by replication backlog. 0 (the default) uses 0.5% of maxmemory.");
 
@@ -36,7 +36,7 @@ using namespace std;
 using namespace util;
 
 namespace {
-constexpr uint64_t kTimeBucketMs = 1000;
+constexpr size_t kMaxTimeEvictionsPerCall = 100;
 
 size_t GetPerShardBacklogMaxBytes() {
   size_t total_max_bytes = absl::GetFlag(FLAGS_shard_repl_backlog_max_bytes).value;
@@ -137,11 +137,14 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
   // This lock is never blocking because it contends with UnregisterOnChange, which is cpu only.
   // Hence this lock prevents the UnregisterOnChange to start running in the middle of CallOnChange.
   // CallOnChange is atomic if JournalSlice::SetFlushMode(false) is called before.
+  auto& item = change_item->journal_item;
+  const uint64_t now_ms = GetCurrentTimeMs();
+  item.time_ms = now_ms;
+
   std::shared_lock lk(cb_mu_);
   for (auto k_v : journal_consumers_arr_) {
     k_v.second->ConsumeJournalChange(*change_item);
   }
-  auto& item = change_item->journal_item;
 
   // We preserve order here. After ConsumeJournalChange there can be reordering.
   if (!ring_buffer_.empty()) {
@@ -155,32 +158,9 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
     data.shrink_to_fit();
   }
   const size_t item_bytes = ItemBytes(item);
-  const uint64_t now_ms = max_age_ms_ != 0 ? GetCurrentTimeMs() : 0;
-
-  Prune(item_bytes, now_ms);
-
-  if (ring_buffer_.full()) {
-    const size_t capacity = ring_buffer_.capacity();
-    const size_t avg_item_bytes = ring_buffer_bytes_ / capacity;
-    DCHECK_GT(avg_item_bytes, 0u);
-
-    const size_t available_bytes =
-        max_bytes_ > ring_buffer_bytes_ ? max_bytes_ - ring_buffer_bytes_ : 0;
-    const size_t growth = available_bytes / avg_item_bytes;
-    if (growth == 0) {
-      // Do not grow the metadata buffer once the byte budget is exhausted.
-      // Pop explicitly so boost::circular_buffer does not overwrite without accounting for it.
-      PopFront();
-    } else {
-      ring_buffer_.set_capacity(capacity + growth);
-    }
-  }
+  CleanEntries(item_bytes, now_ms);
   ring_buffer_.push_back(std::move(item));
   ring_buffer_bytes_ += item_bytes;
-
-  if (max_age_ms_ != 0) {
-    AddTimeBucket(now_ms);
-  }
 
   if (enable_journal_flush_) {
     for (auto k_v : journal_consumers_arr_) {
@@ -189,50 +169,60 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
   }
 }
 
-void JournalSlice::AddTimeBucket(uint64_t now_ms) {
-  DCHECK_NE(max_age_ms_, 0u);
-
-  const uint64_t bucket_start_ms = now_ms - now_ms % kTimeBucketMs;
-  if (!time_buckets_.empty() && bucket_start_ms <= time_buckets_.back().start_time_ms) {
-    return;
-  }
-
-  time_buckets_.push_back(TimeBucket{bucket_start_ms, ring_buffer_.back().lsn});
-}
-
 size_t JournalSlice::ItemBytes(const JournalItem& item) {
   return sizeof(item) + item.data.capacity();
 }
 
-void JournalSlice::Prune(size_t next_item_bytes, uint64_t now_ms) {
-  if (max_age_ms_ != 0) {
-    const uint64_t max_bucket_age_ms = uint64_t{max_age_ms_} + kTimeBucketMs;
-    auto first_retained = time_buckets_.begin();
-    while (first_retained != time_buckets_.end() && now_ms >= first_retained->start_time_ms &&
-           now_ms - first_retained->start_time_ms >= max_bucket_age_ms) {
-      ++first_retained;
-    }
-    if (first_retained != time_buckets_.begin()) {
-      const LSN first_retained_lsn =
-          first_retained == time_buckets_.end() ? lsn_ : first_retained->first_lsn;
-      while (!ring_buffer_.empty() && ring_buffer_.front().lsn < first_retained_lsn) {
-        PopFront();
+void JournalSlice::CleanEntries(size_t next_item_bytes, uint64_t now_ms) {
+  size_t retained_bytes = ring_buffer_bytes_;
+  size_t time_evictions = 0;
+  size_t bytes_to_free = 0;
+
+  auto first_retained = ring_buffer_.begin();
+  while (first_retained != ring_buffer_.end()) {
+    const bool exceeds_byte_limit =
+        retained_bytes > max_bytes_ || next_item_bytes > max_bytes_ - retained_bytes;
+    const bool expired = max_age_ms_ != 0 && now_ms >= first_retained->time_ms &&
+                         now_ms - first_retained->time_ms >= max_age_ms_;
+    const bool evict_for_time = expired && time_evictions < kMaxTimeEvictionsPerCall;
+    bool evict_for_capacity = bytes_to_free != 0;
+
+    if (!exceeds_byte_limit && !evict_for_time && !evict_for_capacity &&
+        first_retained == ring_buffer_.begin() && ring_buffer_.full()) {
+      const size_t capacity = ring_buffer_.capacity();
+      const size_t avg_item_bytes = retained_bytes / capacity;
+      DCHECK_GT(avg_item_bytes, 0u);
+
+      const size_t available_bytes = max_bytes_ > retained_bytes ? max_bytes_ - retained_bytes : 0;
+      const size_t growth = available_bytes / avg_item_bytes;
+      if (growth != 0) {
+        ring_buffer_.set_capacity(capacity + growth);
+        return;
       }
-      time_buckets_.erase(time_buckets_.begin(), first_retained);
+      bytes_to_free = next_item_bytes;
+      evict_for_capacity = true;
     }
+
+    if (!exceeds_byte_limit && !evict_for_time && !evict_for_capacity) {
+      break;
+    }
+
+    const size_t item_bytes = ItemBytes(*first_retained);
+    DCHECK_GE(retained_bytes, item_bytes);
+    retained_bytes -= item_bytes;
+    if (evict_for_capacity) {
+      bytes_to_free = item_bytes >= bytes_to_free ? 0 : bytes_to_free - item_bytes;
+    }
+    if (evict_for_time && !exceeds_byte_limit && !evict_for_capacity) {
+      ++time_evictions;
+    }
+    ++first_retained;
   }
 
-  while (!ring_buffer_.empty() &&
-         (ring_buffer_bytes_ > max_bytes_ || next_item_bytes > max_bytes_ - ring_buffer_bytes_)) {
-    PopFront();
+  if (first_retained != ring_buffer_.begin()) {
+    ring_buffer_bytes_ = retained_bytes;
+    ring_buffer_.rerase(ring_buffer_.begin(), first_retained);
   }
-}
-
-void JournalSlice::PopFront() {
-  const size_t item_bytes = ItemBytes(ring_buffer_.front());
-  DCHECK_GE(ring_buffer_bytes_, item_bytes);
-  ring_buffer_bytes_ -= item_bytes;
-  ring_buffer_.pop_front();
 }
 
 uint32_t JournalSlice::RegisterOnChange(JournalConsumerInterface* consumer) {

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -4,26 +4,52 @@
 
 #include "server/journal/journal_slice.h"
 
-#include <absl/container/inlined_vector.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
 #include <fcntl.h>
 
+#include <algorithm>
 #include <filesystem>
 
 #include "base/function2.hpp"
 #include "base/logging.h"
+#include "server/common.h"
+#include "server/engine_shard_set.h"
 #include "server/journal/serializer.h"
+#include "strings/human_readable.h"
 #include "util/fibers/fibers.h"
 
-ABSL_FLAG(uint32_t, shard_repl_backlog_len, 8192,
-          "The length of the circular replication log per shard");
+ABSL_RETIRED_FLAG(uint32_t, shard_repl_backlog_len, 0,
+                  "Deprecated. Use --shard_repl_backlog_time_ms and "
+                  "--shard_repl_backlog_max_bytes instead.");
+ABSL_FLAG(uint32_t, shard_repl_backlog_time_ms, 5000,
+          "Target retention age in milliseconds of entries in the per-shard replication backlog. "
+          "Entries are evicted in one-second buckets and can be retained for up to one extra "
+          "second. 0 disables time-based eviction.");
+ABSL_FLAG(strings::MemoryBytesFlag, shard_repl_backlog_max_bytes, 0,
+          "Total bytes retained by replication backlog. 0 (the default) uses 0.5% of maxmemory.");
 
 namespace dfly {
 namespace journal {
 using namespace std;
 using namespace util;
+
+namespace {
+constexpr uint64_t kTimeBucketMs = 1000;
+
+size_t GetPerShardBacklogMaxBytes() {
+  size_t total_max_bytes = absl::GetFlag(FLAGS_shard_repl_backlog_max_bytes).value;
+  if (total_max_bytes == 0) {
+    constexpr size_t kBacklogMemoryFraction = 200;
+    total_max_bytes = max_memory_limit.load(memory_order_relaxed) / kBacklogMemoryFraction;
+  }
+
+  const size_t shard_count = shard_set ? max<size_t>(1, shard_set->size()) : 1;
+  return total_max_bytes / shard_count;
+}
+
+}  // namespace
 
 JournalSlice::JournalSlice() {
 }
@@ -36,8 +62,10 @@ void JournalSlice::Init() {
   if (ring_buffer_.capacity() > 0)
     return;
 
-  ring_buffer_.set_capacity(absl::GetFlag(FLAGS_shard_repl_backlog_len));
-  ring_buffer_bytes_ = ring_buffer_.capacity() * sizeof(JournalItem);
+  constexpr size_t kDefaultBacklogCapacity = 8192;
+  ring_buffer_.set_capacity(kDefaultBacklogCapacity);
+  max_age_ms_ = absl::GetFlag(FLAGS_shard_repl_backlog_time_ms);
+  max_bytes_ = GetPerShardBacklogMaxBytes();
 }
 
 bool JournalSlice::IsLSNInBuffer(LSN lsn) const {
@@ -115,30 +143,96 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
   }
   auto& item = change_item->journal_item;
 
-  // We preserve order here. After ConsumeJournalChange there can reordering
-  if (ring_buffer_.size() == ring_buffer_.capacity()) {
-    const size_t bytes_removed = ring_buffer_.front().data.capacity();
-    DCHECK_GE(ring_buffer_bytes_, bytes_removed);
-    ring_buffer_bytes_ -= bytes_removed;
-  }
+  // We preserve order here. After ConsumeJournalChange there can be reordering.
   if (!ring_buffer_.empty()) {
     DCHECK(item.lsn == ring_buffer_.back().lsn + 1);
   }
-  ring_buffer_.push_back(std::move(item));
-  auto& data = ring_buffer_.back().data;
+  auto& data = item.data;
 
   // Small strings assignment keep the existing capacity intact due to SSO.
   // Shrink strings in this case to prevent excessive memory usage.
   if (data.size() < 32 && data.capacity() > 64) {
     data.shrink_to_fit();
   }
-  ring_buffer_bytes_ += data.capacity();
+  const size_t item_bytes = ItemBytes(item);
+  const uint64_t now_ms = max_age_ms_ != 0 ? GetCurrentTimeMs() : 0;
+
+  Prune(item_bytes, now_ms);
+
+  if (ring_buffer_.full()) {
+    const size_t capacity = ring_buffer_.capacity();
+    const size_t avg_item_bytes = ring_buffer_bytes_ / capacity;
+    DCHECK_GT(avg_item_bytes, 0u);
+
+    const size_t available_bytes =
+        max_bytes_ > ring_buffer_bytes_ ? max_bytes_ - ring_buffer_bytes_ : 0;
+    const size_t growth = available_bytes / avg_item_bytes;
+    if (growth == 0) {
+      // Do not grow the metadata buffer once the byte budget is exhausted.
+      // Pop explicitly so boost::circular_buffer does not overwrite without accounting for it.
+      PopFront();
+    } else {
+      ring_buffer_.set_capacity(capacity + growth);
+    }
+  }
+  ring_buffer_.push_back(std::move(item));
+  ring_buffer_bytes_ += item_bytes;
+
+  if (max_age_ms_ != 0) {
+    AddTimeBucket(now_ms);
+  }
 
   if (enable_journal_flush_) {
     for (auto k_v : journal_consumers_arr_) {
       k_v.second->ThrottleIfNeeded();
     }
   }
+}
+
+void JournalSlice::AddTimeBucket(uint64_t now_ms) {
+  DCHECK_NE(max_age_ms_, 0u);
+
+  const uint64_t bucket_start_ms = now_ms - now_ms % kTimeBucketMs;
+  if (!time_buckets_.empty() && bucket_start_ms <= time_buckets_.back().start_time_ms) {
+    return;
+  }
+
+  time_buckets_.push_back(TimeBucket{bucket_start_ms, ring_buffer_.back().lsn});
+}
+
+size_t JournalSlice::ItemBytes(const JournalItem& item) {
+  return sizeof(item) + item.data.capacity();
+}
+
+void JournalSlice::Prune(size_t next_item_bytes, uint64_t now_ms) {
+  if (max_age_ms_ != 0) {
+    const uint64_t max_bucket_age_ms = uint64_t{max_age_ms_} + kTimeBucketMs;
+    auto first_retained = time_buckets_.begin();
+    while (first_retained != time_buckets_.end() && now_ms >= first_retained->start_time_ms &&
+           now_ms - first_retained->start_time_ms >= max_bucket_age_ms) {
+      ++first_retained;
+    }
+    if (first_retained != time_buckets_.begin()) {
+      const LSN first_retained_lsn =
+          first_retained == time_buckets_.end() ? lsn_ : first_retained->first_lsn;
+      while (!ring_buffer_.empty() && ring_buffer_.front().lsn < first_retained_lsn) {
+        PopFront();
+      }
+      time_buckets_.erase(time_buckets_.begin(), first_retained);
+    }
+  }
+
+  while (!ring_buffer_.empty() &&
+         (ring_buffer_bytes_ > max_bytes_ || next_item_bytes > max_bytes_ - ring_buffer_bytes_)) {
+    PopFront();
+  }
+}
+
+void JournalSlice::PopFront() {
+  const size_t item_bytes = ItemBytes(ring_buffer_.front());
+  DCHECK_GE(ring_buffer_bytes_, item_bytes);
+  ring_buffer_bytes_ -= item_bytes;
+  ring_buffer_.pop_front();
 }
 
 uint32_t JournalSlice::RegisterOnChange(JournalConsumerInterface* consumer) {

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <absl/container/inlined_vector.h>
-
 #include <boost/circular_buffer.hpp>
 #include <boost/circular_buffer/space_optimized.hpp>
 #include <cstdint>
@@ -70,7 +68,6 @@ class JournalSlice {
 
   void ResetRingBuffer() {
     ring_buffer_.clear();
-    time_buckets_.clear();
     ring_buffer_bytes_ = 0;
   }
 
@@ -79,19 +76,11 @@ class JournalSlice {
   }
 
  private:
-  struct TimeBucket {
-    uint64_t start_time_ms;
-    LSN first_lsn;
-  };
-
   void CallOnChange(JournalChangeItem* item);
-  void AddTimeBucket(uint64_t now_ms);
-  void Prune(size_t next_item_bytes, uint64_t now_ms);
-  void PopFront();
+  void CleanEntries(size_t next_item_bytes, uint64_t now_ms);
   static size_t ItemBytes(const JournalItem& item);
 
   boost::circular_buffer_space_optimized<JournalItem> ring_buffer_;
-  absl::InlinedVector<TimeBucket, 6> time_buckets_;
 
   mutable util::fb2::SharedMutex cb_mu_;  // to prevent removing callback during call
   std::list<std::pair<uint32_t, JournalConsumerInterface*>> journal_consumers_arr_;

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <absl/container/inlined_vector.h>
+
 #include <boost/circular_buffer.hpp>
-#include <optional>
+#include <boost/circular_buffer/space_optimized.hpp>
+#include <cstdint>
 #include <shared_mutex>
 #include <string_view>
 
@@ -67,7 +70,8 @@ class JournalSlice {
 
   void ResetRingBuffer() {
     ring_buffer_.clear();
-    ring_buffer_bytes_ = ring_buffer_.capacity() * sizeof(JournalItem);
+    time_buckets_.clear();
+    ring_buffer_bytes_ = 0;
   }
 
   void SetStartingLSN(LSN lsn) {
@@ -75,8 +79,19 @@ class JournalSlice {
   }
 
  private:
+  struct TimeBucket {
+    uint64_t start_time_ms;
+    LSN first_lsn;
+  };
+
   void CallOnChange(JournalChangeItem* item);
-  boost::circular_buffer<JournalItem> ring_buffer_;
+  void AddTimeBucket(uint64_t now_ms);
+  void Prune(size_t next_item_bytes, uint64_t now_ms);
+  void PopFront();
+  static size_t ItemBytes(const JournalItem& item);
+
+  boost::circular_buffer_space_optimized<JournalItem> ring_buffer_;
+  absl::InlinedVector<TimeBucket, 6> time_buckets_;
 
   mutable util::fb2::SharedMutex cb_mu_;  // to prevent removing callback during call
   std::list<std::pair<uint32_t, JournalConsumerInterface*>> journal_consumers_arr_;
@@ -86,6 +101,9 @@ class JournalSlice {
   uint32_t next_cb_id_ = 1;
   std::error_code status_ec_;
   bool enable_journal_flush_ = true;
+
+  uint32_t max_age_ms_ = 0;
+  size_t max_bytes_ = 0;
 
   size_t ring_buffer_bytes_ = 0;
 };

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -213,48 +213,39 @@ void AddSetRecord(JournalSlice* slice, string_view value) {
       Entry{0, Op::COMMAND, 0, nullopt, Entry::Payload{"SET", ArgSlice{args.data(), args.size()}}});
 }
 
-TEST(Journal, BacklogRetainsOversizedRecord) {
-  absl::FlagSaver flag_saver;
-  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
-  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024});
-
-  JournalSlice slice;
-  slice.Init();
-
-  string large_value(2048, 'x');
-  AddSetRecord(&slice, large_value);
-  EXPECT_TRUE(slice.IsLSNInBuffer(1));
-
-  AddSetRecord(&slice, "x");
-  EXPECT_FALSE(slice.IsLSNInBuffer(1));
-  EXPECT_TRUE(slice.IsLSNInBuffer(2));
-
-  AddSetRecord(&slice, large_value);
-  EXPECT_FALSE(slice.IsLSNInBuffer(2));
-  EXPECT_TRUE(slice.IsLSNInBuffer(3));
-}
-
-TEST(Journal, BacklogHonorsByteLimit) {
+TEST(Journal, BacklogHonorsByteLimitAndReplacesOversizedRecord) {
   absl::FlagSaver flag_saver;
   absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 0u);
 
   JournalSlice probe;
   probe.Init();
-  AddSetRecord(&probe, "value");
+  AddSetRecord(&probe, "x");
   const size_t item_bytes = probe.GetRingBufferBytes();
   ASSERT_GT(item_bytes, 1u);
 
-  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{2 * item_bytes - 1});
+  const size_t max_bytes = 2 * item_bytes - 1;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{max_bytes});
   JournalSlice slice;
   slice.Init();
 
-  AddSetRecord(&slice, "value");
-  AddSetRecord(&slice, "value");
-
+  AddSetRecord(&slice, "x");
+  AddSetRecord(&slice, "x");
   EXPECT_EQ(slice.GetRingBufferSize(), 1u);
   EXPECT_FALSE(slice.IsLSNInBuffer(1));
   EXPECT_TRUE(slice.IsLSNInBuffer(2));
-  EXPECT_LE(slice.GetRingBufferBytes(), 2 * item_bytes - 1);
+  EXPECT_LE(slice.GetRingBufferBytes(), max_bytes);
+
+  string large_value(2048, 'x');
+  AddSetRecord(&slice, large_value);
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(3));
+
+  AddSetRecord(&slice, "x");
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(3));
+  EXPECT_TRUE(slice.IsLSNInBuffer(4));
+  EXPECT_LE(slice.GetRingBufferBytes(), max_bytes);
 }
 
 TEST(Journal, BacklogDefaultByteLimitUsesHalfPercentOfMaxmemory) {
@@ -296,42 +287,40 @@ TEST(Journal, BacklogGrowsBeyondInitialCapacity) {
   EXPECT_TRUE(slice.IsLSNInBuffer(kRecordCount));
 }
 
-TEST(Journal, BacklogDropsOldestWhenAtByteCapacity) {
+TEST(Journal, BacklogDropsOldestWhenMetadataCannotGrow) {
   absl::FlagSaver flag_saver;
   absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 0u);
-  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{4 * 1024 * 1024});
 
-  JournalSlice probe;
-  probe.Init();
-  AddSetRecord(&probe, "value");
-  const size_t item_bytes = probe.GetRingBufferBytes();
+  const string large_value(128, 'x');
+  JournalSlice large_probe;
+  large_probe.Init();
+  AddSetRecord(&large_probe, large_value);
+  const size_t large_item_bytes = large_probe.GetRingBufferBytes();
+
+  JournalSlice small_probe;
+  small_probe.Init();
+  AddSetRecord(&small_probe, "x");
+  const size_t small_item_bytes = small_probe.GetRingBufferBytes();
+  ASSERT_LT(small_item_bytes, large_item_bytes);
 
   constexpr size_t kInitialCapacity = 8192;
-  ASSERT_GT(item_bytes, 1u);
   absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes,
-                strings::MemoryBytesFlag{kInitialCapacity * item_bytes + item_bytes - 1});
+                strings::MemoryBytesFlag{kInitialCapacity * large_item_bytes + small_item_bytes});
 
   JournalSlice slice;
   slice.Init();
   for (size_t i = 0; i < kInitialCapacity; ++i) {
-    AddSetRecord(&slice, "value");
+    AddSetRecord(&slice, large_value);
   }
 
-  AddSetRecord(&slice, "value");
-  EXPECT_EQ(slice.GetRingBufferSize(), kInitialCapacity);
-  EXPECT_FALSE(slice.IsLSNInBuffer(1));
-  EXPECT_TRUE(slice.IsLSNInBuffer(2));
-  EXPECT_TRUE(slice.IsLSNInBuffer(kInitialCapacity + 1));
+  AddSetRecord(&slice, "x");
 
-  AddSetRecord(&slice, "value");
   EXPECT_EQ(slice.GetRingBufferSize(), kInitialCapacity);
   EXPECT_FALSE(slice.IsLSNInBuffer(1));
-  EXPECT_FALSE(slice.IsLSNInBuffer(2));
-  EXPECT_TRUE(slice.IsLSNInBuffer(3));
-  EXPECT_TRUE(slice.IsLSNInBuffer(kInitialCapacity + 2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(kInitialCapacity + 1));
 }
 
-TEST(Journal, BacklogRetainsRecordsWhileIdle) {
+TEST(Journal, BacklogCleansExpiredEntriesOnAppend) {
   absl::FlagSaver flag_saver;
   absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
   absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
@@ -342,20 +331,24 @@ TEST(Journal, BacklogRetainsRecordsWhileIdle) {
 
   JournalSlice slice;
   slice.Init();
-  AddSetRecord(&slice, "value");
+  AddSetRecord(&slice, "first");
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+
+  TEST_current_time_ms = 1999;
   EXPECT_TRUE(slice.IsLSNInBuffer(1));
 
   TEST_current_time_ms = 2000;
   EXPECT_TRUE(slice.IsLSNInBuffer(1));
 
-  TEST_current_time_ms = 3000;
-  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+  AddSetRecord(&slice, "second");
   EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
 }
 
-TEST(Journal, BacklogExpiresNonAlignedTimeOnAppend) {
+TEST(Journal, BacklogBoundsTimeBasedCleanup) {
   absl::FlagSaver flag_saver;
-  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 5001u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
   absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
 
   const uint64_t original_time = TEST_current_time_ms;
@@ -365,74 +358,19 @@ TEST(Journal, BacklogExpiresNonAlignedTimeOnAppend) {
   slice.Init();
 
   TEST_current_time_ms = 1000;
-  AddSetRecord(&slice, "first");
-  TEST_current_time_ms = 7000;
-  AddSetRecord(&slice, "second");
-  TEST_current_time_ms = 7001;
-  AddSetRecord(&slice, "third");
+  constexpr size_t kExpiredEntries = 101;
+  for (size_t i = 0; i < kExpiredEntries; ++i) {
+    AddSetRecord(&slice, "expired");
+  }
+
+  TEST_current_time_ms = 2000;
+  AddSetRecord(&slice, "current");
 
   EXPECT_EQ(slice.GetRingBufferSize(), 2u);
   EXPECT_FALSE(slice.IsLSNInBuffer(1));
-  EXPECT_TRUE(slice.IsLSNInBuffer(2));
-  EXPECT_TRUE(slice.IsLSNInBuffer(3));
-}
-
-TEST(Journal, BacklogDropsMultipleExpiredSecondBuckets) {
-  absl::FlagSaver flag_saver;
-  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 5000u);
-  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
-
-  const uint64_t original_time = TEST_current_time_ms;
-  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
-
-  JournalSlice slice;
-  slice.Init();
-
-  TEST_current_time_ms = 1000;
-  AddSetRecord(&slice, "first");
-  TEST_current_time_ms = 2000;
-  AddSetRecord(&slice, "second");
-  TEST_current_time_ms = 3000;
-  AddSetRecord(&slice, "third");
-
-  TEST_current_time_ms = 9000;
-  AddSetRecord(&slice, "fourth");
-
-  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
-  EXPECT_FALSE(slice.IsLSNInBuffer(1));
-  EXPECT_FALSE(slice.IsLSNInBuffer(2));
-  EXPECT_FALSE(slice.IsLSNInBuffer(3));
-  EXPECT_TRUE(slice.IsLSNInBuffer(4));
-}
-
-TEST(Journal, BacklogDropsExpiredSecondBucket) {
-  absl::FlagSaver flag_saver;
-  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
-  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
-
-  const uint64_t original_time = TEST_current_time_ms;
-  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
-
-  JournalSlice slice;
-  slice.Init();
-
-  TEST_current_time_ms = 1000;
-  AddSetRecord(&slice, "first");
-  TEST_current_time_ms = 1999;
-  AddSetRecord(&slice, "second");
-  TEST_current_time_ms = 2000;
-  AddSetRecord(&slice, "third");
-
-  EXPECT_TRUE(slice.IsLSNInBuffer(1));
-  EXPECT_TRUE(slice.IsLSNInBuffer(2));
-
-  TEST_current_time_ms = 3000;
-  AddSetRecord(&slice, "fourth");
-
-  EXPECT_FALSE(slice.IsLSNInBuffer(1));
-  EXPECT_FALSE(slice.IsLSNInBuffer(2));
-  EXPECT_TRUE(slice.IsLSNInBuffer(3));
-  EXPECT_TRUE(slice.IsLSNInBuffer(4));
+  EXPECT_FALSE(slice.IsLSNInBuffer(kExpiredEntries - 1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(kExpiredEntries));
+  EXPECT_TRUE(slice.IsLSNInBuffer(kExpiredEntries + 1));
 }
 
 }  // namespace journal

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -1,18 +1,27 @@
+#include <absl/cleanup/cleanup.h>
+#include <absl/flags/reflection.h>
 #include <absl/strings/str_join.h>
 
-#include <boost/circular_buffer.hpp>
+#include <array>
 #include <random>
 #include <string>
 
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "core/detail/gen_utils.h"
 #include "server/common.h"
+#include "server/engine_shard_set.h"
+#include "server/journal/journal_slice.h"
 #include "server/journal/pending_buf.h"
 #include "server/journal/serializer.h"
 #include "server/journal/types.h"
 #include "server/serializer_commons.h"
+#include "strings/human_readable.h"
 #include "util/fibers/fibers.h"
+
+ABSL_DECLARE_FLAG(uint32_t, shard_repl_backlog_time_ms);
+ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, shard_repl_backlog_max_bytes);
 
 using namespace testing;
 using namespace std;
@@ -198,31 +207,232 @@ TEST(Journal, PendingBuf) {
   ASSERT_EQ(pbuf.Size(), 0);
 }
 
-TEST(Journal, CircularMemory) {
-  boost::circular_buffer<string> ring_buffer(1024);
-  for (int i = 0; i < 2000; ++i) {
-    ring_buffer.push_back(string(512, 'a'));
+void AddSetRecord(JournalSlice* slice, string_view value) {
+  array<string_view, 2> args{"key", value};
+  slice->AddLogRecord(
+      Entry{0, Op::COMMAND, 0, nullopt, Entry::Payload{"SET", ArgSlice{args.data(), args.size()}}});
+}
+
+TEST(Journal, BacklogRetainsOversizedRecord) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024});
+
+  JournalSlice slice;
+  slice.Init();
+
+  string large_value(2048, 'x');
+  AddSetRecord(&slice, large_value);
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+
+  AddSetRecord(&slice, "x");
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+
+  AddSetRecord(&slice, large_value);
+  EXPECT_FALSE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(3));
+}
+
+TEST(Journal, BacklogHonorsByteLimit) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 0u);
+
+  JournalSlice probe;
+  probe.Init();
+  AddSetRecord(&probe, "value");
+  const size_t item_bytes = probe.GetRingBufferBytes();
+  ASSERT_GT(item_bytes, 1u);
+
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{2 * item_bytes - 1});
+  JournalSlice slice;
+  slice.Init();
+
+  AddSetRecord(&slice, "value");
+  AddSetRecord(&slice, "value");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+  EXPECT_LE(slice.GetRingBufferBytes(), 2 * item_bytes - 1);
+}
+
+TEST(Journal, BacklogDefaultByteLimitUsesHalfPercentOfMaxmemory) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{});
+
+  const size_t original_max_memory = max_memory_limit.exchange(200 * 1024, memory_order_relaxed);
+  auto restore_max_memory = absl::MakeCleanup(
+      [original_max_memory] { max_memory_limit.store(original_max_memory, memory_order_relaxed); });
+
+  JournalSlice slice;
+  slice.Init();
+
+  string large_value(2048, 'x');
+  AddSetRecord(&slice, large_value);
+  AddSetRecord(&slice, "x");
+
+  // 0.5% of 200 KiB is 1 KiB, so the oversized record is evicted.
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+}
+
+TEST(Journal, BacklogGrowsBeyondInitialCapacity) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 0u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{4 * 1024 * 1024});
+
+  JournalSlice slice;
+  slice.Init();
+
+  constexpr size_t kRecordCount = 10'000;
+  for (size_t i = 0; i < kRecordCount; ++i) {
+    AddSetRecord(&slice, "value");
   }
 
-  size_t cap = 0;
-  for (size_t i = 0; i < ring_buffer.size(); ++i) {
-    cap += ring_buffer[i].capacity();
-  }
-  LOG(INFO) << "Total capacity: " << cap;
-  for (size_t i = 0; i < 2000; ++i) {
-    ring_buffer.push_back(string(16, 'a'));
-  }
-  cap = 0;
-  for (size_t i = 0; i < ring_buffer.size(); ++i) {
-    cap += ring_buffer[i].capacity();
-  }
-  LOG(INFO) << "Total capacity after push: " << cap;
+  EXPECT_EQ(slice.GetRingBufferSize(), kRecordCount);
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(kRecordCount));
+}
 
-  string tmp(1 << 16, 'x');
-  tmp = string(4, 'a');
-  LOG(INFO) << "Tmp string capacity: " << tmp.capacity();
-  tmp = string(32, 'a');
-  LOG(INFO) << "Tmp string capacity: " << tmp.capacity();
+TEST(Journal, BacklogDropsOldestWhenAtByteCapacity) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 0u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{4 * 1024 * 1024});
+
+  JournalSlice probe;
+  probe.Init();
+  AddSetRecord(&probe, "value");
+  const size_t item_bytes = probe.GetRingBufferBytes();
+
+  constexpr size_t kInitialCapacity = 8192;
+  ASSERT_GT(item_bytes, 1u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes,
+                strings::MemoryBytesFlag{kInitialCapacity * item_bytes + item_bytes - 1});
+
+  JournalSlice slice;
+  slice.Init();
+  for (size_t i = 0; i < kInitialCapacity; ++i) {
+    AddSetRecord(&slice, "value");
+  }
+
+  AddSetRecord(&slice, "value");
+  EXPECT_EQ(slice.GetRingBufferSize(), kInitialCapacity);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(kInitialCapacity + 1));
+
+  AddSetRecord(&slice, "value");
+  EXPECT_EQ(slice.GetRingBufferSize(), kInitialCapacity);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_FALSE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(3));
+  EXPECT_TRUE(slice.IsLSNInBuffer(kInitialCapacity + 2));
+}
+
+TEST(Journal, BacklogRetainsRecordsWhileIdle) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
+
+  const uint64_t original_time = TEST_current_time_ms;
+  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
+  TEST_current_time_ms = 1000;
+
+  JournalSlice slice;
+  slice.Init();
+  AddSetRecord(&slice, "value");
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+
+  TEST_current_time_ms = 2000;
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+
+  TEST_current_time_ms = 3000;
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+}
+
+TEST(Journal, BacklogExpiresNonAlignedTimeOnAppend) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 5001u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
+
+  const uint64_t original_time = TEST_current_time_ms;
+  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
+
+  JournalSlice slice;
+  slice.Init();
+
+  TEST_current_time_ms = 1000;
+  AddSetRecord(&slice, "first");
+  TEST_current_time_ms = 7000;
+  AddSetRecord(&slice, "second");
+  TEST_current_time_ms = 7001;
+  AddSetRecord(&slice, "third");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 2u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(3));
+}
+
+TEST(Journal, BacklogDropsMultipleExpiredSecondBuckets) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 5000u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
+
+  const uint64_t original_time = TEST_current_time_ms;
+  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
+
+  JournalSlice slice;
+  slice.Init();
+
+  TEST_current_time_ms = 1000;
+  AddSetRecord(&slice, "first");
+  TEST_current_time_ms = 2000;
+  AddSetRecord(&slice, "second");
+  TEST_current_time_ms = 3000;
+  AddSetRecord(&slice, "third");
+
+  TEST_current_time_ms = 9000;
+  AddSetRecord(&slice, "fourth");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_FALSE(slice.IsLSNInBuffer(2));
+  EXPECT_FALSE(slice.IsLSNInBuffer(3));
+  EXPECT_TRUE(slice.IsLSNInBuffer(4));
+}
+
+TEST(Journal, BacklogDropsExpiredSecondBucket) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1000u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1024 * 1024});
+
+  const uint64_t original_time = TEST_current_time_ms;
+  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
+
+  JournalSlice slice;
+  slice.Init();
+
+  TEST_current_time_ms = 1000;
+  AddSetRecord(&slice, "first");
+  TEST_current_time_ms = 1999;
+  AddSetRecord(&slice, "second");
+  TEST_current_time_ms = 2000;
+  AddSetRecord(&slice, "third");
+
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+
+  TEST_current_time_ms = 3000;
+  AddSetRecord(&slice, "fourth");
+
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_FALSE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(3));
+  EXPECT_TRUE(slice.IsLSNInBuffer(4));
 }
 
 }  // namespace journal

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -3,6 +3,7 @@
 //
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <variant>
@@ -81,6 +82,7 @@ struct ParsedEntry : public EntryBase {
 
 struct JournalItem {
   LSN lsn;
+  uint64_t time_ms = 0;
   std::string data;
 };
 

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -563,18 +563,18 @@ async def test_take_over_timeout(df_factory, df_seeder_factory):
 
 
 @pytest.mark.parametrize(
-    "master_threads, backlog_len, stream_during, stream_target_ops, num_drops, sleep_range, check_stale_log",
+    "master_threads, backlog_max_bytes, stream_during, stream_target_ops, num_drops, sleep_range, check_stale_log",
     [
         (6, None, False, None, 10, (0, 10), False),
-        (4, 4000, True, 4000, 3, (10, 20), False),
-        (4, 1, True, None, 3, (5, 10), True),
+        (4, "4mb", True, 4000, 3, (10, 20), False),
+        (4, "1b", True, None, 3, (5, 10), True),
     ],
 )
 async def test_network_disconnect(
     df_factory,
     df_seeder_factory,
     master_threads,
-    backlog_len,
+    backlog_max_bytes,
     stream_during,
     stream_target_ops,
     num_drops,
@@ -583,8 +583,8 @@ async def test_network_disconnect(
     proxy_factory,
 ):
     master_kwargs = dict(proactor_threads=master_threads)
-    if backlog_len is not None:
-        master_kwargs["shard_repl_backlog_len"] = backlog_len
+    if backlog_max_bytes is not None:
+        master_kwargs["shard_repl_backlog_max_bytes"] = backlog_max_bytes
     master = df_factory.create(**master_kwargs)
     replica = df_factory.create(proactor_threads=4)
 
@@ -987,12 +987,19 @@ async def test_replica_of_replica(df_factory):
 
 
 @pytest.mark.parametrize(
-    "use_takeover, backlog_len",
-    [(False, 2), (False, 1), (True, 1), (True, 10)],
+    "use_takeover, backlog_max_bytes, send_writes",
+    [
+        (False, "1mb", False),
+        (False, "1b", False),
+        (True, "1b", False),
+        (True, "1mb", True),
+    ],
 )
-async def test_partial_replication_on_same_source_master(df_factory, use_takeover, backlog_len):
+async def test_partial_replication_on_same_source_master(
+    df_factory, use_takeover, backlog_max_bytes, send_writes
+):
     master = df_factory.create()
-    replica1 = df_factory.create(shard_repl_backlog_len=backlog_len)
+    replica1 = df_factory.create(shard_repl_backlog_max_bytes=backlog_max_bytes)
     replica2 = df_factory.create()
 
     df_factory.start_all([master, replica1, replica2])
@@ -1020,7 +1027,7 @@ async def test_partial_replication_on_same_source_master(df_factory, use_takeove
     if use_takeover:
         # Promote first replica to master
         await c_replica1.execute_command("REPLTAKEOVER 5")
-        if backlog_len > 1:
+        if send_writes:
             await c_replica1.execute_command("SET bar foo")
             await c_replica1.execute_command("SET foo bar")
 
@@ -1277,8 +1284,8 @@ async def test_cascaded_partial_sync_split_brain(df_factory):
 
 
 @pytest.mark.parametrize("proactors", [1, 4, 6])
-@pytest.mark.parametrize("backlog_len", [1, 256, 1024, 1300])
-async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
+@pytest.mark.parametrize("stream_count", [1, 256, 1024, 1300])
+async def test_partial_sync(df_factory, proactors, stream_count, proxy_factory):
     keys = 5_000
     if proactors > 1:
         keys = 10_000
@@ -1286,7 +1293,10 @@ async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
     # We use lock_on_hashtag because we want to seed enough elements to one flow/journal such that
     # the partial sync stales.
     master = df_factory.create(
-        proactor_threads=proactors, shard_repl_backlog_len=backlog_len, lock_on_hashtags=True
+        proactor_threads=proactors,
+        shard_repl_backlog_time_ms=0,
+        shard_repl_backlog_max_bytes="1b",
+        lock_on_hashtags=True,
     )
     replica = df_factory.create(proactor_threads=proactors)
 
@@ -1307,7 +1317,7 @@ async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
         # Reach stable sync
         await wait_for_replicas_state(c_replica)
         # Stream some elements
-        await stream(c_master, backlog_len)
+        await stream(c_master, stream_count)
 
         proxy.drop_connection()
         # Give time to detect dropped connection and reconnect
@@ -1319,7 +1329,7 @@ async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
 
         await proxy.close()
         # Whoops we moved too much, no partial sync here
-        await stream(c_master, backlog_len + 10)
+        await stream(c_master, stream_count + 10)
         await proxy.start_serving()
         await asyncio.sleep(1.0)
 
@@ -1340,6 +1350,39 @@ async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
     # Second partial sync failed because of stale LSN
     lines = master.find_in_logs("Partial sync requested from stale LSN")
     assert len(lines) == 1
+
+
+async def test_partial_sync_keeps_oversized_backlog_record(df_factory, proxy_factory):
+    master = df_factory.create(
+        proactor_threads=2,
+        shard_repl_backlog_time_ms=5_000,
+        shard_repl_backlog_max_bytes="64kb",
+    )
+    replica = df_factory.create(proactor_threads=2)
+    df_factory.start_all([master, replica])
+
+    c_master, c_replica = master.client(), replica.client()
+    proxy = await proxy_factory(master.port)
+
+    await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
+    await wait_for_replicas_state(c_replica)
+    await check_all_replicas_finished([c_replica], c_master)
+
+    # Keep the replica disconnected while the master receives a record larger than the configured
+    # byte budget. The record must remain available for partial sync.
+    await proxy.close()
+    await c_master.append("large", "x" * (128 * 1024))
+    await proxy.start_serving()
+
+    await check_all_replicas_finished([c_replica], c_master)
+    assert await c_replica.get("large") == "x" * (128 * 1024)
+
+    await c_master.aclose()
+    await c_replica.aclose()
+    master.stop()
+    replica.stop()
+
+    assert len(master.find_in_logs("Partial sync requested from LSN")) == 1
 
 
 @pytest.mark.large

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -1284,8 +1284,7 @@ async def test_cascaded_partial_sync_split_brain(df_factory):
 
 
 @pytest.mark.parametrize("proactors", [1, 4, 6])
-@pytest.mark.parametrize("stream_count", [1, 256, 1024, 1300])
-async def test_partial_sync(df_factory, proactors, stream_count, proxy_factory):
+async def test_partial_sync(df_factory, proactors, proxy_factory):
     keys = 5_000
     if proactors > 1:
         keys = 10_000
@@ -1316,8 +1315,10 @@ async def test_partial_sync(df_factory, proactors, stream_count, proxy_factory):
         await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
         # Reach stable sync
         await wait_for_replicas_state(c_replica)
-        # Stream some elements
-        await stream(c_master, stream_count)
+        await stream(c_master, 2)
+        # The first reconnect must start at the current LSN; the one-byte backlog cannot cover
+        # records that are still in flight.
+        await check_all_replicas_finished([c_replica], c_master)
 
         proxy.drop_connection()
         # Give time to detect dropped connection and reconnect
@@ -1328,8 +1329,8 @@ async def test_partial_sync(df_factory, proactors, stream_count, proxy_factory):
         assert hash1 == hash2
 
         await proxy.close()
-        # Whoops we moved too much, no partial sync here
-        await stream(c_master, stream_count + 10)
+        # The one-byte backlog retains only the latest record, making this flow stale.
+        await stream(c_master, 2)
         await proxy.start_serving()
         await asyncio.sleep(1.0)
 


### PR DESCRIPTION
fixes: #7994

Summary: This PR replaces the fixed per-shard replication backlog entry count with time- and byte-based retention.

Changes:

- Adds a five-second default age target via --shard_repl_backlog_time_ms.
- Adds --shard_repl_backlog_max_bytes, defaulting to 0.5% of maxmemory.
- Deprecates --shard_repl_backlog_len and updates stale-partial-sync guidance.
- Expands C++ coverage for byte limits, capacity growth, oversized records, and time expiry.
- Updates replication-resilience tests to configure byte-based backlog behavior.

Technical Notes: The byte allowance is divided among shards, while time eviction is evaluated on append and grouped into one-second buckets.