### PR TITLE
refactor: improve stream tests

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3083,10 +3083,9 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     return rb->SendError("-NOGROUP the consumer group this client was blocked on no longer exists");
   };
 
-  // Re-resolves the streams owned by a single shard. Never trusts the cached streamCG*: background
-  // deletions (slot flush, eviction) bypass intent locks, so a stream may have been freed since it
-  // was last seen. Returns INVALID_VALUE for a missing stream or group, WRONG_TYPE if the key was
-  // replaced by another type.
+  // Re-resolves the streams owned by a single shard. The cached streamCG* predates the wake: the
+  // waking transaction can drop the group or replace the key. Returns INVALID_VALUE for a missing
+  // stream or group, WRONG_TYPE if the key was replaced by another type.
   auto validate_shard_keys = [&](const OpArgs& op_args, const ShardArgs& keys) {
     OpStatus status = OpStatus::OK;
     for (string_view skey : keys) {
@@ -3111,14 +3110,11 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
   // While we were blocked any of the watched streams could have been deleted, retyped or lost its
   // consumer group. XREADGROUP mutates the stream (it moves entries into the consumer PEL), so it
   // must not touch the woken key if another stream already invalidated the request. Streams on the
-  // woken shard are validated inside the action hop for free, so only reads that actually span
-  // shards pay for this extra hop.
-  // Note this must not be folded into the action hop with a cross shard barrier: waiting for
-  // sibling shards from inside a transaction callback stalls the whole shard and can deadlock two
-  // interleaved multi shard readers.
+  // woken shard are validated inside the action hop, so only cross shard reads pay for this hop.
+  // It cannot be folded into the action hop: waiting for sibling shards from inside a transaction
+  // callback stalls the shard and can deadlock two interleaved multi shard readers.
   if (opts->read_group && tx->GetUniqueShardCnt() > 1) {
-    // Indexed by shard id - every shard writes only its own slot, so no synchronization is needed
-    // beyond the hop boundary.
+    // Indexed by shard id; each shard writes only its own slot.
     vector<OpStatus> validation_status(shard_set->size(), OpStatus::OK);
 
     auto validate_cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -367,8 +367,8 @@ TEST_F(StreamFamilyTest, XReadBlockIgnoresNonDataWake) {
   EXPECT_THAT(Run({"PEXPIRE", "foo", "60000"}), IntArg(1));
   EXPECT_TRUE(IsConnBlocked("IO1"));
 
-  // PEXPIRE is a non-data update. Repeat the wake explicitly so this test also checks the
-  // readiness predicate on the parent revision, where PEXPIRE did not notify blocked readers.
+  // PEXPIRE is a non-data update, so it may not notify blocked readers at all. Drive the wake
+  // explicitly to make sure the readiness predicate itself is what keeps XREAD blocked.
   const ShardId sid = Shard("foo", shard_set->size());
   shard_set->Await(sid, [] {
     auto* bc =
@@ -607,20 +607,57 @@ TEST_F(StreamFamilyTest, XReadBlockOnMaxMsId) {
               ElementsAre("18446744073709551615-2", ArrLen(2)));
 }
 
-// A blocked XREADGROUP watches a key that can never become ready once the stream is deleted, so
-// it must be told that its consumer group is gone instead of sleeping forever.
-TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnDeletedStream) {
-  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
+// Wake paths differ: DEL/UNLINK/FLUSH and expiry remove the key, while BITOP/RENAME/SUNIONSTORE
+// overwrite it in place.
+TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnInvalidatedStream) {
+  const string kNoGroup = "consumer group this client was blocked on no longer exists";
 
-  RespExpr resp;
-  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
-    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
+  struct Case {
+    string_view name;
+    vector<vector<string>> setup;
+    vector<string> invalidate;
+    string_view error;
+  };
 
-  pp_->at(1)->Await([&] { return Run({"del", "foo"}); });
-  reader.Join();
-  EXPECT_THAT(resp, ErrArg("consumer group this client was blocked on no longer exists"));
+  const vector<Case> cases = {
+      {"del", {}, {"DEL", "wake-del"}, kNoGroup},
+      {"unlink", {}, {"UNLINK", "wake-unlink"}, kNoGroup},
+      {"flushdb", {}, {"FLUSHDB"}, kNoGroup},
+      {"flushall", {}, {"FLUSHALL"}, kNoGroup},
+      {"expireat", {}, {"EXPIREAT", "wake-expireat", "1"}, kNoGroup},
+      {"set", {}, {"SET", "wake-set", "value"}, "WRONGTYPE"},
+      {"bitop",
+       {{"SET", "bitop-src1", "a"}, {"SET", "bitop-src2", "b"}},
+       {"BITOP", "OR", "wake-bitop", "bitop-src1", "bitop-src2"},
+       "WRONGTYPE"},
+      {"rename",
+       {{"SET", "rename-src", "v"}},
+       {"RENAME", "rename-src", "wake-rename"},
+       "WRONGTYPE"},
+      {"sunionstore",
+       {{"SADD", "union-src", "member"}},
+       {"SUNIONSTORE", "wake-sunionstore", "union-src"},
+       "WRONGTYPE"},
+  };
+
+  for (const Case& tc : cases) {
+    SCOPED_TRACE(tc.name);
+    const string key = absl::StrCat("wake-", tc.name);
+
+    Run({"XGROUP", "CREATE", key, "group", "0", "MKSTREAM"});
+    for (const vector<string>& cmd : tc.setup)
+      Run(absl::Span<const string>(cmd));
+
+    RespExpr resp;
+    auto reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+      resp = Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "STREAMS", key, ">"});
+    });
+    ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+    Run(absl::Span<const string>(tc.invalidate));
+    reader.Join();
+    EXPECT_THAT(resp, ErrArg(tc.error));
+  }
 }
 
 // Deleting the stream must not wake a plain XREAD: it is waiting for entries that a recreated
