### PR TITLE
fix(server): Bound DeleteExpiredStep traversal with TraverseBySegment…

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -367,7 +367,8 @@ class DashTable : public detail::DashTableBase {
   // segment by segment over physical backets.
   // traverse by segment order does not guarantees coverage if the table grows/shrinks, it is useful
   // when formal full coverage is not critically important.
-  template <typename Cb> Cursor TraverseBySegmentOrder(Cursor curs, Cb&& cb);
+  // count bounds how many physical buckets are visited in a single call.
+  template <typename Cb> Cursor TraverseBySegmentOrder(Cursor curs, Cb&& cb, unsigned count = 8);
 
   // Discards slots information.
   static const_bucket_iterator BucketIt(const_iterator it) {
@@ -1195,23 +1196,27 @@ void DashTable<_Key, _Value, Policy>::Split(uint32_t seg_id, EvictionPolicy& ev)
 
 template <typename _Key, typename _Value, typename Policy>
 template <typename Cb>
-auto DashTable<_Key, _Value, Policy>::TraverseBySegmentOrder(Cursor curs, Cb&& cb) -> Cursor {
+auto DashTable<_Key, _Value, Policy>::TraverseBySegmentOrder(Cursor curs, Cb&& cb, unsigned count)
+    -> Cursor {
   uint32_t sid = curs.segment_id(global_depth_);
   assert(sid < segment_.size());
-  SegmentType* s = segment_[sid];
-  assert(s);
   uint8_t bid = curs.bucket_id();
 
-  auto dt_cb = [&](const SegmentIterator& it) { cb(iterator{this, sid, it.index, it.slot}); };
-  s->TraverseBucket(bid, std::move(dt_cb));
+  for (unsigned i = 0; i < count; ++i) {
+    SegmentType* s = segment_[sid];
+    assert(s);
 
-  ++bid;
-  if (SegmentType::OutOfRange(bid)) {
-    sid = NextSeg(sid);
-    if (sid >= segment_.size()) {
-      return Cursor::end();
+    auto dt_cb = [&](const SegmentIterator& it) { cb(iterator{this, sid, it.index, it.slot}); };
+    s->TraverseBucket(bid, dt_cb);
+
+    ++bid;
+    if (SegmentType::OutOfRange(bid)) {
+      sid = NextSeg(sid);
+      if (sid >= segment_.size()) {
+        return Cursor::end();
+      }
+      bid = 0;
     }
-    bid = 0;
   }
 
   return Cursor{global_depth_, sid, bid};

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1628,21 +1628,21 @@ auto DbSlice::DeleteExpiredStep(const Context& cntx, unsigned count) -> DeleteEx
     ++result.deleted;
   };
 
-  unsigned i = 0;
-
   auto quota_remains = [] {
     // Break out of traversal if we spent more than 1ms
     return base::CycleClock::ToUsec(ThisFiber::GetRunningTimeCycles()) < 1000;
   };
 
-  for (; i < count / 3 && quota_remains(); ++i) {
-    db.expire_cursor = db.prime.Traverse(db.expire_cursor, cb);
+  constexpr unsigned kStep = 8;
+
+  while (result.traversed < count / 3 && quota_remains()) {
+    db.expire_cursor = db.prime.TraverseBySegmentOrder(db.expire_cursor, cb, kStep);
   }
 
   // Continue traversing if we had a strong deletion rate among checked TTL keys.
   if (result.deleted * 4 > checked) {
-    for (; i < count && quota_remains(); ++i) {
-      db.expire_cursor = db.prime.Traverse(db.expire_cursor, cb);
+    while (result.traversed < count && quota_remains()) {
+      db.expire_cursor = db.prime.TraverseBySegmentOrder(db.expire_cursor, cb, kStep);
     }
   }
 


### PR DESCRIPTION
Fixes #8125. Even though the expiry table was removed, the problem persists in a different place.

Traverse() is unbounded and does not stop until it finds a placed (non-empty) value. On a nearly empty or empty table the traversal costs are just too high