### PR TITLE
fix(tiering): Attribute list-node offload/load bytes to the right slot

### DIFF
--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -179,6 +179,7 @@ class QList {
     void (*offload)(QList* ql, Node* node) = nullptr;
     void (*load)(QList* ql, Node* node) = nullptr;
     void (*cleanup)(QList* ql, Node* node) = nullptr;
+    std::string key;
   };
 
   /**
@@ -340,6 +341,19 @@ class QList {
 
   // Updates the db index associated with this list.
   void SetDbIndex(DbIndex db_id);
+
+  void SetKey(std::string_view key) {
+    if (tiering_enabled_) {
+      tiering_params_->key = key;
+    }
+  }
+
+  std::string_view GetKey() const {
+    if (tiering_enabled_) {
+      return std::string_view(tiering_params_->key);
+    }
+    return {};
+  }
 
   struct Stats {
     uint64_t compression_attempts = 0;

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -745,6 +745,35 @@ TEST_F(ClusterTieredTest, SlotCountersFollowOffloadAndDelete) {
   ExpectSlotEmpty(slot);
 }
 
+// List-node tiering offloads individual QList nodes, not the whole value; slot counters must
+// still track those bytes and return to zero after DEL.
+TEST_F(ClusterTieredTest, SlotCountersFollowListNodeOffloadAndDelete) {
+  const string kKey = "tiered-list-del";
+  const SlotId slot = KeySlot(kKey);
+  const int kItems = 8;  // Total number of nodes in the list.
+
+  SetTestFlag("tiered_experimental_list_support", "true");
+  SetTestFlag("list_tiering_threshold", "1");
+  SetTestFlag("list_max_listpack_size", "1");
+
+  pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->UpdateFromFlags(); });
+
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_THAT(Run({"RPUSH", kKey, string(2048, char('A' + i))}), IntArg(i + 1));
+  }
+
+  WaitForOffload(6);
+
+  // Only the head and tail nodes stay resident - 2 nods; Due to additional structure
+  // overhead we can still expect that the memory_bytes is less than 3 * 2048.
+  EXPECT_LT(RawSlotMemory(slot), int64_t(3 * 2048));
+  EXPECT_GT(GetSlotInfo(slot).tiered_bytes, 0);
+  ExpectSlotMirrorsDb(slot);
+
+  EXPECT_EQ(CheckedInt({"DEL", kKey}), 1);
+  ExpectSlotEmpty(slot);
+}
+
 // The single key lives in one slot, so the slot counters must mirror the db-wide ones exactly.
 TEST_F(ClusterTieredTest, SlotCountersFollowExternalOverwrite) {
   const string kKey = "tiered-set";

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1126,6 +1126,14 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
 
   AddKeyToIndexesIfNeeded(to_key, op_args.db_cntx, to_res.it->second, op_args.shard);
 
+  // When tiering is enabled, update tiered-storage metadata to the new key.
+  if (EngineShard::tlocal()->tiered_storage()) {
+    if (to_res.it->second.ObjType() == OBJ_LIST && to_res.it->second.Encoding() == kEncodingQL2) {
+      auto* ql = static_cast<QList*>(to_res.it->second.RObjPtr());
+      ql->SetKey(to_key);
+    }
+  }
+
   auto bc = op_args.db_cntx.ns->GetBlockingController(es->shard_id());
   if (!is_prior_list && to_res.it->second.ObjType() == OBJ_LIST && bc) {
     bc->Awaken(op_args.db_cntx.db_index, to_key);

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -151,7 +151,7 @@ void CleanupListNode(QList* ql, QList::Node* node) {
       }
       // We don't pass QList pointer so we need to decrease num_offloaded_nodes_ now.
       ql->AdjustOffloadNodeCount(-1);
-      ts->Delete(ql->GetDbIndex(), node);
+      ts->Delete(ql->GetDbIndex(), ql->GetKey(), node);
     }
   }
 }
@@ -160,6 +160,7 @@ class ListWrapper {
   using LP = detail::ListPack;
 
   DbIndex db_id_;
+  string_view key_;
   std::variant<QList*, LP> impl_;
 
   template <typename F> decltype(auto) VisitRef(F f) const {  // Cast T* to T&
@@ -189,6 +190,7 @@ class ListWrapper {
           .offload = OffloadListNode,
           .load = LoadListNode,
           .cleanup = CleanupListNode,
+          .key = std::string(key_),
       };
       ql->EnableTiering(params);
     }
@@ -259,7 +261,8 @@ class ListWrapper {
   // TODO: passing current dbid of object. It could happen that object is moved to
   // another db so this dbid will be incorrect. Refactor to support moving objects between dbs.
   template <typename T>
-  explicit ListWrapper(DbIndex dbid, T t) : db_id_(dbid), impl_(std::forward<T>(t)) {
+  explicit ListWrapper(DbIndex dbid, string_view key, T t)
+      : db_id_(dbid), key_(key), impl_(std::forward<T>(t)) {
   }
 
   size_t Size() const {
@@ -392,11 +395,11 @@ unsigned ListWrapper::Remove(string_view elem, unsigned count, QList::Where wher
   return removed;
 }
 
-ListWrapper GetLW(DbIndex dbid, const PrimeValue& mv) {
+ListWrapper GetLW(DbIndex dbid, string_view key, const PrimeValue& mv) {
   if (mv.Encoding() == kEncodingQL2) {
-    return ListWrapper{dbid, static_cast<QList*>(mv.RObjPtr())};
+    return ListWrapper{dbid, key, static_cast<QList*>(mv.RObjPtr())};
   }
-  return ListWrapper{dbid, detail::ListPack(static_cast<uint8_t*>(mv.RObjPtr()))};
+  return ListWrapper{dbid, key, detail::ListPack(static_cast<uint8_t*>(mv.RObjPtr()))};
 }
 
 enum class ListDir : uint8_t { LEFT, RIGHT };
@@ -438,7 +441,7 @@ std::string OpBPop(Transaction* t, EngineShard* shard, std::string_view key, Lis
   std::string value;
   size_t len;
 
-  ListWrapper lw = GetLW(t->GetDbContext().db_index, it->second);
+  ListWrapper lw = GetLW(t->GetDbContext().db_index, key, it->second);
   QList::Where where = ToWhere(dir);
   value = lw.Pop(where);
   lw.Launder(&it->second);
@@ -469,10 +472,10 @@ ListWrapper CreateOrGet(const OpArgs& op_args, string_view key, bool create, Pri
 
     uint8_t* lp = lpNew(0);
     pv->InitRobj(OBJ_LIST, kEncodingListPack, lp);
-    return ListWrapper{op_args.db_cntx.db_index, detail::ListPack(lp)};
+    return ListWrapper{op_args.db_cntx.db_index, key, detail::ListPack(lp)};
   }
 
-  return GetLW(op_args.db_cntx.db_index, *pv);
+  return GetLW(op_args.db_cntx.db_index, key, *pv);
 }
 
 OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, string_view dest,
@@ -484,7 +487,7 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
 
   auto src_it = src_res->it;
   string val;
-  ListWrapper srcql_v2 = GetLW(op_args.db_cntx.db_index, src_it->second);
+  ListWrapper srcql_v2 = GetLW(op_args.db_cntx.db_index, src, src_it->second);
   size_t prev_len = srcql_v2.Size();
 
   if (src == dest) {  // simple case.
@@ -536,7 +539,7 @@ OpResult<string> Peek(const OpArgs& op_args, string_view key, ListDir dir, bool 
   const PrimeValue& pv = it_res.value()->second;
   DCHECK_GT(pv.Size(), 0u);  // should be not-empty.
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, pv);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, pv);
   return lw.First(ToWhere(dir));
 }
 
@@ -592,7 +595,7 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, ListDir dir, u
   size_t prev_len = 0;
   StringVec res;
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, it->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, it->second);
   prev_len = lw.Size();
 
   if (prev_len < count) {
@@ -696,7 +699,7 @@ OpResult<uint32_t> OpLen(const OpArgs& op_args, std::string_view key) {
   if (!res)
     return res.status();
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, res.value()->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, res.value()->second);
   return lw.Size();
 }
 
@@ -705,7 +708,7 @@ OpResult<string> OpIndex(const OpArgs& op_args, std::string_view key, long index
   if (!res)
     return res.status();
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, res.value()->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, res.value()->second);
   optional elem = lw.At(index);
   if (!elem)
     return OpStatus::KEY_NOTFOUND;
@@ -722,7 +725,7 @@ OpResult<vector<uint32_t>> OpPos(const OpArgs& op_args, string_view key, string_
     return it_res.status();
 
   const PrimeValue& pv = (*it_res)->second;
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, pv);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, pv);
 
   QList::Where where = QList::HEAD;
   if (rank < 0) {
@@ -742,7 +745,7 @@ OpResult<int> OpInsert(const OpArgs& op_args, string_view key, string_view pivot
   if (!it_res)
     return it_res.status();
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, it_res->it->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, it_res->it->second);
 
   int res = -1;
 
@@ -760,7 +763,7 @@ OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, string_view ele
   if (!it_res)
     return it_res.status();
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, it_res->it->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, it_res->it->second);
 
   QList::Where where = QList::HEAD;
   if (count < 0) {
@@ -786,7 +789,7 @@ OpStatus OpSet(const OpArgs& op_args, string_view key, string_view elem, long in
   if (!it_res)
     return it_res.status();
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, it_res->it->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, it_res->it->second);
   OpStatus status = OpStatus::OUT_OF_RANGE;
   if (lw.Replace(index, elem)) {
     lw.Launder(&it_res->it->second);
@@ -828,7 +831,7 @@ OpStatus OpTrim(const OpArgs& op_args, string_view key, long start, long end) {
     rtrim = llen - end - 1;
   }
 
-  ListWrapper lw = GetLW(op_args.db_cntx.db_index, it->second);
+  ListWrapper lw = GetLW(op_args.db_cntx.db_index, key, it->second);
   lw.Erase(0, ltrim);
   lw.Erase(-rtrim, rtrim);
   lw.Launder(&it->second);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -295,7 +295,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   // Finalize stash for a fragments identified by pointer
   void SetExternal(tiering::ListNodeId id, tiering::DiskSegment segment) {
-    auto* stats = GetDbTableStats(std::get<0>(id));
+    DbTable* table = db_slice_.GetDBTable(std::get<0>(id));
+    DbTableStats* stats = &table->stats;
 
     stats->tiered_entries++;
     stats->tiered_used_bytes += segment.length;
@@ -310,7 +311,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     ql->AdjustMallocSize(-segment.length);
     node->SetExternal(segment.offset, segment.length);
 
-    stats->AddTypeMemoryUsage(OBJ_LIST, -segment.length);
+    AccountSlotTieredBytes(ql->GetKey(), segment.length, table);
+    AccountObjectMemory(ql->GetKey(), OBJ_LIST, -int64_t(segment.length), table);
   }
 
   // If any backpressure (throttling) is active, notify that the operation finished
@@ -404,14 +406,11 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
 
   if (const auto* key = std::get_if<tiering::ListNodeId>(&id); key) {
     DbIndex db_id = std::get<0>(*key);
+    QList* ql = reinterpret_cast<QList*>(std::get<1>(*key));
     QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(*key));
     ++stats_.total_uploads;
     decoder->Upload(node);
-    // TODO: per-slot accounting is skipped because node ids carry no slot/key information.
-    auto* stats = GetDbTableStats(db_id);
-    stats->AddTypeMemoryUsage(OBJ_LIST, node->sz);
-    stats->tiered_entries--;
-    stats->tiered_used_bytes -= segment.length;
+    AccountTieredUpload(node, segment.length, ql->GetKey(), db_slice_.GetDBTable(db_id));
     return true;
   }
 


### PR DESCRIPTION
When individual list nodes were offloaded to or loaded from disk, the memory and
disk-usage bytes were only tracked at the table level, never at the per-slot level.
This let per-slot statistics silently drift out of sync with reality, permanently
stranding bytes in the slot ledger even after the underlying data was gone.

Connect QList structure with their own key so tiering can correctly attribute
node-level byte movements to the right slot, matching how whole-value tiering
already works.

Add a regression test covering this scenario.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
