### PR TITLE
perf(build): use minimal debug info in CI

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -210,6 +210,12 @@ runs:
           CMAKE_CMD+=(-DCMAKE_CXX_FLAGS="${{ inputs.cxx-flags }}")
         fi
 
+        # Use minimal debug info for CI Debug builds. Measurements showed ~60% smaller objects and ~5% faster builds.
+        # This makes builds and ccache transfers faster while preserving crash stack traces.
+        if [ "${{ inputs.build-type }}" = "Debug" ]; then
+          CMAKE_CMD+=(-DDF_MINIMAL_DEBUG_INFO=ON)
+        fi
+
         # Add fixed options
         CMAKE_CMD+=(
           -DPRINT_STACKTRACES_ON_SIGNAL=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # AFL++ fuzzing support - must be set BEFORE project() command
 option(USE_AFL "Enable AFL++ fuzzing" OFF)
+option(DF_MINIMAL_DEBUG_INFO "Use minimal debug information for CI builds" OFF)
 if(USE_AFL)
   # Automatically set AFL++ compilers if not already set
   if(NOT CMAKE_C_COMPILER MATCHES "afl-" AND NOT CMAKE_CXX_COMPILER MATCHES "afl-")
@@ -146,6 +147,10 @@ set(WITH_AWS OFF CACHE BOOL "Build with helio native AWS support")
 
 include(third_party)
 include(internal)
+
+if(DF_MINIMAL_DEBUG_INFO AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_compile_options(-g1)
+endif()
 
 include_directories(src)
 include_directories(helio)


### PR DESCRIPTION
Use -g1 for CI Debug builds - this is harmless for our needs in CI.
This has multiple gains:
1) Reduces object size by up to 60%
2) Reduces build time by ~5%.
3) Since object sizes are smaller, ccache transfers are faster for
Debug builds.
4) Since object sizes are smaller, the overall ccache size for Debug
builds is reduced significantly (by up to 60%).

The builder enables DF_MINIMAL_DEBUG_INFO, which appends -g1 after
Helio's global -g option. This makes -g1 the effective debug level
without changing local Debug builds.