@@ -694,66 +731,6 @@ TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnActivelyExpiredStream) {
   EXPECT_THAT(resp, ErrArg("consumer group this client was blocked on no longer exists"));
 }
 
-TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnRetypedStream) {
-  Run({"xgroup", "create", "foo", "group", "$", "MKSTREAM"});
-
-  RespExpr resp;
-  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
-    resp = Run({"xreadgroup", "group", "group", "alice", "block", "0", "streams", "foo", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
-
-  pp_->at(1)->Await([&] { return Run({"set", "foo", "value"}); });
-  reader.Join();
-  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
-}
-
-TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnBitOpRetype) {
-  Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
-  Run({"SET", "src1", "a"});
-  Run({"SET", "src2", "b"});
-
-  RespExpr resp0;
-  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    resp0 = Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "streams", "foo", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  Run({"BITOP", "OR", "foo", "src1", "src2"});
-  fb0.Join();
-  EXPECT_THAT(resp0, ErrArg("WRONGTYPE"));
-}
-
-TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnStoreRetypes) {
-  Run({"XGROUP", "CREATE", "rename-dst", "group", "0", "MKSTREAM"});
-  Run({"SET", "rename-src", "value"});
-
-  RespExpr rename_resp;
-  auto rename_reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    rename_resp = Run(
-        {"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "STREAMS", "rename-dst", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  Run({"RENAME", "rename-src", "rename-dst"});
-  rename_reader.Join();
-  EXPECT_THAT(rename_resp, ErrArg("WRONGTYPE"));
-
-  Run({"XGROUP", "CREATE", "union-dst", "group", "0", "MKSTREAM"});
-  Run({"SADD", "union-src", "member"});
-
-  RespExpr union_resp;
-  auto union_reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    union_resp =
-        Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "STREAMS", "union-dst", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  Run({"SUNIONSTORE", "union-dst", "union-src"});
-  union_reader.Join();
-  EXPECT_THAT(union_resp, ErrArg("WRONGTYPE"));
-}
-
 TEST_F(StreamFamilyTest, XReadAheadDoesNotSuppressXReadGroupWake) {
   Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
 
@@ -778,135 +755,81 @@ TEST_F(StreamFamilyTest, XReadAheadDoesNotSuppressXReadGroupWake) {
   fb0.Join();
 }
 
-TEST_F(StreamFamilyTest, XReadGroupBlockMultiStreamRevalidatesGroups) {
+// A woken XREADGROUP must validate every watched stream, not just the one that woke it: delivering
+// an entry would also add it to the consumer PEL. Both shard layouts matter - the woken shard is
+// validated in the action hop, remote ones need the extra validation hop.
+TEST_F(StreamFamilyTest, XReadGroupBlockMultiStreamRevalidatesStreams) {
   ASSERT_GT(shard_set->size(), 1u);
 
-  const string key_a = "multi-stream-a";
-  string key_b;
-  for (unsigned i = 0; key_b.empty(); ++i) {
-    string candidate = absl::StrCat("multi-stream-b-", i);
-    if (Shard(candidate, shard_set->size()) != Shard(key_a, shard_set->size()))
-      key_b = std::move(candidate);
+  struct Case {
+    string_view name;
+    bool same_shard;
+    vector<string> invalidate;  // applied to key_b, "%s" placeholder replaced by its name
+    string_view error;
+  };
+
+  const vector<Case> cases = {
+      {"remote-group",
+       false,
+       {"XGROUP", "DESTROY", "%s", "group"},
+       "consumer group this client was blocked on no longer exists"},
+      {"remote-retype", false, {"SET", "%s", "value"}, "WRONGTYPE"},
+      {"same-shard-group",
+       true,
+       {"XGROUP", "DESTROY", "%s", "group"},
+       "consumer group this client was blocked on no longer exists"},
+  };
+
+  for (const Case& tc : cases) {
+    SCOPED_TRACE(tc.name);
+
+    const string key_a = absl::StrCat(tc.name, "-a");
+    string key_b;
+    for (unsigned i = 0; key_b.empty(); ++i) {
+      string candidate = absl::StrCat(tc.name, "-b-", i);
+      const bool collocated =
+          Shard(candidate, shard_set->size()) == Shard(key_a, shard_set->size());
+      if (collocated == tc.same_shard)
+        key_b = std::move(candidate);
+    }
+
+    Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
+    Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
+
+    // Keep the target behind another waiter on key_b, so invalidating key_b wakes only the guard
+    // and the target must wake on key_a and revalidate key_b itself.
+    RespExpr guard_resp;
+    auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+      guard_resp =
+          Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "200", "STREAMS", key_b, ">"});
+    });
+    ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+    RespExpr target_resp;
+    auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
+      target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "200", "STREAMS", key_a,
+                         key_b, ">", ">"});
+    });
+    ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
+
+    vector<string> invalidate = tc.invalidate;
+    for (string& arg : invalidate) {
+      if (arg == "%s")
+        arg = key_b;
+    }
+
+    Run({"MULTI"});
+    Run({"XADD", key_a, "1-0", "f", "v"});
+    Run(absl::Span<const string>(invalidate));
+    Run({"EXEC"});
+
+    guard.Join();
+    target.Join();
+    EXPECT_THAT(guard_resp, ErrArg(tc.error));
+    EXPECT_THAT(target_resp, ErrArg(tc.error));
+    auto pending = Run({"XPENDING", key_a, "group"});
+    EXPECT_THAT(pending.GetVec()[0], IntArg(0));
   }
