### PR TITLE
fix(cluster): delete slots when OOM is discovered via ACK

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -340,8 +340,8 @@ void OutgoingMigration::SyncFb() {
 
     long attempt = 0;
     while (GetState() != MigrationState::C_FINISHED && !FinalizeMigration(++attempt)) {
-      // Break loop and don't sleep in case of C_FATAL
-      if (GetState() == MigrationState::C_FATAL) {
+      // Break loop and don't sleep in case of C_FATAL, or a reported error (e.g. OOM on ACK).
+      if (GetState() == MigrationState::C_FATAL || !exec_st_.IsRunning()) {
         break;
       }
       // Process commands that were on pause and try again
@@ -429,10 +429,12 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
       return false;
     }
 
-    // Check OOM from incoming slot migration on ACK request
+    // OOM might reach the target node from a flow or from the ack here. Both should report
+    // an error to the context such that the next iteration of the control loop deletes the slots
+    // on the target before it finishes.
     if (CheckRespSimpleError(kIncomingMigrationOOM)) {
-      Finish(GenericError{std::make_error_code(errc::not_enough_memory),
-                          std::string(kIncomingMigrationOOM)});
+      exec_st_.ReportError(GenericError(std::make_error_code(errc::not_enough_memory),
+                                        std::string(kIncomingMigrationOOM)));
       return false;
     }
 


### PR DESCRIPTION
Apparently we had two diverging behaviors when the source node got OOM replies:

* If it happened during flow -> we would cancel the context -> iterate the control loop which would delete the slots -> Finish

That was not true for OOM replies when the source node send `ACK` after a migration finished. Upon that case:

* ACK -> OOM -> call Finish -> no retries (init) and NO delete slots

This PR converges the behaviour by cancelling the context such that the slots on the target get deleted on all paths. 

This is the actual fix for the test https://github.com/dragonflydb/dragonfly/issues/8106