### PR TITLE
fix: reply with a null array for empty ZMPOP/BZMPOP/LMPOP/BLMPOP

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -371,11 +371,7 @@ void RedisReplyBuilderBase::SendDouble(double val) {
 
 void RedisReplyBuilderBase::SendNullArray() {
   ReplyScope scope(this);
-  if (IsResp3()) {
-    WritePieces(kNullStringR3);
-  } else {
-    WritePieces("*-1", kCRLF);
-  }
+  IsResp3() ? WritePieces(kNullStringR3) : WritePieces("*-1", kCRLF);
 }
 
 constexpr static const char START_SYMBOLS2[4][2] = {"*", "~", "%", ">"};

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1230,7 +1230,7 @@ void CmdLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
     if (found_wrong_type) {
       response_builder->SendError(kWrongTypeErr);
     } else {
-      response_builder->SendNull();
+      response_builder->SendNullArray();
     }
     return;
   }
@@ -1254,7 +1254,7 @@ void CmdLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
     response_builder->SendBulkString(*key_to_pop);
     response_builder->SendBulkStrArr(*result);
   } else {
-    response_builder->SendNull();
+    response_builder->SendNullArray();
   }
 }
 
@@ -1289,9 +1289,24 @@ void CmdBLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
     response_builder->StartArray(2);
     response_builder->SendBulkString(*popped_key);
     response_builder->SendBulkStrArr(*result);
-  } else {
-    response_builder->SendNull();
+    return;
   }
