### PR TITLE
test(facade): exclude debug traffic tests on epoll

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -272,6 +272,7 @@ def _read_traffic_log_records(path):
     {"enable_resp_io_loop_v2": "false", "proactor_threads": 1},
     {"enable_resp_io_loop_v2": "true", "proactor_threads": 1},
 )
+@pytest.mark.exclude_epoll
 async def test_debug_traffic_records_pipeline_in_dispatch_order(df_server, tmp_path):
     """Verify DEBUG TRAFFIC records a non-transactional pipeline in dispatch order."""
     client = aioredis.Redis(port=df_server.port)
@@ -298,6 +299,7 @@ async def test_debug_traffic_records_pipeline_in_dispatch_order(df_server, tmp_p
 
 
 @dfly_args({"enable_resp_io_loop_v2": "true", "proactor_threads": 1})
+@pytest.mark.exclude_epoll
 async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tmp_path):
     """V2 logging records queued commands and does not preempt proactor parsing."""
     client = df_server.client()
@@ -345,6 +347,7 @@ async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tm
         "proactor_threads": 1,
     }
 )
+@pytest.mark.exclude_epoll
 async def test_debug_traffic_v2_logs_retried_sync_command_once(df_server, tmp_path):
     """V2 does not log a command rejected with WOULD_BLOCK before retrying it as the head."""
     client = df_server.client()


### PR DESCRIPTION
Commit 2073b4e669c12b923fcf1dfb1506195aa4b587d5 added DEBUG TRAFFIC regression tests but forgot to exclude them from the epoll backend, where traffic recording is unsupported.

Mark the three affected tests with exclude_epoll so they run in the io_uring regression lane while avoiding false failures on epoll.
