### PR TITLE
feat(server): throttle defrag task CPU duty cycle

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -321,6 +321,10 @@ int32_t AsyncDeleter::IdleCb() {
   if (head_ == nullptr)
     return -1;  // unregister itself.
 
+  if (EngineShard* shard = EngineShard::tlocal(); shard) {
+    shard->stats().async_delete_task_invocation_total++;
+  }
+
   auto* current = head_;
   DVLOG(2) << "IdleCb " << current->cursor;
   if (current->step(current)) {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -48,6 +48,15 @@ ABSL_FLAG(float, mem_defrag_page_utilization_threshold, 0.8,
           "memory page under utilization threshold. Ratio between used and committed size, below "
           "this, memory in this page will defragmented");
 
+ABSL_FLAG(uint64_t, mem_defrag_max_burst_duration_us, 0,
+          "Maximum real (CycleClock-measured) time DefragTask() may spend running at the "
+          "proactor's highest on-idle priority before forcing a cooldown. 0 disables the "
+          "duty-cycle cap (unbounded, previous behavior)");
+
+ABSL_FLAG(uint32_t, mem_defrag_backoff_duration_us, 0,
+          "Duration in microseconds to drop to low on-idle priority once "
+          "mem_defrag_max_burst_duration_us is reached, before resuming at high priority");
+
 ABSL_FLAG(int32_t, hz, 100,
           "Base frequency at which the server performs other background tasks. "
           "Warning: not advised to decrease in production.");
@@ -232,7 +241,7 @@ string EngineShard::TxQueueInfo::Format() const {
 }
 
 EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
-  static_assert(sizeof(Stats) == 136);
+  static_assert(sizeof(Stats) == 144);
 
 #define ADD(x) x += o.x
 
@@ -242,6 +251,7 @@ EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
   ADD(defrag_skipped_mem_under_threshold);
   ADD(defrag_skipped_within_check_interval);
   ADD(defrag_skipped_not_enough_fragmentation);
+  ADD(async_delete_task_invocation_total);
   ADD(poll_execution_total);
   ADD(tx_ooo_total);
   ADD(tx_optimistic_total);
@@ -278,6 +288,18 @@ void EngineShard::DefragTaskState::ResetScanState() {
 // (control by mem_defrag_waste_threshold flag)
 EngineShard::DefragTaskState::SkipReason EngineShard::DefragTaskState::CheckRequired() {
   using enum SkipReason;
+
+  // Duty-cycle backoff takes priority over everything else, including an in-progress cursor:
+  // once mem_defrag_max_burst_duration_us of real time was spent this burst, we force a rest
+  // period before resuming, regardless of how much of the pass is left.
+  if (cooldown_until_cycles != 0) {
+    if (base::CycleClock::Now() < cooldown_until_cycles) {
+      return CoolingDown;
+    }
+    cooldown_until_cycles = 0;
+    consecutive_burst_cycles = 0;
+  }
+
   if (cursor > kCursorDoneState) {
     VLOG(2) << "cursor: " << cursor;
     return NotSkipped;
@@ -434,10 +456,26 @@ uint32_t EngineShard::DefragTask() {
     // TODO (abhijat): implement move ctor for PageUsage so this object can be moved into the task.
     PageUsage page_usage{CollectPageStats::NO, threshold,
                          CycleQuota{CycleQuota::kDefaultDefragQuota}};
-    if (DoDefrag(&page_usage)) {
+    const uint64_t call_start_cycles = base::CycleClock::Now();
+    const bool scan_incomplete = bool(DoDefrag(&page_usage));
+    defrag_state_.consecutive_burst_cycles += base::CycleClock::Now() - call_start_cycles;
+    if (scan_incomplete) {
       // we didn't finish the scan
+      const uint64_t max_burst_cycles =
+          base::CycleClock::FromUsec(GetFlag(FLAGS_mem_defrag_max_burst_duration_us));
+      if (max_burst_cycles > 0 && defrag_state_.consecutive_burst_cycles >= max_burst_cycles) {
+        // Burst budget spent. Force a cooldown before we're allowed to spin again, capping
+        // the achievable duty cycle insteadof running flat-out until completion.
+        defrag_state_.consecutive_burst_cycles = 0;
+        defrag_state_.cooldown_until_cycles =
+            base::CycleClock::Now() +
+            base::CycleClock::FromUsec(GetFlag(FLAGS_mem_defrag_backoff_duration_us));
+        return 6;
+      }
       return ProactorBase::kOnIdleMaxLevel;
     }
+    // Pass finished naturally - start the next pass with a fresh burst budget.
+    defrag_state_.consecutive_burst_cycles = 0;
   } else {
     std::string_view reason;
     switch (check_result) {
@@ -459,6 +497,9 @@ uint32_t EngineShard::DefragTask() {
         break;
       case CheckInProgress:
         reason = "check is in progress";
+        break;
+      case CoolingDown:
+        reason = "cooling down after duty-cycle burst limit";
         break;
       default:
         DCHECK(false) << "unexpected result";

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -31,6 +31,8 @@ class EngineShard {
     uint64_t defrag_skipped_mem_under_threshold = 0;
     uint64_t defrag_skipped_within_check_interval = 0;
     uint64_t defrag_skipped_not_enough_fragmentation = 0;
+    // In case it spins similarly to defragmentation. See pr #8115
+    uint64_t async_delete_task_invocation_total = 0;
     uint64_t poll_execution_total = 0;
 
     // number of optimistic executions - that were run as part of the scheduling.
@@ -251,12 +253,19 @@ class EngineShard {
     time_t last_check_time = 0;
     float page_utilization_threshold = 0.8;
 
+    // Duty-cycle backoff: bounds how much of this shard's CPU % defrag can burst.
+    // Without this, defrag task will return kOnIdleMaxLevel and will spin CPU without a cap.
+    // For more info, check helio's proactor event loop and how background tasks are run.
+    uint64_t consecutive_burst_cycles = 0;
+    uint64_t cooldown_until_cycles = 0;  // CycleClock ticks; 0 means "not cooling down"
+
     enum class SkipReason : uint8_t {
       MemoryTooLow,
       MemoryBelowThreshold,
       CheckWithinInterval,
       NotEnoughFragmentation,
       CheckInProgress,
+      CoolingDown,
       NotSkipped,
     };
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2844,6 +2844,7 @@ string ServerFamily::FormatInfoMetrics(
     append("defrag_attempt_total", m.shard_stats.defrag_attempt_total);
     append("defrag_realloc_total", m.shard_stats.defrag_realloc_total);
     append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
+    append("async_delete_task_invocation_total", m.shard_stats.async_delete_task_invocation_total);
     append("borrowed_strings_sent_total", reply_stats.borrowed_string_sent_cnt);
 
     // Number of connections that are currently blocked on grabbing interpreter.

--- a/tests/dragonfly/defrag_test.py
+++ b/tests/dragonfly/defrag_test.py
@@ -1,0 +1,91 @@
+import asyncio
+import logging
+
+import aiohttp
+import pytest
+from redis import asyncio as aioredis
+
+from . import dfly_args
+from .instance import DflyInstance
+from .seeder import Seeder as SeederV2
+
+
+async def get_stat(async_client: aioredis.Redis, name: str) -> int:
+    info = await async_client.info("stats")
+    return info.get(name, 0)
+
+
+async def set_flag(df_server: DflyInstance, flag: str, value: str):
+    async with aiohttp.ClientSession() as session:
+        resp = await session.get(
+            f"http://localhost:{df_server.port}/flagz?flag={flag}&value={value}"
+        )
+        assert resp.status == 200
+
+
+@pytest.mark.opt_only
+@dfly_args({"proactor_threads": "1"})
+async def test_defrag_flags_are_not_cached(df_server: DflyInstance, async_client: aioredis.Redis):
+    key_target = 390_000
+    seeder = SeederV2(
+        units=8, key_target=key_target, data_size=10_000, collection_size=100, types=["ZSET"]
+    )
+    await seeder.run(async_client, target_deviation=0.05)
+    logging.info(f"[defrag_test] seeded dbsize={await async_client.dbsize()}")
+
+    # Delete 90% of keys
+    keys_to_delete = []
+    async for key in async_client.scan_iter(match="*", count=1000):
+        keys_to_delete.append(key)
+    keys_to_delete = [k for i, k in enumerate(keys_to_delete) if i % 10 != 0]
+    logging.info(f"[defrag_test] deleting {len(keys_to_delete)} keys")
+    for i in range(0, len(keys_to_delete), 5000):
+        await async_client.delete(*keys_to_delete[i : i + 5000])
+
+    baseline = await get_stat(async_client, "defrag_task_invocation_total")
+    assert baseline == 0
+    logging.info(f"[defrag_test] baseline defrag_invocations={baseline} - settling for 4s now")
+
+    await asyncio.sleep(4)
+
+    logging.info("[defrag_test] opening defrag gates via /flagz - watch cpu spike now")
+
+    # Actually start testing defragmentation
+    await set_flag(df_server, "mem_defrag_threshold", "0.0")
+    await set_flag(df_server, "mem_defrag_check_sec_interval", "0")
+    await set_flag(df_server, "mem_defrag_waste_threshold", "0.01")
+
+    # Cap the duty cycle at ~1%: burst of 10ms real time, then a 990ms cooldown -
+    # duty_cycle = 10ms / (10ms + 990ms) = 1%.
+    await set_flag(df_server, "mem_defrag_max_burst_duration_us", "10000")
+    await set_flag(df_server, "mem_defrag_backoff_duration_us", "990000")
+    logging.info("[defrag_test] duty-cycle cap armed: target ~1% of one core")
+
+    # Check the impact every 25 seconds, printing the delta between each so the spike is visible
+    # as it happens rather than only checked once at the end.
+    prev_invocations = 0
+    total_invocations = 0
+    for checkpoint in (25, 50, 75):
+        await asyncio.sleep(25)
+        total_invocations = await get_stat(async_client, "defrag_task_invocation_total")
+        delta = total_invocations - prev_invocations
+        prev_invocations = total_invocations
+        logging.info(
+            f"[defrag_test] t={checkpoint}s defrag_invocations_total={total_invocations:.0f} "
+            f"delta_last_25s={delta:.0f}"
+        )
+
+    final_moved = await get_stat(async_client, "defrag_realloc_total")
+    logging.info(
+        f"[defrag_test] defrag_invocations={total_invocations} defrag_objects_moved={final_moved}"
+    )
+
+    # At a 1% duty cycle (~1 burst/sec, each burst fitting however many calls the CPU can do in
+    # ~10ms) we expect nowhere near the tens of thousands seen with the cap disabled - but the
+    # exact count scales with per-call cost, which varies with CPU speed (faster CI hardware fits
+    # more calls into the same time-bounded burst). Generous upper bound to absorb that variance
+    # while still clearly distinguishing "capped" from "unbounded spin".
+    assert 0 < total_invocations < 12_000, f"{total_invocations} invocations - cap not effective"
+
+    # And confirm real reallocation work actually happened
+    assert final_moved > 0


### PR DESCRIPTION
Add a cap/throttle for defrag task via the formula: 

`max_burst_duration_us / (max_burst_duration_us + backoff_duration_us) = estimated cpu time taken when defrag spins%`

Controlled by two flags: `max_burst_duration_us` and `backoff_duration_us`.

Why ? Because when CPU is idle helio's event loop will spin again and run the background tasks.

From an engineering perspective, what helio is doing makes sense: `if cpu is idle and there are background tasks instead of sleeping the CPU spin it and aggressively run whatever work is left`. This in principle is well engineered but can cause unexpected paging alerts for operators that monitor CPU time because it causes sudden jitters. 

You can see the difference in these two runs (with uncapped CPU + capped CPU at 1%) -- the CPU spikes would be more extreme on larger instances (it's just a small dev 10gb instance so defrag finishes quickly and the spikes are mild in the first case):

Without cap:
<img width="761" height="273" alt="Screenshot 2026-08-21 at 7 18 34 PM" src="https://github.com/user-attachments/assets/5e679817-8e54-4c6f-8e0a-7bbdc3243f8d" />


First high rise is seeding, second rise is deleting (to cause fragmentation) and `third one is defrag spinning`.

With 1% cap:

<img width="761" height="273" alt="Screenshot 2026-08-21 at 7 35 00 PM" src="https://github.com/user-attachments/assets/6da9ff97-6a81-496a-b2b3-8bd7289c4570" />

`no cpu spike` after second rise (dels)!

This can also happen on async deletes. For now I just added relative metrics in info command. 

`Downside is ofc defrag now will take a lot of time to finish but that's acceptable tradeoff for operators that monitor CPU time and 30% CAP might be a good starting point`