### PR TITLE
ci(tests): add scheduled e2e workflow for ioredis client

### DIFF
--- a/.github/workflows/ioredis-tests.yml
+++ b/.github/workflows/ioredis-tests.yml
@@ -1,0 +1,98 @@
+name: ioredis-tests
+
+on:
+  schedule:
+    - cron: '15 7 * * *' # run at 7:15 AM daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "22.12.0"
+
+jobs:
+  build:
+    if: github.repository == 'dragonflydb/dragonfly'
+    runs-on: ubuntu-latest
+    name: Build
+    timeout-minutes: 60
+
+    container:
+      image: ghcr.io/romange/ubuntu-dev:20-gcc14
+      options: --security-opt seccomp=unconfined
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Build Dragonfly
+        run: |
+          cmake -B ${GITHUB_WORKSPACE}/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DWITH_AWS=OFF \
+            -DWITH_GCP=OFF \
+            -DWITH_UNWIND=OFF \
+            -DWITH_GPERF=OFF \
+            -GNinja \
+            -L
+          cd ${GITHUB_WORKSPACE}/build && ninja dragonfly
+
+      - name: Install Node.js
+        run: |
+          wget -q https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-glibc-217.tar.xz
+          tar -xf node-v${NODE_VERSION}-linux-x64-glibc-217.tar.xz
+          cp -r node-v${NODE_VERSION}-linux-x64-glibc-217/* /usr/local/
+          apt-get update && apt-get install -y jq redis-tools git
+          node --version
+          npm --version
+
+      - name: Start Dragonfly
+        run: |
+          mkdir -p /tmp/df-logs
+          ${GITHUB_WORKSPACE}/build/dragonfly \
+            --alsologtostderr \
+            --log_dir=/tmp/df-logs \
+            --cluster_mode=emulated \
+            --lock_on_hashtags \
+            --dbfilename= \
+            --port 6379 \
+            >/tmp/df-logs/stdout.log 2>/tmp/df-logs/stderr.log &
+          timeout 15s bash -c 'until redis-cli -p 6379 PING 2>/dev/null | grep -q PONG; do sleep 0.1; done'
+
+      - name: Build ioredis
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          git clone https://github.com/luin/ioredis
+          cd ioredis
+          npm install
+
+      - name: Run ioredis tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/ioredis
+          cp ${GITHUB_WORKSPACE}/tests/integration/.run_ioredis_valid_test.sh ./run_tests.sh
+          chmod +x ./run_tests.sh
+          npm run env -- TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test ./run_tests.sh
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dragonfly-logs
+          path: /tmp/df-logs/
+
+      - name: Send notification on failure
+        if: failure() && github.ref == 'refs/heads/main'
+        run: |
+          job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          message="ioredis e2e tests failed.\\n Commit: ${{github.sha}}\\n Job Link: ${job_link}\\n"
+
+          curl -s \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            '${{ secrets.GSPACES_BOT_DF_BUILD }}' \
+            -d '{"text": "'"${message}"'"}'

--- a/.github/workflows/ioredis-tests.yml
+++ b/.github/workflows/ioredis-tests.yml
@@ -10,6 +10,9 @@ permissions:
 
 env:
   NODE_VERSION: "22.12.0"
+  # Pinned so nightly failures reflect Dragonfly regressions rather than
+  # unrelated upstream ioredis changes. Bump deliberately when needed.
+  IOREDIS_REF: "v5.4.1"
 
 jobs:
   build:
@@ -67,8 +70,9 @@ jobs:
       - name: Build ioredis
         run: |
           cd ${GITHUB_WORKSPACE}
-          git clone https://github.com/luin/ioredis
+          git clone --depth 1 --branch "${IOREDIS_REF}" https://github.com/luin/ioredis
           cd ioredis
+          git rev-parse HEAD
           npm install
 
       - name: Run ioredis tests
@@ -85,8 +89,14 @@ jobs:
           name: dragonfly-logs
           path: /tmp/df-logs/
 
+  notify:
+    needs: build
+    if: always() && needs.build.result == 'failure' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    name: Notify on failure
+    timeout-minutes: 5
+    steps:
       - name: Send notification on failure
-        if: failure() && github.ref == 'refs/heads/main'
         run: |
           job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           message="ioredis e2e tests failed.\\n Commit: ${{github.sha}}\\n Job Link: ${job_link}\\n"

--- a/tests/README.md
+++ b/tests/README.md
@@ -121,6 +121,9 @@ be in lower case.
 Integration tests for ioredis client.
 [ioredis](https://github.com/luin/ioredis) is a robust, performance-focused and full-featured Redis client for Node.js.
 It contains a very extensive test coverage for Redis. Currently not all features are supported by Dragonfly.
+These tests also run automatically once a day against `main` via the
+[ioredis-tests](../.github/workflows/ioredis-tests.yml) GitHub Actions workflow (can also be triggered manually
+via `workflow_dispatch`), mirroring the existing `bullmq-tests` workflow.
 As such please use the scripts for running the test successfully -
  **[run_ioredis_on_docker.sh](./integration/run_ioredis_on_docker.sh)**: to run the supported tests on a docker image
  Please note that you can run this script in two forms:


### PR DESCRIPTION
## What

Adds a scheduled GitHub Actions workflow, `.github/workflows/ioredis-tests.yml`, that runs the existing
[ioredis](https://github.com/luin/ioredis) end-to-end test suite against a freshly built Dragonfly binary
every day, and points to it from `tests/README.md`.

## Why (closes part of #383)

`#383` asked for e2e coverage of the `ioredis` client. Looking at the history:

- `tests/integration/ioredis.Dockerfile` and `tests/integration/run_ioredis_on_docker.sh` (added in #394 / #459)
  already give a local script + README instructions for running the curated ioredis test suite against Dragonfly
  (deliverables 1 & 2 from the issue).
- What was still missing is what @romange asked for in the issue thread: *"we just need to run them via the
  testing pipeline on github"*. There was no CI workflow exercising these tests — `ioredis`/`node-redis`/`jedis`
  Dockerfiles are all local-only, and grepping every workflow in `.github/workflows` shows none of them touch
  `tests/integration`.
- The repo already has exactly this pattern for another ioredis-based client, `bullmq-tests.yml` (nightly
  scheduled job, builds Dragonfly from source, installs Node, runs the client's own test suite with a
  skip-list). This PR mirrors that same structure for `ioredis` itself, reusing the pre-existing
  `tests/integration/.run_ioredis_valid_test.sh` skip/grep list rather than duplicating it.

## What this does NOT do

- It does not touch the existing local Docker scripts — those keep working as-is for local development.
- It does not attempt the issue's "bonus" deliverable (a bespoke Dragonfly-authored pub/sub regression test);
  that's a separate, larger piece of work and is left as a possible follow-up so this PR stays focused on the
  CI-wiring gap.

## Testing

Since building the full C++ project wasn't practical in my environment, I validated the actual test-execution
path the workflow runs:

- Started the official `dragonfly` Docker image (`--cluster_mode=emulated --lock_on_hashtags --dbfilename=`,
  same flags as `bullmq-tests.yml` uses for Dragonfly).
- Cloned `luin/ioredis`, ran `npm install`, then ran the exact command the new workflow runs:
  `npm run env -- TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test ./run_tests.sh` using the repo's own
  `tests/integration/.run_ioredis_valid_test.sh` as `run_tests.sh`.
- Result: **493 passing / 2 failing**, both failures being `Timeout of 8000ms exceeded` on tests unrelated to
  correctness (a large-pipeline timing test and a cluster startup-nodes teardown hook) — consistent with the
  constrained local sandbox rather than a real regression.

I couldn't run the pre-commit C++/format hooks in this environment (no C++ toolchain available), but this PR
only touches a workflow YAML file and a doc file, so `clang-format`/`black` are not applicable.

Closes (partially) #383
