### PR TITLE
fix(tls): atomic context switch and correct tls_bytes accounting

### DIFF
--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -109,7 +109,10 @@ bool ConfigureKeepAlive(int fd) {
 }
 
 struct ListenerStats {
-  size_t tls_allocated_bytes = 0;
+  // Signed: OpenSSL objects are allocated and freed on different threads (contexts are built
+  // once and shared across listeners), so per-thread values can go negative; only the sum
+  // across threads is meaningful.
+  int64_t tls_allocated_bytes = 0;
   uint64_t refused_conn_maxclients_reached_cnt = 0;
 };
 
@@ -125,8 +128,12 @@ void* OverriddenSSLMalloc(size_t size, const char* file, int line) {
 void* OverriddenSSLRealloc(void* addr, size_t size, const char* file, int line) {
   size_t prev_size = mi_malloc_usable_size(addr);
   void* res = mi_realloc(addr, size);
-  listener_tl_stats.tls_allocated_bytes += mi_malloc_usable_size(res);
-  listener_tl_stats.tls_allocated_bytes -= prev_size;
+  // On failure the original block stays allocated and will be freed (and subtracted) later,
+  // so adjusting the counter here would subtract it twice.
+  if (res) {
+    listener_tl_stats.tls_allocated_bytes += mi_malloc_usable_size(res);
+    listener_tl_stats.tls_allocated_bytes -= prev_size;
+  }
   return res;
 }
 
@@ -283,7 +290,32 @@ std::shared_ptr<const TlsCertInfo> Listener::GetTlsCertInfo() const {
 #endif
 }
 
-size_t Listener::TLSUsedMemoryThreadLocal() {
+void Listener::ApplyTlsCtx(SSL_CTX* ctx) {
+#ifdef DFLY_USE_SSL
+  const bool tls_on_privileged_port = !GetFlag(FLAGS_no_tls_on_admin_port);
+  SSL_CTX* prev_ctx = ctx_;
+  std::shared_ptr<const TlsCertInfo> info;
+  if (ctx && (!IsPrivilegedInterface() || tls_on_privileged_port)) {
+    SSL_CTX_up_ref(ctx);
+    ctx_ = ctx;
+    auto parsed = ParseTlsCertInfo(SSL_CTX_get0_certificate(ctx));
+    if (parsed) {
+      info = std::make_shared<const TlsCertInfo>(*parsed);
+    }
+  } else {
+    ctx_ = nullptr;
+  }
+  {
+    util::fb2::LockGuard lk(tls_cert_info_mu_);
+    tls_cert_info_ = std::move(info);
+  }
+  if (prev_ctx) {
+    SSL_CTX_free(prev_ctx);
+  }
+#endif
+}
+
+int64_t Listener::TLSUsedMemoryThreadLocal() {
   return listener_tl_stats.tls_allocated_bytes;
 }
 

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -249,33 +249,16 @@ error_code Listener::ConfigureServerSocket(int fd) {
 
 bool Listener::ReconfigureTLS() {
 #ifdef DFLY_USE_SSL
-  SSL_CTX* prev_ctx = ctx_;
-  const bool tls_on_privileged_port = !GetFlag(FLAGS_no_tls_on_admin_port);
-
-  if (GetFlag(FLAGS_tls) && (!IsPrivilegedInterface() || tls_on_privileged_port)) {
-    SSL_CTX* ctx = CreateSslCntx(facade::TlsContextRole::SERVER);
+  SSL_CTX* ctx = nullptr;
+  if (GetFlag(FLAGS_tls)) {
+    ctx = CreateSslCntx(facade::TlsContextRole::SERVER);
     if (!ctx) {
       return false;
     }
-    ctx_ = ctx;
-    X509* cert = SSL_CTX_get0_certificate(ctx);
-    auto info = ParseTlsCertInfo(cert);
-    {
-      util::fb2::LockGuard lk(tls_cert_info_mu_);
-      tls_cert_info_ = info ? std::make_shared<const TlsCertInfo>(*info) : nullptr;
-    }
-  } else {
-    ctx_ = nullptr;
-    {
-      util::fb2::LockGuard lk(tls_cert_info_mu_);
-      tls_cert_info_.reset();
-    }
   }
-
-  if (prev_ctx) {
-    // SSL_CTX is reference counted so if other connections have a reference
-    // to the context it won't be freed yet.
-    SSL_CTX_free(prev_ctx);
+  ApplyTlsCtx(ctx);
+  if (ctx) {
+    SSL_CTX_free(ctx);
   }
 #endif
   return true;

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -45,12 +45,18 @@ class Listener : public util::ListenerInterface {
   // ReconfigureTLS MUST be called from the same proactor as the listener.
   bool ReconfigureTLS();
 
+  // Replaces the TLS context with ctx (or drops it for a privileged interface when
+  // no_tls_on_admin_port is set). Takes its own reference on ctx and never fails, so a set of
+  // listeners can be switched without partial state. MUST be called from the listener proactor.
+  void ApplyTlsCtx(SSL_CTX* ctx);
+
   // Returns the TLS certificate metadata currently used by this listener.
   // nullptr if TLS is not configured or the certificate could not be parsed.
   std::shared_ptr<const TlsCertInfo> GetTlsCertInfo() const;
 
-  // Returns thread-local dynamic memory usage by TLS.
-  static size_t TLSUsedMemoryThreadLocal();
+  // Thread-local TLS memory delta; can be negative (frees may run on another thread), only the
+  // sum across all threads is meaningful.
+  static int64_t TLSUsedMemoryThreadLocal();
   static uint64_t RefusedConnectionMaxClientsCount();
 
   bool IsPrivilegedInterface() const;

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -226,8 +226,9 @@ string NormalizePaths(std::string_view path) {
 template <typename... Args> unique_ptr<Listener> MakeListener(ProactorPool* pool, Args&&... args) {
   unique_ptr<Listener> res;
   // The constructor allocates TLS state; run it on a proactor thread so those bytes land on a
-  // thread included in the tls_bytes sum (the main thread is not).
-  pool->GetNextProactor()->Await([&] {
+  // thread included in the tls_bytes sum (the main thread is not). at(0), not GetNextProactor():
+  // the latter would shift the round-robin AddListener uses to spread accept loops.
+  pool->at(0)->Await([&] {
     res = make_unique<Listener>(std::forward<Args>(args)...);
     res->SetConnFiberStackSize(kFiberDefaultStackSize);
   });

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -223,9 +223,14 @@ string NormalizePaths(std::string_view path) {
   return string(path);
 }
 
-template <typename... Args> unique_ptr<Listener> MakeListener(Args&&... args) {
-  auto res = make_unique<Listener>(std::forward<Args>(args)...);
-  res->SetConnFiberStackSize(kFiberDefaultStackSize);
+template <typename... Args> unique_ptr<Listener> MakeListener(ProactorPool* pool, Args&&... args) {
+  unique_ptr<Listener> res;
+  // The constructor allocates TLS state; run it on a proactor thread so those bytes land on a
+  // thread included in the tls_bytes sum (the main thread is not).
+  pool->GetNextProactor()->Await([&] {
+    res = make_unique<Listener>(std::forward<Args>(args)...);
+    res->SetConnFiberStackSize(kFiberDefaultStackSize);
+  });
   return res;
 }
 
@@ -328,7 +333,7 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   // we depend on tcp listener to be at the front since we later
   // need to pass it to the AclFamily::Init
   if (!tcp_disabled) {
-    auto listener = MakeListener(Protocol::REDIS, &service, Listener::Role::MAIN);
+    auto listener = MakeListener(pool, Protocol::REDIS, &service, Listener::Role::MAIN);
     main_listener = listener.get();
     listeners.push_back(listener.release());
   }
@@ -393,7 +398,7 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
     }
     unlink(unix_sock.c_str());
 
-    auto uds_listener = MakeListener(Protocol::REDIS, &service);
+    auto uds_listener = MakeListener(pool, Protocol::REDIS, &service);
     error_code ec =
         acceptor->AddUDSListener(unix_sock.c_str(), unix_socket_perm, uds_listener.get());
     if (ec) {
@@ -423,7 +428,7 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
     const char* interface_addr = admin_bind.empty() ? nullptr : admin_bind.c_str();
     const std::string printable_addr =
         absl::StrCat("admin socket ", interface_addr ? interface_addr : "any", ":", admin_port);
-    auto admin_listener = MakeListener(Protocol::REDIS, &service, Listener::Role::PRIVILEGED);
+    auto admin_listener = MakeListener(pool, Protocol::REDIS, &service, Listener::Role::PRIVILEGED);
 
     error_code ec = acceptor->AddListener(interface_addr, admin_port, admin_listener.get());
 
@@ -449,7 +454,7 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   }
 
   if (mc_port > 0 && !tcp_disabled) {
-    auto listener = MakeListener(Protocol::MEMCACHE, &service);
+    auto listener = MakeListener(pool, Protocol::MEMCACHE, &service);
     error_code ec = acceptor->AddListener(bind_addr, mc_port, listener.get());
     if (ec) {
       LOG(ERROR) << "Could not open memcached port " << mc_port << ", error: " << ec.message();

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -7,6 +7,7 @@ extern "C" {
 #include "redis/zmalloc.h"
 }
 
+#include <absl/container/flat_hash_set.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/strip.h>
@@ -16,11 +17,13 @@ extern "C" {
 #include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "facade/dragonfly_listener.h"
 #include "facade/error.h"
 #include "facade/facade_test.h"
 #include "server/command_registry.h"
 #include "server/main_service.h"
 #include "server/test_utils.h"
+#include "util/accept_server.h"
 
 ABSL_DECLARE_FLAG(float, mem_defrag_threshold);
 ABSL_DECLARE_FLAG(float, mem_defrag_waste_threshold);
@@ -1098,6 +1101,30 @@ TEST_F(DflyEngineTest, ExpireInlineKeyAccounting) {
   EXPECT_EQ(stats.inline_keys, 0u);
   EXPECT_EQ(stats.expire_count, 0u);
   EXPECT_EQ(stats.memory_usage_by_type[OBJ_KEY], 0);
+}
+
+// AddListener picks the accept-loop proactor via the pool's shared round-robin, so listener
+// construction (see MakeListener in dfly_main.cc) must not call GetNextProactor() in between —
+// that would stack several accept loops on one proactor.
+TEST_F(DflyEngineTest, ListenerAcceptLoopDistribution) {
+  util::AcceptServer acceptor{pp_.get(), /*break_on_int=*/false};
+  const size_t kListeners = 3;
+  ASSERT_LE(kListeners, pp_->size());
+
+  std::vector<facade::Listener*> listeners;
+  for (size_t i = 0; i < kListeners; ++i) {
+    facade::Listener* listener = nullptr;
+    // Construct on a fixed proactor, mirroring MakeListener.
+    pp_->at(0)->Await(
+        [&] { listener = new facade::Listener(facade::Protocol::REDIS, service_.get()); });
+    ASSERT_FALSE(acceptor.AddListener("localhost", 0, listener));  // Takes ownership.
+    listeners.push_back(listener);
+  }
+
+  absl::flat_hash_set<util::ProactorBase*> accept_proactors;
+  for (facade::Listener* listener : listeners)
+    accept_proactors.insert(listener->socket()->proactor());
+  EXPECT_EQ(kListeners, accept_proactors.size());
 }
 
 class DflyCommandAliasTest : public DflyEngineTest {

--- a/src/server/metrics.h
+++ b/src/server/metrics.h
@@ -90,7 +90,8 @@ struct Metrics {
   uint64_t hoffman_encode_total = 0, hoffman_encode_success = 0;
   uint64_t fiber_switch_cnt = 0;
   uint64_t fiber_switch_delay_usec = 0;
-  uint64_t tls_bytes = 0;
+  // Per-thread deltas may be negative (cross-thread frees); clamped after aggregation.
+  int64_t tls_bytes = 0;
   uint64_t refused_conn_max_clients_reached_count = 0;
   uint64_t serialization_bytes = 0;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2547,7 +2547,11 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, const MetricsCollectOpts& opts) 
     result.Merge(partial);
 
   // The per-thread deltas are read at slightly different moments, so the sum can transiently
-  // dip below zero.
+  // dip below zero; a large negative value however means an accounting leak.
+  constexpr int64_t kTlsAccountingDipThreshold = -1024 * 1024;
+  if (result.tls_bytes < kTlsAccountingDipThreshold) {
+    LOG_EVERY_T(WARNING, 60) << "tls_bytes accounting went negative: " << result.tls_bytes;
+  }
   result.tls_bytes = std::max<int64_t>(0, result.tls_bytes);
 
 #ifdef WITH_SEARCH

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1229,12 +1229,25 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
     if (!ValidateServerTlsFlags()) {
       return false;
     }
-    for (facade::Listener* l : listeners_) {
-      // Must reconfigure in the listener proactor to avoid a race.
-      if (!l->socket()->proactor()->Await([l] { return l->ReconfigureTLS(); })) {
+#ifdef DFLY_USE_SSL
+    // Build the new context before touching any listener: a bad cert/key must fail here, not
+    // midway through the listeners (a failed callback only rolls back the flag value, so a
+    // partial switch would leave listeners split between old and new TLS state).
+    SSL_CTX* ctx = nullptr;
+    if (absl::GetFlag(FLAGS_tls)) {
+      ctx = facade::CreateSslCntx(facade::TlsContextRole::SERVER);
+      if (!ctx) {
         return false;
       }
     }
+    for (facade::Listener* l : listeners_) {
+      // Must reconfigure in the listener proactor to avoid a race.
+      l->socket()->proactor()->Await([l, ctx] { l->ApplyTlsCtx(ctx); });
+    }
+    if (ctx) {
+      SSL_CTX_free(ctx);
+    }
+#endif
     return true;
   });
   config_registry.RegisterMutable("tls_cert_file");
@@ -2532,6 +2545,10 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, const MetricsCollectOpts& opts) 
   // Fold per-thread partials into the aggregate result on this thread.
   for (const Metrics& partial : partials)
     result.Merge(partial);
+
+  // The per-thread deltas are read at slightly different moments, so the sum can transiently
+  // dip below zero.
+  result.tls_bytes = std::max<int64_t>(0, result.tls_bytes);
 
 #ifdef WITH_SEARCH
   // HNSW indices live in a single global registry shared across shards, so their

--- a/tests/dragonfly/tls_conf_test.py
+++ b/tests/dragonfly/tls_conf_test.py
@@ -168,3 +168,22 @@ async def test_config_disable_tls(
         # Connecting without TLS should succeed.
         async with server.client() as client_unauth:
             await client_unauth.ping()
+
+
+async def test_tls_reload_memory_metric(df_factory, with_tls_server_args):
+    # The TLS context is built on the main thread at startup but freed on a listener thread on
+    # reload, which used to wrap the summed per-thread tls_bytes accounting to a huge value.
+    with df_factory.create(
+        admin_port=1114, no_tls_on_admin_port="true", requirepass="XXX", **with_tls_server_args
+    ) as server:
+        async with server.admin_client(password="XXX") as client:
+            # Drop the TLS contexts without any TLS connection alive.
+            await client.config_set("tls", "false")
+            info = await client.info("memory")
+            # An underflowed counter shows up as an astronomically large value.
+            assert info["tls_bytes"] < 100 * 1024 * 1024
+
+            # Re-enabling rebuilds the contexts; the metric must stay sane after churn.
+            await client.config_set("tls", "true")
+            info = await client.info("memory")
+            assert 0 < info["tls_bytes"] < 100 * 1024 * 1024


### PR DESCRIPTION
Two coupled TLS defects:
- The `tls` CONFIG callback reconfigured listeners one by one; a bad cert/key failed midway and left listeners split between old and new TLS state (a failed callback only rolls back the flag value).
- `tls_bytes` summed per-thread counters, but OpenSSL objects are allocated on one thread and freed on another (startup contexts are built on the main thread, which the metric sum never includes), so after a reload the summed metric wrapped to ~UINT64_MAX. Deterministic repro: no TLS connections alive + `CONFIG SET tls false` -> `tls_bytes` = 18446744073709531520.

Changes:
- The callback builds the SSL_CTX once before touching any listener; the new infallible `Listener::ApplyTlsCtx()` then switches each listener (taking its own reference), so a bad cert fails with zero listeners touched. `ApplyTlsCtx` also refreshes the listener's `tls_cert_info_`, keeping INFO's certificate metadata correct after a reload.
- TLS memory accounting is a single process-wide relaxed atomic counter (cross-thread alloc/free pairs make per-thread counters structurally wrong); the metric is read once instead of summed per thread. The realloc hook no longer adjusts the counter on a failed reallocation, which would otherwise subtract the still-live block twice.
- Regression test with main+admin listeners covering disable/enable reload.