### PR TITLE
fix(server): emit expired keyspace events for already-past expirations

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1289,13 +1289,23 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
     return OpStatus::SKIPPED;
 
   // If we update and the new value is already expired, delete the key
+  // Already-expired new value: delete; the caller emits the expired event after journaling.
   if (rel_msec <= 0) {
     Del(cntx, prime_it);
+    ++events_.expired_keys;
+    db_arr_[cntx.db_index]->stats.events.expired_keys++;
     return -1;
   }
 
   AddExpire(cntx.db_index, prime_it, abs_msec);
   return abs_msec;
+}
+
+void DbSlice::SendExpiredKeyEvent(const Context& cntx, std::string_view key) const {
+  if (!expired_keys_events_recording_)
+    return;
+  channel_store->SendMessages(absl::StrCat("__keyevent@", cntx.db_index, "__:expired"),
+                              absl::Span<const std::string_view>{&key, 1}, false);
 }
 
 OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrUpdateInternal(const Context& cntx,

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -327,6 +327,9 @@ class DbSlice {
   facade::OpResult<int64_t> UpdateExpire(const Context& cntx, Iterator prime_it,
                                          const ExpireParams& params);
 
+  // Publishes the expired keyspace event; call AFTER the deletion has been journaled.
+  void SendExpiredKeyEvent(const Context& cntx, std::string_view key) const;
+
   // Adds expiry on a key. If the key already has expiry, updates it.
   void AddExpire(DbIndex db_ind, const Iterator& main_it, uint64_t at);
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -870,6 +870,10 @@ OpStatus OpExpire(const OpArgs& op_args, string_view key, const DbSlice::ExpireP
     }
   }
 
+  if (res.ok() && res.value() == -1) {
+    db_slice.SendExpiredKeyEvent(op_args.db_cntx, key);
+  }
+
   return res.status();
 }
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -2304,8 +2304,12 @@ TEST_F(GenericFamilyTest, SortByNosortStoreInMulti) {
 // Regression test for https://github.com/dragonflydb/dragonfly/issues/7052
 // Heartbeat-driven key expiry must not call SendMessages inside a fiber-atomic section.
 TEST_F(GenericFamilyTest, KeyspaceNotificationNoAtomicSectionOnExpiry) {
-  // Enable expired-key keyspace notifications.
+  const string prev_notify =
+      Run({"CONFIG", "GET", "notify_keyspace_events"}).GetVec()[1].GetString();
   Run({"CONFIG", "SET", "notify_keyspace_events", "EX"});
+  absl::Cleanup restore_notify = [&] {
+    Run({"CONFIG", "SET", "notify_keyspace_events", prev_notify});
+  };
 
   single_response_ = false;
   auto sub_resp = pp_->at(1)->Await([&] { return Run({"subscribe", "__keyevent@0__:expired"}); });
@@ -2334,9 +2338,6 @@ TEST_F(GenericFamilyTest, KeyspaceNotificationNoAtomicSectionOnExpiry) {
   const auto& msg = GetPublishedMessage("IO1", 0);
   EXPECT_EQ("__keyevent@0__:expired", msg.channel);
   EXPECT_EQ("mykey", msg.message);
-
-  // Restore the flag so it doesn't bleed into other tests.
-  Run({"CONFIG", "SET", "notify_keyspace_events", ""});
 }
 
 // A rejected CONFIG SET must not leave the invalid value observable: CONFIG GET has to keep
@@ -2379,6 +2380,33 @@ TEST_F(GenericFamilyTest, ConfigNotifyAppliesToAllNamespaces) {
     EXPECT_FALSE(ns->GetDbSlice(i).IsExpiredEventsRecording()) << i;
     EXPECT_FALSE(late_ns->GetDbSlice(i).IsExpiredEventsRecording()) << i;
   }
+}
+
+// EXPIRE with an already-past time deleted the key silently, so a subscriber waiting for the
+// expired event blocked forever.
+TEST_F(GenericFamilyTest, ExpirePastEmitsExpiredEvent) {
+  const string prev_notify =
+      Run({"CONFIG", "GET", "notify_keyspace_events"}).GetVec()[1].GetString();
+  Run({"CONFIG", "SET", "notify_keyspace_events", "EX"});
+  absl::Cleanup restore_notify = [&] {
+    Run({"CONFIG", "SET", "notify_keyspace_events", prev_notify});
+  };
+
+  Run({"SET", "foo", "1"});
+
+  single_response_ = false;
+  auto sub_resp = pp_->at(1)->Await([&] { return Run({"subscribe", "__keyevent@0__:expired"}); });
+  ASSERT_THAT(sub_resp, ArrLen(3));
+
+  EXPECT_THAT(Run({"EXPIRE", "foo", "-1"}), IntArg(1));
+  EXPECT_THAT(Run({"GET", "foo"}), ArgType(RespExpr::NIL));
+
+  pp_->AwaitFiberOnAll([](util::ProactorBase*) {});  // flush pending publishes
+  ASSERT_EQ(1u, SubscriberMessagesLen("IO1"));
+  const auto& msg = GetPublishedMessage("IO1", 0);
+  EXPECT_EQ("__keyevent@0__:expired", msg.channel);
+  EXPECT_EQ("foo", msg.message);
+  EXPECT_GE(GetMetrics().events.expired_keys, 1u);
 }
 
 }  // namespace dfly

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -878,6 +878,7 @@ OpResult<DbSlice::Iterator> FindKeyAndSetExpiry(const GetAndTouchParams& params)
   }
 
   if (expired) {
+    db_slice.SendExpiredKeyEvent(ctx, params.key);
     return OpStatus::KEY_NOTFOUND;
   }
   return find_res->it;
