### PR TITLE
fix: SET with a past expiration honors NX/XX/GET and journals the delete

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -32,7 +32,6 @@
 #include "server/error.h"
 #include "server/execution_state.h"
 #include "server/family_utils.h"
-#include "server/generic_family.h"
 #include "server/journal/journal.h"
 #include "server/namespaces.h"
 #include "server/search/doc_index.h"
@@ -116,6 +115,7 @@ class SetCmd {
     uint64_t expire_after_ms = 0;  // Relative value based on now. 0 means no expiration.
     optional<StringResult>* prev_val = nullptr;  // if set, previous value will be stored if found
     BackPressureFuture* backpressure = nullptr;
+    bool expire_in_past = false;  // the parsed absolute expiration has already elapsed
 
     constexpr bool IsConditionalSet() const {
       return flags & SET_IF_NOTEXIST || flags & SET_IF_EXISTS;
@@ -138,6 +138,8 @@ class SetCmd {
   void RecordJournal(const SetParams& params, std::string_view key, std::string_view value);
 
   OpStatus CachePrevIfNeeded(const SetParams& params, DbSlice::Iterator it);
+
+  OpStatus DeleteExpiredKey(std::string_view key, DbSlice::ItAndUpdater* it_upd);
 
   OpArgs op_args_;
   bool explicit_journal_;  // call RecordJournal (auto journaling disabled)
@@ -919,6 +921,8 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
 
     if (params.flags & SET_IF_EXISTS) {
       if (IsValid(find_res.it)) {
+        if (params.expire_in_past)
+          return DeleteExpiredKey(key, &find_res);
         return SetExisting(params, value, &find_res);
       } else {
         return OpStatus::SKIPPED;
@@ -927,8 +931,20 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
       DCHECK(params.flags & SET_IF_NOTEXIST) << params.flags;
       if (IsValid(find_res.it)) {
         return OpStatus::SKIPPED;
-      }  // else AddNew() is called below
+      }
+      // The new value would already be expired: nothing to create.
+      if (params.expire_in_past)
+        return OpStatus::OK;
+      // else AddNew() is called below
     }
+  } else if (params.expire_in_past) {
+    // Unconditional set with an elapsed expiration: delete the existing key instead of storing.
+    auto find_res = db_slice.FindMutable(op_args_.db_cntx, key);
+    if (auto status = CachePrevIfNeeded(params, find_res.it); status != OpStatus::OK)
+      return status;
+    if (!IsValid(find_res.it))
+      return OpStatus::OK;
+    return DeleteExpiredKey(key, &find_res);
   }
 
   // Enable journal omits for this operation
@@ -1081,6 +1097,23 @@ void SetCmd::RecordJournal(const SetParams& params, string_view key, string_view
   dfly::RecordJournal(op_args_, "SET", ArgSlice{cmds});
 }
 
+OpStatus SetCmd::DeleteExpiredKey(string_view key, DbSlice::ItAndUpdater* it_upd) {
+  auto& db_slice = op_args_.GetDbSlice();
+  it_upd->post_updater.Run();  // finalize memory accounting before the delete
+
+  DbSlice::ExpireParams past{TimeUnit::MSEC, -1, op_args_.db_cntx.time_now_ms, /*cap=*/true};
+  auto res = db_slice.UpdateExpire(op_args_.db_cntx, it_upd->it, past);
+  RETURN_ON_BAD_STATUS(res);
+  DCHECK_EQ(*res, -1);
+
+  // SET is NO_AUTOJOURNAL: journal the delete explicitly or the replica keeps the key forever.
+  if (op_args_.shard->journal()) {
+    dfly::RecordJournal(op_args_, "DEL"sv, ArgSlice{key});
+  }
+  db_slice.SendExpiredKeyEvent(op_args_.db_cntx, key);
+  return OpStatus::OK;
+}
+
 OpStatus SetCmd::CachePrevIfNeeded(const SetCmd::SetParams& params, DbSlice::Iterator it) {
   if (!params.prev_val || !IsValid(it))
     return OpStatus::OK;
@@ -1092,53 +1125,38 @@ OpStatus SetCmd::CachePrevIfNeeded(const SetCmd::SetParams& params, DbSlice::Ite
   return OpStatus::OK;
 }
 
-struct NegativeExpire {};  // Returned if relative expiry was in the past
-std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetParams(
-    CmdArgParser parser, const CommandContext* cmd_cntx) {
+struct SetOpts {
+  ExpiryOption expiry;
+  uint16_t flags = SetCmd::SET_ALWAYS;
+  uint32_t memcache_flags = 0;
+};
+
+std::variant<SetCmd::SetParams, facade::ErrorReply> ParseSetParams(CmdArgParser parser,
+                                                                   const CommandContext* cmd_cntx) {
+  static constexpr auto kGrammar = Compile(Options(
+      Into(&SetOpts::expiry, ExpiryOneOf()),
+      Flags(&SetOpts::flags, "GET", SetCmd::SET_GET, "STICK", SetCmd::SET_STICK, "KEEPTTL",
+            SetCmd::SET_KEEP_EXPIRE, "XX", SetCmd::SET_IF_EXISTS, "NX", SetCmd::SET_IF_NOTEXIST),
+      Field("_MCFLAGS", &SetOpts::memcache_flags)));
+
+  SetOpts opts;
+  opts.memcache_flags = cmd_cntx->mc_command() ? cmd_cntx->mc_command()->flags : 0;
+  kGrammar.Apply(&parser, &opts);
+  if (!parser.Finalize())
+    return parser.TakeError().MakeReply();
+
   SetCmd::SetParams sparams;
+  sparams.flags = opts.flags;
+  sparams.memcache_flags = opts.memcache_flags;
 
-  sparams.memcache_flags = cmd_cntx->mc_command() ? cmd_cntx->mc_command()->flags : 0;
-
-  while (parser.HasNext()) {
-    if (auto exp_type = parser.TryMapNext("EX", ExpT::EX, "PX", ExpT::PX, "EXAT", ExpT::EXAT,
-                                          "PXAT", ExpT::PXAT);
-        exp_type) {
-      auto int_arg = parser.Next<int64_t>();
-      if (parser.HasError())
-        break;
-
-      // We can set expiry only once.
-      if (sparams.flags & SetCmd::SET_EXPIRE_AFTER_MS)
-        return facade::ErrorReply{kSyntaxErr};
-
-      sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
-
-      // Since PXAT/EXAT can change this, we need to check this ahead
-      if (int_arg <= 0)
-        return facade::ErrorReply{InvalidExpireTime("set")};
-
-      const uint64_t now_ms = GetCurrentTimeMs();
-      DbSlice::ExpireParams expiry{*exp_type, int_arg, now_ms};
-
-      auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
-      if (abs_ms < 0)
-        return facade::ErrorReply{InvalidExpireTime("set")};
-
-      // Remove existed key if the key is expired already
-      if (rel_ms < 0)
-        return NegativeExpire{};
-
-      tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
-    } else if (!parser.Check("_MCFLAGS", &sparams.memcache_flags)) {
-      uint16_t flag = parser.MapNext(  //
-          "GET", SetCmd::SET_GET, "STICK", SetCmd::SET_STICK, "KEEPTTL", SetCmd::SET_KEEP_EXPIRE,
-          "XX", SetCmd::SET_IF_EXISTS, "NX", SetCmd::SET_IF_NOTEXIST);
-      sparams.flags |= flag;
-    }
+  optional<DbSlice::ExpireParams> expiry;
+  // The transaction time: the same clock that anchors expire_after_ms during execution.
+  const uint64_t now_ms = cmd_cntx->tx()->GetDbContext().time_now_ms;
+  if (opts.expiry.value) {
+    if (*opts.expiry.value <= 0)
+      return facade::ErrorReply{InvalidExpireTime("set")};
+    expiry.emplace(opts.expiry.type, *opts.expiry.value, now_ms);
   }
-
-  if (auto err = parser.TakeError(); err)
-    return err.MakeReply();
 
   if (auto* mc = cmd_cntx->mc_command()) {
     using MP = facade::MemcacheParser;
@@ -1147,17 +1165,20 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
     else if (mc->type == MP::REPLACE)
       sparams.flags |= SetCmd::SET_IF_EXISTS;
 
-    if (mc->expire_ts > 0) {
-      sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
-      DbSlice::ExpireParams expiry{TimeUnit::SEC, mc->expire_ts};
-      int64_t now_ms = GetCurrentTimeMs();
-      auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
-      if (abs_ms < 0)
-        return facade::ErrorReply{InvalidExpireTime("set")};
-      if (rel_ms < 0)
-        return NegativeExpire{};
-      tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
-    }
+    if (mc->expire_ts > 0)
+      expiry.emplace(TimeUnit::SEC, mc->expire_ts);  // absolute unix seconds
+  }
+
+  if (expiry) {
+    sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
+    // The cap keeps negative rel_ms and the overflow marker intact, so one call suffices.
+    auto [rel_ms, abs_ms] = expiry->Calculate(now_ms, true);
+    if (abs_ms < 0)
+      return facade::ErrorReply{InvalidExpireTime("set")};
+    if (rel_ms <= 0)
+      sparams.expire_in_past = true;
+    else
+      sparams.expire_after_ms = rel_ms;
   }
 
   auto has_mask = [&](uint16_t m) { return (sparams.flags & m) == m; };
@@ -1175,23 +1196,6 @@ cmd::CmdR CmdSet(CmdArgParser parser, CommandContext* cmd_cntx) {
 
   if (holds_alternative<facade::ErrorReply>(params_result))
     co_return get<facade::ErrorReply>(params_result);
-
-  if (holds_alternative<NegativeExpire>(params_result)) {
-    auto del_cb = [](const Transaction* tx, EngineShard* es) {
-      ShardArgs args = tx->GetShardArgs(es->shard_id());
-      GenericFamily::OpDel(tx->GetOpArgs(es), args, false);
-      return OpStatus::OK;
-    };
-    co_await cmd::SingleHop(del_cb);
-
-    if (cmd_cntx->mc_command() != nullptr) {
-      cmd_cntx->rb()->SendSimpleString(
-          MCRender{cmd_cntx->mc_command()->cmd_flags}.RenderStored(true));
-    } else {
-      cmd_cntx->rb()->SendOk();
-    }
-    co_return std::nullopt;
-  }
 
   auto& sparams = get<SetCmd::SetParams>(params_result);
 

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -1248,6 +1248,90 @@ TEST_F(StringFamilyTest, PastExpiryEmitsExpiredEvent) {
   pp_->AwaitFiberOnAll([](util::ProactorBase*) {});
   ASSERT_EQ(2u, SubscriberMessagesLen("IO1"));
   EXPECT_EQ("key", GetPublishedMessage("IO1", 1).message);
+
+  Run({"SET", "foo2", "bar"});
+  EXPECT_EQ(Run({"SET", "foo2", "x", "PXAT", "1"}), "OK");
+  pp_->AwaitFiberOnAll([](util::ProactorBase*) {});
+  ASSERT_EQ(3u, SubscriberMessagesLen("IO1"));
+  EXPECT_EQ("foo2", GetPublishedMessage("IO1", 2).message);
+
+  MCArgs past_args{"new"};
+  past_args.ttl = std::chrono::seconds{TEST_current_time_ms / 1000 - 100};
+  EXPECT_THAT(RunMC(MP::SET, "k2", MCArgs{"val"}), ElementsAre("+STORED"));
+  EXPECT_THAT(RunMC(MP::SET, "k2", past_args), ElementsAre("+STORED"));
+  pp_->AwaitFiberOnAll([](util::ProactorBase*) {});
+  ASSERT_EQ(4u, SubscriberMessagesLen("IO1"));
+  EXPECT_EQ("k2", GetPublishedMessage("IO1", 3).message);
+
+  EXPECT_THAT(RunMC(MP::SET, "k3", MCArgs{"val"}), ElementsAre("+STORED"));
+  EXPECT_THAT(RunMC(MP::REPLACE, "k3", past_args), ElementsAre("+STORED"));
+  pp_->AwaitFiberOnAll([](util::ProactorBase*) {});
+  ASSERT_EQ(5u, SubscriberMessagesLen("IO1"));
+  EXPECT_EQ("k3", GetPublishedMessage("IO1", 4).message);
+}
+
+TEST_F(StringFamilyTest, SetPastExpiryHonorsConditions) {
+  // NX on an existing key: the condition fails first - key kept, nil reply.
+  Run({"SET", "foo", "bar"});
+  EXPECT_THAT(Run({"SET", "foo", "x", "NX", "PXAT", "1"}), ArgType(RespExpr::NIL));
+  EXPECT_EQ(Run({"GET", "foo"}), "bar");
+
+  // NX on a missing key: nothing to store (the value would already be expired), OK reply.
+  EXPECT_EQ(Run({"SET", "nokey", "x", "NX", "PXAT", "1"}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "nokey"}), IntArg(0));
+
+  // XX on a missing key: nil, nothing created.
+  EXPECT_THAT(Run({"SET", "nokey2", "x", "XX", "PXAT", "1"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"EXISTS", "nokey2"}), IntArg(0));
+
+  // GET returns the old value while the key is deleted.
+  EXPECT_EQ(Run({"SET", "foo", "x", "GET", "PXAT", "1"}), "bar");
+  EXPECT_THAT(Run({"EXISTS", "foo"}), IntArg(0));
+
+  // NX+GET on an existing key: the aborted set still replies with the old value, key kept.
+  Run({"SET", "foo3", "bar"});
+  EXPECT_EQ(Run({"SET", "foo3", "x", "GET", "NX", "PXAT", "1"}), "bar");
+  EXPECT_EQ(Run({"GET", "foo3"}), "bar");
+
+  // Options after the past expiry are still parsed: trailing garbage is a syntax error.
+  Run({"SET", "foo2", "bar"});
+  EXPECT_THAT(Run({"SET", "foo2", "x", "PXAT", "1", "BOGUS"}), ErrArg("syntax error"));
+  EXPECT_EQ(Run({"GET", "foo2"}), "bar");
+
+  // Unconditional set on a missing key: OK, nothing stored.
+  EXPECT_EQ(Run({"SET", "nokey3", "x", "PXAT", "1"}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "nokey3"}), IntArg(0));
+}
+
+// An expiration equal to the current time is already elapsed: delete, not persist.
+TEST_F(StringFamilyTest, SetExpiryAtNowDeletes) {
+  Run({"SET", "foo", "bar"});
+  EXPECT_EQ(Run({"SET", "foo", "x", "PXAT", absl::StrCat(TEST_current_time_ms)}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "foo"}), IntArg(0));
+}
+
+// Memcached SET/ADD/REPLACE with a past absolute exptime: store conditions are honored first,
+// then delete-instead-of-store applies. RunMC bypasses the text parser, so ttl is absolute
+// unix seconds.
+TEST_F(StringFamilyTest, McSetPastExpiry) {
+  using MP = facade::MemcacheParser;
+  MCArgs past_args{"new"};
+  past_args.ttl = std::chrono::seconds{TEST_current_time_ms / 1000 - 100};
+
+  EXPECT_THAT(RunMC(MP::SET, "key", MCArgs{"val"}), ElementsAre("STORED"));
+  EXPECT_THAT(RunMC(MP::SET, "key", past_args), ElementsAre("STORED"));
+  EXPECT_THAT(RunMC(MP::GET, "key"), ElementsAre("END"));
+
+  EXPECT_THAT(RunMC(MP::SET, "key", MCArgs{"val"}), ElementsAre("STORED"));
+  EXPECT_THAT(RunMC(MP::ADD, "key", past_args), ElementsAre("NOT_STORED"));
+  EXPECT_THAT(RunMC(MP::GET, "key"), ElementsAre("VALUE key 0 3", "val", "END"));
+
+  EXPECT_THAT(RunMC(MP::ADD, "miss", past_args), ElementsAre("STORED"));
+  EXPECT_THAT(RunMC(MP::GET, "miss"), ElementsAre("END"));
+
+  EXPECT_THAT(RunMC(MP::REPLACE, "key", past_args), ElementsAre("STORED"));
+  EXPECT_THAT(RunMC(MP::GET, "key"), ElementsAre("END"));
+  EXPECT_THAT(RunMC(MP::REPLACE, "miss2", past_args), ElementsAre("NOT_STORED"));
 }
 
 }  // namespace dfly

--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -737,6 +737,25 @@ async def test_mc_gat_replication(df_factory):
         assert await c_replica.pttl(key) == -1
 
 
+async def test_set_past_expiry_replication(df_factory):
+    master = df_factory.create(proactor_threads=1)
+    replica = df_factory.create(proactor_threads=1)
+    df_factory.start_all([master, replica])
+
+    async with master.client() as c_master, replica.client() as c_replica:
+        await c_master.set("k", "v")
+        await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+        await wait_available_async(c_replica)
+        assert await c_replica.get("k") == "v"
+
+        # SET with a past expiry deletes the key; SET is not auto-journaled, so the delete
+        # needs an explicit journal record to reach the replica
+        assert await c_master.execute_command("SET", "k", "v2", "PXAT", "1")
+        assert await c_master.exists("k") == 0
+        await check_all_replicas_finished([c_replica], c_master)
+        assert await c_replica.exists("k") == 0
+
+
 @pytest.mark.large
 @dfly_args({"proactor_threads": 1})
 async def test_big_strings(df_factory):


### PR DESCRIPTION
`SET k v [NX|XX|GET] EXAT/PXAT <past>` short-circuited parsing and unconditionally deleted the key replying OK: NX/XX/GET were ignored, trailing options were accepted unparsed, an expiration equal to now made the key persistent, and the delete was not journaled at all (SET is NO_AUTOJOURNAL), permanently desyncing replicas. Memcached SET/ADD/REPLACE with a past absolute exptime shared all of it.

Changes:

- The parser only marks `SetParams::expire_in_past` (now also for `== now`) and keeps parsing; `SetCmd::Set` evaluates NX/XX/GET through the regular condition machinery before applying delete-instead-of-store, matching upstream semantics.
- The delete reuses `UpdateExpire` (same stats), journals an explicit `DEL`, and emits the expired keyspace event after the journal record.