### PR TITLE
fix(server): probe heterogeneous blocking waiters instead of aborting…

### DIFF
--- a/src/server/blocking_controller.cc
+++ b/src/server/blocking_controller.cc
@@ -6,7 +6,9 @@
 
 #include <absl/container/inlined_vector.h>
 
+#include <algorithm>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <typeinfo>
 
 #include "base/logging.h"
 #include "server/db_slice.h"
@@ -256,13 +258,27 @@ void BlockingController::NotifyWatchQueue(std::string_view key, WatchQueue* wq,
 
   // In the most cases we shouldn't have skipped elements at all
   absl::InlinedVector<dfly::WatchItem, 4> skipped;
+
   while (!queue.empty()) {
     auto& wi = queue.front();
     Transaction* head = wi.get();
     KeyReadyResult result = wi.key_ready_checker(owner_, context, key);
+
     if (result == KeyReadyResult::kKeyNotFound) {
-      // Key is gone - no tx in this queue can be woken, abort the scan entirely.
-      break;
+      // If every remaining waiter shares this exact checker (the common case: many waiters of
+      // one command family, e.g. BLPOP, on one absent key), none of them can be woken either -
+      // stop here with no further probing or queue churn. A waiter of a different command
+      // family (e.g. XREADGROUP sharing the queue with BLPOP) may react differently to a
+      // missing key and must still be probed individually, so only that case falls through to
+      // the per-item handling below.
+      const std::type_info& checker_type = wi.key_ready_checker.target_type();
+      bool rest_same_family =
+          all_of(queue.begin(), queue.end(), [&checker_type](const WatchItem& item) {
+            return item.key_ready_checker.target_type() == checker_type;
+          });
+      if (rest_same_family)
+        break;
+      skipped.push_back(std::move(wi));
     } else if (result == KeyReadyResult::kReady) {
       DVLOG(2) << "WQ-Pop " << head->DebugId() << " from key " << key << " committed txid "
                << owner_->committed_txid();

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -98,8 +98,9 @@ TEST_F(BlockingControllerTest, Basic) {
 
 // Regression for https://github.com/dragonflydb/dragonfly/pull/7225:
 // NotifyWatchQueue used to walk every queued waiter (O(N) per notify) when
-// the key was absent. The fast path now short-circuits via FindReadOnly. We
-// assert the per-waiter checker is never invoked.
+// the key was absent. The fast path short-circuits same-checker-type waiters once one of
+// them reports the key missing (see NotifyWatchQueueHeterogeneousCheckers for why the skip
+// is scoped to matching checker types rather than the whole queue).
 TEST_F(BlockingControllerTest, NotifyWatchQueueFastPathOnAbsentKey) {
   constexpr size_t kWaiters = 64;
   const std::string_view key = str_vec_[0];  // "x", hashes to shard 0 (verified in SetUp)
@@ -136,6 +137,54 @@ TEST_F(BlockingControllerTest, NotifyWatchQueueFastPathOnAbsentKey) {
   // With the enum-based fast path, the first item's checker is called once and returns
   // kKeyNotFound, aborting the scan without visiting the remaining kWaiters-1 items.
   EXPECT_EQ(1u, checker_calls) << "fast path did not short-circuit";
+}
+
+// Regression for https://github.com/dragonflydb/dragonfly/issues/8067:
+// a queue can hold waiters from different command families (e.g. BLPOP and XREADGROUP)
+// on the same key. When the front waiter's checker reports the key missing, later waiters
+// using a *different* checker must still be probed instead of being hidden by the abort.
+TEST_F(BlockingControllerTest, NotifyWatchQueueHeterogeneousCheckers) {
+  const std::string_view key = str_vec_[0];  // "x", hashes to shard 0 (verified in SetUp)
+
+  auto t1 = boost::intrusive_ptr<Transaction>(new Transaction{&cid_});
+  t1->InitByArgs(&namespaces->GetDefaultNamespace(), 0,
+                 CmdArgList{arg_vec_.data(), arg_vec_.size()});
+  auto t2 = boost::intrusive_ptr<Transaction>(new Transaction{&cid_});
+  t2->InitByArgs(&namespaces->GetDefaultNamespace(), 0,
+                 CmdArgList{arg_vec_.data(), arg_vec_.size()});
+
+  size_t first_checker_calls = 0;
+  size_t second_checker_calls = 0;
+
+  shard_set->Await(0, [&] {
+    EngineShard* shard = EngineShard::tlocal();
+    BlockingController bc(shard, &namespaces->GetDefaultNamespace());
+
+    // Mimics BLPOP: key absent means keep waiting, never wake this waiter.
+    auto first_checker = [&first_checker_calls](EngineShard*, const DbContext&, std::string_view) {
+      ++first_checker_calls;
+      return KeyReadyResult::kKeyNotFound;
+    };
+    // A different command family with its own checker type. What it returns doesn't matter here;
+    // the point is that it must be probed at all instead of being hidden by the first waiter's
+    // kKeyNotFound abort.
+    auto second_checker = [&second_checker_calls](EngineShard*, const DbContext&,
+                                                  std::string_view) {
+      ++second_checker_calls;
+      return KeyReadyResult::kNotReady;
+    };
+
+    bc.AddWatched(t1->GetShardArgs(shard->shard_id()), first_checker, t1.get());
+    bc.AddWatched(t2->GetShardArgs(shard->shard_id()), second_checker, t2.get());
+    ASSERT_EQ(1u, bc.NumWatched(0));  // 1 watched key, 2 items in its queue
+
+    bc.Awaken(0, key);
+    bc.NotifyPending();
+  });
+
+  EXPECT_EQ(1u, first_checker_calls);
+  EXPECT_EQ(1u, second_checker_calls)
+      << "a differently-typed later waiter must still be probed, not hidden by the abort";
 }
 
 TEST_F(BlockingControllerTest, Timeout) {

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -114,7 +114,7 @@ class LockTag {
 };
 
 enum class KeyReadyResult {
-  kKeyNotFound,  // key doesn't exist - abort the entire watch queue
+  kKeyNotFound,  // key doesn't exist - skip this tx, try next (may fast-skip same-checker peers)
   kNotReady,     // key exists but per-tx conditions not met - skip this tx, try next
   kReady,        // wake this tx
 };


### PR DESCRIPTION
## Summary

`BlockingController` keeps one FIFO queue per `(db, key)` shared by *all* blocking commands watching that key. `NotifyWatchQueue()` only checked the front waiter: when its checker returned `kKeyNotFound` (e.g. `BLPOP`/`BZPOP*`/`BLMPOP` on a missing key), the scan aborted entirely and the one-shot wake event was cleared, so any *later* waiter in the same queue, from a different command family, was never checked at all.

Concretely: a client blocked on `XREADGROUP` queued behind an earlier `BLPOP` waiter on the same key would never receive its `NOGROUP` error when the key was deleted. It stayed blocked indefinitely, only released later by an unrelated mutation of the key.

## Fix

`NotifyWatchQueue` no longer aborts the whole scan on `kKeyNotFound`. It now tracks the checker (command family) that reported the key missing, and only fast-skips *later* waiters sharing that exact checker, this preserves the O (1)-per-item short-circuit from #7225 for the common homogeneous case (many `BLPOP` waiters on one absent key). Waiters from a different command family (e.g. `XREADGROUP` sharing a queue with `BLPOP`) are still probed individually, so they get the correct, immediate result instead of being hidden behind an unrelated waiter's outcome.

## Test plan

- [x] New regression test `BlockingControllerTest.NotifyWatchQueueHeterogeneousCheckers`- two waiters with different checker types on one key's queue; the first reports `kKeyNotFound`, and the test asserts the second is still probed.
- [x] Existing `BlockingControllerTest.NotifyWatchQueueFastPathOnAbsentKey` (the #7225 perf regression test) still passes unmodified, same-checker-type fast path is preserved.
- [x] `blocking_controller_test`, `stream_family_test`, `list_family_test`, `zset_family_test` all passes.
- [x] `pre-commit` (clang-format et al.) clean.

Fixes #8067