+
+  switch (popped_key.status()) {
+    case OpStatus::WRONG_TYPE:
+      return cmd_cntx->SendError(kWrongTypeErr);
+    case OpStatus::CANCELLED:
+    case OpStatus::TIMED_OUT:
+      return response_builder->SendNullArray();
+    case OpStatus::KEY_MOVED: {
+      auto error = cluster::SlotOwnershipError(*cmd_cntx->tx()->GetUniqueSlotId());
+      CHECK(!error.status.has_value() || error.status.value() != facade::OpStatus::OK);
+      return cmd_cntx->SendError(error);
+    }
+    default:
+      LOG(ERROR) << "Unexpected error " << popped_key.status();
+  }
+  return response_builder->SendNullArray();
 }
 
 void CmdLPush(CmdArgParser parser, CommandContext* cmd_cntx) {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -146,6 +146,17 @@ TEST_F(ListFamilyTest, BLMPopInvalidSyntax) {
   EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
+TEST_F(ListFamilyTest, BLMPopWrongType) {
+  Run({"set", "str_key", "value"});
+  auto resp = Run({"blmpop", "0.1", "1", "str_key", "LEFT"});
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+
+  // A wrong-typed key preceding a non-empty list must still report the error.
+  Run({"rpush", "real_list", "a"});
+  resp = Run({"blmpop", "0.1", "2", "str_key", "real_list", "LEFT"});
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+}
+
 TEST_F(ListFamilyTest, BLMPopBlocking) {
   // attempting to pop from empty key results in blocking and returns
   // null if no values are pushed to the key.
@@ -158,7 +169,7 @@ TEST_F(ListFamilyTest, BLMPopBlocking) {
 
   fb0.Join();
   ASSERT_FALSE(IsLocked(0, kKey1));
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 
   // BLMPOP should not block if there is a non-empty key available
   resp = Run({"lpush", kKey1, "0"});
@@ -1315,9 +1326,8 @@ TEST_F(ListFamilyTest, LMPopInvalidSyntax) {
 }
 
 TEST_F(ListFamilyTest, LMPop) {
-  // All lists are empty
   auto resp = Run({"lmpop", "1", "e", "LEFT"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 
   // LEFT operation
   resp = Run({"lpush", "a", "a1", "a2"});
@@ -1410,11 +1420,11 @@ TEST_F(ListFamilyTest, LMPopEdgeCases) {
   Run({"rpush", "empty_list", "a"});
   Run({"lpop", "empty_list"});
   auto resp = Run({"lmpop", "1", "empty_list", "LEFT"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 
   // Test with non-existent list
   resp = Run({"lmpop", "1", "nonexistent", "LEFT"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 
   // Test with wrong type key
   Run({"set", "string_key", "value"});
@@ -1440,7 +1450,7 @@ TEST_F(ListFamilyTest, LMPopEdgeCases) {
 TEST_F(ListFamilyTest, LMPopDocExample) {
   // Try to pop from non-existing lists
   auto resp = Run({"LMPOP", "2", "non1", "non2", "LEFT", "COUNT", "10"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 
   // Create first list and test basic pop
   resp = Run({"LPUSH", "mylist", "one", "two", "three", "four", "five"});

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -487,7 +487,8 @@ void InterpreterReplier::SendSimpleString(string_view str) {
 }
 
 void InterpreterReplier::SendNullArray() {
-  SendSimpleStrArr(ArgSlice{});
+  // A null array converts to false, same as a null string.
+  explr_->OnNil();
   PostItem();
 }
 

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1761,4 +1761,16 @@ TEST_F(MultiTest, ResetSelectsDB0) {
   EXPECT_THAT(Run({"get", "resetkey"}), "val");
 }
 
+TEST_F(MultiTest, EvalMPopEmptyIsFalse) {
+  // Empty-result ZMPOP/LMPOP inside a script replies with a null array, which must
+  // produce Lua false, never a table.
+  auto resp = Run(
+      {"eval", "local r = redis.call('zmpop', '1', KEYS[1], 'MIN') return type(r)", "1", "nozset"});
+  EXPECT_EQ(resp, "boolean");
+
+  resp = Run({"eval", "local r = redis.call('lmpop', '1', KEYS[1], 'LEFT') return type(r)", "1",
+              "nolist"});
+  EXPECT_EQ(resp, "boolean");
+}
+
 }  // namespace dfly

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2489,7 +2489,7 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
 
   if (!key_to_pop.has_value() && (!is_blocking || cmd_cntx->tx()->IsMulti())) {
     cmd_cntx->tx()->Conclude();
-    response_builder->SendNull();
+    response_builder->SendNullArray();
     return;
   }
   // if we don't have any key to pop and it's blocking then we will block it using `WaitOnWatch`
@@ -2520,7 +2520,7 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
                                      &cntx->paused);
 
     if (status != OpStatus::OK) {
-      response_builder->SendNull();
+      response_builder->SendNullArray();
       return;
     }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -884,9 +884,8 @@ TEST_F(ZSetFamilyTest, ZMPopInvalidSyntax) {
 }
 
 TEST_F(ZSetFamilyTest, ZMPop) {
-  // All sets are empty.
   auto resp = Run({"zmpop", "1", "e", "MIN"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 
   // Min operation.
   resp = Run({"zadd", "a", "1", "a1", "2", "a2"});
@@ -1054,7 +1053,7 @@ TEST_F(ZSetFamilyTest, BMPOPBlockingTimeout) {
 
   // Check that the timeout duration is not too crazy.
   EXPECT_LT(AbsDuration(dur - absl::Milliseconds(1000)), absl::Milliseconds(300));
-  EXPECT_THAT(resp0, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp0, ArgType(RespExpr::NIL_ARRAY));
 }
 
 TEST_F(ZSetFamilyTest, ZPopMin) {

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1802,6 +1802,27 @@ async def test_reset_clears_client_tracking(df_server: DflyInstance):
 
 
 @dfly_args({"proactor_threads": 1})
+async def test_zmpop_empty_null_array(df_server: DflyInstance):
+    """An empty ZMPOP result is a null array on the wire: *-1 under RESP2 and _ under RESP3,
+    never the RESP2 null string $-1, which aggregate-reply parsers reject."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    cmd = _resp_cmd_writer(writer)
+
+    await cmd("ZMPOP", "1", "nokey", "MIN")
+    assert await _read_resp_frame(reader) == b"*-1\r\n"
+
+    # Drain the entire HELLO map so trailing fields cannot desync later frame reads.
+    await cmd("HELLO", "3")
+    await _read_resp_frame(reader)
+
+    await cmd("ZMPOP", "1", "nokey", "MIN")
+    assert await _read_resp_frame(reader) == b"_\r\n"
+
+    writer.close()
+    await writer.wait_closed()
+
+
+@dfly_args({"proactor_threads": 1})
 async def test_invalidation_dropped_on_resp2_connection(df_server: DflyInstance):
     """An invalidation can be generated for a connection that left RESP3 while tracking was still on
     (RESET does exactly this - switches to RESP2 and disables tracking - but a queued invalidation


### PR DESCRIPTION
When no element can be popped, ZMPOP/BZMPOP/LMPOP/BLMPOP replied with a RESP2 null bulk string (`$-1\r\n`) instead of the null array (`*-1\r\n`) expected for aggregate-reply commands, so strict clients (e.g. PhpRedis) rejected the reply. Builds on #8085, which made `SendNullArray()` protocol-aware (RESP2 `*-1`, RESP3 `_`).

Changes:
- The empty/timeout reply paths of ZMPOP/BZMPOP (`zset_family.cc`) and LMPOP/BLMPOP (`list_family.cc`) use `SendNullArray()`.
- BLMPOP now maps non-OK statuses the same way BLPOP does; a `WRONGTYPE` error is no longer swallowed into a null reply.
- `InterpreterReplier::SendNullArray()` converts a null-array reply to Lua `false` (previously it produced an empty table and called `PostItem()` twice, which hit a DCHECK in debug builds when reached, e.g. via `EVAL` calling `XINFO STREAM` on an empty stream).
- Simplify `SendNullArray()` to a ternary, matching `SendNull()`.
- Tests: existing empty/timeout assertions now expect the null array; added a BLMPOP wrong-type test, a Lua conversion test, and a raw-socket pytest asserting the exact wire bytes under RESP2 and RESP3 (draining the full HELLO reply via `_read_resp_frame`).

Fixes #8087