### PR TITLE
fix(tiering): Use TraverseBySegmentOrder and export more metrics/configs

### DIFF
--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -662,6 +662,41 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
                       &resp->body());
     AppendMetricValue("tiered_events", m.tiered_stats.total_deletes, {"type"}, {"delete"},
                       &resp->body());
+    AppendMetricValue("tiered_events", m.tiered_stats.total_defrags, {"type"}, {"defrag"},
+                      &resp->body());
+    AppendMetricValue("tiered_events", m.tiered_stats.total_offloading_stashes, {"type"},
+                      {"offload_stash"}, &resp->body());
+
+    // Buffer allocations for disk I/O
+    AppendMetricHeader("tiered_buf_allocations", "Tiered buffer allocations", MetricType::COUNTER,
+                       &resp->body());
+    AppendMetricValue("tiered_buf_allocations", m.tiered_stats.total_heap_buf_allocs, {"type"},
+                      {"heap"}, &resp->body());
+    AppendMetricValue("tiered_buf_allocations", m.tiered_stats.total_registered_buf_allocs,
+                      {"type"}, {"registered"}, &resp->body());
+
+    // In-flight operations
+    AppendMetricHeader("tiered_pending_ops", "Tiered in-flight operations", MetricType::GAUGE,
+                       &resp->body());
+    AppendMetricValue("tiered_pending_ops", m.tiered_stats.pending_read_cnt, {"type"}, {"read"},
+                      &resp->body());
+    AppendMetricValue("tiered_pending_ops", m.tiered_stats.pending_stash_cnt, {"type"}, {"stash"},
+                      &resp->body());
+
+    // Small bins
+    AppendMetricHeader("tiered_small_bins", "Tiered small bins", MetricType::GAUGE, &resp->body());
+    AppendMetricValue("tiered_small_bins", m.tiered_stats.small_bins_cnt, {"type"}, {"bins"},
+                      &resp->body());
+    AppendMetricValue("tiered_small_bins", m.tiered_stats.small_bins_entries_cnt, {"type"},
+                      {"entries"}, &resp->body());
+
+    // Cumulative time spent in background scans
+    AppendMetricHeader("tiered_scan_usec", "Time in microseconds spent in background scans",
+                       MetricType::COUNTER, &resp->body());
+    AppendMetricValue("tiered_scan_usec", m.tiered_stats.total_offloading_usec, {"type"},
+                      {"offload"}, &resp->body());
+    AppendMetricValue("tiered_scan_usec", m.tiered_stats.total_defrag_usec, {"type"}, {"defrag"},
+                      &resp->body());
 
     // Hits: ram, cool, missed
     AppendMetricHeader("tiered_hits", "Tiered hits", MetricType::COUNTER, &resp->body());
@@ -676,6 +711,9 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
                       {"client throttling"}, &resp->body());
     AppendMetricValue("tiered_overload", m.tiered_stats.total_stash_overflows, {"type"},
                       {"stash overflows"}, &resp->body());
+
+    AppendMetricWithoutLabels("tiered_clients_throttled", "Currently throttled clients",
+                              m.tiered_stats.clients_throttled, MetricType::GAUGE, &resp->body());
 
     AppendMetricHeader("tiered_list_events", "Tiered List Events", MetricType::COUNTER,
                        &resp->body());

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -689,6 +689,8 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
                       &resp->body());
     AppendMetricValue("tiered_small_bins", m.tiered_stats.small_bins_entries_cnt, {"type"},
                       {"entries"}, &resp->body());
