### PR TITLE
fix(stream): Reply with RESP3 map for XREAD BLOCK

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3220,7 +3220,7 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
 
   if (result) {
     SinkReplyBuilder::ReplyAggregator agg(rb);
-    if (opts->read_group && rb->IsResp3()) {
+    if (rb->IsResp3()) {
       rb->StartCollection(1, CollectionType::MAP);
     } else {
       rb->StartArray(1);

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -374,7 +374,7 @@ TEST_F(StreamFamilyTest, XReadBlock) {
   auto fb2 = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
     resp3_reply = Run({"xread", "block", "0", "streams", "foo", "$"});
   });
-  ThisFiber::SleepFor(50us);
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO0"); }, 500ms));
 
   resp = pp_->at(1)->Await([&] { return Run("xadd", {"xadd", "foo", "1-*", "k6", "v6"}); });
 

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -367,6 +367,24 @@ TEST_F(StreamFamilyTest, XReadBlock) {
   // Both xread calls should have been unblocked.
   EXPECT_THAT(resp0.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
   EXPECT_THAT(resp1.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+
+  // With the RESP3 protocol, a blocked XREAD woken by a new entry should get a valid response.
+  Run({"HELLO", "3"});
+  RespExpr resp3_reply;
+  auto fb2 = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp3_reply = Run({"xread", "block", "0", "streams", "foo", "$"});
+  });
+  ThisFiber::SleepFor(50us);
+
+  resp = pp_->at(1)->Await([&] { return Run("xadd", {"xadd", "foo", "1-*", "k6", "v6"}); });
+
+  fb2.Join();
+
+  ASSERT_THAT(resp3_reply, RespArray(ElementsAre("foo", ArrLen(1))));
+  const auto foo_resp = resp3_reply.GetVec()[1];
+  const auto first_entry = foo_resp.GetVec()[0];
+  const auto expected = RespArray(ElementsAre("k6", "v6"));
+  ASSERT_THAT(first_entry, RespArray(ElementsAre(_, expected)));
 }
 
 TEST_F(StreamFamilyTest, XReadBlockIgnoresNonDataWake) {


### PR DESCRIPTION
XReadBlock gated the RESP3 map shape on opts->read_group, so a plain blocking XREAD 
always fell back to the RESP2 array shape even on a RESP3 connection.
The non-blocking path already applies the map shape to both XREAD and XREADGROUP, so
drop the read_group condition.

Fixes #8056

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
