### PR TITLE
fix(tests): fix test_pubsub_pipeline_starvation test

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -3643,11 +3643,26 @@ async def test_blocking_command_pipeline_flush(df_server: DflyInstance):
     {"proactor_threads": 2, "async_dispatch_quota": 50, "enable_resp_io_loop_v2": "true"},
 )
 async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
+    """
+    Tests that a connection subscribed to a high-volume Pub/Sub channel
+    does not suffer from input starvation.
+
+    In a high-throughput scenario, a server might get stuck constantly
+    sending outgoing Pub/Sub messages to a subscriber, neglecting to read
+    new incoming commands from that subscriber's TCP socket.
+
+    This test spawns a background task that floods a channel with messages.
+    Meanwhile, the subscriber injects an UNSUBSCRIBE and a PING command.
+    The test verifies that the server's quota logic correctly forces it to
+    yield, read the socket, and respond to the PING within a 2-second timeout,
+    rather than getting trapped infinitely draining the Pub/Sub queue.
+    """
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     # Send subscribe and consume the standard 6-line RESP array reply
     # to completely clean the socket buffer before the flood begins.
     writer.write(b"SUBSCRIBE starvation_chan\r\n")
     await writer.drain()
+    # A RESP array reply for a successful subscription takes exactly 6 lines
     for _ in range(6):
         await reader.readline()
 
@@ -3665,6 +3680,8 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
             await asyncio.sleep(0.001)
         await pub.aclose()
 
+    # Create a separate, continuous background task: open a second connection (pub) and constantly publish messages to
+    # the starvation_chan in large batches of 500.
     flood_task = asyncio.create_task(flood())
 
     try:
@@ -3676,8 +3693,6 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
         writer.write(b"UNSUBSCRIBE starvation_chan\r\nPING starvation_survived\r\n")
         await writer.drain()
 
-        # Count the PubSub messages that arrive before the PING
-        pubsub_messages_before_ping = 0
         ping_found = False
         async with async_timeout.timeout(2.0):
             while True:
@@ -3689,17 +3704,9 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
                     ping_found = True
                     break
 
-                if b"message" in line:
-                    pubsub_messages_before_ping += 1
-
-        # Assert 1: The PING must arrive before the flood is fully drained.
+        # The PING must arrive within the timeout despite the Pub/Sub flood. If the async fiber
+        # never yields to parse pending commands, this times out.
         assert ping_found, "PING was starved and timed out!"
-
-        # Assert 2: the quota logic prioritized the pipeline.
-        # If it was truly starving, this would timeout or hit tens of thousands.
-        assert (
-            pubsub_messages_before_ping <= 1000
-        ), f"Starvation detected! Pipeline queued behind {pubsub_messages_before_ping} messages."
     finally:
         keep_flooding = False
         await flood_task


### PR DESCRIPTION
Update test_pubsub_pipeline_starvation to require a timely PING while a continuous Pub/Sub flood is active. Remove the timing-dependent backlog threshold that caused flaky CI failures despite correct starvation handling.

Fixes #8009.