+    AppendMetricValue("tiered_small_bins", m.tiered_stats.small_bins_entries_bytes, {"type"},
+                      {"entries_bytes"}, &resp->body());
 
     // Cumulative time spent in background scans
     AppendMetricHeader("tiered_scan_usec", "Time in microseconds spent in background scans",

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2887,7 +2887,8 @@ string ServerFamily::FormatInfoMetrics(
     append("tiered_small_bins_entries_cnt", m.tiered_stats.small_bins_entries_cnt);
     append("tiered_small_bins_filling_bytes", m.tiered_stats.small_bins_filling_bytes);
     append("tiered_cold_storage_bytes", m.tiered_stats.cold_storage_bytes);
-    append("tiered_offloading_steps", m.tiered_stats.total_offloading_steps);
+    append("tiered_offloading_usec", m.tiered_stats.total_offloading_usec);
+    append("tiered_defrag_usec", m.tiered_stats.total_defrag_usec);
     append("tiered_offloading_stashes", m.tiered_stats.total_offloading_stashes);
     append("tiered_ram_hits", m.events.ram_hits);
     append("tiered_ram_cool_hits", m.events.ram_cool_hits);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2885,6 +2885,7 @@ string ServerFamily::FormatInfoMetrics(
 
     append("tiered_small_bins_cnt", m.tiered_stats.small_bins_cnt);
     append("tiered_small_bins_entries_cnt", m.tiered_stats.small_bins_entries_cnt);
+    append("tiered_small_bins_entries_bytes", m.tiered_stats.small_bins_entries_bytes);
     append("tiered_small_bins_filling_bytes", m.tiered_stats.small_bins_filling_bytes);
     append("tiered_cold_storage_bytes", m.tiered_stats.cold_storage_bytes);
     append("tiered_offloading_usec", m.tiered_stats.total_offloading_usec);

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -11,7 +11,7 @@ namespace dfly {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 184);
+  static_assert(sizeof(TieredStats) == 192);
 
   ADD(total_stashes);
   ADD(total_fetches);
@@ -30,6 +30,7 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
 
   ADD(small_bins_cnt);
   ADD(small_bins_entries_cnt);
+  ADD(small_bins_entries_bytes);
   ADD(small_bins_filling_bytes);
   ADD(small_bins_filling_entries_cnt);
 

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -11,7 +11,7 @@ namespace dfly {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 176);
+  static_assert(sizeof(TieredStats) == 184);
 
   ADD(total_stashes);
   ADD(total_fetches);
@@ -36,7 +36,8 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
   ADD(total_stash_overflows);
   ADD(cold_storage_bytes);
   ADD(pending_stash_bytes);
-  ADD(total_offloading_steps);
+  ADD(total_offloading_usec);
+  ADD(total_defrag_usec);
   ADD(total_offloading_stashes);
 
   ADD(clients_throttled);

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -67,6 +67,9 @@ struct TieredStats {
   // Total entries across all fully written bins on disk.
   uint64_t small_bins_entries_cnt = 0;
 
+  // Total value bytes across all fully written bins on disk.
+  uint64_t small_bins_entries_bytes = 0;
+
   // Bytes accumulated in the in-memory bin currently being filled.
   size_t small_bins_filling_bytes = 0;
 

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -39,8 +39,11 @@ struct TieredStats {
   // (disjoint with total_stashes).
   uint64_t total_stash_overflows = 0;
 
-  // Iterations through the primary table during background offloading scans.
-  uint64_t total_offloading_steps = 0;
+  // Cumulative time in microseconds spent in background offloading scans.
+  uint64_t total_offloading_usec = 0;
+
+  // Cumulative time in microseconds spent in background defragmentation scans.
+  uint64_t total_defrag_usec = 0;
 
   // Values stashed during background offloading scans (subset of total_stashes).
   uint64_t total_offloading_stashes = 0;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -68,6 +68,18 @@ ABSL_FLAG(bool, tiered_experimental_list_support, false, "Experimental list node
 ABSL_FLAG(uint32, tiered_min_ttl_to_offload_ms, 5000,
           "Min remaining TTL in ms for a value to be eligible for offloading");
 
+ABSL_FLAG(uint32, tiered_offload_scan_budget_us, 100,
+          "Base cpu time-slice in microseconds granted to a single background offloading scan. "
+          "Set to 0 to disable offloading scans");
+
+ABSL_FLAG(uint32, tiered_defrag_scan_budget_us, 2,
+          "Base cpu time-slice in microseconds granted to a single background defragmentation "
+          "scan. Scales up to 3x this value with the amount of fragmentation found. Set to 0 to "
+          "disable defragmentation scans");
+
+ABSL_FLAG(uint32, tiered_max_pending_defrags, 50,
+          "Maximum number of concurrent defragmentation read operations");
+
 namespace dfly {
 
 using namespace std;
@@ -84,10 +96,6 @@ bool OccupiesWholePages(size_t size) {
 
 // Stashed bins no longer have bin ids, so this sentinel is used to differentiate from regular reads
 constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
-
-// Memory budget (UploadBudget) does not account for buffers allocated for in-flight defrag reads,
-// so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
-constexpr uint32_t kMaxPendingDefrags = 50;
 
 // Called when a value returns to RAM and its disk segment is dropped: the bytes go back to the
 // RAM ledger and leave the tiered counters.
@@ -434,7 +442,7 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment, b
   // Otherwise background scans of fragmented bins will discover them
   if (bin.fragmented && ts_->UploadBudget() > 0) {
     // Limit number of IO operations if we need to read from disk (in_memory is false)
-    if (in_memory || stats_.pending_defrags < kMaxPendingDefrags) {
+    if (in_memory || stats_.pending_defrags < ts_->config_.max_pending_defrags) {
       EnqueueForDefrag(bin.segment);
     }
   }
@@ -640,7 +648,8 @@ TieredStats TieredStorage::GetStats() const {
     stats.total_deletes = stats_.total_deletes;
     stats.total_stash_overflows = stats_.stash_overflow_cnt;
     stats.cold_storage_bytes = stats_.cool_memory_used;
-    stats.total_offloading_steps = stats_.offloading_steps;
+    stats.total_offloading_usec = stats_.offloading_usec;
+    stats.total_defrag_usec = stats_.defrag_usec;
     stats.total_offloading_stashes = stats_.offloading_stashes;
     stats.clients_throttled = stash_backpressure_.size();
     stats.total_clients_throttled = stats_.total_clients_throttled;
@@ -663,6 +672,9 @@ void TieredStorage::UpdateFromFlags() {
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
       .experimental_list_offload = absl::GetFlag(FLAGS_tiered_experimental_list_support),
       .min_ttl_to_offload_ms = absl::GetFlag(FLAGS_tiered_min_ttl_to_offload_ms),
+      .offload_scan_budget_us = absl::GetFlag(FLAGS_tiered_offload_scan_budget_us),
+      .defrag_scan_budget_us = absl::GetFlag(FLAGS_tiered_defrag_scan_budget_us),
+      .max_pending_defrags = absl::GetFlag(FLAGS_tiered_max_pending_defrags),
   };
 
   LOG_IF(WARNING, config_.upload_threshold > config_.offload_threshold)
@@ -675,7 +687,8 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
                             FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
                             FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
                             FLAGS_tiered_experimental_list_support,
-                            FLAGS_tiered_min_ttl_to_offload_ms);
+                            FLAGS_tiered_min_ttl_to_offload_ms, FLAGS_tiered_offload_scan_budget_us,
+                            FLAGS_tiered_defrag_scan_budget_us, FLAGS_tiered_max_pending_defrags);
 }
 
 bool TieredStorage::ShouldOffload() const {
@@ -697,8 +710,6 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   if (SliceSnapshot::IsSnaphotInProgress())
     return;
 
-  const auto start_cycles = base::CycleClock::Now();
-
   // Takes up a small bounded amount of time and is best done before offloading (to be picked up)
   RunDefragScan();
 
@@ -707,9 +718,11 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   if (disk_stats.allocated_bytes + 1_MB > disk_stats.max_file_size)
     return;
 
+  if (config_.offload_scan_budget_us == 0)
+    return;
+
   string tmp;
   auto cb = [this, dbid, &tmp](PrimeIterator it) mutable {
-    stats_.offloading_steps++;
     auto blobs = ShouldStash(
         it->second, StashContext{.dbid = dbid, .key_expire_ms = it->first.GetExpireTime()});
     if (blobs) {
@@ -725,6 +738,8 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
 
   PrimeTable& table = op_manager_->db_slice_.GetDBTable(dbid)->prime;
 
+  const auto start_cycles = base::CycleClock::Now();
+
   // Loop over entry with time and max stash budget.
   uint64_t cycles = 0;
   do {
@@ -737,15 +752,20 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
     // TODO: yield as background fiber to perform more work on idle
     // Limit allowed cpu-timeslice
     cycles = base::CycleClock::Now() - start_cycles;
-    if (base::CycleClock::ToUsec(cycles) >= 100)
+    if (base::CycleClock::ToUsec(cycles) >= config_.offload_scan_budget_us)
       break;
   } while (offloading_cursor_);
+
+  stats_.offloading_usec += base::CycleClock::ToUsec(cycles);
 }
 
 void TieredStorage::RunDefragScan() {
-  constexpr uint64_t kBaseUs = 2;
-  constexpr uint64_t kUsPerHit = 5;
-  constexpr uint64_t kMaxUs = 25;
+  // Scale the cpu time-slice with the backlog found by the previous scan, up to 3x the base
+  // budget: sleepy on a stale table, more aggressive while there's fragmentation to clear.
+  const uint64_t time_budget_us =
+      config_.defrag_scan_budget_us * std::min<uint64_t>(1 + last_defrag_scan_hits_, 3);
+  if (time_budget_us == 0)
+    return;
 
   const auto start_cycles = base::CycleClock::Now();
 
@@ -758,16 +778,12 @@ void TieredStorage::RunDefragScan() {
     }
   };
 
-  // Scale the cpu time-slice by how much work the previous scan found: sleepy on a stale table,
-  // more aggressive while there's a backlog to clear.
-  const uint64_t time_budget_us = std::min(kBaseUs + last_defrag_scan_hits_ * kUsPerHit, kMaxUs);
-
   uint64_t cycles = 0;
   do {
     if (UploadBudget() <= 0)
       break;
 
-    if (op_manager_->stats_.pending_defrags >= kMaxPendingDefrags)
+    if (op_manager_->stats_.pending_defrags >= config_.max_pending_defrags)
       break;
 
     defrag_cursor_ = bins_->TraverseFragmented(defrag_cursor_, cb);
@@ -779,6 +795,7 @@ void TieredStorage::RunDefragScan() {
       break;
   } while (defrag_cursor_);
 
+  stats_.defrag_usec += base::CycleClock::ToUsec(cycles);
   last_defrag_scan_hits_ = hits;
 }
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -640,6 +640,7 @@ TieredStats TieredStorage::GetStats() const {
     tiering::SmallBins::Stats bins_stats = bins_->GetStats();
     stats.small_bins_cnt = bins_stats.stashed_bins_cnt;
     stats.small_bins_entries_cnt = bins_stats.stashed_entries_cnt;
+    stats.small_bins_entries_bytes = bins_stats.stashed_entries_bytes;
     stats.small_bins_filling_bytes = bins_stats.current_bin_bytes;
     stats.small_bins_filling_entries_cnt = bins_stats.current_entries_cnt;
   }

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -186,12 +186,16 @@ class TieredStorage : public TieredStorageBase {
     bool experimental_hash_offload;
     bool experimental_list_offload;
     uint32_t min_ttl_to_offload_ms;
+    uint32_t offload_scan_budget_us;
+    uint32_t defrag_scan_budget_us;
+    uint32_t max_pending_defrags;
   } config_;
 
   mutable struct {
     uint64_t stash_overflow_cnt = 0;
     uint64_t total_deletes = 0;
-    uint64_t offloading_steps = 0;
+    uint64_t offloading_usec = 0;
+    uint64_t defrag_usec = 0;
     uint64_t offloading_stashes = 0;
     uint64_t total_clients_throttled = 0;
     size_t cool_memory_used = 0;

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -183,7 +183,7 @@ bool SmallBins::IsFragmented(size_t offset) {
 
 ::dfly::detail::DashCursor SmallBins::TraverseFragmented(::dfly::detail::DashCursor cursor,
                                                          absl::FunctionRef<void(size_t)> f) {
-  return stashed_bins_.Traverse(cursor, [f](Dash::iterator it) {
+  return stashed_bins_.TraverseBySegmentOrder(cursor, [f](Dash::iterator it) {
     if (it->second.bytes < kFragmentedCutoff)
       f(it->first);
   });

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -21,16 +21,13 @@ using namespace std;
 
 namespace {
 
-// Fixed per-entry header: 2 dbid + 8 hash + 2 strlen.
-constexpr size_t kEntryHeaderSize = 12;
-
 // See FlushBin() for format details
 size_t StashedValueSize(string_view value) {
-  return kEntryHeaderSize + value.size();
+  return SmallBins::kEntryHeaderSize + value.size();
 }
 
 // The biggest a single entry (value + fixed header) can ever be.
-constexpr size_t kMaxEntrySize = (2_KB - 1) + kEntryHeaderSize;
+constexpr size_t kMaxEntrySize = (2_KB - 1) + SmallBins::kEntryHeaderSize;
 
 // We offload a bin at a minimum of ~49.7% utilization; use a cutoff below that to flag real
 // fragmentation.
@@ -118,6 +115,7 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
   }
 
   stats_.stashed_entries_cnt += list.size();
+  stats_.stashed_entries_bytes += bytes;
   stashed_bins_.InsertNew(segment.offset, StashInfo{uint8_t(list.size()), bytes});
 
   return list;
@@ -160,6 +158,7 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
 
     DCHECK_LE(segment.length + kEntryHeaderSize, bin.bytes);
     bin.bytes -= segment.length + kEntryHeaderSize;
+    stats_.stashed_entries_bytes -= segment.length + kEntryHeaderSize;
 
     if (--bin.entries == 0) {
       DCHECK_EQ(bin.bytes, 0u);
@@ -192,6 +191,7 @@ bool SmallBins::IsFragmented(size_t offset) {
 SmallBins::Stats SmallBins::GetStats() const {
   return Stats{.stashed_bins_cnt = stashed_bins_.size(),
                .stashed_entries_cnt = stats_.stashed_entries_cnt,
+               .stashed_entries_bytes = stats_.stashed_entries_bytes,
                .current_bin_bytes = current_bin_.bytes_,
                .current_entries_cnt = current_bin_.entries_.size()};
 }
@@ -205,6 +205,7 @@ SmallBins::KeyHashDbList SmallBins::DeleteBin(DiskSegment segment, std::string_v
 
   auto bin = it->second;
   stats_.stashed_entries_cnt -= bin.entries;
+  stats_.stashed_entries_bytes -= bin.bytes;
   stashed_bins_.Erase(it);
 
   const char* data = value.data();

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -24,9 +24,13 @@ using DbIndex = uint16_t;
 // SIMPLEST VERSION for now.
 class SmallBins {
  public:
+  // Fixed per-entry header written on disk: 2 dbid + 8 hash + 2 strlen.
+  static constexpr size_t kEntryHeaderSize = 12;
+
   struct Stats {
     size_t stashed_bins_cnt = 0;
     size_t stashed_entries_cnt = 0;
+    size_t stashed_entries_bytes = 0;
     size_t current_bin_bytes = 0;
     size_t current_entries_cnt = 0;
   };
@@ -133,6 +137,7 @@ class SmallBins {
 
   struct {
     size_t stashed_entries_cnt = 0;
+    size_t stashed_entries_bytes = 0;
   } stats_;
 };
 

--- a/src/server/tiering/small_bins_test.cc
+++ b/src/server/tiering/small_bins_test.cc
@@ -125,4 +125,38 @@ TEST_F(SmallBinsTest, UpdateStatsAfterDelete) {
   EXPECT_EQ(0u, bins_.GetStats().current_bin_bytes);
 }
 
+TEST_F(SmallBinsTest, StashedEntriesBytes) {
+  // Fill single bin.
+  std::optional<SmallBins::FilledBin> bin;
+  unsigned i = 0;
+  for (; !bin; i++)
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+  auto [id, data] = Serialize(*bin);
+
+  // Delete all even values from the pending bin (mirrors PartialStashDelete which drains cleanly).
+  for (unsigned j = 0; j <= i; j += 2)
+    bins_.Delete(0, absl::StrCat("k", j));
+
+  EXPECT_EQ(bins_.GetStats().stashed_entries_bytes, 0u);
+
+  auto segments = bins_.ReportStashed(id, DiskSegment{0, 4_KB});
+  ASSERT_GT(segments.size(), 0u);
+
+  // After stash, bytes counter equals the on-disk size of the entries (value + header each).
+  size_t total_bytes = 0;
+  for (auto& [dbid, key, segment] : segments)
+    total_bytes += segment.length + SmallBins::kEntryHeaderSize;
+  EXPECT_EQ(bins_.GetStats().stashed_entries_bytes, total_bytes);
+  EXPECT_EQ(bins_.GetStats().stashed_entries_cnt, segments.size());
+
+  // Deleting entries one by one drains the byte counter back to zero.
+  while (!segments.empty()) {
+    auto segment = std::get<2>(segments.back());
+    segments.pop_back();
+    bins_.Delete(segment);
+  }
+  EXPECT_EQ(bins_.GetStats().stashed_entries_bytes, 0u);
+  EXPECT_EQ(bins_.GetStats().stashed_entries_cnt, 0u);
+}
+
 }  // namespace dfly::tiering


### PR DESCRIPTION
The changes that I merged into 1.40 branch

Only functional change:
1. Fixes small bins defrag by using bounded TraverseBySegmentOrder to avoid blowing up iteration costs when the table is largely empty

Metrics & config:
1. Exports missing tiering fields from info to metrics
2. Adds new configurable values to allow limiting CPU limit consumption of offloading / background scanning