### PR TITLE
feat(tiering): Account for tiered storage utility RAM

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1110,7 +1110,7 @@ void EngineShard::CacheStats() {
 
 size_t EngineShard::UsedMemory() const {
   return mi_resource_.used() + zmalloc_used_memory_tl + SmallString::UsedThreadLocal() +
-         search_indices()->GetUsedMemory();
+         search_indices()->GetUsedMemory() + (tiered_storage_ ? tiered_storage_->UsedMemory() : 0);
 }
 
 bool EngineShard::ShouldThrottleForTiering() const {

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -430,6 +430,9 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
   AppendMetricValue("memory_by_class_bytes", total.obj_memory_usage, {"class"}, {"object_used"},
                     &memory_by_class_bytes);
 
+  AppendMetricValue("memory_by_class_bytes", m.tiered_stats.used_memory, {"class"},
+                    {"tiered_utility_ram"}, &memory_by_class_bytes);
+
   AppendMetricValue("memory_by_class_bytes", m.coordinator_stats.stored_cmd_bytes, {"class"},
                     {"conn_stored_commands"}, &memory_by_class_bytes);
 

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -11,7 +11,7 @@ namespace dfly {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 176);
+  static_assert(sizeof(TieredStats) == 184);
 
   ADD(total_stashes);
   ADD(total_fetches);
@@ -41,6 +41,7 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
 
   ADD(clients_throttled);
   ADD(total_clients_throttled);
+  ADD(used_memory);
   return *this;
 }
 

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -82,6 +82,8 @@ struct TieredStats {
   // Total number of client throttle events.
   uint64_t total_clients_throttled = 0;
 
+  size_t used_memory = 0;
+
   TieredStats& operator+=(const TieredStats&);
 };
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -605,6 +605,10 @@ void TieredStorage::CancelStash(tiering::PendingId id, tiering::FragmentRef frag
   fragment_ref.SetStashPending(false);
 }
 
+size_t TieredStorage::UsedMemory() const {
+  return bins_->UsedMemory() + op_manager_->UsedMemory();
+}
+
 TieredStats TieredStorage::GetStats() const {
   TieredStats stats{};
 
@@ -644,6 +648,7 @@ TieredStats TieredStorage::GetStats() const {
     stats.total_offloading_stashes = stats_.offloading_stashes;
     stats.clients_throttled = stash_backpressure_.size();
     stats.total_clients_throttled = stats_.total_clients_throttled;
+    stats.used_memory = UsedMemory();
   }
   return stats;
 }

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -140,6 +140,8 @@ class TieredStorage : public TieredStorageBase {
     return stats_.cool_memory_used;
   }
 
+  size_t UsedMemory() const;
+
   bool IsClosed() const {
     return is_closed_;
   }
@@ -319,6 +321,10 @@ class TieredStorage : public TieredStorageBase {
   }
 
   size_t CoolMemoryUsage() const {
+    return 0;
+  }
+
+  size_t UsedMemory() const {
     return 0;
   }
 

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -58,6 +58,10 @@ class DiskStorage {
 
   Stats GetStats() const;
 
+  size_t UsedMemory() const {
+    return alloc_.UsedMemory();
+  }
+
  private:
   // Try asynchronously growing backing file by at least min requested size
   std::error_code RequestGrow(off_t min_size);

--- a/src/server/tiering/external_alloc.cc
+++ b/src/server/tiering/external_alloc.cc
@@ -337,6 +337,10 @@ ExternalAllocator::~ExternalAllocator() {
   }
 }
 
+size_t ExternalAllocator::UsedMemory() const {
+  return segments_.capacity() * sizeof(SegmentDescr*) + segments_metadata_bytes_;
+}
+
 int64_t ExternalAllocator::Malloc(size_t sz) {
   uint8_t bin_idx = ToBinIdx(sz);
   Page* page = free_pages_[bin_idx];
@@ -467,10 +471,11 @@ auto ExternalAllocator::FindPage(PageClass pc) -> Page* {
       segments_.resize(seg_idx + 1);
     }
 
-    void* ptr =
-        mi_malloc_aligned(sizeof(SegmentDescr) + num_pages * sizeof(Page), kSegDescrAlignment);
+    size_t metadata_size = sizeof(SegmentDescr) + num_pages * sizeof(Page);
+    void* ptr = mi_malloc_aligned(metadata_size, kSegDescrAlignment);
     SegmentDescr* seg = new (ptr) SegmentDescr(pc, op_range->first, num_pages);
     segments_[seg_idx] = seg;
+    segments_metadata_bytes_ += metadata_size;
 
     DCHECK(sq_[pc] == NULL);
     DCHECK(seg->next == seg->prev && seg == seg->next);

--- a/src/server/tiering/external_alloc.h
+++ b/src/server/tiering/external_alloc.h
@@ -80,6 +80,8 @@ class ExternalAllocator {
     return allocated_bytes_;
   }
 
+  size_t UsedMemory() const;
+
  private:
   class SegmentDescr;
   using Page = detail::Page;
@@ -104,6 +106,7 @@ class ExternalAllocator {
 
   size_t capacity_ = 0;  // in bytes.
   size_t allocated_bytes_ = 0;
+  size_t segments_metadata_bytes_ = 0;
 };
 
 }  // namespace dfly::tiering

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -83,6 +83,10 @@ class OpManager {
 
   Stats GetStats() const;
 
+  size_t UsedMemory() const {
+    return storage_.UsedMemory();
+  }
+
  protected:
   using OwnedEntryId = std::variant<uintptr_t, DbKeyId, ListNodeId>;
 

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -95,6 +95,10 @@ class SmallBins {
 
   Stats GetStats() const;
 
+  size_t UsedMemory() const {
+    return stashed_bins_.mem_usage();
+  }
+
  private:
   struct StashInfo {
     uint8_t entries = 0;


### PR DESCRIPTION
With dozens of millions of small bins, the dash tables memory usage can grow to hundreds of megabytes. We need to account for this memory, as well as the dozens of megabytes coming potentially form "external alloc"