### PR TITLE
fix: handle bad_alloc in squashed MULTI callback and surface hop status

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -12,6 +12,7 @@
 #include "base/logging.h"
 #include "core/interpreter.h"
 #include "facade/facade_test.h"
+#include "facade/reply_builder.h"
 #include "facade/resp_expr.h"
 #include "server/conn_context.h"
 #include "server/main_service.h"
@@ -1779,6 +1780,45 @@ TEST_F(MultiTest, EvalMPopEmptyIsFalse) {
   resp = Run({"eval", "local r = redis.call('lmpop', '1', KEYS[1], 'LEFT') return type(r)", "1",
               "nolist"});
   EXPECT_EQ(resp, "boolean");
+}
+
+// A bad_alloc thrown by a shard callback inside a squashed MULTI must surface as an error reply.
+TEST_F(MultiTest, SquashedCallbackBadAlloc) {
+  absl::FlagSaver fs;
+  absl::SetFlag(&FLAGS_multi_exec_squash, true);
+
+  static atomic_bool threw_in_stub;
+  threw_in_stub = false;
+
+  auto handler = [](CmdArgParser, CommandContext* cmd_cntx) {
+    auto cb = [](Transaction* t, EngineShard*) -> OpResult<long> {
+      threw_in_stub = t->IsSquashedStub();
+      throw std::bad_alloc{};
+    };
+    OpResult<long> res = cmd_cntx->tx()->ScheduleSingleHopT(cb);
+    auto* rb = cmd_cntx->rb();
+    if (res)
+      rb->SendLong(*res);
+    else
+      rb->SendError(res.status());
+  };
+  std::move(*service_->mutable_registry()->Find("LPUSH")).SetHandler(handler);
+
+  Run({"multi"});
+  Run({"lpush", kKey1, "a"});
+  Run({"set", kKey2, "b"});
+  RespExpr resp = Run({"exec"});
+
+  // Otherwise the throw happened on the unsquashed path and the test is vacuous.
+  EXPECT_TRUE(threw_in_stub.load());
+
+  ASSERT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp.GetVec()[0], ErrArg("Out of memory"));
+  EXPECT_EQ(resp.GetVec()[1], "OK");
+
+  // The connection must stay in sync after the failed sub-command.
+  EXPECT_EQ(Run({"ping"}), "PONG");
+  EXPECT_EQ(Run({"get", kKey2}), "b");
 }
 
 }  // namespace dfly

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1520,7 +1520,14 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
     shard->set_running_tx(this);
   }
 
-  auto result = cb(this, shard);
+  // An escaping exception would skip the cleanup below and leave the EXEC reply incomplete.
+  RunnableResult result;
+  try {
+    result = cb(this, shard);
+  } catch (std::bad_alloc&) {
+    LOG_EVERY_T(ERROR, 1) << " out of memory";
+    result = OpStatus::OUT_OF_MEMORY;
+  }
   db_slice.OnCbFinishBlocking();
 
   LogAutoJournalOnShard(shard, result);

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -694,10 +694,14 @@ class Transaction {
 template <typename F> auto Transaction::ScheduleSingleHopT(F&& f) -> decltype(f(this, nullptr)) {
   decltype(f(this, nullptr)) res;
 
-  ScheduleSingleHop([&res, f = std::forward<F>(f)](Transaction* t, EngineShard* shard) {
-    res = f(t, shard);
-    return res.status();
-  });
+  OpStatus status =
+      ScheduleSingleHop([&res, f = std::forward<F>(f)](Transaction* t, EngineShard* shard) {
+        res = f(t, shard);
+        return res.status();
+      });
+  // A throwing callback leaves res unassigned; surface the hop status instead of a default value.
+  if (status != OpStatus::OK)
+    return status;
   return res;
 }
 


### PR DESCRIPTION
A `bad_alloc` thrown by a shard callback inside a squashed `MULTI` escaped `RunSquashedMultiCb` uncaught, so the sub-command wrote no reply into the already-started `EXEC` array - tripping the reply-guard CHECK in debug builds (SIGABRT, found by the RESP fuzzer) and desyncing the connection in release builds.

Verified against the original repro (`ulimit -v 4194304`, 200x `MULTI`/`CF.ADD`/`EXEC` on a filter with `EXPANSION 2`): previously aborted at iteration ~153, now the failing iterations reply `ERR Out of memory`, the server stays responsive and the connection stays in sync.

Fixes: #8102
