### PR TITLE
fix: null reply shapes for blocking moves, LPOP COUNT, ZRANK WITHSCORE, EXEC and friends

### DIFF
--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -384,7 +384,7 @@ void CmdGeoPos(CmdArgParser parser, CommandContext* cmd_cntx) {
       rb->SendDouble(xy[0]);
       rb->SendDouble(xy[1]);
     } else {
-      rb->SendNull();
+      rb->SendNullArray();
     }
   }
 }

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -35,7 +35,7 @@ TEST_F(GeoFamilyTest, GeoAddOptions) {
   auto resp = Run({"geopos", "Sicily", "Palermo", "Messina"});
   EXPECT_THAT(
       resp, RespArray(ElementsAre(RespArray(ElementsAre("15.361389219760895", "38.1155563954963")),
-                                  ArgType(RespExpr::NIL))));
+                                  ArgType(RespExpr::NIL_ARRAY))));
 
   // add 1 + update 1 + NX
   EXPECT_EQ(1, CheckedInt({"geoadd", "Sicily", "NX", "18.361389", "38.115556", "Palermo", "15.2875",
@@ -79,7 +79,7 @@ TEST_F(GeoFamilyTest, GeoPos) {
   auto resp = Run({"geopos", "Sicily", "Palermo", "NonExisting"});
   EXPECT_THAT(
       resp, RespArray(ElementsAre(RespArray(ElementsAre("13.361389338970184", "38.1155563954963")),
-                                  ArgType(RespExpr::NIL))));
+                                  ArgType(RespExpr::NIL_ARRAY))));
 }
 
 TEST_F(GeoFamilyTest, GeoPosWrongType) {

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -942,8 +942,9 @@ void BRPopLPush(CmdArgParser parser, CommandContext* cmd_cntx) {
   switch (op_res.status()) {
     case OpStatus::CANCELLED:
     case OpStatus::TIMED_OUT:
-      return builder->SendNull();
-      break;
+      // On a miss deny-blocking (MULTI/script) replies a scalar null, a blocked timeout replies a
+      // null array.
+      return cmd_cntx->tx()->IsMulti() ? builder->SendNull() : builder->SendNullArray();
 
     default:
       return builder->SendError(op_res.status());
@@ -971,8 +972,9 @@ void BLMove(CmdArgParser parser, CommandContext* cmd_cntx) {
   switch (op_res.status()) {
     case OpStatus::CANCELLED:
     case OpStatus::TIMED_OUT:
-      return builder->SendNull();
-      break;
+      // On a miss deny-blocking (MULTI/script) replies a scalar null, a blocked timeout replies a
+      // null array.
+      return cmd_cntx->tx()->IsMulti() ? builder->SendNull() : builder->SendNullArray();
 
     default:
       return builder->SendError(op_res.status());
@@ -1093,7 +1095,8 @@ void PopGeneric(ListDir dir, CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   switch (result.status()) {
     case OpStatus::KEY_NOTFOUND:
-      return rb->SendNull();
+      // With COUNT the reply is an aggregate, so its null form is a null array.
+      return return_arr ? rb->SendNullArray() : rb->SendNull();
     case OpStatus::WRONG_TYPE:
       return cmd_cntx->SendError(kWrongTypeErr);
     default:;

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -582,6 +582,8 @@ TEST_F(ListFamilyTest, LPop) {
   auto resp = Run({"lpop", "foo", "0"});
   EXPECT_THAT(resp, RespArray(ElementsAre()));
   resp = Run({"lpop", "bar", "0"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
+  resp = Run({"lpop", "bar"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 }
 
@@ -809,7 +811,7 @@ TEST_F(ListFamilyTest, TwoQueueBug451) {
 }
 
 TEST_F(ListFamilyTest, BRPopLPushSingleShard) {
-  EXPECT_THAT(Run({"brpoplpush", "x", "y", "0.05"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"brpoplpush", "x", "y", "0.05"}), ArgType(RespExpr::NIL_ARRAY));
   ASSERT_EQ(0, NumWatched());
 
   EXPECT_THAT(Run({"lpush", "x", "val1"}), IntArg(1));
@@ -846,7 +848,7 @@ TEST_F(ListFamilyTest, BRPopLPushSingleShardBug2857) {
 
   // Timeout
   f = pp_->at(1)->LaunchFiber(Launch::dispatch, blpop);
-  EXPECT_THAT(Run({"brpoplpush", "src", "dest", "1"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"brpoplpush", "src", "dest", "1"}), ArgType(RespExpr::NIL_ARRAY));
   f.Join();
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 }
@@ -916,7 +918,7 @@ TEST_F(ListFamilyTest, BRPopContended) {
 
 TEST_F(ListFamilyTest, BRPopLPushTwoShards) {
   RespExpr resp;
-  EXPECT_THAT(Run({"brpoplpush", "x", "z", "0.05"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"brpoplpush", "x", "z", "0.05"}), ArgType(RespExpr::NIL_ARRAY));
 
   ASSERT_EQ(0, NumWatched());
 
@@ -957,7 +959,7 @@ TEST_F(ListFamilyTest, BRPopLPushTwoShards) {
 }
 
 TEST_F(ListFamilyTest, BLMove) {
-  EXPECT_THAT(Run({"blmove", "x", "y", "right", "right", "0.05"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"blmove", "x", "y", "right", "right", "0.05"}), ArgType(RespExpr::NIL_ARRAY));
   ASSERT_EQ(0, NumWatched());
 
   EXPECT_THAT(Run({"lpush", "x", "val1"}), IntArg(1));
@@ -1010,6 +1012,15 @@ TEST_F(ListFamilyTest, BlockingTimeoutValidation) {
   // A large-but-representable timeout is accepted (returns immediately since the key exists).
   Run({"rpush", "k", "v"});
   EXPECT_THAT(Run({"blpop", "k", "4000000"}).GetVec(), ElementsAre("k", "v"));
+}
+
+TEST_F(ListFamilyTest, BLMoveMultiNull) {
+  // Inside MULTI blocking is denied and the miss reply is a scalar null,
+  // unlike the null array replied on a blocking timeout.
+  Run({"multi"});
+  Run({"blmove", "nokey", "dst", "LEFT", "RIGHT", "0.01"});
+  auto resp = Run({"exec"});
+  ASSERT_THAT(resp, RespArray(ElementsAre(ArgType(RespExpr::NIL))));
 }
 
 // Wake two BLMOVEs on the same shard simultaneously

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2571,7 +2571,7 @@ void Service::Exec(CmdArgParser, CommandContext* cmd_cntx) {
   }
 
   if (exec_info.watched_dirty.load(memory_order_relaxed)) {
-    return rb->SendNull();
+    return rb->SendNullArray();
   }
 
   auto keys = CollectAllKeys(&exec_info);
@@ -2609,7 +2609,7 @@ void Service::Exec(CmdArgParser, CommandContext* cmd_cntx) {
   if (!exec_info.watched_keys.empty() &&
       !CheckWatchedKeyExpiry(cntx, registry_.Find("EXISTS"), exec_cid_)) {
     cmd_cntx->tx()->UnlockMulti();
-    return rb->SendNull();
+    return rb->SendNullArray();
   }
 
   exec_info.state = ConnectionState::ExecInfo::EXEC_RUNNING;
@@ -2880,15 +2880,20 @@ void Service::Command(CmdArgParser parser, CommandContext* cmd_cntx) {
     return rb->SendLong(cmd_cnt);
   }
 
-  // INFO [cmd]
+  // INFO [cmd ...]
   if (subcmd == "INFO" && parser.HasNext()) {
-    string cmd = absl::AsciiStrToUpper(parser.Next());
+    vector<string> names;
+    while (parser.HasNext())
+      names.push_back(absl::AsciiStrToUpper(parser.Next()));
 
-    if (const auto* cid = registry_.Find(cmd); cid) {
-      rb->StartArray(1);
-      serialize_command(cmd, *cid);
-    } else {
-      rb->SendNull();
+    // One entry per requested name; an unknown name gets a null entry.
+    rb->StartArray(names.size());
+    for (const string& name : names) {
+      if (const auto* cid = registry_.Find(name); cid) {
+        serialize_command(name, *cid);
+      } else {
+        rb->SendNull();
+      }
     }
 
     return;

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -689,7 +689,7 @@ TEST_F(MultiTest, Eval) {
 }
 
 TEST_F(MultiTest, Watch) {
-  auto kExecFail = ArgType(RespExpr::NIL);
+  auto kExecFail = ArgType(RespExpr::NIL_ARRAY);
   auto kExecSuccess = ArgType(RespExpr::ARRAY);
 
   // Check watch doesn't run in multi.
@@ -728,6 +728,14 @@ TEST_F(MultiTest, Watch) {
   Run({"watch", "a"});
   Run({"expire", "a", "1"});
   AdvanceTime(1000);
+  Run({"multi"});
+  Run({"get", "a"});
+  ASSERT_THAT(Run({"exec"}), kExecFail);
+
+  // A TTL set before WATCH that lapses untouched aborts EXEC via the expiry check.
+  Run({"set", "a", "1", "ex", "1"});
+  Run({"watch", "a"});
+  AdvanceTime(1100);
   Run({"multi"});
   Run({"get", "a"});
   ASSERT_THAT(Run({"exec"}), kExecFail);

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -719,6 +719,15 @@ TEST_F(ServerFamilyTest, CommandDocsOk) {
   EXPECT_THAT(Run({"command", "docs"}), ErrArg("COMMAND DOCS Not Implemented"));
 }
 
+TEST_F(ServerFamilyTest, CommandInfoUnknown) {
+  // The reply is an array with one entry per requested command name, null for unknown names.
+  auto resp = Run({"command", "info", "nosuchcmd"});
+  ASSERT_THAT(resp, RespArray(ElementsAre(ArgType(RespExpr::NIL))));
+
+  resp = Run({"command", "info", "nosuchcmd", "get"});
+  ASSERT_THAT(resp, RespArray(ElementsAre(ArgType(RespExpr::NIL), ArgType(RespExpr::ARRAY))));
+}
+
 TEST_F(ServerFamilyTest, PubSubCommandErr) {
   // Check conditions only in non cluster mode
   if (auto cluster_mode = absl::GetFlag(FLAGS_cluster_mode); cluster_mode == "") {

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3851,14 +3851,14 @@ void CmdXInfo(CmdArgParser parser, CommandContext* cmd_cntx) {
           if (sinfo->first_entry.kv_arr.size() != 0) {
             StreamReplies{rb}.SendRecord(sinfo->first_entry);
           } else {
-            rb->SendNullArray();
+            rb->SendNull();
           }
 
           rb->SendBulkString("last-entry");
           if (sinfo->last_entry.kv_arr.size() != 0) {
             StreamReplies{rb}.SendRecord(sinfo->last_entry);
           } else {
-            rb->SendNullArray();
+            rb->SendNull();
           }
         }
         return;
@@ -3956,8 +3956,9 @@ void CmdXPending(CmdArgParser parser, CommandContext* cmd_cntx) {
         rb->SendLong(count);
       }
     } else {
-      for (unsigned j = 0; j < 3; ++j)
-        rb->SendNull();
+      rb->SendNull();       // min id
+      rb->SendNull();       // max id
+      rb->SendNullArray();  // consumer list
     }
   } else {
     const auto& res = std::get<PendingExtendedResultList>(result);

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -1310,7 +1310,9 @@ TEST_F(StreamFamilyTest, XPendingEmpty) {
   Run({"XADD", "stream", "*", "foo", "bar"});
   Run({"XGROUP", "CREATE", "stream", "group", "0"});
   auto resp = Run({"XPENDING", "stream", "group"});
-  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(0), kMatchNil, kMatchNil, kMatchNil)));
+  // Empty PEL: null min/max ids and a null array for the consumers list.
+  EXPECT_THAT(
+      resp, RespArray(ElementsAre(IntArg(0), kMatchNil, kMatchNil, ArgType(RespExpr::NIL_ARRAY))));
 }
 
 TEST_F(StreamFamilyTest, XAck) {
@@ -1560,7 +1562,7 @@ TEST_F(StreamFamilyTest, XInfoStream) {
       ElementsAre("length", IntArg(0), "radix-tree-keys", IntArg(0), "radix-tree-nodes", IntArg(1),
                   "last-generated-id", "0-0", "max-deleted-entry-id", "0-0", "entries-added",
                   IntArg(0), "recorded-first-entry-id", "0-0", "groups", IntArg(1), "first-entry",
-                  ArgType(RespExpr::NIL_ARRAY), "last-entry", ArgType(RespExpr::NIL_ARRAY)));
+                  ArgType(RespExpr::NIL), "last-entry", ArgType(RespExpr::NIL)));
 
   Run({"xadd", "mystream", "1-1", "message", "one"});
   Run({"xadd", "mystream", "2-1", "message", "two"});

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1847,7 +1847,8 @@ void ZRankGeneric(CmdArgParser parser, bool reverse, CommandContext* cmd_cntx) {
       rb->SendLong(result->rank);
     }
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    rb->SendNull();
+    // With WITHSCORE the reply is an aggregate, so its null form is a null array.
+    with_score ? rb->SendNullArray() : rb->SendNull();
   } else {
     cmd_cntx->SendError(result.status());
   }

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -386,8 +386,8 @@ TEST_F(ZSetFamilyTest, ZRank) {
   EXPECT_EQ(0, CheckedInt({"zrevrank", "x", "b"}));
   EXPECT_THAT(Run({"zrevrank", "x", "c"}), ArgType(RespExpr::NIL));
   EXPECT_THAT(Run({"zrank", "y", "c"}), ArgType(RespExpr::NIL));
-  EXPECT_THAT(Run({"zrevrank", "x", "c", "WITHSCORE"}), ArgType(RespExpr::NIL));
-  EXPECT_THAT(Run({"zrank", "y", "c", "WITHSCORE"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"zrevrank", "x", "c", "WITHSCORE"}), ArgType(RespExpr::NIL_ARRAY));
+  EXPECT_THAT(Run({"zrank", "y", "c", "WITHSCORE"}), ArgType(RespExpr::NIL_ARRAY));
 
   auto resp = Run({"zrank", "x", "a", "WITHSCORE"});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));


### PR DESCRIPTION
Follow-up to #8092: fixes the remaining commands whose null replies use the wrong RESP2 kind (null bulk string vs null array), plus two reverse cases where a null array was sent where a scalar null belongs.

Changes:

- BRPOPLPUSH/BLMOVE: a blocked timeout now replies a null array; inside MULTI/scripts (blocking denied) the reply stays a scalar null.
- LPOP/RPOP with COUNT and ZRANK/ZREVRANK with WITHSCORE reply a null array on a missing key/member; without the option the scalar null is unchanged.
- EXEC aborted by a WATCH (modified or expired key) replies a null array.
- GEOPOS: missing members (and a missing key) produce null-array elements.
- XPENDING summary with an empty PEL: the consumers element is a null array; min/max ids stay scalar nulls.
- XINFO STREAM: empty `first-entry`/`last-entry` are scalar nulls, not null arrays (wrong in both RESP2 and RESP3 before).
- COMMAND INFO: an unknown command name gets a null entry inside the reply array instead of a bare null.
- Tests: existing assertions updated in place; added BLMOVE-under-MULTI and EXEC-abort-by-expiry coverage (the latter path was previously unreached by the suite).

Part of the null-reply cleanup started in #8087 / #8092.