### PR TITLE
server: Fix stream size memory accounting

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1095,16 +1095,25 @@ void CompactObj::SetJsonSize(int64_t size) {
   }
 }
 
-void CompactObj::AddStreamSize(int64_t size) {
+void CompactObj::AddStreamSize(int64_t delta) {
   DCHECK_EQ(taglen_, STREAM_TAG);
-  if (size < 0) {
-    // We might have a negative size. For example, if we remove a consumer,
-    // the tracker will report a negative net (since we deallocated),
-    // so the object now consumes less memory than it did before. This DCHECK
-    // is for fanity and to catch any potential issues with our tracking approach.
-    DCHECK(static_cast<int64_t>(u_.r_obj.Size()) >= size);
+
+  const uint64_t current = u_.r_obj.Size();
+  if (delta >= 0) {
+    u_.r_obj.SetSize(current + delta);
+    return;
   }
-  u_.r_obj.SetSize((u_.r_obj.Size() + size));
+
+  const int64_t signed_current = static_cast<int64_t>(current);
+  if (delta > -signed_current) {
+    u_.r_obj.SetSize(signed_current + delta);
+    return;
+  }
+
+  const size_t slow_measure = MallocUsed(true);
+  LOG_EVERY_T(ERROR, 30) << "Invalid stream memory delta: cached=" << current << ", delta=" << delta
+                         << ", measured=" << slow_measure;
+  u_.r_obj.SetSize(slow_measure);
 }
 
 void CompactObj::SetJson(const uint8_t* buf, size_t len) {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -372,7 +372,7 @@ class CompactObj {
   // Adjusts the size used by json
   void SetJsonSize(int64_t size);
   // Adjusts the size used by a stream
-  void AddStreamSize(int64_t size);
+  void AddStreamSize(int64_t delta);
 
   // pre condition - the type here is OBJ_JSON and was set with SetJson
   JsonType* GetJson() const;

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -1415,6 +1415,15 @@ TEST_F(CompactObjectTest, TryBorrow_DefragSkipsWhenPinned) {
   cobj_.Reset();
 }
 
+TEST_F(CompactObjectTest, StreamSizeDoesNotWrap) {
+  cobj_.InitRobj(OBJ_STREAM, OBJ_ENCODING_STREAM, streamNew());
+  const auto initial = cobj_.MallocUsed(true);
+  cobj_.AddStreamSize(initial);
+  cobj_.AddStreamSize(-static_cast<int64_t>(initial) - 1);
+  EXPECT_EQ(cobj_.MallocUsed(), cobj_.MallocUsed(true));
+  EXPECT_GT(cobj_.MallocUsed(), 0);
+}
+
 static void ascii_pack_naive(const char* ascii, size_t len, uint8_t* bin) {
   const char* end = ascii + len;
 


### PR DESCRIPTION
It has been seen in certain cases that the stream size accounting breaks due to a negative delta. In that case, the metrics depending on this type go completely wrong and start showing object size in terrabytes instead of a few GiB.

There are a couple of fixes and safeguards:

* original check that size>=delta if delta<0 was not doing anythingi it was always true. it is removed
* now the change requested in bytes is compared with the curr. size and the limit ie 56 bit int maximum
* if the value does not fit, then we do slow recomputation of the real size instead of clamping to 0 etc.

There is also removed a buggy cast, previously we did something like: `SetSize(Size() + size)`

So first the sum was cast to uint64_t, which might already wrap a negative value (if size is negative of more magnitude than Size()).

Then that value was stored from uint64_t into a 56 bit field. In addition a negative delta was first cast by C++ itself to uint64_t.

In the current code the cast for negative delta is done correctly and the case where delta is at boundary INT64_MIN is also handled

---

The added test was failing without the changes. 
