### PR TITLE
fix(server): skip evicting keys in buckets a full sync hasn't capture…

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1714,6 +1714,26 @@ pair<uint64_t, size_t> DbSlice::FreeMemWithEvictionStepAtomic(DbIndex db_ind, co
         if (lt.Find(LockTag(key)).has_value())
           continue;
 
+        // Eviction deletes the key without going through the CoW OnChange hook (it runs
+        // under FiberAtomicGuard, which disallows OnChange's blocking call), so a full-sync
+        // snapshot that hasn't serialized this key's bucket yet, or is currently mid-flight
+        // streaming a large value from an earlier bucket, won't get a chance to capture the
+        // key's baseline before the eviction's journal DEL reaches the wire. The DEL can then
+        // race ahead of the bucket's still-in-progress baseline, so the replica applies it as
+        // a no-op and later resurrects the key once the baseline finishes loading. Skip such
+        // keys here; they remain eligible for eviction once no snapshot is in this state.
+        bool snapshot_race_risk = false;
+        for (auto* cb : change_cb_) {
+          if (!cb->is_snapshot_)
+            continue;
+          if (evict_it.GetVersion() < cb->snapshot_version_ || cb->IsAnyBucketBlocked()) {
+            snapshot_race_risk = true;
+            break;
+          }
+        }
+        if (snapshot_race_risk)
+          continue;
+
         if (record_keys)
           keys_to_journal.emplace_back(key);
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -114,6 +114,13 @@ class DbSlice {
 
     bool eventually_consistent_ = false;
     uint64_t snapshot_version_ = 0;
+
+    // True for consumers that stream a point-in-time baseline to a remote target (full sync,
+    // migration), where a bucket not yet reached by snapshot_version_ still needs its old state
+    // captured before mutation. False for consumers like FlushSlots' CallbackConsumer, which
+    // register on_change purely to react to concurrent mutations during their own traversal and
+    // are not affected by this ordering requirement.
+    bool is_snapshot_ = false;
   };
 
   // Auto-laundering iterator wrapper. Laundering means re-finding keys if they moved between

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -161,6 +161,7 @@ void SerializerBase::SerializeFetchedEntry(const TieredDelayedEntry& tde, const 
 //   emitting large values.
 void SerializerBase::RegisterChangeListener(bool replication) {
   db_array_ = db_slice_->databases();  // copy pointers to survive flush
+  is_snapshot_ = true;
   db_slice_->RegisterOnChange(this);
   eventually_consistent_ = replication;
 }


### PR DESCRIPTION
Fixes a race between heartbeat/policy-based eviction and full sync that lets a replica retain a key the master has already evicted.

**Root cause:** `DbSlice::FreeMemWithEvictionStepAtomic` deletes evicted keys via `Del()` without going through the CoW `OnChange` hook (`PreUpdateBlocking`/`CallChangeCallbacks`) — that hook can't be called here because eviction runs under `FiberAtomicGuard`, which disallows the hook's blocking call. Normally, `OnChange` is what protects an in-progress full-sync snapshot: if a bucket hasn't been serialized yet, it forces the bucket's pre-mutation state to be captured before the mutation is applied.

Without that protection, eviction can delete a key whose bucket a full-sync snapshot hasn't visited yet, or whose value is currently mid-flight across multiple chunks (large values get split across several `PushToConsumerIfNeeded` calls). The eviction's journal `DEL` is written as untagged raw bytes into the same output stream and can land *between* two chunks of that key's own still-in-progress baseline entry. On the replica, `RDB_OPCODE_JOURNAL_BLOB` entries are applied immediately in stream order (`rdb_load.cc`), so the `DEL` becomes a no-op (the key hasn't finished loading yet) — and once the remaining chunks arrive and the value is fully reassembled, the key gets inserted, resurrecting a key the master no longer has.

`test_heartbeat_eviction_propagation` (#8090) reproduces this directly: it populates 1MB values (`DEBUG POPULATE 233 size 1048576`) against a 300KB serialization chunk size, guaranteeing multi-chunk transmission for the values in play.

`test_policy_based_eviction_propagation` (#7925) shows the same failure signature (replica retains a key master evicted) — plausibly the same underlying gap, though I haven't independently confirmed its value sizes hit the identical multi-chunk condition as #8090.

## Fix

Before evicting a candidate key, skip it if any currently-registered full-sync consumer either:
- hasn't yet serialized that key's bucket (`evict_it.GetVersion() < cb->snapshot_version_`), or
- is currently mid-flight serializing some bucket (`cb->IsAnyBucketBlocked()`)

Both checks reuse existing non-blocking infrastructure (`DbSlice::change_cb_`, `ChangeConsumerInterface::IsAnyBucketBlocked()`) and add no locking or yielding, so they're safe to call under the existing `FiberAtomicGuard`. Skipped keys remain eligible for eviction on the next heartbeat tick once the snapshot has moved past them — this doesn't reduce total eviction throughput, only defers eviction of specific keys that are momentarily in the race window.

## Test plan

- [x] `test_heartbeat_eviction_propagation` — 5/5 passes locally with the fix (previously failing intermittently in CI, see #8090)
- [x] `test_policy_based_eviction_propagation` — 5/5 passes locally with the fix (previously failing intermittently in CI, see #7925)
- [ ] Not stress-tested: sustained full sync + heavy concurrent memory pressure, to confirm eviction doesn't stall behind a slow-syncing replica for longer than acceptable

## Notes for reviewers

This is a targeted mitigation, not the full fix implied by the `snapshot.cc` comment referencing a "delayed deletion queue proposal" design doc — that would presumably address the same class of gap more comprehensively (e.g. for expiry too, not just eviction). Flagging in case this should be superseded by or coordinated with that design work rather than merged as a standalone patch.


Fixes #8090
Fixes #7925
