### PR TITLE
fix(server): handle exceptions in squashed MULTI stub callback

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -7,6 +7,8 @@
 #include <absl/strings/match.h>
 
 #include <memory>
+#include <new>
+#include <stdexcept>
 
 #include "base/flags.h"
 #include "base/logging.h"
@@ -1520,14 +1522,41 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
     shard->set_running_tx(this);
   }
 
-  auto result = cb(this, shard);
-  db_slice.OnCbFinishBlocking();
+  // Cleanup that must run regardless of how cb() exits (normal return, converted OOM, or an
+  // exception we don't handle here and let propagate) -- unlike the OOM handling below, this is
+  // unconditional so a rethrown exception can never leave running_tx_ dangling or skip
+  // OnCbFinishBlocking (see #8102).
+  auto cleanup = [&] {
+    db_slice.OnCbFinishBlocking();
+    if (owns_running_tx)
+      shard->set_running_tx(nullptr);
+  };
+
+  RunnableResult result;
+  try {
+    result = cb(this, shard);
+  } catch (std::bad_alloc&) {
+    // Mirrors RunCallback's bad_alloc handling: convert to a regular client-visible error instead
+    // of letting the exception escape uncaught, which would leave the reply unsent (see #8102).
+    // Unlike RunCallback, other exceptions are intentionally left uncaught here rather than
+    // LOG(FATAL)'d, since this stub runs squashed sub-commands and a crash here is worse than
+    // falling back to the generic top-level handler in Service::InvokeCmd.
+    LOG_EVERY_T(ERROR, 1) << " out of memory";
+    result = OpStatus::OUT_OF_MEMORY;
+  } catch (std::length_error&) {
+    // A too-large container growth request (e.g. a cuckoo filter sub-filter allocation that
+    // clears the SIZE_MAX overflow guard but still exceeds the target container's max_size())
+    // throws length_error rather than bad_alloc. Same handling applies.
+    LOG_EVERY_T(ERROR, 1) << " out of memory";
+    result = OpStatus::OUT_OF_MEMORY;
+  } catch (...) {
+    cleanup();
+    throw;
+  }
+  cleanup();
 
   LogAutoJournalOnShard(shard, result);
   MaybeInvokeTrackingCb();
-
-  if (owns_running_tx)
-    shard->set_running_tx(nullptr);
 
   DCHECK_EQ(result.flags, 0);  // if it's sophisticated, we shouldn't squash it
   return result;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -11,10 +11,13 @@
 #include <absl/functional/function_ref.h>
 
 #include <atomic>
+#include <new>
+#include <stdexcept>
 #include <string_view>
 #include <variant>
 #include <vector>
 
+#include "base/logging.h"
 #include "core/intent_lock.h"
 #include "core/tx_queue.h"
 #include "facade/op_status.h"
@@ -695,7 +698,20 @@ template <typename F> auto Transaction::ScheduleSingleHopT(F&& f) -> decltype(f(
   decltype(f(this, nullptr)) res;
 
   ScheduleSingleHop([&res, f = std::forward<F>(f)](Transaction* t, EngineShard* shard) {
-    res = f(t, shard);
+    // f() may throw (e.g. bad_alloc/length_error from container growth). Catch it here, at the
+    // point that owns `res`, rather than letting it propagate to RunCallback/RunSquashedMultiCb:
+    // those only see the RunnableResult returned below, not `res` itself, so a caught-but-not-set
+    // `res` would stay default-constructed (status OK) and the caller would see a misleadingly
+    // successful reply instead of OOM (see #8102).
+    try {
+      res = f(t, shard);
+    } catch (std::bad_alloc&) {
+      LOG_EVERY_T(ERROR, 1) << " out of memory";
+      res = OpStatus::OUT_OF_MEMORY;
+    } catch (std::length_error&) {
+      LOG_EVERY_T(ERROR, 1) << " out of memory";
+      res = OpStatus::OUT_OF_MEMORY;
+    }
     return res.status();
   });
   return res;


### PR DESCRIPTION
`Transaction::RunSquashedMultiCb` — the callback path used for every command
inside a squashed `MULTI` (atomic or non-atomic) — ran its callback with no
exception handling, unlike the ordinary `RunCallback` path which already
catches `std::bad_alloc` and converts it into a client-visible
`OpStatus::OUT_OF_MEMORY`.

When a squashed sub-command throws (e.g. `CF.ADD` growing a cuckoo filter
under memory pressure), the exception escaped `RunSquashedMultiCb` uncaught:

- The `running_tx_` shard-cleanup at the end of the function was skipped,
  leaving a dangling pointer on the shard for the `NON_ATOMIC` case.
- The exception was only caught by `Service::InvokeCmd`'s generic top-level
  handler, which logs `"Internal error, system probably unstable"` but never
  sends a reply — the `ReplyGuard` DCHECK then fires in debug builds, and in
  release builds the client's `EXEC` array is left with a missing element,
  desyncing the connection's reply stream.

## Fix

Wrap the callback invocation in `RunSquashedMultiCb` with a try/catch that
mirrors `RunCallback`'s `bad_alloc` handling (log + convert to
`OpStatus::OUT_OF_MEMORY`), and additionally catch `std::length_error`, since
`CuckooFilter::AddNewSubFilter`'s overflow guard bounds the requested size by
`SIZE_MAX` but the underlying `pmr::vector`'s `max_size()` is smaller, so a
large-but-guard-passing growth request can throw `length_error` instead of
`bad_alloc`.

Deliberately **not** copying `RunCallback`'s `catch (std::exception&) {
LOG(FATAL) }` branch — that would turn today's silent-no-reply bug into a
guaranteed crash for any other exception type escaping a squashed
sub-command.

Addresses defect 2 of #8102. Defect 1 (unbounded cuckoo filter growth itself)
is left for a follow-up, since it needs a design decision on how to bound
filter memory (fixed constant vs. new config flag vs. tying to `maxmemory`).

## Test plan

- [x] `ctest -R "transaction|multi|cuckoo"` passes
- [x] Manually reproduced the original crash repro from #8102 under
      `ulimit -v 4194304` — confirmed the server previously aborted
      (`SIGABRT`) partway through the `CF.ADD` loop
- [x] With the fix, the same repro hits the real `mimalloc` OOM condition but
      the server stays alive, `PING` and a fresh `CF.RESERVE` both reply
      cleanly afterward (no connection desync), and the log shows no
      `RepliesRecorded`/`Check failed`/`SIGABRT` markers
