### PR TITLE
fix(acl): script context acl and enable flaky tests

### DIFF
--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -92,12 +92,17 @@ std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(bool literal_match,
     return false;
   }
 
+  // While a script is running, redis.call() must be checked against the
+  // ACL rules that were in effect when the script started.
+  const auto* sinfo = cntx.conn_state.script_info.get();
+  const std::vector<uint64_t>& acl_commands = sinfo ? sinfo->acl_commands : cntx.acl_commands;
+  const AclPubSub& pub_sub = sinfo ? sinfo->acl_pub_sub : cntx.pub_sub;
+
   std::pair<bool, AclLog::Reason> auth_res;
 
   if (id.IsPubSub()) {
     bool is_pattern = id.IsPatternPubSub();
-    auth_res =
-        IsPubSubCommandAuthorized(is_pattern, cntx.acl_commands, cntx.pub_sub, tail_args, id);
+    auth_res = IsPubSubCommandAuthorized(is_pattern, acl_commands, pub_sub, tail_args, id);
   } else {
     auth_res = IsUserAllowedToInvokeCommandGeneric(cntx, id, tail_args);
   }
@@ -114,22 +119,26 @@ std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(bool literal_match,
 
 [[nodiscard]] std::pair<bool, AclLog::Reason> IsUserAllowedToInvokeCommandGeneric(
     const ConnectionContext& cntx, const CommandId& id, const facade::ParsedArgs& tail_args) {
+  // See the comment in IsUserAllowedToInvokeCommand: while a script is running, checks are done
+  // against the ACL snapshot taken when the script started, not the connection's live rules.
+  const auto* sinfo = cntx.conn_state.script_info.get();
+  const std::vector<uint64_t>& acl_commands = sinfo ? sinfo->acl_commands : cntx.acl_commands;
+  const AclKeys& keys = sinfo ? sinfo->acl_keys : cntx.keys;
+  const size_t acl_db_idx = sinfo ? sinfo->acl_db_idx : cntx.acl_db_idx;
+
   const size_t max = std::numeric_limits<size_t>::max();
   // Once we support ranges this must change
-  const bool reject_move_command = cntx.acl_db_idx != max && id.name() == "MOVE";
+  const bool reject_move_command = acl_db_idx != max && id.name() == "MOVE";
   const bool reject_trans_command =
-      cntx.acl_db_idx != max && cntx.acl_db_idx != cntx.db_index() && id.IsTransactional();
+      acl_db_idx != max && acl_db_idx != cntx.db_index() && id.IsTransactional();
   if (reject_move_command || reject_trans_command) {
     return {false, AclLog::Reason::AUTH};
   }
   size_t res = 0;
   if (tail_args.size() == 1 && id.name() == "SELECT" && absl::SimpleAtoi(tail_args[0], &res) &&
-      cntx.acl_db_idx != max && cntx.acl_db_idx != res) {
+      acl_db_idx != max && acl_db_idx != res) {
     return {false, AclLog::Reason::AUTH};
   }
-
-  const auto& acl_commands = cntx.acl_commands;
-  const auto& keys = cntx.keys;
   if (!ValidateCommand(acl_commands, id)) {
     return {false, AclLog::Reason::COMMAND};
   }

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -198,7 +198,8 @@ size_t ConnectionState::ExecInfo::ClearStoredCmds() {
 }
 
 size_t ConnectionState::ScriptInfo::UsedMemory() const {
-  return HeapSize(lock_tags) + async_cmds_heap_mem;
+  return HeapSize(lock_tags) + async_cmds_heap_mem + HeapSize(acl_commands) +
+         HeapSize(acl_keys.key_globs) + HeapSize(acl_pub_sub.globs);
 }
 
 size_t ConnectionState::SubscribeInfo::UsedMemory() const {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -143,6 +143,13 @@ struct ConnectionState {
     std::vector<std::string> key_backing;    // storage for keys provided from lua
     bool read_only = false;
 
+    // ACL rules snapshotted from the connection when the script started. That way,
+    // concurrent ACL modifications of that user do not affect the script execution.
+    std::vector<uint64_t> acl_commands;
+    dfly::acl::AclKeys acl_keys;
+    dfly::acl::AclPubSub acl_pub_sub;
+    size_t acl_db_idx = std::numeric_limits<size_t>::max();
+
     size_t async_cmds_heap_mem = 0;     // bytes used by async_cmds
     size_t async_cmds_heap_limit = 0;   // max bytes allowed for async_cmds
     std::vector<StoredCmd> async_cmds;  // aggregated by acall

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2333,6 +2333,10 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, 
   sinfo->lock_tags.reserve(eval_args.num_keys);
   sinfo->read_only = read_only;
   memcpy(sinfo->stats.sha, eval_args.sha.data(), eval_args.sha.size());
+  sinfo->acl_commands = conn_cntx->acl_commands;
+  sinfo->acl_keys = conn_cntx->keys;
+  sinfo->acl_pub_sub = conn_cntx->pub_sub;
+  sinfo->acl_db_idx = conn_cntx->acl_db_idx;
 
   optional<ShardId> sid{nullopt};
   UniqueSlotChecker slot_checker;

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -11,6 +11,7 @@ import redis
 from redis import asyncio as aioredis
 
 from . import dfly_args
+from .utility import assert_eventually
 
 
 @pytest.mark.asyncio
@@ -258,7 +259,7 @@ async def test_acl_deluser(df_server):
 
 
 script = """
-for i = 1, 10000 do
+for i = 1, 280000 do
   redis.call('SET', 'key', i)
   redis.call('SET', 'key1', i)
   redis.call('SET', 'key2', i)
@@ -268,9 +269,24 @@ end
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("Flaky on CI, needs investigation")
+@pytest.mark.debug_only
+@dfly_args(
+    {
+        "proactor_threads": 8,
+        "num_shards": 7,
+        "conn_io_threads": 1,
+        "conn_io_thread_start": 7,
+        "shard_round_robin_prefix": "key",
+    }
+)
 async def test_acl_del_user_while_running_lua_script(df_server):
-    client = aioredis.Redis(port=df_server.port)
+    # Disable client-side retries: newer redis-py versions retry a ConnectionError by
+    # default, which would silently resend EVAL on a fresh (unauthenticated) connection
+    # instead of letting it propagate here.
+    from redis.backoff import NoBackoff
+    from redis.retry import Retry
+
+    client = aioredis.Redis(port=df_server.port, retry=Retry(NoBackoff(), 0))
     await client.execute_command("ACL SETUSER kostas ON >kk +@string +@scripting ~*")
     await client.execute_command("AUTH kostas kk")
     admin_client = aioredis.Redis(port=df_server.port, decode_responses=True)
@@ -287,14 +303,20 @@ async def test_acl_del_user_while_running_lua_script(df_server):
     with pytest.raises(redis.exceptions.ConnectionError):
         await eval_task
 
-    # The script should have run to completion on the server side.
-    for i in range(1, 4):
-        res = await admin_client.get(f"key{i}")
-        assert res == "10000"
+    @assert_eventually(timeout=20)
+    async def check_keys_written():
+        for i in range(1, 4):
+            res = await admin_client.get(f"key{i}")
+            assert res == "280000"
+
+    await check_keys_written()
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("Check TODO in the body below")
+@pytest.mark.debug_only
+@dfly_args(
+    {"proactor_threads": 2, "num_shards": 1, "conn_io_threads": 1, "conn_io_thread_start": 1}
+)
 async def test_acl_with_long_running_script(df_server):
     client = aioredis.Redis(port=df_server.port)
     await client.execute_command("ACL SETUSER roman ON >yoman +@string +@scripting ~*")
@@ -310,14 +332,11 @@ async def test_acl_with_long_running_script(df_server):
     await admin_client.execute_command("ACL SETUSER roman -@string -@scripting")
 
     # The script should continue and finish successfully
-    # TODO(fix): acl context should be immutable while the script is running. This requires
-    # a "dummy" context so we can allow acl commands to run in parallel but we don't use stubs
-    # anymore. Figure out a good solution for this.
     await eval_task
 
     for i in range(1, 4):
         res = await admin_client.get(f"key{i}")
-        assert res == "10000"
+        assert res == "280000"
 
 
 def create_temp_file(content, tmp_dir):

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -681,7 +681,7 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
 
     c_replica = replica.client()
 
-    await c_replica.execute_command("DEBUG POPULATE 1000 key 1000 RAND type set elements 500")
+    await c_replica.execute_command("DEBUG POPULATE 2100 key 1000 RAND type set elements 1000")
 
     replica.stop()
     replica.start()
@@ -713,6 +713,11 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     # Check one we finish loading snapshot replicaof success
     await wait_available_async(c_replica, timeout=180)
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_available_async(c_replica, timeout=180)
+
+    await c_replica.execute_command("REPLICAOF NO ONE")
+    await c_replica.execute_command("FLUSHALL")
+    await master.client().execute_command("FLUSHALL")
 
 
 async def test_journal_doesnt_yield_issue_2500(df_factory, df_seeder_factory):


### PR DESCRIPTION
Long ago we changed how acl's are verified for multi/exec by effectively matching against a user's acl list at the command verification (and not later again). We never adjusted this for lua scripts. For reference: https://github.com/dragonflydb/dragonfly/pull/6340  

* check acl's for a user only at eval
* re-enable flaky tests

As for test_acl_del_user_while_running_lua_script  the two main issues:

1. client would retry again so it would not throw (because of redis-py 7)
2. script would run optimistically without any yields so the connection would not shutdown until DEL actually is done dispatching.

* additionally increase the load test_replicaof_reject_on_load