### PR TITLE
fix(facade): log V2 traffic before dispatch

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -785,7 +785,8 @@ void Connection::AsyncOperations::operator()(ParsedCommand& cmd) {
            << "Dispatching pipeline: " << cmd.Front();
 
   ++self->local_stats_.cmds;
-  self->service_->DispatchCommand(ParsedArgs{cmd}, &cmd, facade::AsyncPreference::ONLY_SYNC);
+  self->service_->DispatchCommand(ParsedArgs{cmd}, &cmd, facade::AsyncPreference::ONLY_SYNC,
+                                  nullptr);
 
   self->last_interaction_ = time(nullptr);
   self->skip_next_squashing_ = false;
@@ -1579,12 +1580,14 @@ void Connection::DispatchSingle(bool has_more, absl::FunctionRef<void()> invoke_
 
 Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t max_busy_cycles,
                                                 bool enqueue_only) {
+  DCHECK_EQ(enqueue_only, ioloop_v2_)
+      << "enqueue_only==true should only be used for ioloop_v2_ and vice versa";
   uint32_t consumed = 0;
   RespSrvParser::Result result = RespSrvParser::OK;
 
   auto dispatch_sync = [this] {
     service_->DispatchCommand(ParsedArgs{*parsed_cmd_}, parsed_cmd_,
-                              facade::AsyncPreference::ONLY_SYNC);
+                              facade::AsyncPreference::ONLY_SYNC, nullptr);
   };
   auto dispatch_async = [this]() -> void {
     PipelineMessagePtr ptr = GetFromPoolOrCreate();
@@ -1614,8 +1617,13 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
         io_req_size_hist->Add(request_consumed_bytes_);
       request_consumed_bytes_ = 0;
       bool has_more = consumed < read_buffer.size();
+      parsed_cmd_->has_unparsed_input = has_more;
 
-      if (tl_traffic_logger.log_file && tl_traffic_logger.listener_type == listener_type_) {
+      // V1 only: log traffic if requested. Traffic logging may write to a file and suspend the
+      // fiber. Since we cannot allow suspending the fiber during ParseRedis in V2 (e.g read+parse
+      // in proactor), traffic logging is done just before execution.
+      if (!enqueue_only && tl_traffic_logger.log_file &&
+          tl_traffic_logger.listener_type == listener_type_) {
         LogTraffic(id_, has_more, *parsed_cmd_, service_->GetContextInfo(cc_.get()));
       }
 
@@ -1937,7 +1945,7 @@ void Connection::SquashPipeline() {
   cc_->async_dispatch = true;
 
   uint32_t squashed =
-      service_->DispatchSquashedBatch(parsed_to_execute_, pipeline_count, cc_.get());
+      service_->DispatchSquashedBatch(parsed_to_execute_, pipeline_count, cc_.get(), nullptr);
 
   // Nothing was squashed (the head command can't join a batch, e.g. MULTI/EXEC, EVAL,
   // subscribe, blocking, or unknown). Hand it off to regular dispatch without flushing or
@@ -2144,7 +2152,7 @@ void Connection::ProcessPipelineCommandV1() {
 
   cc_->async_dispatch = true;
   local_stats_.cmds++;
-  service_->DispatchCommand(ParsedArgs{*cmd}, cmd, facade::AsyncPreference::ONLY_SYNC);
+  service_->DispatchCommand(ParsedArgs{*cmd}, cmd, facade::AsyncPreference::ONLY_SYNC, nullptr);
   last_interaction_ = time(nullptr);
   skip_next_squashing_ = false;
   cc_->async_dispatch = false;
@@ -2987,6 +2995,15 @@ Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
   return OK;
 }
 
+bool Connection::ShouldLogTrafficV2() const {
+  return ioloop_v2_ && (protocol_ == Protocol::REDIS) && tl_traffic_logger.log_file &&
+         (tl_traffic_logger.listener_type == listener_type_);
+}
+
+void Connection::LogTrafficV2(ParsedCommand* cmd) {
+  LogTraffic(id_, cmd->has_unparsed_input, *cmd, service_->GetContextInfo(cc_.get()));
+}
+
 bool Connection::SquashPipelineV2() {
   // vectorized squash phase: pack multiple commands and dispatch at once.
   // dispatch_waiting_count_ is the exact length of the run starting at parsed_to_execute_, so the
@@ -3000,8 +3017,14 @@ bool Connection::SquashPipelineV2() {
   // Invariant: clear on entry - only reached from the V2 loop between per-command dispatches.
   DCHECK(!cc_->sync_dispatch);
   cc_->sync_dispatch = true;
+  const bool log_traffic = ShouldLogTrafficV2();
+  auto log_command = [this](ParsedCommand* cmd) { LogTrafficV2(cmd); };
+  // FunctionRef is non-owning. Keep log_command and the log_command_ref alive through the
+  // synchronous dispatch.
+  absl::FunctionRef<void(ParsedCommand*)> log_command_ref = log_command;
   unsigned squashed =
-      service_->DispatchSquashedBatch(parsed_to_execute_, dispatch_waiting_count_, cc_.get());
+      service_->DispatchSquashedBatch(parsed_to_execute_, dispatch_waiting_count_, cc_.get(),
+                                      log_traffic ? &log_command_ref : nullptr);
   cc_->sync_dispatch = false;
   fiber_park_spot_ = FiberParkSpot::kNone;
 
@@ -3135,7 +3158,13 @@ bool Connection::ExecuteBatch() {
     // need to update is_true_pipeline.
     size_t q_len_before_dispatch = parsed_cmd_q_len_;
     uint64_t dispatch_start = CycleClock::Now();
-    auto dispatch_res = service_->DispatchCommandSimple(cmd, mode);
+    // Log here because V2 parsing may run in a proactor callback, where logging must not suspend.
+    // Note: Squashed commands are logged in SquashPipelineV2.
+    const bool log_traffic = ShouldLogTrafficV2();
+    auto log_command = [this](ParsedCommand* command) { LogTrafficV2(command); };
+    absl::FunctionRef<void(ParsedCommand*)> log_command_ref = log_command;
+    auto dispatch_res =
+        service_->DispatchCommandSimple(cmd, mode, log_traffic ? &log_command_ref : nullptr);
     if (ioloop_v2_) {
       fiber_park_spot_ = FiberParkSpot::kNone;
       cc_->sync_dispatch = false;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -552,6 +552,12 @@ class Connection : public util::Connection {
   // Returns true on successful execution, false on reply builder error.
   bool ExecuteBatch();
 
+  // V2: Returns true if the connection is currently logging traffic to a file.
+  bool ShouldLogTrafficV2() const;
+
+  // V2: A helper function to log a single command to a file.
+  void LogTrafficV2(ParsedCommand* cmd);
+
   // V2 vectorized squash phase: dispatch the run starting at parsed_to_execute_ through
   // DispatchSquashedBatch when squashing is enabled. Returns true if a squashed batch was
   // dispatched (and parsed_to_execute_ advanced).

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -348,9 +348,10 @@ class OkService : public ServiceInterface {
   explicit OkService(ProactorPool* pool) : pool_(pool) {
   }
 
-  DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd, AsyncPreference mode) final;
-  uint32_t DispatchSquashedBatch(ParsedCommand* first, unsigned count,
-                                 ConnectionContext* cntx) final;
+  DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd, AsyncPreference mode,
+                                 absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) final;
+  uint32_t DispatchSquashedBatch(ParsedCommand* first, unsigned count, ConnectionContext* cntx,
+                                 absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) final;
   void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) final;
 
   ConnectionContext* CreateContext(Connection* owner) final {
@@ -377,8 +378,12 @@ class OkService : public ServiceInterface {
   ProactorPool* pool_;
 };
 
-DispatchResult OkService::DispatchCommand([[maybe_unused]] ParsedArgs args, ParsedCommand* cmd,
-                                          AsyncPreference mode) {
+DispatchResult OkService::DispatchCommand(
+    [[maybe_unused]] ParsedArgs args, ParsedCommand* cmd, AsyncPreference mode,
+    absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) {
+  if (pre_dispatch_cb)
+    (*pre_dispatch_cb)(cmd);
+
   ++tl_facade_stats->conn_stats.command_cnt_main;
 
   if (cmd->empty()) {
@@ -432,8 +437,9 @@ DispatchResult OkService::DispatchCommand([[maybe_unused]] ParsedArgs args, Pars
 // the run into per-shard buckets; EmitBlockingBatch then dispatches one task per active shard, so
 // cross-thread cost drops from one Add + one Dec per command to one Add + one Dec per active shard.
 // Returns the run length consumed.
-uint32_t OkService::DispatchSquashedBatch(ParsedCommand* first, unsigned count,
-                                          [[maybe_unused]] ConnectionContext* cntx) {
+uint32_t OkService::DispatchSquashedBatch(
+    ParsedCommand* first, unsigned count, [[maybe_unused]] ConnectionContext* cntx,
+    absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) {
   const unsigned num_shards = pool_->size();
   VLOG(1) << "DispatchSquashedBatch: " << count << " commands";
 
@@ -443,6 +449,13 @@ uint32_t OkService::DispatchSquashedBatch(ParsedCommand* first, unsigned count,
   GroupResult group = GroupSquashableRun(first, count, num_shards, &per_shard);
   if (group.processed == 0)
     return 0;
+
+  if (pre_dispatch_cb) {
+    auto* cmd = first;
+    for (unsigned i = 0; i < group.processed; ++i, cmd = cmd->next) {
+      (*pre_dispatch_cb)(cmd);
+    }
+  }
 
   tl_facade_stats->conn_stats.command_cnt_main += group.processed;
 

--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -51,6 +51,7 @@ string MCRender::RenderDeleted() const {
 void ParsedCommand::ResetForReuse() {
   is_deferred_reply_ = false;
   reply_ = std::monostate{};
+  has_unparsed_input = false;
 
   offsets_.resize(0);
   offsets_.shrink_to_fit();

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -72,6 +72,9 @@ class ParsedCommand : public cmn::BackedArguments {
   uint64_t parsed_cycle = 0;
   ParsedCommand* next = nullptr;
 
+  // True when bytes remained in the parser's input buffer after this command.
+  bool has_unparsed_input = false;
+
   void Init(SinkReplyBuilder* rb, ConnectionContext* conn_cntx) {
     rb_ = rb;
     conn_cntx_ = conn_cntx;

--- a/src/facade/service_interface.cc
+++ b/src/facade/service_interface.cc
@@ -33,8 +33,10 @@ std::string ServiceInterface::ContextInfo::Format() const {
   return res;
 }
 
-DispatchResult ServiceInterface::DispatchCommandSimple(ParsedCommand* cmd, AsyncPreference mode) {
-  return DispatchCommand(ParsedArgs{*cmd}, cmd, mode);
+DispatchResult ServiceInterface::DispatchCommandSimple(
+    ParsedCommand* cmd, AsyncPreference mode,
+    absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) {
+  return DispatchCommand(ParsedArgs{*cmd}, cmd, mode, pre_dispatch_cb);
 }
 
 }  // namespace facade

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <absl/functional/function_ref.h>
+
 #include <string>
 
 #include "facade/facade_types.h"
@@ -39,14 +41,19 @@ class ServiceInterface {
   virtual ~ServiceInterface() {
   }
 
-  virtual DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd, AsyncPreference) = 0;
-  DispatchResult DispatchCommandSimple(ParsedCommand* cmd, AsyncPreference mode);
+  virtual DispatchResult DispatchCommand(
+      ParsedArgs args, ParsedCommand* cmd, AsyncPreference,
+      absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) = 0;
+  DispatchResult DispatchCommandSimple(ParsedCommand* cmd, AsyncPreference mode,
+                                       absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb);
 
   // Dispatches a batch of pipelined commands, squashing consecutive single-shard commands.
+  // If non-null, calls pre_dispatch_cb for each accepted command before its execution path.
   // Replies are deferred into the parsed commands and are sent by the connection afterwards.
   // Returns the number of squashed commands.
   virtual uint32_t DispatchSquashedBatch(ParsedCommand* first, unsigned count,
-                                         ConnectionContext* cntx) {
+                                         ConnectionContext* cntx,
+                                         absl::FunctionRef<void(ParsedCommand*)>* pre_dispatch_cb) {
     return 0;
   }
 

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -220,7 +220,7 @@ void HttpAPI(const http::QueryArgs& args, HttpRequest&& req, Service* service,
     cmd_cntx.PushArg(vec[i].AsString().c_str());
   }
   service->DispatchCommand(facade::ParsedArgs{cmd_cntx}, &cmd_cntx,
-                           facade::AsyncPreference::ONLY_SYNC);
+                           facade::AsyncPreference::ONLY_SYNC, nullptr);
   facade::CapturingReplyBuilder::Payload payload = reply_builder.Take();
 
   auto response = http::MakeStringResponse();

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -70,7 +70,7 @@ void JournalExecutor::FlushSlots(const cluster::SlotRange& slot_range) {
 
 facade::DispatchResult JournalExecutor::Execute(CommandContext* cmd_cntx) {
   return service_->DispatchCommand(facade::ParsedArgs{*cmd_cntx}, cmd_cntx,
-                                   facade::AsyncPreference::ONLY_SYNC);
+                                   facade::AsyncPreference::ONLY_SYNC, nullptr);
 }
 
 void JournalExecutor::SelectDb(DbIndex dbid) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1488,12 +1488,17 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid,
   return VerifyConnectionAclStatus(&cid, &dfly_cntx, "has no ACL permissions", tail_args);
 }
 
-DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedCommand* parsed_cmd,
-                                        facade::AsyncPreference async_pref) {
+DispatchResult Service::DispatchCommand(
+    facade::ParsedArgs args, facade::ParsedCommand* parsed_cmd, facade::AsyncPreference async_pref,
+    absl::FunctionRef<void(facade::ParsedCommand*)>* pre_dispatch_cb) {
   DCHECK_NE(0u, shard_set->size()) << "Init was not called";
 
   const CommandId* cid = nullptr;
   ParsedArgs args_no_cmd;
+  auto invoke_pre_dispatch = [&] {
+    if (pre_dispatch_cb)
+      (*pre_dispatch_cb)(parsed_cmd);
+  };
 
   if (parsed_cmd->mc_command()) {
     auto mc_res = HandleMemcacheCommand(parsed_cmd, async_pref);
@@ -1508,6 +1513,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
   }
 
   if (cid == nullptr) {
+    invoke_pre_dispatch();
     if (async_pref != AsyncPreference::ONLY_SYNC) {
       parsed_cmd->SetDeferredReply();
     }
@@ -1532,6 +1538,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
         parsed_cmd->SetDeferredReply();
       break;
   };
+
+  invoke_pre_dispatch();
 
   CommandContext* cmd_cntx = static_cast<CommandContext*>(parsed_cmd);
   ConnectionContext* dfly_cntx = cmd_cntx->server_conn_cntx();
@@ -1754,8 +1762,9 @@ DispatchResult Service::InvokeCmd(const facade::ParsedArgs& tail_args, CommandCo
   return res;
 }
 
-uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned count,
-                                        facade::ConnectionContext* cntx) {
+uint32_t Service::DispatchSquashedBatch(
+    facade::ParsedCommand* first, unsigned count, facade::ConnectionContext* cntx,
+    absl::FunctionRef<void(facade::ParsedCommand*)>* pre_dispatch_cb) {
   auto* dfly_cntx = static_cast<ConnectionContext*>(cntx);
   DCHECK(!dfly_cntx->conn_state.exec_info.IsRunning());
 
@@ -1845,6 +1854,8 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
         cid->IsSubscribeFamily())
       break;
 
+    if (pre_dispatch_cb)
+      (*pre_dispatch_cb)(cmd);
     if (auto err = VerifyCommandState(*cid, tail_args, *dfly_cntx); err) {
       CapturingReplyBuilder crb{ReplyMode::FULL, rb->GetRespVersion()};
       crb.SendError(std::move(*err));
@@ -2172,7 +2183,7 @@ void Service::CallFromScript(Interpreter::CallArgs& ca, CommandContext* cmd_cntx
       auto saved_tail = cmd_cntx->tail_args();
 
       auto* prev = cmd_cntx->SwapReplier(&replier);
-      DispatchCommand(ParsedArgs{*ca.args}, cmd_cntx, AsyncPreference::ONLY_SYNC);
+      DispatchCommand(ParsedArgs{*ca.args}, cmd_cntx, AsyncPreference::ONLY_SYNC, nullptr);
       cmd_cntx->SwapReplier(prev);
 
       cmd_cntx->SetTailArgs(saved_tail);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -38,12 +38,14 @@ class Service : public facade::ServiceInterface {
   void Shutdown();
 
   // Prepare command execution, verify and execute, reply to context
-  facade::DispatchResult DispatchCommand(facade::ParsedArgs args, facade::ParsedCommand* parsed_cmd,
-                                         facade::AsyncPreference apref) final;
+  facade::DispatchResult DispatchCommand(
+      facade::ParsedArgs args, facade::ParsedCommand* parsed_cmd, facade::AsyncPreference apref,
+      absl::FunctionRef<void(facade::ParsedCommand*)>* pre_dispatch_cb) final;
 
   // Execute multiple consecutive commands, possibly in parallel by squashing
-  uint32_t DispatchSquashedBatch(facade::ParsedCommand* first, unsigned count,
-                                 facade::ConnectionContext* cntx) final;
+  uint32_t DispatchSquashedBatch(
+      facade::ParsedCommand* first, unsigned count, facade::ConnectionContext* cntx,
+      absl::FunctionRef<void(facade::ParsedCommand*)>* pre_dispatch_cb) final;
 
   // Check OOM and invoke command with args
   facade::DispatchResult InvokeCmd(const facade::ParsedArgs& tail_args, CommandContext* cmd_cntx);

--- a/src/server/rdb_load_context.cc
+++ b/src/server/rdb_load_context.cc
@@ -230,7 +230,7 @@ void LoadSearchCommandFromAux(Service* service, std::string&& def, std::string_v
     cntx_cmd.PushArg(resp_vec[i].GetView());
   }
   service->DispatchCommand(facade::ParsedArgs{cntx_cmd}, &cntx_cmd,
-                           facade::AsyncPreference::ONLY_SYNC);
+                           facade::AsyncPreference::ONLY_SYNC, nullptr);
 
   auto response = crb.Take();
   if (auto err = facade::CapturingReplyBuilder::TryExtractError(response); err) {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -846,14 +846,14 @@ error_code Replica::ConsumeRedisStream() {
         // Try dispatching the batch of commands - if the batch didn't process any commands than
         // fall back to dispatching the first command in the batch synchronously.
         auto dispatch_batch = [&](size_t idx) {
-          size_t processed =
-              service_.DispatchSquashedBatch(batch[idx].cmd, batch.size() - idx, &conn_context);
+          size_t processed = service_.DispatchSquashedBatch(batch[idx].cmd, batch.size() - idx,
+                                                            &conn_context, nullptr);
           if (processed > 0) {
             return processed;
           }
           auto* cmd = batch[idx].cmd;
           service_.DispatchCommand(facade::ParsedArgs{*cmd}, cmd,
-                                   facade::AsyncPreference::ONLY_SYNC);
+                                   facade::AsyncPreference::ONLY_SYNC, nullptr);
           return size_t{1};
         };
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -474,7 +474,7 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
   CommandContext cmd_cntx;
   cmd_cntx.Init(conn_wrapper->builder(), context);
   cmd_cntx.Assign(args.begin(), args.end(), args.size());
-  service_->DispatchCommand(ParsedArgs{cmd_cntx}, &cmd_cntx, AsyncPreference::ONLY_SYNC);
+  service_->DispatchCommand(ParsedArgs{cmd_cntx}, &cmd_cntx, AsyncPreference::ONLY_SYNC, nullptr);
 
   DCHECK(context->transaction == nullptr);
 
@@ -504,7 +504,7 @@ void BaseFamilyTest::RunMany(const std::vector<std::vector<std::string>>& cmds) 
     if (i + 1 < cmds.size())
       cmd_cntxs[i].next = &cmd_cntxs[i + 1];
   }
-  service_->DispatchSquashedBatch(cmd_cntxs.data(), cmds.size(), context);
+  service_->DispatchSquashedBatch(cmd_cntxs.data(), cmds.size(), context, nullptr);
 
   // DispatchSquashedBatch defers replies into the parsed commands; flush them in order.
   for (auto& cmd_cntx : cmd_cntxs) {
@@ -541,7 +541,7 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, MCArgs args) -
 
   DCHECK(context->transaction == nullptr);
 
-  service_->DispatchCommandSimple(&cmd_cntx, AsyncPreference::ONLY_SYNC);
+  service_->DispatchCommandSimple(&cmd_cntx, AsyncPreference::ONLY_SYNC, nullptr);
 
   DCHECK(context->transaction == nullptr);
 
@@ -577,7 +577,7 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
   }
 
   cmd_cntx.Assign(src, list.end(), list.end() - src);
-  service_->DispatchCommandSimple(&cmd_cntx, AsyncPreference::ONLY_SYNC);
+  service_->DispatchCommandSimple(&cmd_cntx, AsyncPreference::ONLY_SYNC, nullptr);
 
   return conn->SplitLines();
 }

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -5,6 +5,7 @@ import re
 import socket
 import ssl
 import string
+import struct
 import subprocess
 import time
 from dataclasses import dataclass
@@ -245,6 +246,134 @@ async def test_monitor_multi_exec_close(df_server: DflyInstance):
     # If we get here, the server did not crash.
     client = df_server.client()
     assert await client.ping()
+
+
+def _read_traffic_log_records(path):
+    """Helper for test_debug_traffic_records_pipeline_in_dispatch_order."""
+    data = path.read_bytes()
+    assert data[0] == 3
+
+    offset = 2
+    records = []
+    while offset < len(data):
+        _, _, _, has_more, num_parts = struct.unpack_from("<IQIII", data, offset)
+        offset += struct.calcsize("<IQIII")
+        part_lengths = struct.unpack_from(f"<{num_parts}I", data, offset)
+        offset += 4 * num_parts
+        parts = []
+        for part_len in part_lengths:
+            parts.append(data[offset : offset + part_len])
+            offset += part_len
+        records.append((has_more, parts))
+    return records
+
+
+@dfly_multi_test_args(
+    {"enable_resp_io_loop_v2": "false", "proactor_threads": 1},
+    {"enable_resp_io_loop_v2": "true", "proactor_threads": 1},
+)
+async def test_debug_traffic_records_pipeline_in_dispatch_order(df_server, tmp_path):
+    """Verify DEBUG TRAFFIC records a non-transactional pipeline in dispatch order."""
+    client = aioredis.Redis(port=df_server.port)
+    log_prefix = tmp_path / "traffic"
+
+    try:
+        assert await client.execute_command("DEBUG", "TRAFFIC", "START", str(log_prefix)) == b"OK"
+
+        pipeline = client.pipeline(transaction=False)
+        pipeline.set("traffic:key:1", "one")
+        pipeline.set("traffic:key:2", "two")
+        pipeline.get("traffic:key:1")
+        assert await pipeline.execute() == [True, True, b"one"]
+
+        assert await client.execute_command("DEBUG", "TRAFFIC", "STOP") == b"OK"
+    finally:
+        await client.aclose()
+
+    assert _read_traffic_log_records(log_prefix.with_name("traffic-000.bin")) == [
+        (1, [b"SET", b"traffic:key:1", b"one"]),
+        (1, [b"SET", b"traffic:key:2", b"two"]),
+        (0, [b"GET", b"traffic:key:1"]),
+    ]
+
+
+@dfly_args({"enable_resp_io_loop_v2": "true", "proactor_threads": 1})
+async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tmp_path):
+    """V2 logging records queued commands and does not preempt proactor parsing."""
+    client = df_server.client()
+    log_prefix = tmp_path / "traffic-proactor"
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+
+    try:
+        # The SET is queued behind the blocking command before logging starts.
+        writer.write(b"BLPOP traffic:block 0\r\nSET traffic:queued before-start\r\n")
+        await writer.drain()
+        await asyncio.sleep(0.05)
+
+        assert await client.execute_command("DEBUG", "TRAFFIC", "START", str(log_prefix)) == "OK"
+
+        # BLPOP keeps the execution fiber parked at kSimpleHop. This later input is parsed by
+        # OnRecvNotification in the proactor callback, where traffic logging must not suspend.
+        writer.write(b"SET traffic:proactor one\r\n")
+        await writer.drain()
+        await asyncio.sleep(0.05)
+        assert await client.lpush("traffic:block", "unblock") == 1
+
+        first_response = await asyncio.wait_for(reader.readuntil(b"+OK\r\n"), timeout=2)
+        second_response = await asyncio.wait_for(reader.readuntil(b"+OK\r\n"), timeout=2)
+        assert b"traffic:block" in first_response
+        assert b"unblock" in first_response
+        assert second_response == b"+OK\r\n"
+        assert await client.execute_command("DEBUG", "TRAFFIC", "STOP") == "OK"
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await client.aclose()
+
+    logged_commands = [
+        parts
+        for _, parts in _read_traffic_log_records(log_prefix.with_name("traffic-proactor-000.bin"))
+    ]
+    assert [b"SET", b"traffic:queued", b"before-start"] in logged_commands
+    assert [b"SET", b"traffic:proactor", b"one"] in logged_commands
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_pipeline_squashing_v2": "false",
+        "proactor_threads": 1,
+    }
+)
+async def test_debug_traffic_v2_logs_retried_sync_command_once(df_server, tmp_path):
+    """V2 does not log a command rejected with WOULD_BLOCK before retrying it as the head."""
+    client = df_server.client()
+    log_prefix = tmp_path / "traffic-retry"
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+
+    try:
+        assert await client.execute_command("DEBUG", "TRAFFIC", "START", str(log_prefix)) == "OK"
+
+        # SET first attempts ONLY_ASYNC behind BLPOP and returns WOULD_BLOCK. Once BLPOP finishes,
+        # it retries as the head and must produce only one traffic record.
+        writer.write(b"BLPOP traffic:retry:block 0\r\nSET traffic:retry:key value\r\n")
+        await writer.drain()
+        await asyncio.sleep(0.05)
+        assert await client.lpush("traffic:retry:block", "unblock") == 1
+
+        await asyncio.wait_for(reader.readuntil(b"+OK\r\n"), timeout=2)
+        assert await client.execute_command("DEBUG", "TRAFFIC", "STOP") == "OK"
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await client.aclose()
+
+    logged_set_commands = [
+        parts
+        for _, parts in _read_traffic_log_records(log_prefix.with_name("traffic-retry-000.bin"))
+        if parts == [b"SET", b"traffic:retry:key", b"value"]
+    ]
+    assert logged_set_commands == [[b"SET", b"traffic:retry:key", b"value"]]
 
 
 """


### PR DESCRIPTION
Move V2 traffic logging out of ParseRedis: V2 can call it from a receive
callback that must not preempt, while logging may suspend. Log at the
pre-dispatch boundary instead, preserving squashing and dispatch order.
V1 stays the same.

Extend DispatchSquashedBatch with an optional pre-dispatch callback
that is invoked for each accepted command immediately before execution.
has_unparsed_input preserves parser-buffer continuation metadata when logging
is deferred.

Tests cover ordered V1/V2 pipeline records and V2 proactor parsing without
preemption.