-  ASSERT_NE(Shard(key_a, shard_set->size()), Shard(key_b, shard_set->size()));
-
-  Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
-  Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
-
-  // Keep the target read behind another waiter on key_b. Destroying key_b's group wakes this
-  // guard, forcing the target transaction to wake on key_a and revalidate key_b remotely.
-  RespExpr guard_resp;
-  auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    guard_resp =
-        Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "0", "STREAMS", key_b, ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  RespExpr target_resp;
-  auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
-    target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "0", "STREAMS", key_a,
-                       key_b, ">", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
-
-  Run({"MULTI"});
-  Run({"XADD", key_a, "1-0", "f", "v"});
-  Run({"XGROUP", "DESTROY", key_b, "group"});
-  Run({"EXEC"});
-
-  guard.Join();
-  target.Join();
-  EXPECT_THAT(guard_resp, ErrArg("consumer group this client was blocked on no longer exists"));
-  EXPECT_THAT(target_resp, ErrArg("consumer group this client was blocked on no longer exists"));
-  auto pending = Run({"XPENDING", key_a, "group"});
-  EXPECT_THAT(pending.GetVec()[0], IntArg(0));
-}
-
-// This is the wrong-type counterpart of XReadGroupBlockMultiStreamRevalidatesGroups.
-// The target is woken only by key_a, while key_b is retyped behind its guard. The final
-// XREADGROUP action must validate key_b before it adds key_a's entry to the consumer PEL.
-TEST_F(StreamFamilyTest, XReadGroupBlockMultiStreamRevalidatesRetypedStream) {
-  ASSERT_GT(shard_set->size(), 1u);
-
-  const string key_a = "multi-stream-retype-a";
-  string key_b;
-  for (unsigned i = 0; key_b.empty(); ++i) {
-    string candidate = absl::StrCat("multi-stream-retype-b-", i);
-    if (Shard(candidate, shard_set->size()) != Shard(key_a, shard_set->size()))
-      key_b = std::move(candidate);
-  }
-  ASSERT_NE(Shard(key_a, shard_set->size()), Shard(key_b, shard_set->size()));
-
-  Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
-  Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
-
-  RespExpr guard_resp;
-  auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    guard_resp =
-        Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "200", "STREAMS", key_b, ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  RespExpr target_resp;
-  auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
-    target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "200", "STREAMS", key_a,
-                       key_b, ">", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
-
-  Run({"MULTI"});
-  Run({"XADD", key_a, "1-0", "f", "v"});
-  Run({"SET", key_b, "value"});
-  Run({"EXEC"});
-
-  guard.Join();
-  target.Join();
-  EXPECT_THAT(guard_resp, ErrArg("WRONGTYPE"));
-  EXPECT_THAT(target_resp, ErrArg("WRONGTYPE"));
-  auto pending = Run({"XPENDING", key_a, "group"});
-  EXPECT_THAT(pending.GetVec()[0], IntArg(0));
-}
-
-// Same as XReadGroupBlockMultiStreamRevalidatesGroups, but both streams live on one shard, so the
-// remote validation hop is skipped and the action hop must validate them itself.
-TEST_F(StreamFamilyTest, XReadGroupBlockSingleShardMultiStreamRevalidatesGroups) {
-  const string key_a = "same-shard-a";
-  string key_b;
-  for (unsigned i = 0; key_b.empty(); ++i) {
-    string candidate = absl::StrCat("same-shard-b-", i);
-    if (Shard(candidate, shard_set->size()) == Shard(key_a, shard_set->size()))
-      key_b = std::move(candidate);
-  }
-  ASSERT_EQ(Shard(key_a, shard_set->size()), Shard(key_b, shard_set->size()));
-
-  Run({"XGROUP", "CREATE", key_a, "group", "0", "MKSTREAM"});
-  Run({"XGROUP", "CREATE", key_b, "group", "0", "MKSTREAM"});
-
-  RespExpr guard_resp;
-  auto guard = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    guard_resp =
-        Run({"XREADGROUP", "GROUP", "group", "guard", "BLOCK", "0", "STREAMS", key_b, ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  RespExpr target_resp;
-  auto target = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
-    target_resp = Run({"XREADGROUP", "GROUP", "group", "target", "BLOCK", "0", "STREAMS", key_a,
-                       key_b, ">", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO2"); }, 500ms));
-
-  Run({"MULTI"});
-  Run({"XADD", key_a, "1-0", "f", "v"});
-  Run({"XGROUP", "DESTROY", key_b, "group"});
-  Run({"EXEC"});
-
-  guard.Join();
-  target.Join();
-  EXPECT_THAT(guard_resp, ErrArg("consumer group this client was blocked on no longer exists"));
-  EXPECT_THAT(target_resp, ErrArg("consumer group this client was blocked on no longer exists"));
-  auto pending = Run({"XPENDING", key_a, "group"});
-  EXPECT_THAT(pending.GetVec()[0], IntArg(0));
 }
 
 TEST_F(StreamFamilyTest, XReadGroupBlockLazyExpireDuringWakeDoesNotCrash) {
@@ -932,34 +855,6 @@ TEST_F(StreamFamilyTest, XReadGroupBlockLazyExpireDuringWakeDoesNotCrash) {
     bc->NotifyPending();
   });
 
-  fb0.Join();
-  EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
-}
-
-TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnFlushDb) {
-  Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
-
-  RespExpr resp0;
-  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    resp0 = Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "streams", "foo", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  Run({"FLUSHDB"});
-  fb0.Join();
-  EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
-}
-
-TEST_F(StreamFamilyTest, XReadGroupBlockWakeOnImmediateExpire) {
-  Run({"XGROUP", "CREATE", "foo", "group", "0", "MKSTREAM"});
-
-  RespExpr resp0;
-  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
-    resp0 = Run({"XREADGROUP", "GROUP", "group", "alice", "BLOCK", "200", "streams", "foo", ">"});
-  });
-  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
-
-  Run({"EXPIREAT", "foo", "1"});
   fb0.Join();
   EXPECT_THAT(resp0, ErrArg("consumer group this client was blocked on no longer exists"));
 }


### PR DESCRIPTION
Summary: This PR refactors stream blocking tests while preserving the existing XREAD/XREADGROUP wake-validation behavior.

Changes:

- Clarifies the stale stream/group revalidation comments in XReadBlock.
- Updates the non-data wake test to explicitly trigger the readiness predicate.
- Consolidates stream deletion, expiry, flush, and type-replacement wake tests into a table-driven test.
- Covers DEL, UNLINK, database/server flushes, immediate expiry, and several overwrite commands.
- Consolidates multi-stream consumer-group revalidation cases for remote and colocated shard layouts.
- Retains assertions that invalidated reads return NOGROUP or WRONGTYPE.
- Retains the check that an invalidated companion stream does not add entries to the other stream's consumer PEL.

Technical Notes: The tests continue to distinguish woken-shard validation in the action hop from cross-shard validation before that hop, avoiding the transaction-callback deadlock described in the implementation comments.