@@ -1420,21 +1421,29 @@ cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
 
     StringResult value = ReadString(t->GetDbIndex(), key, it_res->it->second, shard);
 
+    bool key_expired = false;
     if (exp_params.IsDefined()) {
       it_res->post_updater.Run();  // Run manually before possible delete due to negative expire
-      RETURN_ON_BAD_STATUS(
-          op_args.GetDbSlice().UpdateExpire(op_args.db_cntx, it_res->it, exp_params));
+      auto expire_res = op_args.GetDbSlice().UpdateExpire(op_args.db_cntx, it_res->it, exp_params);
+      RETURN_ON_BAD_STATUS(expire_res);
+      key_expired = *expire_res == -1;
     }
 
-    // Replicate GETEX as PEXPIREAT or PERSIST
+    // Replicate GETEX as DEL (already-past expiration), PEXPIREAT or PERSIST.
     if (shard->journal() && exp_params.IsDefined()) {
       if (exp_params.persist) {
         RecordJournal(op_args, "PERSIST", {key});
+      } else if (key_expired) {
+        RecordJournal(op_args, "DEL", {key});
       } else {
         auto [ignore, abs_time] = exp_params.Calculate(op_args.db_cntx.time_now_ms, false);
         auto abs_time_str = absl::StrCat(abs_time);
         RecordJournal(op_args, "PEXPIREAT", {key, abs_time_str});
       }
+    }
+
+    if (key_expired) {
+      op_args.GetDbSlice().SendExpiredKeyEvent(op_args.db_cntx, key);
     }
 
     return value;

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -1,6 +1,8 @@
 // Copyright 2022, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
+#include <absl/cleanup/cleanup.h>
+
 #include <random>
 
 #include "base/gtest.h"
@@ -1215,6 +1217,37 @@ TEST_F(StringFamilyTest, PendingReadDrainNonOrphaned) {
     CompactObj::DrainPendingReads();
     cobj.Reset();
   });
+}
+
+// GETEX and memcached GAT with an already-past expiration delete the key and must emit the
+// expired keyspace event.
+TEST_F(StringFamilyTest, PastExpiryEmitsExpiredEvent) {
+  using MP = facade::MemcacheParser;
+  const string prev_notify =
+      Run({"CONFIG", "GET", "notify_keyspace_events"}).GetVec()[1].GetString();
+  Run({"CONFIG", "SET", "notify_keyspace_events", "EX"});
+  absl::Cleanup restore_notify = [&] {
+    Run({"CONFIG", "SET", "notify_keyspace_events", prev_notify});
+  };
+
+  single_response_ = false;
+  auto sub_resp = pp_->at(1)->Await([&] { return Run({"subscribe", "__keyevent@0__:expired"}); });
+  ASSERT_THAT(sub_resp, ArrLen(3));
+
+  Run({"SET", "foo", "bar"});
+  EXPECT_EQ(Run({"GETEX", "foo", "PXAT", "1"}), "bar");
+  EXPECT_THAT(Run({"EXISTS", "foo"}), IntArg(0));
+  pp_->AwaitFiberOnAll([](util::ProactorBase*) {});  // flush pending publishes
+  ASSERT_EQ(1u, SubscriberMessagesLen("IO1"));
+  EXPECT_EQ("foo", GetPublishedMessage("IO1", 0).message);
+
+  // Replies keep their raw RESP form in subscriber mode.
+  EXPECT_THAT(RunMC(MP::SET, "key", MCArgs{"val"}), ElementsAre("+STORED"));
+  EXPECT_THAT(GetMC(MP::GAT, {absl::StrCat(TEST_current_time_ms / 1000 - 100), "key"}),
+              ElementsAre("END"));
+  pp_->AwaitFiberOnAll([](util::ProactorBase*) {});
+  ASSERT_EQ(2u, SubscriberMessagesLen("IO1"));
+  EXPECT_EQ("key", GetPublishedMessage("IO1", 1).message);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Deleting a key because its newly set expiration is already in the past emitted no `__keyevent@<db>__:expired` notification, so a subscriber waiting for the event was blocked forever (found via the upstream Valkey pubsub TCL suite: "expired event (Expiration time is already expired)" hangs). This covers the `DbSlice::UpdateExpire` funnel: EXPIRE/PEXPIRE/(P)EXPIREAT, GETEX, and memcached GAT/GATS.
