### PR TITLE
fix(stream): Only create stream group when key is missing and MKSTREAM is set

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1779,8 +1779,9 @@ OpStatus OpCreate(const OpArgs& op_args, string_view key, const CreateOpts& opts
   StreamMemTracker mem_tracker;
   bool stream_created_by_mkstream = false;
   if (!res_it) {
-    if (opts.flags & kCreateOptMkstream) {
-      // MKSTREAM is enabled, so create the stream
+    // If the key doesn't exists and we have the MKSTREAM flag, we need create the stream.
+    // Otherwise, we return an error.
+    if (res_it.status() == OpStatus::KEY_NOTFOUND && opts.flags & kCreateOptMkstream) {
       res_it = db_slice.AddNew(op_args.db_cntx, key, PrimeValue{}, 0);
       if (!res_it)
         return res_it.status();

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -142,6 +142,20 @@ TEST_F(StreamFamilyTest, GroupCreate) {
   EXPECT_THAT(resp, ErrArg("BUSYGROUP"));
 }
 
+TEST_F(StreamFamilyTest, GroupCreateOnWrongType) {
+  Run({"set", "key", "value"});
+
+  auto resp = Run({"xgroup", "create", "key", "grname", "$"});
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+
+  resp = Run({"xgroup", "create", "key", "grname", "$", "MKSTREAM"});
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+
+  // The existing string value must remain untouched.
+  resp = Run({"get", "key"});
+  EXPECT_EQ(resp, "value");
+}
+
 TEST_F(StreamFamilyTest, XRead) {
   Run({"xadd", "foo", "1-*", "k1", "v1"});
   Run({"xadd", "foo", "1-*", "k2", "v2"});


### PR DESCRIPTION
XGROUP CREATE should create the stream only when the key doesn't exist and
MKSTREAM is given; otherwise it must return an error.

Closes #8055

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
