### PR TITLE
fix(zset): honor GT/LT flags for skiplist-encoded sorted sets

### DIFF
--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -706,6 +706,14 @@ int SortedMap::AddElem(double score, std::string_view ele, int in_flags, int* ou
     }
   }
 
+  // GT/LT? Only update if score is greater/less than current.
+  double curscore = GetObjScore(obj);
+  if (((in_flags & ZADD_IN_LT) && score >= curscore) ||
+      ((in_flags & ZADD_IN_GT) && score <= curscore)) {
+    *out_flags = ZADD_OUT_NOP;
+    return 1;
+  }
+
   // Update the score.
   CHECK(score_tree->Delete(obj));
   SetObjScore(obj, score);

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -169,34 +169,51 @@ TEST_F(ZSetFamilyTest, Add) {
 }
 
 TEST_F(ZSetFamilyTest, AddGtLtSkiplist) {
-  // A 33-byte member forces skiplist encoding immediately (ZSET_MAX_LISTPACK_VALUE is 32).
+  // A 33-byte member converts the key to skiplist inside ZsetAdd (ZSET_MAX_LISTPACK_VALUE is 32).
   string long_member(33, 'a');
 
-  auto resp = Run({"zadd", "x", "gt", "10", long_member});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(Run({"zadd", "x", "gt", "10", long_member}), IntArg(1));
+  EXPECT_THAT(Run({"debug", "object", "x"}).GetString(), HasSubstr("encoding:btree"));
 
-  // GT with a lower score must be a no-op.
-  resp = Run({"zadd", "x", "gt", "3", long_member});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(Run({"zadd", "x", "gt", "ch", "3", long_member}), IntArg(0));
   EXPECT_EQ(Run({"zscore", "x", long_member}), "10");
 
-  // GT with a higher score must update.
-  resp = Run({"zadd", "x", "gt", "20", long_member});
-  EXPECT_THAT(resp, IntArg(0));
+  // Equal score pins the >= / <= direction.
+  EXPECT_THAT(Run({"zadd", "x", "gt", "ch", "10", long_member}), IntArg(0));
+  EXPECT_EQ(Run({"zscore", "x", long_member}), "10");
+
+  EXPECT_THAT(Run({"zadd", "x", "gt", "ch", "20", long_member}), IntArg(1));
   EXPECT_EQ(Run({"zscore", "x", long_member}), "20");
 
-  resp = Run({"zadd", "y", "lt", "10", long_member});
-  EXPECT_THAT(resp, IntArg(1));
+  // A rejected GT+INCR replies nil and leaves the score alone.
+  EXPECT_THAT(Run({"zadd", "x", "gt", "incr", "-5", long_member}), ArgType(RespExpr::NIL));
+  EXPECT_EQ(Run({"zscore", "x", long_member}), "20");
+  EXPECT_EQ(Run({"zadd", "x", "gt", "incr", "5", long_member}), "25");
 
-  // LT with a higher score must be a no-op.
-  resp = Run({"zadd", "y", "lt", "20", long_member});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(Run({"zadd", "x", "xx", "gt", "ch", "1", long_member}), IntArg(0));
+  EXPECT_EQ(Run({"zscore", "x", long_member}), "25");
+
+  EXPECT_THAT(Run({"zadd", "y", "lt", "10", long_member}), IntArg(1));
+  EXPECT_THAT(Run({"zadd", "y", "lt", "ch", "20", long_member}), IntArg(0));
   EXPECT_EQ(Run({"zscore", "y", long_member}), "10");
-
-  // LT with a lower score must update.
-  resp = Run({"zadd", "y", "lt", "3", long_member});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(Run({"zadd", "y", "lt", "ch", "10", long_member}), IntArg(0));
+  EXPECT_EQ(Run({"zscore", "y", long_member}), "10");
+  EXPECT_THAT(Run({"zadd", "y", "lt", "ch", "3", long_member}), IntArg(1));
   EXPECT_EQ(Run({"zscore", "y", long_member}), "3");
+  EXPECT_THAT(Run({"zadd", "y", "lt", "incr", "5", long_member}), ArgType(RespExpr::NIL));
+  EXPECT_EQ(Run({"zscore", "y", long_member}), "3");
+}
+
+TEST_F(ZSetFamilyTest, AddGtLtSkiplistManyMembers) {
+  for (unsigned i = 0; i < 129; ++i) {
+    Run({"zadd", "z", "10", absl::StrCat("m", i)});
+  }
+  EXPECT_THAT(Run({"debug", "object", "z"}).GetString(), HasSubstr("encoding:btree"));
+
+  EXPECT_THAT(Run({"zadd", "z", "gt", "ch", "3", "m1"}), IntArg(0));
+  EXPECT_EQ(Run({"zscore", "z", "m1"}), "10");
+  EXPECT_THAT(Run({"zadd", "z", "lt", "ch", "30", "m1"}), IntArg(0));
+  EXPECT_EQ(Run({"zscore", "z", "m1"}), "10");
 }
 
 TEST_F(ZSetFamilyTest, AddNonUniqeMembers) {

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -168,6 +168,37 @@ TEST_F(ZSetFamilyTest, Add) {
   EXPECT_EQ(resp, "1.1");
 }
 
+TEST_F(ZSetFamilyTest, AddGtLtSkiplist) {
+  // A 33-byte member forces skiplist encoding immediately (ZSET_MAX_LISTPACK_VALUE is 32).
+  string long_member(33, 'a');
+
+  auto resp = Run({"zadd", "x", "gt", "10", long_member});
+  EXPECT_THAT(resp, IntArg(1));
+
+  // GT with a lower score must be a no-op.
+  resp = Run({"zadd", "x", "gt", "3", long_member});
+  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_EQ(Run({"zscore", "x", long_member}), "10");
+
+  // GT with a higher score must update.
+  resp = Run({"zadd", "x", "gt", "20", long_member});
+  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_EQ(Run({"zscore", "x", long_member}), "20");
+
+  resp = Run({"zadd", "y", "lt", "10", long_member});
+  EXPECT_THAT(resp, IntArg(1));
+
+  // LT with a higher score must be a no-op.
+  resp = Run({"zadd", "y", "lt", "20", long_member});
+  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_EQ(Run({"zscore", "y", long_member}), "10");
+
+  // LT with a lower score must update.
+  resp = Run({"zadd", "y", "lt", "3", long_member});
+  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_EQ(Run({"zscore", "y", long_member}), "3");
+}
+
 TEST_F(ZSetFamilyTest, AddNonUniqeMembers) {
   auto resp = Run({"zadd", "x", "2", "a", "1", "a"});
   EXPECT_THAT(resp, IntArg(1));


### PR DESCRIPTION
## Summary

`ZADD ... GT` and `ZADD ... LT` were silently ignored once a sorted set
left listpack encoding (i.e. once it had a member longer than 32 bytes,
or more than 128 members). The score was overwritten unconditionally,
as if the command were a plain `ZADD`, with no error.

Root cause: the GT/LT clamp check exists in the listpack path
(`ZsetAdd` in `zset_family.cc`) but was missing entirely from the
skiplist path (`SortedMap::AddElem` in `sorted_map.cc`), which just
updated the score whenever the element already existed.

## Fix

Add the same GT/LT clamp to `SortedMap::AddElem`: if `LT` and the new
score isn't lower, or `GT` and the new score isn't higher, treat the
update as a no-op (matching the listpack path and Redis semantics).

## Test plan

- Added `ZSetFamilyTest.AddGtLtSkiplist`, using a 33-byte member to force
  skiplist encoding immediately, covering both GT and LT in both the
  no-op and update directions.
- `ninja zset_family_test && ./zset_family_test --gtest_filter='*GtLt*:*Add*'` — all 5 tests pass.
- `pre-commit` clang-format check passes on both changed files.

Fixes #8089
