### PR TITLE
fix(ci): run cache reaper hourly

### DIFF
--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
     types: [closed]
   schedule:
-    - cron: "0 */3 * * *"
+    # Run every hour
+    - cron: "0 * * * *"
   workflow_dispatch:
 
 # One reap per PR - scheduled/manual reaps share a single group. A newer run supersedes an in-flight one.


### PR DESCRIPTION
Running the cache reaper every three hours leaves stale caches around too long between cleanup runs.
Schedule it hourly so expired cache entries are removed sooner and storage usage stays under control.
