### PR TITLE
fix(server): lower table growth margin default

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -43,7 +43,7 @@ ABSL_FLAG(uint32_t, max_segment_to_consider, 4,
           "The maximum number of dashtable segments to scan in each eviction "
           "when heartbeat based eviction is triggered under memory pressure.");
 
-ABSL_FLAG(double, table_growth_margin, 0.4,
+ABSL_FLAG(double, table_growth_margin, 0.15,
           "Prevents table from growing if number of free slots x average object size x this ratio "
           "is larger than memory budget.");
 

--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -160,6 +160,10 @@ async def test_policy_based_eviction_propagation(df_factory, df_seeder_factory):
             "maxmemory": "512mb",
             "enable_heartbeat_eviction": "false",
             "rss_oom_deny_ratio": 1.3,
+            # The test fills the master to ~87% of maxmemory and relies on the conservative
+            # table growth estimate to deny dashtable growth, which is what triggers policy
+            # based eviction. Pin the margin instead of depending on its default.
+            "table_growth_margin": 0.4,
         },
         replica_args={"proactor_threads": 2},
         connect=False,


### PR DESCRIPTION
## Summary
- Lower the default `table_growth_margin` from `0.4` to `0.15`.
- Reduce the conservative free-capacity estimate before allowing table growth.

## Test plan
- `git diff --check` passed.
- `ninja -C build-dbg dragonfly` reached and compiled `src/server/db_slice.cc`; the full build was blocked by the host filesystem running out of space.