### PR TITLE
fix(cluster): scope slot migration finalize pause to migrated slots only

### DIFF
--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -6,6 +6,7 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-matchers.h>
 
+#include <atomic>
 #include <string>
 #include <string_view>
 
@@ -1125,6 +1126,59 @@ TEST_F(ClusterFamilyTest, FlushSlots) {
                                                   _, "total_writes", _, "memory_bytes", _)),
                             RespArray(ElementsAre(IntArg(1), "key_count", IntArg(0), "total_reads",
                                                   _, "total_writes", _, "memory_bytes", _)))));
+}
+
+// Regression test for the slot migration finalize pause: it must only block commands touching
+// the slots being migrated, not every command on the node (see OutgoingMigration::
+// FinalizeMigration, which used to pause ClientPause::ALL for the whole finalize step).
+TEST_F(ClusterFamilyTest, SlotScopedPauseOnlyBlocksMatchingSlot) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  const SlotId paused_slot = CheckedInt({"CLUSTER", "KEYSLOT", "in"});
+  const SlotId other_slot = CheckedInt({"CLUSTER", "KEYSLOT", "out"});
+  ASSERT_NE(paused_slot, other_slot);
+  cluster::SlotRanges paused_ranges({{paused_slot, paused_slot}});
+
+  // Driven directly by `pause_active` (not a wall-clock deadline), so the pause stays up for
+  // exactly as long as this test needs it, regardless of CI/host speed.
+  std::atomic_bool pause_active{true};
+  auto is_pause_in_progress = [&pause_active] { return pause_active.load(); };
+  // Pause() must run from a proactor-pool fiber (as it does in production, from a connection or
+  // migration fiber) since its continuation touches ServerState::tlocal(), which is only set up
+  // on those threads.
+  bool started = false;
+  pp_->at(0)->Await([&] {
+    auto pause_fb = dfly::Pause(service_->server_family().GetNonPriviligedListeners(),
+                                &namespaces->GetDefaultNamespace(), nullptr, ClientPause::ALL,
+                                is_pause_in_progress, /*maybe_cleanup=*/{}, paused_ranges);
+    started = pause_fb.has_value();
+    if (pause_fb)
+      pause_fb->Detach();
+  });
+  ASSERT_TRUE(started);
+
+  // A command touching an unrelated slot must complete promptly, even while the slot-scoped
+  // pause is active - proven by running it in its own fiber and waiting for it to finish.
+  std::atomic_bool unrelated_done{false};
+  auto unrelated_reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    Run({"get", "out"});
+    unrelated_done.store(true);
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return unrelated_done.load(); }, 2000ms));
+  unrelated_reader.Join();
+
+  // A command touching the paused slot must actually block while the pause is active...
+  std::atomic_bool paused_get_done{false};
+  auto paused_reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    Run({"get", "in"});
+    paused_get_done.store(true);
+  });
+  EXPECT_FALSE(WaitUntilCondition([&] { return paused_get_done.load(); }, 200ms));
+
+  // ...and must complete promptly once the pause ends.
+  pause_active.store(false);
+  ASSERT_TRUE(WaitUntilCondition([&] { return paused_get_done.load(); }, 2000ms));
+  paused_reader.Join();
 }
 
 TEST_F(ClusterFamilyTest, FlushSlotsWakesBlockedXReadGroup) {

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -376,13 +376,14 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   }
 
   // Migration finalization has to be done via client pause because commands need to
-  // be blocked on coordinator level to avoid intializing transactions with stale cluster slot info
-  // TODO implement blocking on migrated slots only
+  // be blocked on coordinator level to avoid intializing transactions with stale cluster slot
+  // info. Only the slots actually being migrated are paused, so traffic to the rest of the
+  // keyspace keeps flowing during finalize.
   bool is_block_active = true;
   auto is_pause_in_progress = [&is_block_active] { return is_block_active; };
   auto pause_fb_opt =
       dfly::Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
-                  nullptr, ClientPause::ALL, is_pause_in_progress);
+                  nullptr, ClientPause::ALL, is_pause_in_progress, {}, migration_info_.slot_ranges);
 
   DCHECK(pause_fb_opt);
   if (!pause_fb_opt) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -836,17 +836,21 @@ void TrackIfNeeded(CommandContext* cmd_cntx) {
   }
 }
 
