### PR TITLE
feat(server): make conn_use_incoming_cpu runtime mutable

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1053,6 +1053,9 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   dfly::search::InitSimSIMD();
 #endif
 
+  // Read on every accept in Listener::PickConnectionProactor, so changes take
+  // effect immediately for new connections.
+  config_registry.RegisterMutable("conn_use_incoming_cpu");
   config_registry.RegisterMutable("dbfilename");
   config_registry.Register("dbnum");  // equivalent to databases in redis.
   config_registry.Register("dir");

--- a/tests/dragonfly/config_test.py
+++ b/tests/dragonfly/config_test.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from redis.asyncio import Redis as RedisClient
 
@@ -22,3 +24,55 @@ async def test_maxclients(df_factory):
             assert ["maxclients", "3"] == await client1.execute_command("CONFIG GET maxclients")
             async with server.client() as client2:
                 await client2.get("test")
+
+
+async def test_conn_use_incoming_cpu(df_factory):
+    with df_factory.create(proactor_threads=4) as server:
+        async with server.client() as client:
+            assert ["conn_use_incoming_cpu", "false"] == await client.execute_command(
+                "CONFIG GET conn_use_incoming_cpu"
+            )
+
+            # Connections established before any toggle. Placement is decided once,
+            # at accept time, so these must be unaffected by later flag changes.
+            persistent = [server.client() for _ in range(5)]
+            for i, c in enumerate(persistent):
+                await c.set(f"persistent:{i}", f"value:{i}")
+
+            async def churn_connections(worker):
+                # Every iteration opens a fresh connection, so its placement decision
+                # races with the concurrent CONFIG SET flips below.
+                for i in range(20):
+                    async with server.client() as c:
+                        key = f"churn:{worker}:{i}"
+                        await c.set(key, "x")
+                        assert "x" == await c.get(key)
+
+            async def toggle_flag():
+                for i in range(40):
+                    value = "true" if i % 2 == 0 else "false"
+                    assert "OK" == await client.execute_command(
+                        "CONFIG SET conn_use_incoming_cpu", value
+                    )
+
+            # Race new-connection creation against runtime toggles of the placement
+            # policy: every accept must take a valid placement path either way.
+            await asyncio.gather(*(churn_connections(w) for w in range(4)), toggle_flag())
+
+            # Connections that predate the toggles still serve traffic and kept state.
+            for i, c in enumerate(persistent):
+                assert f"value:{i}" == await c.get(f"persistent:{i}")
+
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu true")
+            assert ["conn_use_incoming_cpu", "true"] == await client.execute_command(
+                "CONFIG GET conn_use_incoming_cpu"
+            )
+
+            # A connection accepted while the policy is enabled is served normally.
+            async with server.client() as c:
+                await c.ping()
+
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu false")
+            assert ["conn_use_incoming_cpu", "false"] == await client.execute_command(
+                "CONFIG GET conn_use_incoming_cpu"
+            )

--- a/tests/dragonfly/config_test.py
+++ b/tests/dragonfly/config_test.py
@@ -1,9 +1,14 @@
 import asyncio
+import os
+import socket
+import sys
 
 import pytest
 from redis.asyncio import Redis as RedisClient
 
 import redis
+
+SO_INCOMING_CPU = 49
 
 
 async def test_maxclients(df_factory):
@@ -26,14 +31,83 @@ async def test_maxclients(df_factory):
                 await client2.get("test")
 
 
