### PR TITLE
fix(facade): Handle RESP3 null array response

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -371,7 +371,11 @@ void RedisReplyBuilderBase::SendDouble(double val) {
 
 void RedisReplyBuilderBase::SendNullArray() {
   ReplyScope scope(this);
-  WritePieces("*-1", kCRLF);
+  if (IsResp3()) {
+    WritePieces(kNullStringR3);
+  } else {
+    WritePieces("*-1", kCRLF);
+  }
 }
 
 constexpr static const char START_SYMBOLS2[4][2] = {"*", "~", "%", ">"};

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -393,19 +393,39 @@ TEST_F(RedisReplyBuilderTest, StringMessage) {
   }
 }
 
-TEST_F(RedisReplyBuilderTest, EmptyArray) {
+TEST_F(RedisReplyBuilderTest, EmptyOrNullArray) {
   // This test would build an array and try sending it over the "wire"
   // The array starts with the '*', then the number of elements in the array
   // then "\r\n", then each element inside is encoded accordingly
   // an empty array has this "*0\r\n" form
   const std::string_view empty_array = "*0\r\n";
-  const std::string_view null_array = "*-1\r\n";
+
+  // A null array is "*-1\r\n" on RESP2, but "_\r\n" on RESP3
+  const std::string_view null_array_resp2 = "*-1\r\n";
+  const std::string_view null_array_resp3 = "_\r\n";
+
   builder_->StartArray(0);
   ASSERT_EQ(str(), empty_array);
 
   sink_.Clear();
   builder_->SendNullArray();
-  ASSERT_EQ(null_array, str());
+  ASSERT_EQ(null_array_resp2, str());
+
+  sink_.Clear();
+  builder_->SendEmptyArray();
+  ASSERT_EQ(str(), empty_array);
+
+  // RESP3
+
+  builder_->SetRespVersion(RespVersion::kResp3);
+
+  sink_.Clear();
+  builder_->StartArray(0);
+  ASSERT_EQ(str(), empty_array);
+
+  sink_.Clear();
+  builder_->SendNullArray();
+  ASSERT_EQ(null_array_resp3, str());
 
   sink_.Clear();
   builder_->SendEmptyArray();


### PR DESCRIPTION
RESP3 expects "_\r\n" for a null array, but SendNullArray() always sent 
RESP2's "*-1\r\n" regardless  of protocol. This fixed null replies under 
RESP3 for XREAD, XREADGROUP, BLPOP, BRPOP, BZPOPMIN, and BZPOPMAX.

Closes #8076

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
