### PR TITLE
fix: reply NOSCRIPT for a sha that only has SCRIPT FLAGS set

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -305,6 +305,22 @@ TEST_F(DflyEngineTest, ScriptFlush) {
   EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
+// SCRIPT FLAGS on a sha that was never loaded used to publish script params without a body, so
+// EVALSHA passed its NOSCRIPT guard and aborted inside LoadScript. See #8103.
+TEST_F(DflyEngineTest, ScriptFlagsUnknownSha) {
+  const char kSha[] = "0000000000000000000000000000000000000000";
+
+  EXPECT_EQ(Run({"script", "flags", kSha, "no-writes"}), "OK");
+  EXPECT_THAT(Run({"evalsha", kSha, "0"}), ErrArg("NOSCRIPT No matching script. Please use EVAL."));
+  EXPECT_EQ(Run({"ping"}), "PONG");
+
+  // A body-less entry must not leak into SCRIPT LIST, which is also what gets written to snapshots.
+  auto resp = Run({"script", "load", "return 7"});
+  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
+  string sha{ToSV(resp.GetBuf())};
+  EXPECT_THAT(Run({"script", "list"}), RespElementsAre(RespElementsAre(sha, "return 7")));
+}
+
 TEST_F(DflyEngineTestWithRegistry, Hello) {
   auto resp = Run({"hello"});
   ASSERT_THAT(resp, ArrLen(14));

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2232,21 +2232,26 @@ void Service::CallSHA(const facade::ParsedArgs& args, string_view sha, Interpret
   ServerState::tlocal()->RecordCallLatency(sha, (end - start) / 1000);
 }
 
-void LoadScript(string_view sha, ScriptMgr* script_mgr, Interpreter* interpreter) {
+// Returns false if the script body is unknown to the script manager and can not be run.
+[[nodiscard]] bool LoadScript(string_view sha, ScriptMgr* script_mgr, Interpreter* interpreter) {
   if (interpreter->Exists(sha))
-    return;
+    return true;
 
   auto script_data = script_mgr->Find(sha);
   if (!script_data) {
-    LOG(DFATAL) << "Script " << sha << " not found in script mgr";
-    return;
+    // Unreachable: params are cached only for scripts that have a body.
+    LOG_EVERY_T(WARNING, 1) << "Script " << sha << " has cached params but no body";
+    return false;
   }
 
   string err;
   Interpreter::AddResult add_res = interpreter->AddFunction(sha, script_data->body, &err);
   if (add_res != Interpreter::ADD_OK) {
     LOG(DFATAL) << "Error adding " << sha << " to database, err " << err;
+    return false;
   }
+
+  return true;
 }
 
 // Determine multi mode based on script params.
@@ -2319,7 +2324,9 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, 
     return cmd_cntx->SendError(facade::kScriptNotFound);
   }
 
-  LoadScript(eval_args.sha, server_family_.script_mgr(), interpreter);
+  if (!LoadScript(eval_args.sha, server_family_.script_mgr(), interpreter)) {
+    return cmd_cntx->SendError(facade::kScriptNotFound);
+  }
 
   string error;
   auto* conn_cntx = cmd_cntx->server_conn_cntx();

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -185,7 +185,11 @@ void ScriptMgr::ConfigCmd(CmdArgParser parser, Transaction* tx, SinkReplyBuilder
       return builder->SendError("Invalid config format: " + err.Format());
   }
 
-  UpdateScriptCaches(key, data);
+  // The per-thread params cache doubles as the EVALSHA existence check, so publish only scripts
+  // that are actually loaded. Flags of a not yet loaded script stay in db_ until Insert() runs.
+  if (data.body) {
+    UpdateScriptCaches(key, data);
+  }
 
   // Schedule empty callback inorder to journal command via transaction framework.
   tx->ScheduleSingleHop([](auto* t, auto* shard) { return OpStatus::OK; });
@@ -368,7 +372,7 @@ void ScriptMgr::OnScriptError(std::string_view sha, std::string_view error) {
     size_t pos = error.rfind(kUndeclaredKeyErr);
     lock_guard lk{mu_};
     auto it = db_.find(sha);
-    if (it == db_.end()) {
+    if (it == db_.end() || !it->second.body) {
       return;
     }
 
@@ -396,8 +400,10 @@ vector<pair<string, ScriptMgr::ScriptData>> ScriptMgr::GetAll() const {
   lock_guard lk{mu_};
   res.reserve(db_.size());
   for (const auto& [sha, data] : db_) {
-    string body = data.body ? string{data.body.get()} : string{};
-    res.emplace_back(string{sha.data(), sha.size()}, ScriptData{data, std::move(body)});
+    // Body-less entries only carry flags for a script that was never loaded.
+    if (!data.body)
+      continue;
+    res.emplace_back(string{sha.data(), sha.size()}, ScriptData{data, string{data.body.get()}});
   }
 
   return res;


### PR DESCRIPTION
`SCRIPT FLAGS <sha>` default-inserts a body-less entry into `ScriptMgr::db_` and publishes its params to every thread's cache. That cache is `EVALSHA`'s only existence guard, while `ScriptMgr::Find` requires a non-null body - so `EVALSHA` passed the guard and aborted in `LoadScript` (`LOG(DFATAL)`; in release it falls through to `CHECK(result == RUN_OK)` and aborts too). Reachable from two clients commands, and replicated, so it also killed replicas.

Fixes #8103