+def incoming_cpu_supported(port) -> bool:
+    s = socket.socket()
+    try:
+        s.connect(("localhost", port))
+        s.getsockopt(socket.SOL_SOCKET, SO_INCOMING_CPU)
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+async def new_conn_tid(server) -> int:
+    # CLIENT INFO exposes the proactor thread ("tid=N") the connection landed on.
+    async with server.client() as c:
+        info = await c.execute_command("CLIENT INFO")
+        if not isinstance(info, dict):  # raw reply, redis-py version dependent
+            info = dict(field.split("=", 1) for field in str(info).split())
+        return int(info["tid"])
+
+
+async def test_conn_use_incoming_cpu_placement(df_factory):
+    """CONFIG SET conn_use_incoming_cpu must change where new connections are placed.
+
+    conn_io_thread_start/conn_io_threads restrict the round-robin fallback to tids
+    {2, 3}, so a connection on tid 0 can only result from the incoming-cpu policy.
+    This catches a cached-flag regression: if PickConnectionProactor stopped
+    re-reading the flag, every connection would stay in {2, 3} despite CONFIG SET.
+    """
+    if sys.platform != "linux":
+        pytest.skip("SO_INCOMING_CPU placement requires Linux")
+
+    with df_factory.create(
+        proactor_threads=4,
+        conn_io_thread_start=2,
+        conn_io_threads=2,
+        proactor_affinity_mode="on",
+    ) as server:
+        if not incoming_cpu_supported(server.port):
+            pytest.skip("kernel does not support SO_INCOMING_CPU")
+
+        async with server.client() as client:
+            initial = (await client.execute_command("CONFIG GET conn_use_incoming_cpu"))[1]
+
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu false")
+            assert await new_conn_tid(server) in (2, 3)
+
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu true")
+            # Pin this process to the first allowed CPU: loopback packets are
+            # processed on the sender's CPU, and proactor thread 0 is pinned to that
+            # same CPU (first CPU of the allowed set), so the incoming-cpu policy
+            # must place a fresh connection on tid 0 - outside the fallback window.
+            # A few attempts absorb occasional kernel steering noise; a cached flag
+            # yields zero hits no matter how many attempts.
+            allowed = os.sched_getaffinity(0)
+            try:
+                os.sched_setaffinity(0, {min(allowed)})
+                tids = [await new_conn_tid(server) for _ in range(10)]
+            finally:
+                os.sched_setaffinity(0, allowed)
+            assert 0 in tids, f"no connection was steered by incoming cpu: {tids}"
+
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu false")
+            assert await new_conn_tid(server) in (2, 3)
+
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu", initial)
+
+
 async def test_conn_use_incoming_cpu(df_factory):
     with df_factory.create(proactor_threads=4) as server:
         async with server.client() as client:
-            assert ["conn_use_incoming_cpu", "false"] == await client.execute_command(
-                "CONFIG GET conn_use_incoming_cpu"
-            )
+            # Do not assume the startup value; it can be overridden with --df.
+            initial = (await client.execute_command("CONFIG GET conn_use_incoming_cpu"))[1]
+            assert initial in ("true", "false")
+            flipped = "true" if initial == "false" else "false"
 
-            # Connections established before any toggle. Placement is decided once,
+            # Connections established before the toggles. Placement is decided once,
             # at accept time, so these must be unaffected by later flag changes.
             persistent = [server.client() for _ in range(5)]
             for i, c in enumerate(persistent):
@@ -50,7 +124,7 @@ async def test_conn_use_incoming_cpu(df_factory):
 
             async def toggle_flag():
                 for i in range(40):
-                    value = "true" if i % 2 == 0 else "false"
+                    value = flipped if i % 2 == 0 else initial
                     assert "OK" == await client.execute_command(
                         "CONFIG SET conn_use_incoming_cpu", value
                     )
@@ -63,16 +137,8 @@ async def test_conn_use_incoming_cpu(df_factory):
             for i, c in enumerate(persistent):
                 assert f"value:{i}" == await c.get(f"persistent:{i}")
 
