### PR TITLE
fix(config): make notify_keyspace_events configuration correct

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -467,12 +467,6 @@ DbSlice::DbSlice(uint32_t index, bool cache_mode, EngineShard* owner, Namespace*
   CHECK(ns_ != nullptr);
   db_arr_.emplace_back();
   CreateDb(0);
-  std::string keyspace_events = GetFlag(FLAGS_notify_keyspace_events);
-  if (!keyspace_events.empty() && keyspace_events != "Ex") {
-    LOG(ERROR) << "Only Ex is currently supported";
-    exit(0);
-  }
-  expired_keys_events_recording_ = !keyspace_events.empty();
   journal_omit_redundant_writes_ = absl::GetFlag(FLAGS_journal_omit_redundant_writes);
 }
 
@@ -1827,10 +1821,6 @@ void DbSlice::ResetEvents() {
       db->stats.events = {};
     }
   }
-}
-
-void DbSlice::SetNotifyKeyspaceEvents(std::string_view notify_keyspace_events) {
-  expired_keys_events_recording_ = !notify_keyspace_events.empty();
 }
 
 void DbSlice::QueueInvalidationTrackingMessageAtomic(std::string_view key) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -526,9 +526,14 @@ class DbSlice {
     client_tracking_map_[key].insert(conn_ref);
   }
 
-  // Does not check for non supported events. Callers must parse the string and reject it
-  // if it's not empty and not EX.
-  void SetNotifyKeyspaceEvents(std::string_view notify_keyspace_events);
+  bool IsExpiredEventsRecording() const {
+    return expired_keys_events_recording_;
+  }
+
+  // Driven by Namespaces::SetExpiredEventsRecording; call on the owning shard thread.
+  void SetExpiredEventsRecording(bool enable) {
+    expired_keys_events_recording_ = enable;
+  }
 
   // Returns true if any registered snapshot is blocked on bucket serialiazion (big value, delayed)
   // and thus might reject the journal change

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -1122,12 +1122,12 @@ Usage: dragonfly [FLAGS]
     return 1;
   }
 
-  // Validate startup flags (TLS + snapshot filename) BEFORE creating the pidfile and before
-  // starting the proactor pool. They return false on a bad config; we exit cleanly (code 1)
-  // here, before the fiber runtime exists, which avoids a stale pidfile and aborting during
-  // fiber-runtime teardown.
+  // Validate startup flags (TLS, snapshot filename, keyspace events) BEFORE creating the
+  // pidfile and before starting the proactor pool. They return false on a bad config; we exit
+  // cleanly (code 1) here, before the fiber runtime exists, which avoids a stale pidfile and
+  // aborting during fiber-runtime teardown.
   if (!dfly::ValidateServerTlsFlags() || !dfly::ValidateClientTlsFlags() ||
-      !dfly::ValidateSnapshotFilenameFlags()) {
+      !dfly::ValidateSnapshotFilenameFlags() || !dfly::ValidateNotifyKeyspaceEventsFlag()) {
     return 1;
   }
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -4,6 +4,8 @@
 
 #include "server/generic_family.h"
 
+#include <absl/cleanup/cleanup.h>
+
 extern "C" {
 #include "redis/rdb.h"
 }
