### PR TITLE
fix(metrics): always emit expired_keys_total and evicted_keys_total, including zero

### DIFF
--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -351,12 +351,10 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
     string exp_str, evict_str;
     for (size_t i = 0; i < m.db_stats.size(); ++i) {
       const auto& s = m.db_stats[i];
-      if (s.events.expired_keys > 0)
-        AppendMetricValue("expired_keys_total", s.events.expired_keys, {"db"}, {StrCat("db", i)},
-                          &exp_str);
-      if (s.events.evicted_keys > 0)
-        AppendMetricValue("evicted_keys_total", s.events.evicted_keys, {"db"}, {StrCat("db", i)},
-                          &evict_str);
+      AppendMetricValue("expired_keys_total", s.events.expired_keys, {"db"}, {StrCat("db", i)},
+                        &exp_str);
+      AppendMetricValue("evicted_keys_total", s.events.evicted_keys, {"db"}, {StrCat("db", i)},
+                        &evict_str);
     }
     AppendMetricHeader("expired_keys_total", "", MetricType::COUNTER, &resp->body());
     absl::StrAppend(&resp->body(), exp_str);

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -330,3 +330,37 @@ async def test_command_empty_key(df_factory):
     assert res == 1
     res = await client.execute_command("KEYS *")
     assert len(res) == 1
+
+
+@dfly_args({"proactor_threads": 1})
+async def test_expired_evicted_counters_zero_initialised(
+    async_client: aioredis.Redis, df_server: DflyInstance
+):
+    """
+    expired_keys_total and evicted_keys_total must be exported with a value of 0 on a
+    fresh instance, and must still expose a series after CONFIG RESETSTAT.
+
+    Before the fix, the HELP/TYPE header was emitted without any sample while the
+    counter was zero, so Prometheus ingested no series at all until the first expiry or
+    eviction -- which also made rate()/increase() under-count that very first burst,
+    since there was no earlier sample to diff against.
+    """
+
+    # prometheus_client strips the `_total` suffix from the family name.
+    families = ("dragonfly_expired_keys", "dragonfly_evicted_keys")
+
+    async def db0_values():
+        metrics = await df_server.metrics()
+        values = {}
+        for family in families:
+            assert family in metrics, f"{family} is missing from /metrics"
+            samples = {s.labels["db"]: s.value for s in metrics[family].samples}
+            assert "db0" in samples, f"{family} exposes no db0 sample, only {sorted(samples)}"
+            values[family] = samples["db0"]
+        return values
+
+    assert await db0_values() == {family: 0 for family in families}
+
+    await async_client.execute_command("CONFIG RESETSTAT")
+
+    assert await db0_values() == {family: 0 for family in families}


### PR DESCRIPTION
## Problem

`expired_keys_total` and `evicted_keys_total` only get a sample line when their value is non-zero, while their `HELP`/`TYPE` header is emitted unconditionally. A scrape of a healthy instance contains the header with **no value**:

```
# HELP dragonfly_expired_keys_total
# TYPE dragonfly_expired_keys_total counter
# HELP dragonfly_evicted_keys_total
# TYPE dragonfly_evicted_keys_total counter
# HELP dragonfly_memory_fiberstack_vms_bytes virtual memory size used by all the fibers
```

Prometheus ingests no series at all, so the metric name is absent from the TSDB until the first event.

Observed on `df-v1.37.0` in a Kubernetes deployment used as a Thanos query cache. The endpoint declares **91** metrics but emits a sample line for only **88** — the three without a value are `expired_keys_total`, `evicted_keys_total` and `connected_replica_lag_records` (the last is legitimate: no replica is connected, so there is no series to emit).

## Why it matters

**1. The dashboard in this repo shows "No data".**
`tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json` has an *Expired / Evicted* panel querying both counters. On any healthy instance it renders "No data", which reads as broken monitoring rather than as "nothing evicted".

**2. Alerting cannot be expressed cleanly.**
`rate(dragonfly_evicted_keys_total[5m]) > 0` cannot be authored without an `absent()` workaround, because the series does not exist until after the condition has already occurred.

**3. The first eviction burst is under-counted.**
This is the actual correctness issue. When the series first appears it already carries an accumulated value, and Prometheus has no earlier sample to diff against. `rate()` / `increase()` over the window containing that first appearance therefore under-counts — and the first burst is precisely the one an operator is watching for.

## Fix

Emit the value unconditionally, dropping the two `> 0` guards.

This also makes the two counters **consistent with their siblings in the same loop**: `db_keys`, `db_capacity` and `db_keys_expiring` iterate the identical `m.db_stats` range a few lines below and are already emitted for every entry with no guard.

On cardinality — corrected after review: `m.db_stats` is **not** active-DBs-only. `DbSlice::ActivateDb()` does `db_arr_.resize(db_ind + 1)` and keeps null holes, so a plain `SELECT 15` makes this emit `db0..db15`, i.e. up to `2 * dbnum` series across the two counters. That cost is acceptable precisely because `db_keys`, `db_capacity` and `db_keys_expiring` already emit that same label set unconditionally — this change adds no label combination that is not already exported. Emitting only active DBs was considered and rejected: a label set that diverges from the sibling metrics would break per-DB joins.

For reference, the two other conditional emissions in this file (`type_used_memory`, `transaction_widths_total`) use an `added` flag so that the header is skipped when no value was produced. The `> 0` pattern here does not, which is what leaves the orphan header behind. Adopting the `added` flag would fix the orphan header but not points 2 and 3, so always emitting the counter looks like the better option — happy to switch to the `added` pattern instead if you prefer to keep zero-valued series out of the export.

## Test

Added `test_expired_evicted_counters_zero_initialised` in `tests/dragonfly/generic_test.py`, using the existing `instance.metrics()` harness. It asserts both halves of the regression:

- a fresh instance exposes `expired_keys_total{db="db0"}` and `evicted_keys_total{db="db0"}` at `0`;
- the series are still present after `CONFIG RESETSTAT` — today they vanish from the scrape entirely.

Lookup keys are `dragonfly_expired_keys` / `dragonfly_evicted_keys` because `prometheus_client` strips the `_total` suffix from the family name, matching the convention already used by the pubsub-backpressure and `cmd_squash` assertions.

## Verification

The bug is verified empirically: the scrape output above is a real `/metrics` response from a running v1.37.0 instance, and the declared-vs-sampled counts were taken from that same response.

I have not built the project locally, so compile verification and the new test both rely on CI.

## Related

Not a duplicate of #4164, which is about missing label selectors in the bundled dashboard (cross-namespace leakage) rather than about metric initialisation. I found no existing issue or PR covering this.