-            await client.execute_command("CONFIG SET conn_use_incoming_cpu true")
-            assert ["conn_use_incoming_cpu", "true"] == await client.execute_command(
-                "CONFIG GET conn_use_incoming_cpu"
-            )
-
-            # A connection accepted while the policy is enabled is served normally.
-            async with server.client() as c:
-                await c.ping()
-
-            await client.execute_command("CONFIG SET conn_use_incoming_cpu false")
-            assert ["conn_use_incoming_cpu", "false"] == await client.execute_command(
+            # Restore the startup value and verify the round-trip.
+            await client.execute_command("CONFIG SET conn_use_incoming_cpu", initial)
+            assert ["conn_use_incoming_cpu", initial] == await client.execute_command(
                 "CONFIG GET conn_use_incoming_cpu"
             )


### PR DESCRIPTION
## Summary

`conn_use_incoming_cpu` controls how new connections are distributed across proactor threads, and `Listener::PickConnectionProactor` already reads it on every accept — but it is not registered in the config registry, so changing it requires a restart. This PR registers it as mutable, so `CONFIG SET conn_use_incoming_cpu <bool>` takes effect immediately for new connections.

Note on `CONFIG REWRITE`: registering the flag also makes it participate in `CONFIG REWRITE`, which persists any registered flag whose current value differs from its default — including values that came from the command line or flagfile rather than `CONFIG SET` (`RewriteConfigFile`, src/server/server_family.cc). Conversely, a flag set back to its default is not rewritten, so a stale non-default line in the flagfile survives. Both behaviors are pre-existing properties of every registered flag (e.g. `maxclients`, `timeout`); this PR adds `conn_use_incoming_cpu` to that set rather than changing the semantics. Happy to open a separate issue for the default-value rewrite gap if useful.

## Motivation

The flag's own comment notes it is only safe with correct RPS tuning: *"connections will be handled only on the CPUs that handle the softirqs for the incoming packets. To avoid imbalance in CPU load, RPS tuning is strongly advised."* In practice, steering misconfiguration is discovered in production. On one of our deployments (144 vCPUs; NIC IRQs pinned to CPUs 0–15, Dragonfly on 16–143) an RPS mask covering only part of the worker range concentrated **all** connections on 47 of 128 threads. A latency blip then became a self-feeding reconnect storm: the overloaded connection threads slowed replies, clients timed out and reconnected, and every new connection landed on the same hot threads.

Dragonfly already offers `CLIENT MIGRATE <client-id> <tid>` to rebalance connections that are **already** placed on hot threads. This PR covers the complementary population: with the flag mutable, an operator can flip placement policy for **future** accepts at runtime — stopping the storm from re-concentrating while `CLIENT MIGRATE` (or natural churn) drains the hot threads — and flip it back once steering is fixed, without restarting a loaded master. The structural fix (correct RPS masks / not enabling the flag on such hosts) is what we are rolling out at image level; the runtime toggle is for incident response when the misconfiguration is discovered live.

## Why changing it at runtime is safe

- The flag is read exactly once per accept via `absl::GetFlag` (thread-safe), and the decision is consumed immediately. No state is derived from or cached based on the flag anywhere else: `ProactorPool::MapCpuToThreads` is built once at pool startup and is only consulted, never mutated, by the placement path.
- A toggle only affects **future** accepts. Existing connections are placed once at accept time and are never re-placed by it, so they cannot be affected by a change.
- An accept racing a `CONFIG SET` observes either the old or the new value — both select a well-defined placement path, and the incoming-cpu path already degrades gracefully to round-robin when the reported CPU has no matching thread.

## Tests

- `test_conn_use_incoming_cpu_placement` — proves the toggle actually changes placement (catches a cached-flag regression): `conn_io_thread_start=2 conn_io_threads=2` pins the round-robin fallback to tids {2,3}; the test process is pinned to the first allowed CPU, where proactor thread 0 is pinned, so with the flag **on** a fresh loopback connection must land on `tid=0` (asserted via `CLIENT INFO` `tid=`) — a placement the fallback window can never produce; with the flag **off** connections must stay in {2,3}. Skips on non-Linux or kernels without `SO_INCOMING_CPU`.
- `test_conn_use_incoming_cpu` — reads the startup value instead of assuming the default (so `--df conn_use_incoming_cpu=true` keeps working), races 80 fresh connections against 40 concurrent toggles while 5 pre-existing connections hold state, and restores the startup value at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)