@@ -2335,6 +2337,48 @@ TEST_F(GenericFamilyTest, KeyspaceNotificationNoAtomicSectionOnExpiry) {
 
   // Restore the flag so it doesn't bleed into other tests.
   Run({"CONFIG", "SET", "notify_keyspace_events", ""});
+}
+
+// A rejected CONFIG SET must not leave the invalid value observable: CONFIG GET has to keep
+// returning the previous value (a poisoned raw flag would also crash later flag consumers).
+TEST_F(GenericFamilyTest, ConfigSetRejectedValueRollsBack) {
+  auto initial = Run({"CONFIG", "GET", "notify_keyspace_events"});
+  ASSERT_THAT(initial, ArrLen(2));
+  const string prev = initial.GetVec()[1].GetString();
+
+  EXPECT_THAT(Run({"CONFIG", "SET", "notify_keyspace_events", "nonsense"}),
+              ErrArg("CONFIG SET failed"));
+  auto resp = Run({"CONFIG", "GET", "notify_keyspace_events"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("notify_keyspace_events", prev));
+}
+
+// CONFIG SET notify_keyspace_events must apply to every namespace, not only the default one,
+// and namespaces created afterwards must inherit the current setting.
+TEST_F(GenericFamilyTest, ConfigNotifyAppliesToAllNamespaces) {
+  Namespace* ns = pp_->at(0)->Await([] { return &namespaces->GetOrInsert("ns1"); });
+
+  const string prev_notify =
+      Run({"CONFIG", "GET", "notify_keyspace_events"}).GetVec()[1].GetString();
+  Run({"CONFIG", "SET", "notify_keyspace_events", "EX"});
+  // Scoped so a fatal assertion below cannot leak the setting into other tests.
+  absl::Cleanup restore_notify = [&] {
+    Run({"CONFIG", "SET", "notify_keyspace_events", prev_notify});
+  };
+
+  for (unsigned i = 0; i < shard_set->size(); ++i) {
+    EXPECT_TRUE(ns->GetDbSlice(i).IsExpiredEventsRecording()) << i;
+  }
+
+  Namespace* late_ns = pp_->at(0)->Await([] { return &namespaces->GetOrInsert("ns2"); });
+  for (unsigned i = 0; i < shard_set->size(); ++i) {
+    EXPECT_TRUE(late_ns->GetDbSlice(i).IsExpiredEventsRecording()) << i;
+  }
+
+  Run({"CONFIG", "SET", "notify_keyspace_events", ""});
+  for (unsigned i = 0; i < shard_set->size(); ++i) {
+    EXPECT_FALSE(ns->GetDbSlice(i).IsExpiredEventsRecording()) << i;
+    EXPECT_FALSE(late_ns->GetDbSlice(i).IsExpiredEventsRecording()) << i;
+  }
 }
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1090,24 +1090,21 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("search_query_string_bytes");
 #endif
 
-  config_registry.RegisterMutable(
-      "notify_keyspace_events", [pool = &pp_](const absl::CommandLineFlag& flag) {
-        auto res = flag.TryGet<std::string>();
-        if (!res.has_value() || (!res->empty() && !absl::EqualsIgnoreCase(*res, "EX"))) {
-          return false;
-        }
+  // dfly_main validates before the pidfile/listeners exist; backstop for other embeddings.
+  if (!ValidateNotifyKeyspaceEventsFlag()) {
+    exit(1);
+  }
 
-        pool->AwaitBrief([&res](unsigned, auto*) {
-          auto* shard = EngineShard::tlocal();
-          if (shard) {
-            auto shard_id = shard->shard_id();
-            auto& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id);
-            db_slice.SetNotifyKeyspaceEvents(*res);
-          }
-        });
+  config_registry.RegisterMutable("notify_keyspace_events", [](const absl::CommandLineFlag& flag) {
+    // The candidate value is already parsed into the flag at this point.
+    auto res = flag.TryGet<std::string>();
+    if (!res.has_value() || !ValidateNotifyKeyspaceEventsFlag()) {
+      return false;
+    }
 
-        return true;
-      });
+    namespaces->SetExpiredEventsRecording(!res->empty());
+    return true;
+  });
 
   config_registry.RegisterMutable("aclfile");
   config_registry.RegisterSetter<uint32_t>("acllog_max_len", [](uint32_t val) {

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -11,6 +11,7 @@
 #include "server/engine_shard_set.h"
 
 ABSL_DECLARE_FLAG(bool, cache_mode);
+ABSL_DECLARE_FLAG(std::string, notify_keyspace_events);
 
 namespace dfly {
 
@@ -50,6 +51,11 @@ BlockingController* Namespace::GetBlockingController(ShardId sid) {
 }
 
 Namespaces::Namespaces() {
+  {
+    // Startup only: CONFIG SET is not reachable yet, the validated flag is safe to read.
+    util::fb2::LockGuard guard(mu_);
+    expired_events_recording_default_ = !absl::GetFlag(FLAGS_notify_keyspace_events).empty();
+  }
   default_namespace_ = &GetOrInsert("");
 }
 
@@ -81,6 +87,20 @@ Namespace& Namespaces::GetDefaultNamespace() const {
   return *default_namespace_;
 }
 
+void Namespaces::SetExpiredEventsRecording(bool enable) {
+  util::fb2::LockGuard guard(mu_);
+  expired_events_recording_default_ = enable;
+  // mu_ serializes this with namespace creation, which inherits the default.
+  shard_set->pool()->AwaitFiberOnAll([&](unsigned, util::ProactorBase*) {
+    EngineShard* shard = EngineShard::tlocal();
+    if (shard) {
+      for (auto& entry : ABSL_TS_UNCHECKED_READ(namespaces_)) {
+        entry.second.GetDbSlice(shard->shard_id()).SetExpiredEventsRecording(enable);
+      }
+    }
+  });
+}
+
 Namespace& Namespaces::GetOrInsert(std::string_view ns) {
   {
     // Try to look up under a shared lock
@@ -94,7 +114,17 @@ Namespace& Namespaces::GetOrInsert(std::string_view ns) {
   {
     // Key was not found, so we create create it under unique lock
     util::fb2::LockGuard guard(mu_);
-    return namespaces_[ns];
+    auto it = namespaces_.find(ns);
+    if (it != namespaces_.end()) {
+      return it->second;
+    }
+
+    Namespace& new_ns = namespaces_[ns];
+    // Not published yet (mu_ is held), so plain writes are safe.
+    for (ShardId sid = 0; sid < shard_set->size(); ++sid) {
+      new_ns.GetDbSlice(sid).SetExpiredEventsRecording(expired_events_recording_default_);
+    }
+    return new_ns;
   }
 }
 

--- a/src/server/namespaces.h
+++ b/src/server/namespaces.h
@@ -59,10 +59,15 @@ class Namespaces {
   Namespace& GetDefaultNamespace() const;  // No locks
   Namespace& GetOrInsert(std::string_view ns) ABSL_LOCKS_EXCLUDED(mu_);
 
+  // Applies to all namespaces and becomes the default for namespaces created later.
+  void SetExpiredEventsRecording(bool enable) ABSL_LOCKS_EXCLUDED(mu_);
+
  private:
   util::fb2::SharedMutex mu_{};
   absl::node_hash_map<std::string, Namespace> namespaces_ ABSL_GUARDED_BY(mu_);
   Namespace* default_namespace_ = nullptr;
+  // Kept apart from the raw flag, which briefly holds unvalidated input during CONFIG SET.
+  bool expired_events_recording_default_ ABSL_GUARDED_BY(mu_) = false;
 };
 
 }  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -166,6 +166,7 @@ ABSL_FLAG(bool, replicaof_no_one_start_journal, true,
           "when set, preserves journal offsets after REPLICAOF NO ONE");
 
 ABSL_DECLARE_FLAG(int32_t, port);
+ABSL_DECLARE_FLAG(std::string, notify_keyspace_events);
 ABSL_DECLARE_FLAG(bool, cache_mode);
 ABSL_DECLARE_FLAG(int32_t, hz);
 ABSL_DECLARE_FLAG(bool, experimental_cascaded_partial_sync);
@@ -990,6 +991,15 @@ void SendSaveHelp(RedisReplyBuilder* rb, bool is_bgsave) {
 }
 
 }  // namespace
+
+bool ValidateNotifyKeyspaceEventsFlag() {
+  const string value = absl::GetFlag(FLAGS_notify_keyspace_events);
+  if (!value.empty() && !absl::EqualsIgnoreCase(value, "EX")) {
+    LOG(ERROR) << "Invalid notify_keyspace_events value, only Ex is currently supported";
+    return false;
+  }
+  return true;
+}
 
 bool ValidateServerTlsFlags() {
   if (!absl::GetFlag(FLAGS_tls)) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -55,6 +55,10 @@ bool ValidateServerTlsFlags();
 // separators, extension vs snapshot format). Returns false on an invalid configuration.
 bool ValidateSnapshotFilenameFlags();
 
+// Validates --notify_keyspace_events (only the Ex class is supported). Returns false and logs
+// on an invalid value.
+bool ValidateNotifyKeyspaceEventsFlag();
+
 class CommandContext;
 class CommandRegistry;
 class DflyCmd;


### PR DESCRIPTION
Fixes three defects around `notify_keyspace_events`:

- New DbSlices re-read the raw flag, racing with CONFIG SET whose candidate value is briefly unvalidated (the registry parses first, validates after); a namespace created in that window could observe a rejected value and kill the process. The DbSlice constructor also demanded exactly `"Ex"` while the validator accepts `"EX"`, so even a valid `CONFIG SET notify_keyspace_events EX` would exit the server on a later namespace creation.
- `CONFIG SET notify_keyspace_events` updated only the default namespace; named namespaces kept their stale setting in both directions (kept silent after enable, kept publishing after disable).
- An invalid startup value exited mid-init with code 0, leaving a stale pidfile and unix socket behind.
