### PR TITLE
fix(bloom): reject SBF filters the rdb loader would refuse to load back

### DIFF
--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -426,8 +426,7 @@ SBFLoadResult AddNewFilterToSBF(std::string_view data, SBF* sbf) {
   if (data_length == 0 || !absl::has_single_bit(data_length))
     return kBadInput;
 
-  // probability should be 0 to 1 (probably less than 1)
-  if (!std::isfinite(state.fp_prob) || state.fp_prob <= 0.0 || state.fp_prob >= 1.0)
+  if (!std::isfinite(state.fp_prob) || state.fp_prob <= 0.0 || state.fp_prob > kMaxSBFFpProb)
     return kBadInput;
 
   if (state.max_capacity == 0 || state.current_size >= state.max_capacity)

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -24,6 +24,10 @@ enum class SBFLoadResult : uint8_t {
 
 const char* ToString(SBFLoadResult res);
 
+// Max false-positive probability a persisted filter may carry. BF.LOADCHUNK and the rdb loader
+// must agree on it, else a filter can be built that its own snapshot refuses to load back.
+inline constexpr double kMaxSBFFpProb = 0.5;
+
 /// Bloom filter based on the design of https://github.com/jvirkki/libbloom
 class Bloom {
  public:

--- a/src/server/bloom_family_test.cc
+++ b/src/server/bloom_family_test.cc
@@ -1,8 +1,16 @@
 // Copyright 2024, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
+#include <limits>
+
+#include "absl/base/casts.h"
+#include "absl/base/internal/endian.h"
 #include "facade/facade_test.h"
 #include "server/test_utils.h"
+
+extern "C" {
+#include "redis/crc64.h"
+}
 
 namespace dfly {
 
@@ -10,6 +18,15 @@ using testing::ElementsAre;
 
 class BloomFamilyTest : public BaseFamilyTest {
  protected:
+  struct Chunks {
+    std::string header, filter, filter_cursor;
+  };
+  // Header chunk and first filter chunk of key "src".
+  Chunks DumpChunks() {
+    auto h = Run({"bf.scandump", "src", "0"}).GetVec();
+    auto f = Run({"bf.scandump", "src", std::to_string(*h[0].GetInt())}).GetVec();
+    return {h[1].GetString(), f[1].GetString(), std::to_string(*f[0].GetInt())};
+  }
 };
 
 TEST_F(BloomFamilyTest, Basic) {
@@ -183,6 +200,64 @@ TEST_F(BloomFamilyTest, CopyChunkedRoundTrip) {
 
   for (int i = 0; i < 100; ++i)
     EXPECT_THAT(Run({"bf.exists", "b2", absl::StrCat("item", i)}), IntArg(1));
+}
+
+// A BF.LOADCHUNK stopped after the header leaves a filterless SBF. COPY (DUMP->RESTORE) used
+// to abort on it, and a snapshot holding one used to fail to load, taking every other key with it.
+TEST_F(BloomFamilyTest, LoadChunkHeaderOnly) {
+  InitWithDbFilename();
+  Run({"bf.reserve", "src", "0.01", "100"});
+  Run({"bf.add", "src", "x"});
+  auto [header, filter, cursor] = DumpChunks();
+
+  EXPECT_EQ(Run({"bf.loadchunk", "dst", "1", header}), "OK");
+  Run({"set", "keep", "v"});
+
+  EXPECT_THAT(Run({"copy", "dst", "dst2"}), IntArg(1));
+  EXPECT_EQ(Run({"debug", "reload"}), "OK");
+  EXPECT_EQ(Run({"get", "keep"}), "v");
+  EXPECT_EQ(Run({"bf.loadchunk", "dst", cursor, filter}), "OK");  // still resumable
+  EXPECT_THAT(Run({"bf.exists", "dst", "x"}), IntArg(1));
+}
+
+// LOADCHUNK must refuse an fp_prob the loader would later reject: the cap 0.50 is fine, 0.51 is
+// not.
+TEST_F(BloomFamilyTest, LoadChunkFpProbRange) {
+  Run({"bf.reserve", "src", "0.01", "100"});
+  Run({"bf.add", "src", "x"});
+  auto [header, filter, cursor] = DumpChunks();
+
+  auto with_fp = [&](double fp) {
+    std::string f = filter;
+    absl::little_endian::Store64(f.data() + 12, absl::bit_cast<uint64_t>(fp));  // fp_prob offset
+    return f;
+  };
+  EXPECT_EQ(Run({"bf.loadchunk", "dst", "1", header}), "OK");
+  EXPECT_EQ(Run({"bf.loadchunk", "dst", cursor, with_fp(0.50)}), "OK");
+  Run({"del", "bad"});
+  EXPECT_EQ(Run({"bf.loadchunk", "bad", "1", header}), "OK");
+  EXPECT_THAT(Run({"bf.loadchunk", "bad", cursor, with_fp(0.51)}), ErrArg("out of range"));
+}
+
+// A crafted RESTORE reaches the loader without BF.LOADCHUNK's header check, so the loader itself
+// must reject a grow_factor an expansion would later multiply by.
+TEST_F(BloomFamilyTest, RestoreRejectsBadGrowFactor) {
+  Run({"bf.reserve", "src", "0.01", "100"});
+  Run({"bf.add", "src", "x"});
+  Run({"bf.loadchunk", "hdr", "1", DumpChunks().header});  // header-only SBF, grow_factor 2.0
+
+  std::string dump = Run({"dump", "hdr"}).GetString();
+  const size_t gf_off = 2;  // type(1) + reserved options len(1)
+  ASSERT_EQ(absl::little_endian::Load64(dump.data() + gf_off), absl::bit_cast<uint64_t>(2.0));
+  absl::little_endian::Store64(dump.data() + gf_off,
+                               absl::bit_cast<uint64_t>(std::numeric_limits<double>::infinity()));
+  // Re-sign so RESTORE's checksum passes and the SBF loader is what rejects it.
+  crc64_init();
+  const uint64_t crc =
+      crc64(0, reinterpret_cast<const uint8_t*>(dump.data()), dump.size() - sizeof(uint64_t));
+  absl::little_endian::Store64(dump.data() + dump.size() - sizeof(uint64_t), crc);
+
+  EXPECT_THAT(Run({"restore", "bad", "0", dump}), ErrArg("Bad data format"));
 }
 
 }  // namespace dfly

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2003,15 +2003,24 @@ auto RdbLoaderBase::ReadSBFImpl(bool filter_is_chunked) -> io::Result<OpaqueObj>
     if (options != 0)
       return Unexpected(errc::rdb_file_corrupted);
     SET_OR_UNEXPECT(FetchBinaryDouble(), res.grow_factor);
-    SET_OR_UNEXPECT(FetchBinaryDouble(), res.fp_prob);
-    if (res.fp_prob <= 0 || res.fp_prob > 0.5) {
+    // A later expansion multiplies by grow_factor, so guard it as LoadSBFHeader does - RESTORE
+    // and replicas reach this without going through that check.
+    if (!std::isfinite(res.grow_factor) || res.grow_factor < 1.0)
       return Unexpected(errc::rdb_file_corrupted);
-    }
+    SET_OR_UNEXPECT(FetchBinaryDouble(), res.fp_prob);
     SET_OR_UNEXPECT(LoadLen(nullptr), res.prev_size);
     SET_OR_UNEXPECT(LoadLen(nullptr), res.current_size);
     SET_OR_UNEXPECT(LoadLen(nullptr), res.max_capacity);
 
     SET_OR_UNEXPECT(LoadLen(nullptr), num_filters);
+
+    // A filterless SBF is a BF.LOADCHUNK restore that stopped after the header: no probability
+    // and no sizes yet. A populated one must satisfy the loader's fp_prob range.
+    const bool state_ok = num_filters == 0 ? res.fp_prob == 0 && res.prev_size == 0 &&
+                                                 res.current_size == 0 && res.max_capacity == 0
+                                           : res.fp_prob > 0 && res.fp_prob <= kMaxSBFFpProb;
+    if (!state_ok)
+      return Unexpected(errc::rdb_file_corrupted);
   } else {
     num_filters = pending_read_.remaining;
     pending_read_.remaining = 0;


### PR DESCRIPTION
A `BF.LOADCHUNK` stopped right after the 12-byte header leaves an SBF with zero filters and `fp_prob = 0.0`. That value is written to snapshots unvalidated but the rdb loader rejects it, so the filter's own snapshot fails to load - taking every other key in it down on the next restart - and `COPY` (which always goes through DUMP->RESTORE) aborts the process:

    BF.LOADCHUNK bkey 1 <12-byte header>
    SAVE ; restart          -> exits 1, whole snapshot lost
    COPY bkey dst           -> abort at generic_family.cc:435

The same writer/loader disagreement exists for fully-formed filters: LOADCHUNK accepted any `fp_prob` in (0, 1) while the loader accepts only (0, 0.5]. A restore can be interrupted without any malice - a client dying between the header and the first filter chunk is enough - after which snapshot_cron persists the poison unattended.

Fixes: #8104