### PR TITLE
fix: add validation hop for multi-stream blocking XREADGROUP

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3034,7 +3034,8 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
       // distinguishes a missing stream (NOGROUP) from a non-stream value (WRONGTYPE). A plain
       // XREAD keeps waiting for the stream to be recreated.
       // TODO: Make kKeyNotFound a per-waiter result in BlockingController. It currently
-      // short-circuits the whole queue, so a blocked XREAD would hide an XREADGROUP behind it.
+      // short-circuits the whole queue, allowing a blocked XREAD to hide a later XREADGROUP
+      // waiter. Return kNotReady until the controller handles heterogeneous queues.
       return opts->read_group ? KeyReadyResult::kReady : KeyReadyResult::kNotReady;
     }
 
@@ -3050,7 +3051,7 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     }
 
     // An empty stream has nothing to serve: s->last_id only records the last generated id and
-    // survives XDEL and XTRIM.
+    // survives XDEL, XTRIM and metadata-only XSETID.
     if (!s->length)
       return KeyReadyResult::kNotReady;
 
@@ -3077,90 +3078,144 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
   // transaction to proceed.
   OpResult<RecordVec> result;
   std::string key;
-  auto range_cb = [&](Transaction* t, EngineShard* shard) {
-    if (auto wake_key = t->GetWakeKey(shard->shard_id()); wake_key) {
-      RangeOpts range_opts;
-      // Ensure the woken read honors COUNT like the non-blocking path
-      // (OpRead) does: without it, a consumer woken by a transaction that
-      // added multiple entries receives all of them in one reply.
-      range_opts.count = opts->count;
-      range_opts.end = ParsedStreamId{.val = streamID{
-                                          .ms = UINT64_MAX,
-                                          .seq = UINT64_MAX,
-                                      }};
-      StreamIDsItem& sitem = opts->stream_ids.at(*wake_key);
-      range_opts.start = sitem.id;
 
-      // sitem.group was resolved before we blocked and the stream may have been deleted or
-      // retyped since. Re-resolve it against the current table instead of dereferencing a stale
-      // pointer, preserving WRONGTYPE when a non-stream replaced the key.
-      if (opts->read_group) {
-        auto op_args = t->GetOpArgs(shard);
-        auto res_it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, *wake_key, OBJ_STREAM);
-        if (!res_it.ok()) {
-          result = res_it.status() == OpStatus::WRONG_TYPE ? OpStatus::WRONG_TYPE
+  auto send_nogroup = [rb] {
+    return rb->SendError("-NOGROUP the consumer group this client was blocked on no longer exists");
+  };
+
+  // Re-resolves the streams owned by a single shard. Never trusts the cached streamCG*: background
+  // deletions (slot flush, eviction) bypass intent locks, so a stream may have been freed since it
+  // was last seen. Returns INVALID_VALUE for a missing stream or group, WRONG_TYPE if the key was
+  // replaced by another type.
+  auto validate_shard_keys = [&](const OpArgs& op_args, const ShardArgs& keys) {
+    OpStatus status = OpStatus::OK;
+    for (string_view skey : keys) {
+      auto res_it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, skey, OBJ_STREAM);
+      if (!res_it.ok()) {
+        if (status == OpStatus::OK) {
+          status = res_it.status() == OpStatus::WRONG_TYPE ? OpStatus::WRONG_TYPE
                                                            : OpStatus::INVALID_VALUE;
-          return OpStatus::OK;
         }
-
-        sitem.group =
-            StreamLookupCG(GetReadOnlyStream((*res_it)->second), WrapSds(opts->group_name));
-        if (!sitem.group) {
-          result = OpStatus::INVALID_VALUE;
-          return OpStatus::OK;
-        }
+        continue;
       }
 
-      // '>' is encoded as UINT64_MAX-UINT64_MAX and is only accepted for XREADGROUP, so the start
-      // comes from the group. A plain XREAD has no group and reads from the id it asked for, even
-      // when that id happens to carry a UINT64_MAX component.
-      if (opts->read_group && sitem.id.val.ms == UINT64_MAX && sitem.id.val.seq == UINT64_MAX) {
-        range_opts.start.val = sitem.group->last_id;
-        StreamIncrID(&range_opts.start.val);
+      StreamIDsItem& stream_item = opts->stream_ids.at(skey);
+      stream_item.group =
+          StreamLookupCG(GetReadOnlyStream((*res_it)->second), WrapSds(opts->group_name));
+      if (!stream_item.group && status == OpStatus::OK)
+        status = OpStatus::INVALID_VALUE;
+    }
+    return status;
+  };
+
+  // While we were blocked any of the watched streams could have been deleted, retyped or lost its
+  // consumer group. XREADGROUP mutates the stream (it moves entries into the consumer PEL), so it
+  // must not touch the woken key if another stream already invalidated the request. Streams on the
+  // woken shard are validated inside the action hop for free, so only reads that actually span
+  // shards pay for this extra hop.
+  // Note this must not be folded into the action hop with a cross shard barrier: waiting for
+  // sibling shards from inside a transaction callback stalls the whole shard and can deadlock two
+  // interleaved multi shard readers.
+  if (opts->read_group && tx->GetUniqueShardCnt() > 1) {
+    // Indexed by shard id - every shard writes only its own slot, so no synchronization is needed
+    // beyond the hop boundary.
+    vector<OpStatus> validation_status(shard_set->size(), OpStatus::OK);
+
+    auto validate_cb = [&](Transaction* t, EngineShard* shard) {
+      const ShardId sid = shard->shard_id();
+      validation_status[sid] = validate_shard_keys(t->GetOpArgs(shard), t->GetShardArgs(sid));
+      return OpStatus::OK;
+    };
+    tx->Execute(validate_cb, false);
+
+    for (OpStatus status : validation_status) {
+      if (status == OpStatus::OK)
+        continue;
+
+      tx->Conclude();
+      if (status != OpStatus::INVALID_VALUE)
+        return rb->SendError(status);
+      return send_nogroup();
+    }
+  }
+
+  auto range_cb = [&](Transaction* t, EngineShard* shard) {
+    auto wake_key = t->GetWakeKey(shard->shard_id());
+    if (!wake_key)
+      return OpStatus::OK;
+
+    RangeOpts range_opts;
+    // Ensure the woken read honors COUNT like the non-blocking path
+    // (OpRead) does: without it, a consumer woken by a transaction that
+    // added multiple entries receives all of them in one reply.
+    range_opts.count = opts->count;
+    range_opts.end = ParsedStreamId{.val = streamID{
+                                        .ms = UINT64_MAX,
+                                        .seq = UINT64_MAX,
+                                    }};
+    StreamIDsItem& sitem = opts->stream_ids.at(*wake_key);
+    range_opts.start = sitem.id;
+
+    if (opts->read_group) {
+      // Validates the woken key too, so the action hop never trusts a stale group pointer.
+      if (OpStatus status =
+              validate_shard_keys(t->GetOpArgs(shard), t->GetShardArgs(shard->shard_id()));
+          status != OpStatus::OK) {
+        result = status;
+        return OpStatus::OK;
+      }
+    }
+
+    // '>' is encoded as UINT64_MAX-UINT64_MAX and is only accepted for XREADGROUP, so the start
+    // comes from the group. A plain XREAD has no group and reads from the id it asked for, even
+    // when that id happens to carry a UINT64_MAX component.
+    if (opts->read_group && sitem.id.val.ms == UINT64_MAX && sitem.id.val.seq == UINT64_MAX) {
+      range_opts.start.val = sitem.group->last_id;
+      StreamIncrID(&range_opts.start.val);
+    }
+
+    range_opts.group = sitem.group;
+
+    // Update consumer, only for XReadGroup path
+    std::optional<StreamMemTracker> tracker;
+    if (sitem.group) {
+      tracker = StreamMemTracker{};
+      sitem.is_consumer_new = false;
+      range_opts.consumer = FindOrAddConsumer(opts->consumer_name, sitem.group, GetCurrentTimeMs(),
+                                              &sitem.is_consumer_new);
+      sitem.consumer = range_opts.consumer;
+      if (!sitem.consumer) {
+        result = OpStatus::OUT_OF_MEMORY;
+        return OpStatus::OUT_OF_MEMORY;
       }
 
-      range_opts.group = sitem.group;
-
-      // Update consumer, only for XReadGroup path
-      std::optional<StreamMemTracker> tracker;
-      if (sitem.group) {
-        tracker = StreamMemTracker{};
-        sitem.is_consumer_new = false;
-        range_opts.consumer = FindOrAddConsumer(opts->consumer_name, sitem.group,
-                                                GetCurrentTimeMs(), &sitem.is_consumer_new);
-        sitem.consumer = range_opts.consumer;
-        if (!sitem.consumer) {
-          return OpStatus::OUT_OF_MEMORY;
-        }
-
-        if (sitem.consumer->pel->numnodes == 0) {
-          LOG(DFATAL) << "Internal error when accessing consumer data, seen_time "
-                      << sitem.consumer->seen_time;
-          result = OpStatus::CANCELLED;
-          return OpStatus::OK;
-        }
+      if (sitem.consumer->pel->numnodes == 0) {
+        LOG(DFATAL) << "Internal error when accessing consumer data, seen_time "
+                    << sitem.consumer->seen_time;
+        result = OpStatus::CANCELLED;
+        return OpStatus::OK;
       }
+    }
 
-      key = *wake_key;
+    key = *wake_key;
 
-      if (tracker) {
-        auto op_args = t->GetOpArgs(shard);
-        auto& db_slice = op_args.GetDbSlice();
-        auto it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STREAM);
-        DCHECK(it);
-        if (it) {
-          tracker->UpdateStreamSize(it->it->second);
-        }
+    if (tracker) {
+      auto op_args = t->GetOpArgs(shard);
+      auto& db_slice = op_args.GetDbSlice();
+      auto it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STREAM);
+      DCHECK(it);
+      if (it) {
+        tracker->UpdateStreamSize(it->it->second);
       }
+    }
 
-      range_opts.noack = opts->noack;
-      range_opts.access_kind = StreamAccessKind::kSequential;
+    range_opts.noack = opts->noack;
+    range_opts.access_kind = StreamAccessKind::kSequential;
 
-      result = OpRange(t->GetOpArgs(shard), *wake_key, range_opts);
-      if (result) {
-        JournalConsumerCreationIfNeeded(t->GetOpArgs(shard), *opts, *wake_key);
-        JournalXReadGroupIfNeeded(t->GetOpArgs(shard), *opts, *result, *wake_key);
-      }
+    result = OpRange(t->GetOpArgs(shard), *wake_key, range_opts);
+    if (result) {
+      JournalConsumerCreationIfNeeded(t->GetOpArgs(shard), *opts, *wake_key);
+      JournalXReadGroupIfNeeded(t->GetOpArgs(shard), *opts, *result, *wake_key);
     }
     return OpStatus::OK;
   };
@@ -3176,8 +3231,9 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     }
     return StreamReplies{rb}.SendStreamRecords(key, *result);
   } else if (result.status() == OpStatus::INVALID_VALUE) {
-    return rb->SendError("-NOGROUP the consumer group this client was blocked on no longer exists");
-  } else if (result.status() == OpStatus::WRONG_TYPE) {
+    return send_nogroup();
+  } else if (result.status() == OpStatus::WRONG_TYPE ||
+             result.status() == OpStatus::OUT_OF_MEMORY) {
     return rb->SendError(result.status());
   }
   return rb->SendNullArray();

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -754,6 +754,188 @@ TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnStoreRetypes) {
   EXPECT_THAT(union_resp, ErrArg("WRONGTYPE"));
 }
 