-// Check CLIENT PAUSE state and block if needed
-void CheckPauseState(facade::Connection* conn, ConnectionContext* dfly_cntx, const CommandId* cid) {
+// Check CLIENT PAUSE state and block if needed. `keys_slot`, when set, additionally blocks on any
+// pause scoped to that slot (e.g. an in-progress slot migration finalize), regardless of whether
+// the command is a write.
+void CheckPauseState(facade::Connection* conn, ConnectionContext* dfly_cntx, const CommandId* cid,
+                     std::optional<SlotId> keys_slot) {
   auto& etl = *ServerState::tlocal();
-  if (etl.IsPaused() && !conn->IsPrivileged()) {
+  bool is_slot_paused = keys_slot.has_value() && etl.IsSlotPaused(*keys_slot);
+  if ((etl.IsPaused() || is_slot_paused) && !conn->IsPrivileged()) {
     bool is_write = cid->IsJournaled();
     // PUBLISH and writable EVAL/EVALSHA (not the *_RO variants) count as writes here.
     is_write |= cid->IsPublish() || (cid->IsEvalGroup() && !cid->IsReadOnly());
     is_write |= cid->IsExec() && dfly_cntx->conn_state.exec_info.is_write;
 
     dfly_cntx->paused = true;
-    etl.AwaitPauseState(is_write);
+    etl.AwaitPauseState(is_write, keys_slot);
     dfly_cntx->paused = false;
   }
 }
@@ -1220,13 +1224,10 @@ OpResult<KeyIndex> Service::FindKeys(const CommandId* cid, const facade::ParsedA
   return DetermineKeys(cid, args);
 }
 
-optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid,
+optional<ErrorReply> Service::ResolveCommandSlot(const CommandId& cid,
                                                  const facade::ParsedArgs& args,
-                                                 const ConnectionContext& dfly_cntx) {
-  if (dfly_cntx.is_replicating) {
-    // Always allow commands on the replication port, as it might be for future-owned keys.
-    return nullopt;
-  }
+                                                 optional<SlotId>* slot) {
+  *slot = nullopt;
 
   if (cid.first_key_pos() == 0 && !cid.IsShardedPubSub()) {
     return nullopt;  // No key command.
@@ -1249,7 +1250,25 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid,
     return ErrorReply{kCrossSlotError};
   }
 
-  optional<SlotId> keys_slot = slot_checker.GetUniqueSlotId();
+  *slot = slot_checker.GetUniqueSlotId();
+  return nullopt;
+}
+
+optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid,
+                                                 const facade::ParsedArgs& args,
+                                                 const ConnectionContext& dfly_cntx,
+                                                 const optional<SlotId>* precomputed_slot) {
+  if (dfly_cntx.is_replicating) {
+    // Always allow commands on the replication port, as it might be for future-owned keys.
+    return nullopt;
+  }
+
+  optional<SlotId> keys_slot;
+  if (precomputed_slot) {
+    keys_slot = *precomputed_slot;
+  } else if (auto err = ResolveCommandSlot(cid, args, &keys_slot); err) {
+    return err;
+  }
 
   if (keys_slot.has_value()) {
     if (auto error = cluster::SlotOwnershipError(*keys_slot);
@@ -1261,32 +1280,13 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid,
   return nullopt;
 }
 
-// TODO(kostas) refactor. Almost 1-1 with CheckKeyOwnership() above.
 std::optional<facade::ErrorReply> Service::TakenOverSlotError(const CommandId& cid,
                                                               const facade::ParsedArgs& args,
                                                               const ConnectionContext& dfly_cntx) {
-  if (cid.first_key_pos() == 0 && !cid.IsShardedPubSub()) {
-    return nullopt;  // No key command.
+  optional<SlotId> keys_slot;
+  if (auto err = ResolveCommandSlot(cid, args, &keys_slot); err) {
+    return err;
   }
-
-  OpResult<KeyIndex> key_index_res = FindKeys(&cid, args);
-
-  if (!key_index_res) {
-    return ErrorReply{key_index_res.status()};
-  }
-
-  const auto& key_index = *key_index_res;
-
-  UniqueSlotChecker slot_checker;
-  for (string_view key : key_index.Range(args)) {
-    slot_checker.Add(key);
-  }
-
-  if (slot_checker.IsCrossSlot()) {
-    return ErrorReply{kCrossSlotError};
-  }
-
-  optional<SlotId> keys_slot = slot_checker.GetUniqueSlotId();
   if (!keys_slot.has_value()) {
     return nullopt;
   }
@@ -1341,7 +1341,8 @@ static optional<ErrorReply> VerifyConnectionAclStatus(const CommandId* cid,
 
 std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid,
                                                       const facade::ParsedArgs& tail_args,
-                                                      const ConnectionContext& dfly_cntx) {
+                                                      const ConnectionContext& dfly_cntx,
+                                                      const optional<SlotId>* precomputed_slot) {
   ServerState& etl = *ServerState::tlocal();
 
   // If there is no connection owner, it means the command it being called
@@ -1424,7 +1425,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid,
   }
 
   if (IsClusterEnabled()) {
-    if (auto err = CheckKeysOwnership(cid, tail_args, dfly_cntx); err)
+    if (auto err = CheckKeysOwnership(cid, tail_args, dfly_cntx, precomputed_slot); err)
       return err;
   }
 
@@ -1514,6 +1515,19 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
 
   cmd_cntx->SetTailArgs(args_no_cmd);
 
+  // Only resolve the command's slot if a slot-scoped pause (migration finalize) is actually in
+  // progress - this keeps the common case (no migration running) free of the extra key lookup.
+  // When resolution succeeds, reuse it below for both the pause check and CheckKeysOwnership
+  // (inside VerifyCommandState) instead of resolving the same command's slot twice. On error
+  // (cross-slot, bad key spec), leave precomputed_slot null so CheckKeysOwnership re-resolves
+  // and reports the error itself.
+  optional<SlotId> keys_slot;
+  const optional<SlotId>* precomputed_slot = nullptr;
+  if (IsClusterEnabled() && ServerState::tlocal()->HasActiveSlotPause()) {
+    if (!ResolveCommandSlot(*cid, args_no_cmd, &keys_slot))
+      precomputed_slot = &keys_slot;
+  }
+
   // Block on CLIENT PAUSE if needed
   if (auto* conn = cmd_cntx->conn(); conn /* replica context doesn't have an owner */) {
     if (VLOG_IS_ON(2)) {
@@ -1525,11 +1539,11 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
 
     // Check pause state only if it is a top level transaction.
     if (dfly_cntx->transaction == nullptr)
-      CheckPauseState(conn, dfly_cntx, cid);
+      CheckPauseState(conn, dfly_cntx, cid, keys_slot);
   }
 
   // Verify command state
-  if (auto err = VerifyCommandState(*cid, args_no_cmd, *dfly_cntx); err) {
+  if (auto err = VerifyCommandState(*cid, args_no_cmd, *dfly_cntx, precomputed_slot); err) {
     LOG_IF(WARNING, dfly_cntx->replica_conn || !dfly_cntx->conn() /* no owner in replica context */)
         << "VerifyCommandState error: " << err->ToSv();
     if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
@@ -1734,7 +1748,12 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
   auto* ss = ServerState::tlocal();
 
   // Don't even start when paused. We can only continue if DispatchTracker is aware of us running.
-  if (ss->IsPaused())
+  // Squashed commands bypass CheckPauseState (see DispatchCommand), so also bail out whenever a
+  // slot-scoped pause is active anywhere - conservative (it doesn't matter whether this batch's
+  // commands actually touch the paused slots), but simple and safe: it falls back to the regular
+  // per-command dispatch path, which does check pause state per command, for the bounded duration
+  // of a migration finalize.
+  if (ss->IsPaused() || ss->HasActiveSlotPause())
     return 0;
 
   vector<CmdRef> cmd_refs;
@@ -2543,6 +2562,7 @@ void Service::Exec(CmdArgParser, CommandContext* cmd_cntx) {
   }
 
   auto keys = CollectAllKeys(&exec_info);
+  optional<SlotId> exec_slot;
   if (IsClusterEnabled()) {
     UniqueSlotChecker slot_checker;
     for (const auto& s : keys) {
@@ -2552,6 +2572,18 @@ void Service::Exec(CmdArgParser, CommandContext* cmd_cntx) {
     if (slot_checker.IsCrossSlot()) {
       return rb->SendError(kCrossSlotError);
     }
+    exec_slot = slot_checker.GetUniqueSlotId();
+  }
+
+  // EXEC invokes its queued commands directly via InvokeCmd rather than through DispatchCommand,
+  // so they never go through CheckPauseState. If this transaction's (single, per the cross-slot
+  // check above) slot is currently under a migration-finalize pause, block here before scheduling
+  // - otherwise EXEC could initialize a transaction with stale slot-ownership info for exactly the
+  // slot the pause exists to protect.
+  if (exec_slot.has_value() && ServerState::tlocal()->IsSlotPaused(*exec_slot)) {
+    cntx->paused = true;
+    ServerState::tlocal()->AwaitPauseState(false, exec_slot);
+    cntx->paused = false;
   }
 
   // The transaction can contain script load script execution, determine their presence ahead to

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -51,9 +51,11 @@ class Service : public facade::ServiceInterface {
   // Verify command prepares execution in correct state.
   // It's usually called before command execution. Only for multi/exec transactions it's checked
   // when the command is queued for execution, not before the execution itself.
-  std::optional<facade::ErrorReply> VerifyCommandState(const CommandId& cid,
-                                                       const facade::ParsedArgs& tail_args,
-                                                       const ConnectionContext& cntx);
+  // `precomputed_slot`, when non-null, is an already-resolved slot (see ResolveCommandSlot) that
+  // CheckKeysOwnership reuses instead of re-resolving it from `tail_args`.
+  std::optional<facade::ErrorReply> VerifyCommandState(
+      const CommandId& cid, const facade::ParsedArgs& tail_args, const ConnectionContext& cntx,
+      const std::optional<SlotId>* precomputed_slot = nullptr);
 
   facade::ConnectionContext* CreateContext(facade::Connection* owner) final;
   facade::ParsedCommand* AllocateParsedCommand() final;
@@ -159,16 +161,26 @@ class Service : public facade::ServiceInterface {
     uint32_t num_keys = 0;
   };
 
-  // Return error if not all keys are owned by the server when running in cluster mode
-  std::optional<facade::ErrorReply> CheckKeysOwnership(const CommandId& cid,
-                                                       const facade::ParsedArgs& args,
-                                                       const ConnectionContext& dfly_cntx);
+  // Return error if not all keys are owned by the server when running in cluster mode.
+  // `precomputed_slot`, when non-null, is an already-resolved slot (see ResolveCommandSlot) that
+  // is reused instead of re-resolving it from `args`.
+  std::optional<facade::ErrorReply> CheckKeysOwnership(
+      const CommandId& cid, const facade::ParsedArgs& args, const ConnectionContext& dfly_cntx,
+      const std::optional<SlotId>* precomputed_slot = nullptr);
 
   // Return moved error if we *own* the slot. This function is used from flows that assume our
   // state is TAKEN_OVER which happens after a replica takeover.
   std::optional<facade::ErrorReply> TakenOverSlotError(const CommandId& cid,
                                                        const facade::ParsedArgs& args,
                                                        const ConnectionContext& dfly_cntx);
+
+  // Resolves the single slot touched by a keyed command's keys, validating that they all hash to
+  // the same slot. *slot is reset to nullopt at entry and stays nullopt both for non-keyed
+  // commands and on error (cross-slot access or key lookup failure) - callers must check the
+  // return value to distinguish "no keys" from "resolution failed".
+  std::optional<facade::ErrorReply> ResolveCommandSlot(const CommandId& cid,
+                                                       const facade::ParsedArgs& args,
+                                                       std::optional<SlotId>* slot);
 
   void EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, bool read_only,
                     CommandContext* cmd_cntx);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1113,7 +1113,8 @@ void SlowLogGet(facade::ParsedArgs args, std::string_view sub_cmd, util::Proacto
 std::optional<fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namespace* ns,
                                 facade::Connection* conn, ClientPause pause_state,
                                 std::function<bool()> is_pause_in_progress,
-                                std::function<void()> maybe_cleanup) {
+                                std::function<void()> maybe_cleanup,
+                                std::optional<cluster::SlotRanges> slot_ranges) {
   // Track connections and set pause state to be able to wait until all running transactions read
   // the new pause state. Exlude already paused commands from the busy count. Exlude tracking
   // blocked connections because: a) If the connection is blocked it is puased. b) We read pause
@@ -1121,20 +1122,29 @@ std::optional<fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namesp
   //    command that did not pause on the new state yet we will pause after waking up.
   DispatchTracker tracker{listeners, conn, true /* ignore paused commands */,
                           true /*ignore blocking*/};
-  shard_set->pool()->AwaitFiberOnAll([&tracker, pause_state](unsigned, util::ProactorBase*) {
-    // Commands don't suspend before checking the pause state, so
-    // it's impossible to deadlock on waiting for a command that will be paused.
-    tracker.TrackOnThread();
-    ServerState::tlocal()->SetPauseState(pause_state, true);
-  });
+  shard_set->pool()->AwaitFiberOnAll(
+      [&tracker, pause_state, &slot_ranges](unsigned, util::ProactorBase*) {
+        // Commands don't suspend before checking the pause state, so
+        // it's impossible to deadlock on waiting for a command that will be paused.
+        tracker.TrackOnThread();
+        if (slot_ranges) {
+          ServerState::tlocal()->SetSlotPauseState(*slot_ranges, true);
+        } else {
+          ServerState::tlocal()->SetPauseState(pause_state, true);
+        }
+      });
 
   // Wait for all busy commands to finish running before replying to guarantee
   // that no more (write) operations will occur.
   const absl::Duration kDispatchTimeout = absl::Seconds(absl::GetFlag(FLAGS_pause_wait_timeout));
   if (!tracker.Wait(kDispatchTimeout)) {
     LOG(WARNING) << "Couldn't wait for commands to finish dispatching in " << kDispatchTimeout;
-    shard_set->pool()->AwaitBrief([pause_state](unsigned, util::ProactorBase*) {
-      ServerState::tlocal()->SetPauseState(pause_state, false);
+    shard_set->pool()->AwaitBrief([pause_state, &slot_ranges](unsigned, util::ProactorBase*) {
+      if (slot_ranges) {
+        ServerState::tlocal()->SetSlotPauseState(*slot_ranges, false);
+      } else {
+        ServerState::tlocal()->SetPauseState(pause_state, false);
+      }
     });
     return std::nullopt;
   }
@@ -1143,28 +1153,37 @@ std::optional<fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namesp
   shard_set->RunBriefInParallel(
       [ns](EngineShard* shard) { ns->GetDbSlice(shard->shard_id()).SetExpireAllowed(false); });
 
-  return fb2::Fiber("client_pause",
-                    [is_pause_in_progress, pause_state, ns, maybe_cleanup]() mutable {
-                      // On server shutdown we sleep 10ms to make sure all running task finish,
-                      // therefore 10ms steps ensure this fiber will not left hanging .
-                      constexpr auto step = 10ms;
-                      while (is_pause_in_progress()) {
-                        ThisFiber::SleepFor(step);
-                      }
+  return fb2::Fiber("client_pause", [is_pause_in_progress, pause_state, ns, maybe_cleanup,
+                                     slot_ranges]() mutable {
+    // On server shutdown we sleep 10ms to make sure all running task finish,
+    // therefore 10ms steps ensure this fiber will not left hanging .
+    constexpr auto step = 10ms;
+    while (is_pause_in_progress()) {
+      ThisFiber::SleepFor(step);
+    }
 
-                      ServerState& etl = *ServerState::tlocal();
-                      if (etl.gstate() != GlobalState::SHUTTING_DOWN) {
-                        shard_set->pool()->AwaitFiberOnAll([pause_state](util::ProactorBase* pb) {
-                          ServerState::tlocal()->SetPauseState(pause_state, false);
-                        });
-                        shard_set->RunBriefInParallel([ns](EngineShard* shard) {
-                          ns->GetDbSlice(shard->shard_id()).SetExpireAllowed(true);
-                        });
-                      }
-                      if (maybe_cleanup) {
-                        maybe_cleanup();
-                      }
-                    });
+    ServerState& etl = *ServerState::tlocal();
+    if (etl.gstate() != GlobalState::SHUTTING_DOWN) {
+      shard_set->pool()->AwaitFiberOnAll([pause_state, &slot_ranges](util::ProactorBase* pb) {
+        if (slot_ranges) {
+          ServerState::tlocal()->SetSlotPauseState(*slot_ranges, false);
+        } else {
+          ServerState::tlocal()->SetPauseState(pause_state, false);
+        }
+      });
+      shard_set->RunBriefInParallel([ns](EngineShard* shard) {
+        // Only re-enable expiry/eviction if no other pause remains active on this thread -
+        // otherwise this pause ending would prematurely re-enable it while a different,
+        // concurrent pause (e.g. another slot migration's finalize) still needs it disabled.
+        auto& etl = *ServerState::tlocal();
+        if (!etl.IsPaused() && !etl.HasActiveSlotPause())
+          ns->GetDbSlice(shard->shard_id()).SetExpireAllowed(true);
+      });
+    }
+    if (maybe_cleanup) {
+      maybe_cleanup();
+    }
+  });
 }
 
 ServerFamily::ServerFamily(Service* service) : service_(*service) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -413,10 +413,13 @@ class ServerFamily {
   bool legacy_format_metrics_ = true;
 };
 
-// Reusable CLIENT PAUSE implementation that blocks while polling is_pause_in_progress
-std::optional<util::fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namespace* ns,
-                                      facade::Connection* conn, ClientPause pause_state,
-                                      std::function<bool()> is_pause_in_progress,
-                                      std::function<void()> maybe_cleanup = {});
+// Reusable CLIENT PAUSE implementation that blocks while polling is_pause_in_progress.
+// If `slot_ranges` is set, the pause only blocks commands whose keys fall in those slots
+// (used by slot migration finalize); otherwise it blocks every command, as CLIENT PAUSE does.
+std::optional<util::fb2::Fiber> Pause(
+    std::vector<facade::Listener*> listeners, Namespace* ns, facade::Connection* conn,
+    ClientPause pause_state, std::function<bool()> is_pause_in_progress,
+    std::function<void()> maybe_cleanup = {},
+    std::optional<cluster::SlotRanges> slot_ranges = std::nullopt);
 
 }  // namespace dfly

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -226,10 +226,31 @@ void ServerState::SetPauseState(ClientPause state, bool start) {
   }
 }
 
-void ServerState::AwaitPauseState(bool is_write) {
-  client_pause_ec_.await([is_write, this]() {
-    return client_pauses_[int(ClientPause::ALL)] == 0 &&
-           (!is_write || client_pauses_[int(ClientPause::WRITE)] == 0);
+void ServerState::SetSlotPauseState(cluster::SlotRanges ranges, bool start) {
+  if (start) {
+    paused_slot_ranges_.push_back(std::move(ranges));
+  } else {
+    auto it = rng::find(paused_slot_ranges_, ranges);
+    DCHECK(it != paused_slot_ranges_.end());
+    if (it != paused_slot_ranges_.end())
+      paused_slot_ranges_.erase(it);
+  }
+  client_pause_ec_.notifyAll();
+}
+
+void ServerState::AwaitPauseState(bool is_write, std::optional<SlotId> slot) {
+  client_pause_ec_.await([is_write, slot, this]() {
+    if (client_pauses_[int(ClientPause::ALL)] != 0)
+      return false;
+    if (is_write && client_pauses_[int(ClientPause::WRITE)] != 0)
+      return false;
+    if (slot.has_value()) {
+      for (const auto& ranges : paused_slot_ranges_) {
+        if (ranges.Contains(*slot))
+          return false;
+      }
+    }
+    return true;
   });
 }
 

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -12,6 +12,7 @@
 #include "core/interpreter.h"
 #include "server/acl/acl_log.h"
 #include "server/channel_store.h"
+#include "server/cluster/cluster_defs.h"
 #include "server/common_types.h"
 #include "server/detail/egress_throttle.h"
 #include "server/script_mgr.h"
@@ -274,12 +275,33 @@ class ServerState {  // public struct - to allow initialization.
   // whether this is starting or ending the pause.
   void SetPauseState(ClientPause state, bool start);
 
+  // Starts or ends a pause scoped to the given slot ranges (e.g. while finalizing a slot
+  // migration), instead of pausing every command on this thread. Unlike SetPauseState, this
+  // never blocks non-keyed or out-of-range commands.
+  void SetSlotPauseState(cluster::SlotRanges ranges, bool start);
+
   // Awaits until the pause is over and the command can execute.
   // @is_write controls whether the command is a write command or not.
-  void AwaitPauseState(bool is_write);
+  // @slot, when set, additionally awaits any slot-scoped pause covering that slot, regardless of
+  // @is_write (both reads and writes must wait out a slot migration's finalize step).
+  void AwaitPauseState(bool is_write, std::optional<SlotId> slot = std::nullopt);
 
   bool IsPaused() const {
     return (client_pauses_[0] + client_pauses_[1]) > 0;
+  }
+
+  // True if any slot-scoped pause (see SetSlotPauseState) is currently active on this thread.
+  // Cheap to call on every dispatch to gate whether it's worth resolving a command's slot at all.
+  bool HasActiveSlotPause() const {
+    return !paused_slot_ranges_.empty();
+  }
+
+  bool IsSlotPaused(SlotId slot) const {
+    for (const auto& ranges : paused_slot_ranges_) {
+      if (ranges.Contains(slot))
+        return true;
+    }
+    return false;
   }
 
   SlowLogShard& GetSlowLog() {
@@ -324,6 +346,10 @@ class ServerState {  // public struct - to allow initialization.
   // should subscribe to `client_pause_ec_` through `AwaitPauseState` to be
   // notified when the break is over.
   int client_pauses_[2] = {};
+  // Slot ranges currently paused by in-progress slot migrations. Concurrent migrations covering
+  // disjoint ranges each contribute their own entry; a command only waits if its slot falls in
+  // one of them. Expected to stay small (bounded by the number of concurrent migrations).
+  std::vector<cluster::SlotRanges> paused_slot_ranges_;
   util::fb2::EventCount client_pause_ec_;
 
   // Monitors connections. Currently responsible for closing timed out connections.

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1449,7 +1449,8 @@ OpStatus Transaction::WaitOnWatch(const time_point& tp, WaitKeys wkeys, KeyReady
   --stats->num_blocked_clients;
 
   *pause_flag = true;
-  ServerState::tlocal()->AwaitPauseState(true);  // blocking are always write commands
+  // blocking are always write commands
+  ServerState::tlocal()->AwaitPauseState(true, GetUniqueSlotId());
   *pause_flag = false;
 
   OpStatus result = OpStatus::OK;


### PR DESCRIPTION
## Summary

`OutgoingMigration::FinalizeMigration` currently pauses **every** client command on the node — via `dfly::Pause(..., ClientPause::ALL, ...)` — for the entire duration of each finalize attempt, even though the only reason for the pause is to stop *new transactions on the slots being migrated* from initializing with stale cluster-slot-ownership information. The code even carried a `// TODO implement blocking on migrated slots only` acknowledging this.

In practice this means: every time a slot migration finalizes (which can happen repeatedly across retries during a live resharding operation), **all** read/write traffic on the source node freezes — not just traffic touching the slots actually moving. For clusters doing rolling resharding, this shows up as a latency/availability spike across the entire keyspace, not just the part being migrated.

This PR scopes that pause down to just the slots being migrated.

## What changed

**1. Slot-scoped pause primitive (`ServerState` / `server_state.{h,cc}`)**
- `ServerState` already tracked global `CLIENT PAUSE ALL`/`WRITE` state as simple per-thread counters (`client_pauses_[2]`). Added a parallel, independent mechanism: `paused_slot_ranges_` — a small vector of `cluster::SlotRanges` currently under a slot-scoped pause.
- New `SetSlotPauseState(SlotRanges, bool start)` / `IsSlotPaused(SlotId)` / `HasActiveSlotPause()`.
- `AwaitPauseState(bool is_write, optional<SlotId> slot = nullopt)` now also blocks if the given slot falls inside any active slot-scoped pause, **regardless of `is_write`** — both reads and writes must wait out a migration finalize, since the concern is stale ownership metadata, not write safety.
- Concurrent migrations covering disjoint slot ranges just add independent entries; a command only waits if its own resolved slot intersects one of them.

**2. `dfly::Pause()` (`server_family.{h,cc}`)**
- Gained an optional `cluster::SlotRanges slot_ranges = nullopt` parameter. When set, it calls `SetSlotPauseState` instead of the global `SetPauseState` on every shard thread, both when starting the pause and when the pause-completion fiber tears it down.
- Existing callers (`CLIENT PAUSE` via `ClientPauseCmd`) are unaffected — they don't pass `slot_ranges`, so behavior there is unchanged (still pauses everything, as `CLIENT PAUSE` should).

**3. `OutgoingMigration::FinalizeMigration` (`outgoing_slot_migration.cc`)**
- Now passes `migration_info_.slot_ranges` (the migration's own slots, already tracked) instead of relying on the blanket `ClientPause::ALL` behavior. Closes the standing TODO.

**4. Dispatch path (`main_service.cc`)**
- `CheckPauseState` now accepts an optional resolved `SlotId` and additionally gates on `ServerState::IsSlotPaused`.
- In `DispatchCommand`, the command's slot is only resolved (`ResolveCommandSlot`) when `ServerState::HasActiveSlotPause()` is true — i.e., the extra per-command key lookup only happens while a migration finalize is actually in progress, so the common case (no migration running) pays zero extra cost.
- Resolution errors (cross-slot, bad key spec) are deliberately ignored at this point and left to surface from the existing `CheckKeysOwnership` check later in the same dispatch — this call is only about deciding whether to block, not about validating the command.

**5. Blocking commands (`transaction.cc`)**
- `Transaction::WaitOnWatch` (the post-wakeup pause check for commands like `BLPOP`) now passes its own already-resolved `GetUniqueSlotId()` into `AwaitPauseState`, so blocking commands are correctly slot-scoped too instead of always waiting out any pause unconditionally.

**6. Refactor: `ResolveCommandSlot` (`main_service.{h,cc}`)**
- `CheckKeysOwnership` and `TakenOverSlotError` had near-identical key→slot resolution logic (`FindKeys` → `UniqueSlotChecker` → cross-slot check), flagged by a standing `// TODO(kostas) refactor` comment. Extracted into one shared helper both now call, with no behavior change. This is also the helper reused by the new pause-scoping logic in `DispatchCommand`.

## Why this design

- Slot-scoping only matters in cluster mode with an active migration — by gating the extra key resolution on `HasActiveSlotPause()`, the hot dispatch path is untouched in the overwhelmingly common case (no migration running).
- Reusing the existing `ClientPause` counters for the global case (rather than folding everything into one mechanism) keeps `CLIENT PAUSE`'s existing, well-tested semantics completely unchanged — this PR only adds a new, additive blocking condition.
- The one-time `DispatchTracker` synchronization step at the start of `Pause()` (waiting for already-in-flight commands to finish dispatching) is intentionally left blanket/unscoped — it's a bounded, short wait for correctness at the moment the pause begins, not the sustained blocking the original TODO was about.

## Test plan

- Added `ClusterFamilyTest.SlotScopedPauseOnlyBlocksMatchingSlot` (`cluster_family_test.cc`): starts a slot-scoped pause via `dfly::Pause()` directly (the same code path `FinalizeMigration` uses), then verifies:
  - a `GET` on a key outside the paused slot returns immediately (not delayed by the active pause), and
  - a `GET` on a key inside the paused slot blocks until the pause's timeout elapses.
- Full suite run, no regressions:
  - `cluster_family_test`: 40/40 passed
  - `cluster_config_test`: 41/41 passed
  - `dragonfly_test`: 49/49 passed, 1 pre-existing unrelated skip (`DefragDflyEngineTest.TestDefragOption`)

## Not in scope

Left untouched, as separate follow-ups (surfaced during the initial codebase survey but out of scope here):
- Global commands being hard-rejected during incoming migration replay (`incoming_slot_migration.cc`)
- `FLUSHSLOTS` not canceling an in-flight outgoing migration for the same slots
- No LRU/LFU eviction policy
- `PSYNC CONTINUE` (partial resync) unimplemented
- `Transaction::ScheduleInternal` always taking the pessimistic multi-shard path for `MULTI`/`EVAL`
