### PR TITLE
fix: release the global shard lock in the mode it was taken

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1624,6 +1624,18 @@ TEST_F(MultiTest, EvalRo) {
   EXPECT_THAT(resp, ErrArg("Write commands are not allowed from read-only scripts"));
 }
 
+TEST_F(MultiTest, EvalRoUndeclaredKeys) {
+  EXPECT_THAT(Run({"set", "foo", "bar"}), "OK");
+
+  // Undeclared keys make the script global, and read-only takes the shard lock in shared mode.
+  EXPECT_THAT(
+      Run({"eval_ro", "--!df flags=allow-undeclared-keys\nreturn redis.call('get', 'foo')", "0"}),
+      "bar");
+
+  shard_set->RunBlockingInParallel(
+      [](EngineShard* shard) { EXPECT_TRUE(shard->shard_lock()->IsFree()); });
+}
+
 TEST_F(MultiTest, EvalShaRo) {
   RespExpr resp;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -450,7 +450,9 @@ void Transaction::StartMultiGlobal(Namespace* ns, DbIndex dbid) {
   multi_->mode = GLOBAL;
   InitBase(ns, dbid, {});
   InitGlobal();
-  multi_->lock_mode = IntentLock::EXCLUSIVE;
+  // ScheduleInternal below acquires the shard lock in this mode, so it must not be hardcoded:
+  // a read-only command (EVAL_RO) takes it shared.
+  multi_->lock_mode = LockMode();
 
   ScheduleInternal();
 }
@@ -1537,7 +1539,7 @@ void Transaction::UnlockMultiShardCb(absl::Span<const LockFp> fps, EngineShard* 
   DCHECK(multi_ && multi_->lock_mode);
 
   if (multi_->mode == GLOBAL) {
-    shard->shard_lock()->Release(IntentLock::EXCLUSIVE);
+    shard->shard_lock()->Release(*multi_->lock_mode);
   } else {
     GetDbSlice(shard->shard_id()).Release(*multi_->lock_mode, KeyLockArgs{db_index_, fps});
   }


### PR DESCRIPTION
A read-only script that runs in global mode (`EVAL_RO` / `EVALSHA_RO` with `allow-undeclared-keys`) acquires the shard lock in shared mode but released it as exclusive, so the server aborted on `assert(cnt_[m] >= val)` in `IntentLock::Release`. No setup and no privileges are needed:

    EVAL_RO "--!df flags=allow-undeclared-keys
    return 1" 0

`ScheduleInShard` acquires with `LockMode()`, which is `SHARED` for a `CO::READONLY` command, while `StartMultiGlobal` recorded `EXCLUSIVE` and `UnlockMultiShardCb` released `EXCLUSIVE`. `StartMultiLockedAhead` already used `LockMode()` - the global branch was the only one hardcoding it.

In release builds the assert is compiled out, so `cnt_[EXCLUSIVE]` underflows and `cnt_[SHARED]` stays held. `IntentLock::Check` then fails forever and `EngineShard::Heartbeat` takes its `!can_acquire_global_lock` early return on every tick, silently stopping background expiry and eviction on that shard for the life of the process.


Not reproducible with a single shard: that path goes through `PrepareSingleSquash` and never reaches `UnlockMulti`.