+TEST_F(StreamFamilyTest, XReadAheadDoesNotSuppressXReadGroupWake) {
+  Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
+
+  RespExpr xreadgroup_resp;
+  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    Run({"XREAD", "BLOCK", "0", "STREAMS", "foo", "$"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  auto fb1 = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
+    xreadgroup_resp =
+        Run({"XREADGROUP", "GROUP", "group", "bob", "BLOCK", "200", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
+
+  Run({"DEL", "foo"});
+  fb1.Join();
+  EXPECT_THAT(xreadgroup_resp,
+              ErrArg("consumer group this client was blocked on no longer exists"));
+
+  Run({"XADD", "foo", "1-0", "k", "v"});
+  fb0.Join();
+}
+
+TEST_F(StreamFamilyTest, XReadGroupBlockMultiStreamRevalidatesGroups) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  const string key_a = "multi-stream-a";
+  string key_b;
+  for (unsigned i = 0; key_b.empty(); ++i) {
+    string candidate = absl::StrCat("multi-stream-b-", i);
+    if (Shard(candidate, shard_set->size()) != Shard(key_a, shard_set->size()))
+      key_b = std::move(candidate);
+  }
+  ASSERT_NE(Shard(key_a, shard_set->size()), Shard(key_b, shard_set->size()));
+
+  Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
+  Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
+
+  // Keep the target read behind another waiter on key_b. Destroying key_b's group wakes this
+  // guard, forcing the target transaction to wake on key_a and revalidate key_b remotely.
+  RespExpr guard_resp;
+  auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    guard_resp =
+        Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "0", "STREAMS", key_b, ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  RespExpr target_resp;
+  auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
+    target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "0", "STREAMS", key_a,
+                       key_b, ">", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
+
+  Run({"MULTI"});
+  Run({"XADD", key_a, "1-0", "f", "v"});
+  Run({"XGROUP", "DESTROY", key_b, "group"});
+  Run({"EXEC"});
+
+  guard.Join();
+  target.Join();
+  EXPECT_THAT(guard_resp, ErrArg("consumer group this client was blocked on no longer exists"));
+  EXPECT_THAT(target_resp, ErrArg("consumer group this client was blocked on no longer exists"));
+  auto pending = Run({"XPENDING", key_a, "group"});
+  EXPECT_THAT(pending.GetVec()[0], IntArg(0));
+}
+
+// This is the wrong-type counterpart of XReadGroupBlockMultiStreamRevalidatesGroups.
+// The target is woken only by key_a, while key_b is retyped behind its guard. The final
+// XREADGROUP action must validate key_b before it adds key_a's entry to the consumer PEL.
+TEST_F(StreamFamilyTest, XReadGroupBlockMultiStreamRevalidatesRetypedStream) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  const string key_a = "multi-stream-retype-a";
+  string key_b;
+  for (unsigned i = 0; key_b.empty(); ++i) {
+    string candidate = absl::StrCat("multi-stream-retype-b-", i);
+    if (Shard(candidate, shard_set->size()) != Shard(key_a, shard_set->size()))
+      key_b = std::move(candidate);
+  }
+  ASSERT_NE(Shard(key_a, shard_set->size()), Shard(key_b, shard_set->size()));
+
+  Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
+  Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
+
+  RespExpr guard_resp;
+  auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    guard_resp =
+        Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "200", "STREAMS", key_b, ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  RespExpr target_resp;
+  auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
+    target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "200", "STREAMS", key_a,
+                       key_b, ">", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
+
+  Run({"MULTI"});
+  Run({"XADD", key_a, "1-0", "f", "v"});
+  Run({"SET", key_b, "value"});
+  Run({"EXEC"});
+
+  guard.Join();
+  target.Join();
+  EXPECT_THAT(guard_resp, ErrArg("WRONGTYPE"));
+  EXPECT_THAT(target_resp, ErrArg("WRONGTYPE"));
+  auto pending = Run({"XPENDING", key_a, "group"});
+  EXPECT_THAT(pending.GetVec()[0], IntArg(0));
+}
+
+// Same as XReadGroupBlockMultiStreamRevalidatesGroups, but both streams live on one shard, so the
+// remote validation hop is skipped and the action hop must validate them itself.
+TEST_F(StreamFamilyTest, XReadGroupBlockSingleShardMultiStreamRevalidatesGroups) {
+  const string key_a = "same-shard-a";
+  string key_b;
+  for (unsigned i = 0; key_b.empty(); ++i) {
+    string candidate = absl::StrCat("same-shard-b-", i);
+    if (Shard(candidate, shard_set->size()) == Shard(key_a, shard_set->size()))
+      key_b = std::move(candidate);
+  }
+  ASSERT_EQ(Shard(key_a, shard_set->size()), Shard(key_b, shard_set->size()));
+
+  Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
+  Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
+
+  RespExpr guard_resp;
+  auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    guard_resp =
+        Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "0", "STREAMS", key_b, ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  RespExpr target_resp;
+  auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
+    target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "0", "STREAMS", key_a,
+                       key_b, ">", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
+
+  Run({"MULTI"});
+  Run({"XADD", key_a, "1-0", "f", "v"});
+  Run({"XGROUP", "DESTROY", key_b, "group"});
+  Run({"EXEC"});
+
+  guard.Join();
+  target.Join();
+  EXPECT_THAT(guard_resp, ErrArg("consumer group this client was blocked on no longer exists"));
+  EXPECT_THAT(target_resp, ErrArg("consumer group this client was blocked on no longer exists"));
+  auto pending = Run({"XPENDING", key_a, "group"});
+  EXPECT_THAT(pending.GetVec()[0], IntArg(0));
+}
+
+TEST_F(StreamFamilyTest, XReadGroupBlockLazyExpireDuringWakeDoesNotCrash) {
+  Run({"XGROUP", "CREATE", "s", "g", "0", "MKSTREAM"});
+
+  RespExpr resp0;
+  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    resp0 = Run({"XREADGROUP", "GROUP", "g", "c", "BLOCK", "200", "STREAMS", "s", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  Run({"PEXPIRE", "s", "1"});
+  AdvanceTime(2);
+
+  // Trigger readiness directly after the TTL has elapsed. FindReadOnly lazily deletes the stream
+  // while NotifyPending is scanning it, which queues a duplicate wake for the now-active queue.
+  const ShardId sid = Shard("s", shard_set->size());
+  shard_set->Await(sid, [] {
+    auto* bc =
+        namespaces->GetDefaultNamespace().GetBlockingController(EngineShard::tlocal()->shard_id());
+    ASSERT_NE(bc, nullptr);
+    bc->Awaken(0, "s");
+    bc->NotifyPending();
+  });
+
+  fb0.Join();
+  EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnFlushDb) {
   Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
 
@@ -764,6 +946,20 @@ TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnFlushDb) {
   ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
 
   Run({"FLUSHDB"});
+  fb0.Join();
+  EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
+}
+
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnImmediateExpire) {
+  Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
+
+  RespExpr resp0;
+  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    resp0 = Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "streams", "foo", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  Run({"EXPIREAT", "foo", "1"});
   fb0.Join();
   EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
 }


### PR DESCRIPTION
Summary: This PR fixes blocked multi-stream XREADGROUP requests that could process a woken stream after another watched stream became invalid.

Changes:

- Adds a non-concluding validation hop after a blocked XREADGROUP wakes.
- Revalidates every watched stream and its consumer group before the mutating read hop.
- Returns NOGROUP for missing streams/groups and WRONGTYPE for retyped streams.
- Re-resolves the woken stream during the mutating hop to avoid stale group pointers after background deletion.
- Preserves COUNT handling and maps allocation failures to an error reply.
- Adjusts blocked XREAD readiness so it does not suppress a later XREADGROUP waiter.

Tests: Adds coverage for waiter ordering, multi-shard group deletion/retyping, lazy expiry during wake-up, and immediate expiration.