### PR TITLE
fix: GAT 0 journals PERSIST instead of PEXPIREAT 0

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -869,6 +869,9 @@ OpResult<DbSlice::Iterator> FindKeyAndSetExpiry(const GetAndTouchParams& params)
     const OpArgs& op_args = params.t->GetOpArgs(params.shard);
     if (expired) {
       RecordJournal(op_args, "DEL"sv, ArgSlice{(params.key)});
+    } else if (params.expire_params.persist) {
+      // GAT 0 removes the expiry; PEXPIREAT with the returned 0 would delete the replica's key.
+      RecordJournal(op_args, "PERSIST"sv, ArgSlice{(params.key)});
     } else {
       RecordJournal(op_args, "PEXPIREAT"sv, ArgSlice{(params.key), (absl::StrCat(value))});
     }

--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -726,6 +726,16 @@ async def test_mc_gat_replication(df_factory):
     expected_cas_ver = b"0"
     assert result[key] == (value, expected_cas_ver), f"unexpected result for key: {result=}"
 
+    # GAT 0 removes the expiry; the replica must keep the key as persistent, not delete it
+    assert cm.set(key, value, expire=1000, noreply=True)
+    assert cm._fetch_cmd(b"gat", [str(0), key], expect_cas=False) == {key: value}
+
+    async with master.client() as c_master, replica.client() as c_replica:
+        assert await c_master.pttl(key) == -1
+        await check_all_replicas_finished([c_replica], c_master)
+        # -2 would mean the replica dropped the key instead of persisting it
+        assert await c_replica.pttl(key) == -1
+
 
 @pytest.mark.skip("Fails constantly on CI")
 @pytest.mark.large


### PR DESCRIPTION
Memcached `GAT key 0` removes the key's expiry on the primary, but the journal recorded `PEXPIREAT key 0` (epoch = already past), so replicas deleted the key while the primary kept it persistent - a permanent primary/replica divergence.
