### PR TITLE
fix(tiering): tight small bin fragmentation cutoff

### DIFF
--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -26,6 +26,13 @@ size_t StashedValueSize(string_view value) {
   return 2 /* dbid */ + 8 /* hash */ + 2 /* strlen*/ + value.size();
 }
 
+// The biggest a single entry (value + fixed header) can ever be.
+constexpr size_t kMaxEntrySize = (2_KB - 1) + 12;
+
+// We offload a bin at a minimum of ~49.7% utilization; use a cutoff below that to flag real
+// fragmentation.
+constexpr size_t kFragmentedCutoff = kPageSize - 2 - kMaxEntrySize;
+
 }  // namespace
 
 uint64_t SmallBins::BasicDashPolicy::HashFn(uint64_t v) {
@@ -108,7 +115,7 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
   }
 
   stats_.stashed_entries_cnt += list.size();
-  stashed_bins_.InsertNew(segment.offset, StashInfo{uint8_t(list.size()), bytes, bytes});
+  stashed_bins_.InsertNew(segment.offset, StashInfo{uint8_t(list.size()), bytes});
 
   return list;
 }
@@ -157,8 +164,9 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
       return {full_segment, false /* fragmented */, true /* empty */};
     }
 
-    bool fragmented = bin.bytes * 2 < bin.orig_bytes;
-    return {full_segment, fragmented, false /* empty */};
+    if (bin.bytes < kFragmentedCutoff) {
+      return {full_segment, true /* fragmented */, false /* empty */};
+    }
   }
 
   return {segment};
@@ -166,14 +174,14 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
 
 bool SmallBins::IsFragmented(size_t offset) {
   if (auto it = stashed_bins_.Find(offset); it != stashed_bins_.end())
-    return it->second.bytes * 2 < it->second.orig_bytes;
+    return it->second.bytes < kFragmentedCutoff;
   return false;
 }
 
 ::dfly::detail::DashCursor SmallBins::TraverseFragmented(::dfly::detail::DashCursor cursor,
                                                          absl::FunctionRef<void(size_t)> f) {
   return stashed_bins_.Traverse(cursor, [f](Dash::iterator it) {
-    if (it->second.bytes * 2 < it->second.orig_bytes)
+    if (it->second.bytes < kFragmentedCutoff)
       f(it->first);
   });
 }

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -21,13 +21,16 @@ using namespace std;
 
 namespace {
 
+// Fixed per-entry header: 2 dbid + 8 hash + 2 strlen.
+constexpr size_t kEntryHeaderSize = 12;
+
 // See FlushBin() for format details
 size_t StashedValueSize(string_view value) {
-  return 2 /* dbid */ + 8 /* hash */ + 2 /* strlen*/ + value.size();
+  return kEntryHeaderSize + value.size();
 }
 
 // The biggest a single entry (value + fixed header) can ever be.
-constexpr size_t kMaxEntrySize = (2_KB - 1) + 12;
+constexpr size_t kMaxEntrySize = (2_KB - 1) + kEntryHeaderSize;
 
 // We offload a bin at a minimum of ~49.7% utilization; use a cutoff below that to flag real
 // fragmentation.
@@ -108,7 +111,7 @@ SmallBins::KeySegmentList SmallBins::ReportStashed(BinId id, DiskSegment segment
   uint16_t bytes = 0;
   SmallBins::KeySegmentList list;
   for (auto& [key, sub_segment] : seg_map) {
-    bytes += sub_segment.length;
+    bytes += sub_segment.length + kEntryHeaderSize;
 
     DiskSegment real_segment{segment.offset + sub_segment.offset, sub_segment.length};
     list.emplace_back(key.first, key.second, real_segment);
@@ -155,8 +158,8 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
     stats_.stashed_entries_cnt--;
     auto& bin = it->second;
 
-    DCHECK_LE(segment.length, bin.bytes);
-    bin.bytes -= segment.length;
+    DCHECK_LE(segment.length + kEntryHeaderSize, bin.bytes);
+    bin.bytes -= segment.length + kEntryHeaderSize;
 
     if (--bin.entries == 0) {
       DCHECK_EQ(bin.bytes, 0u);

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -98,13 +98,9 @@ class SmallBins {
  private:
   struct StashInfo {
     uint8_t entries = 0;
-    // Live bytes still occupied by non-deleted entries.
     uint16_t bytes = 0;
-    // Bytes at stash time; used to detect real fragmentation from deletes rather than
-    // flagging bins that were simply packed small.
-    uint16_t orig_bytes = 0;
   };
-  static_assert(sizeof(StashInfo) == 6);
+  static_assert(sizeof(StashInfo) == sizeof(unsigned));
 
   BinId last_bin_id_ = 0;
   FilledBin current_bin_{last_bin_id_};

--- a/src/server/tiering/small_bins_test.cc
+++ b/src/server/tiering/small_bins_test.cc
@@ -93,17 +93,10 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
     EXPECT_EQ(key, "k"s + data.substr(segment.offset, segment.length).substr(1));
   }
 
-  // Delete all stashed values, tracking live bytes to know when we've crossed the
-  // "more than half of this bin's live content was deleted" fragmentation threshold.
-  size_t orig_bytes = 0;
-  for (auto& [dbid, key, segment] : segments)
-    orig_bytes += segment.length;
-
-  size_t deleted_bytes = 0;
+  // Delete all stashed values
   while (!segments.empty()) {
     auto segment = std::get<2>(segments.back());
     segments.pop_back();
-    deleted_bytes += segment.length;
     auto bin = bins_.Delete(segment);
 
     EXPECT_EQ(bin.segment.offset, 0u);
@@ -111,10 +104,8 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
 
     if (segments.empty()) {
       EXPECT_TRUE(bin.empty);
-    } else if (deleted_bytes * 2 > orig_bytes) {
-      EXPECT_TRUE(bin.fragmented);  // more than half of the bin's live bytes were deleted
     } else {
-      EXPECT_FALSE(bin.fragmented);
+      EXPECT_TRUE(bin.fragmented);  // half of the values were deleted
     }
   }
 }


### PR DESCRIPTION
For small bins, the smallest possible utilization for flushing a page is ~49% (because value + constant size header). We don't want this page to be considered for defragmentation (as it will livelock) so we pick a cutoff that is slightly lower (see the math on the PR).

Also StashInfo.bytes `undercounted` because it never `included` the bytes wasted by each entry's header. Fix it by including the header entry overhead per value.

Addresses properly both #8029 and #8024 and #8012