### PR TITLE
fix(pubsub): preserve V2 message ordering

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1708,7 +1708,8 @@ auto Connection::ParseLoop() -> ParserStatus {
 
     // Execute/reply the commands parsed so far first, so a trailing protocol error still flushes
     // earlier replies in order before we report it.
-    if (!ExecuteBatch())
+    ExecuteBatchResult execute_result = ExecuteBatch();
+    if (execute_result == ExecuteBatchResult::kFailure)
       return ERROR;
 
     if (!ReplyBatch())
@@ -1718,7 +1719,11 @@ auto Connection::ParseLoop() -> ParserStatus {
     // protocol error reply (using parser_error_) and close the connection.
     if (parse_status == ERROR)
       return ERROR;
-  } while (parse_status == OK && io_buf_.InputLen() > 0);
+
+    // V2: let IoLoopV2 drain control messages that were queued before this pipeline.
+    if (execute_result == ExecuteBatchResult::kDeferToControlPath)
+      return OK;
+  } while ((parse_status == OK) && (io_buf_.InputLen() > 0));
 
   return parse_status;  // OK or NEED_MORE
 }
@@ -3023,13 +3028,13 @@ bool Connection::SquashPipelineV2() {
   return true;
 }
 
-bool Connection::ExecuteBatch() {
+Connection::ExecuteBatchResult Connection::ExecuteBatch() {
   // Invariant: batched_ must be false on entry.
   // Both ReplyBatch() and ExecuteBatch() reset it via absl::Cleanup guards on all return paths.
   DCHECK(!reply_builder_->IsBatchMode());
 
   if (parsed_to_execute_ == nullptr) {
-    return true;  // no errors.
+    return ExecuteBatchResult::kSuccess;  // no errors.
   }
 
   ConnectionMemoryTracker memory_tracker(this);
@@ -3061,7 +3066,17 @@ bool Connection::ExecuteBatch() {
 
   while (parsed_to_execute_ != nullptr) {
     if (reply_builder_->GetError())
-      return false;
+      return ExecuteBatchResult::kFailure;
+
+    // The V2 loop may parse a pipeline while older control messages are still queued. Running this
+    // command first would let e.g. UNSUBSCRIBE drop those messages, so yield to IoLoopV2, which
+    // owns control-path draining, and retry once the older prefix is gone. dispatch_q_ is FIFO by
+    // dispatch_cycle (checkpoints are front-inserted), so testing the front covers the prefix.
+    if (ioloop_v2_ && !dispatch_q_.empty() &&
+        (dispatch_q_.front().IsCheckPoint() ||
+         dispatch_q_.front().dispatch_cycle < parsed_to_execute_->parsed_cycle)) {
+      return ExecuteBatchResult::kDeferToControlPath;
+    }
 
     if (pipeline_squashing_v2_ && dispatch_waiting_count_ > 1) {
       // if we squashed any commands, continue the loop to check if there are
@@ -3175,7 +3190,7 @@ bool Connection::ExecuteBatch() {
     }
   }
 
-  return true;
+  return ExecuteBatchResult::kSuccess;
 }
 
 bool Connection::ReplyBatch() {
@@ -3784,8 +3799,13 @@ void Connection::DrainQueuedCommands() {
   size_t mem_before = GetLocalConnStats().pipeline_queue_bytes;
 
   if (parsed_head_) {
-    if (HasCommandToExecute())
-      ExecuteBatch();
+    if (HasCommandToExecute()) {
+      ExecuteBatchResult execute_result = ExecuteBatch();
+      if (execute_result == ExecuteBatchResult::kFailure)
+        return;  // IoLoopV2 observes the reply-builder error.
+      if (execute_result == ExecuteBatchResult::kDeferToControlPath)
+        return;  // The next IoLoopV2 iteration drains dispatch_q_ before retrying.
+    }
     ReplyBatch();
   }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -549,8 +549,10 @@ class Connection : public util::Connection {
 
   // Loop over enqueued async commands and enqueue them for async execution.
   // If async execution is not possible, handle them in synchronous mode one by one.
-  // Returns true on successful execution, false on reply builder error.
-  bool ExecuteBatch();
+  // Returns kDeferToControlPath only when V2 stops to let IoLoopV2 drain control messages that
+  // precede the next parsed command.
+  enum class ExecuteBatchResult : uint8_t { kSuccess, kFailure, kDeferToControlPath };
+  ExecuteBatchResult ExecuteBatch();
 
   // V2 vectorized squash phase: dispatch the run starting at parsed_to_execute_ through
   // DispatchSquashedBatch when squashing is enabled. Returns true if a squashed batch was

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -693,17 +693,16 @@ async def test_pubsub_unsubscribe(df_server: DflyInstance):
 # while earlier Pub/Sub messages were still queued, so the client saw messages after the unsubscribe confirmation (or lost them).
 # All messages must precede the confirmation.
 #
-# dfly_args: single proactor thread for deterministic reordering, and tiny quota to trigger anti starvation quickly
-@dfly_args({"proactor_threads": 1, "async_dispatch_quota": 4})
+# Runs four cases: V1 and V2, each with standalone UNSUBSCRIBE and GET + UNSUBSCRIBE. Use a single
+# proactor thread for deterministic reordering and a tiny quota to trigger anti-starvation quickly.
+@dfly_multi_test_args(
+    {"proactor_threads": 1, "async_dispatch_quota": 4, "enable_resp_io_loop_v2": "false"},
+    {"proactor_threads": 1, "async_dispatch_quota": 4, "enable_resp_io_loop_v2": "true"},
+)
+@pytest.mark.parametrize("pipeline_get", [False, True], ids=["standalone", "deferred_get"])
 async def test_pubsub_unsubscribe_message_loss(
-    df_server: DflyInstance, async_client: aioredis.Redis
+    df_server: DflyInstance, async_client: aioredis.Redis, pipeline_get: bool
 ):
-    # The fix currently only covers the V1 io loop. The V2 loop (IoLoopV2) still reorders
-    # UNSUBSCRIBE ahead of queued Pub/Sub messages, so skip until V2 is fixed.
-    # TODO: re-enable for V2 once the IoLoopV2 fix lands (see linked GitHub issue).
-    if is_resp_io_loop_v2(df_server):
-        pytest.skip("V2 io loop still reorders UNSUBSCRIBE ahead of queued messages; fix pending")
-
     publisher = async_client
     channel = "ordering-channel"
     # Well above async_dispatch_quota (and the socket buffer) so the surplus piles up
@@ -733,24 +732,39 @@ async def test_pubsub_unsubscribe_message_loss(
         for _ in range(message_count):
             assert await publisher.publish(channel, payload) == 1
 
-        await loop.sock_sendall(subscriber, f"UNSUBSCRIBE {channel}\r\n".encode())
+        unsubscribe_command = f"UNSUBSCRIBE {channel}\r\n".encode()
+        if pipeline_get:
+            # A deferred GET must not let the following UNSUBSCRIBE bypass older Pub/Sub messages.
+            await loop.sock_sendall(subscriber, b"GET ordering-key\r\n" + unsubscribe_command)
+        else:
+            await loop.sock_sendall(subscriber, unsubscribe_command)
 
-        # Drain replies until the unsubscribe confirmation, then keep reading through a
-        # short idle grace period to catch any message wrongly emitted after it.
+        # Drain replies until the unsubscribe confirmation. It must arrive within the deadline,
+        # but do not include the post-confirmation idle grace period in that deadline: draining
+        # the intentionally backlogged payload can consume most of it.
         stream = b""
         saw_unsubscribe = False
-        async with async_timeout.timeout(60):
-            while True:
+        async with async_timeout.timeout(10):
+            while not saw_unsubscribe:
                 try:
                     data = await asyncio.wait_for(loop.sock_recv(subscriber, 256 * 1024), 2.0)
                 except asyncio.TimeoutError:
-                    if saw_unsubscribe:
-                        break  # idle after the confirmation -> stream is complete
                     continue
                 if not data:
                     break
                 stream += data
                 saw_unsubscribe = saw_unsubscribe or unsubscribe_token in stream
+
+        # Keep reading through a short idle grace period to catch any message wrongly emitted
+        # after the unsubscribe confirmation.
+        while True:
+            try:
+                data = await asyncio.wait_for(loop.sock_recv(subscriber, 256 * 1024), 2.0)
+            except asyncio.TimeoutError:
+                break  # idle after the confirmation -> stream is complete
+            if not data:
+                break
+            stream += data
 
         assert saw_unsubscribe, "never received the unsubscribe confirmation"
 


### PR DESCRIPTION
This PR fixes a known issue that was already fixed for V1 at 5ef35182.

Defer V2 pipeline execution when queued control work predates the next parsed command. Let IoLoopV2 drain that work so UNSUBSCRIBE cannot discard earlier Pub/Sub messages.

Tests:
Extend the unsubscribe regression across V1 and V2 with standalone and deferred-GET commands. Bound the starvation publisher wave to assert fairness without treating ordered backlog as starvation.

