### PR TITLE
fix: validate COUNT in ZMPOP/BZMPOP/LMPOP/BLMPOP and fix large-count overflow

### DIFF
--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -23,6 +23,7 @@ inline constexpr char kKeyNotFoundErr[] = "no such key";
 inline constexpr char kInvalidIntErr[] = "value is not an integer or out of range";
 inline constexpr char kInvalidFloatErr[] = "value is not a valid float";
 inline constexpr char kUintErr[] = "value is out of range, must be positive";
+inline constexpr char kCountNotGreaterThanZeroErr[] = "count should be greater than 0";
 inline constexpr char kTimeoutNegativeErr[] = "timeout is negative";
 inline constexpr char kTimeoutNotFloatErr[] = "timeout is not a float or out of range";
 inline constexpr char kTimeoutOutOfRangeErr[] = "timeout is out of range";

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1187,11 +1187,15 @@ void CmdLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
   parser.NextRange();  // numkeys + keys, handled by the command key spec
 
   ListDir dir = parser.MapNext("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
-  size_t pop_count = 1;
-  parser.Check("COUNT", &pop_count);
+  int64_t count_arg = 1;
+  parser.Check("COUNT", &count_arg);
+  if (!parser.HasError() && (count_arg < 1 || count_arg > UINT32_MAX))
+    return cmd_cntx->SendError(kCountNotGreaterThanZeroErr);
 
   if (!parser.Finalize())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
+
+  uint32_t pop_count = static_cast<uint32_t>(count_arg);
 
   // Create a vector to store first found key for each shard
   vector<optional<pair<string_view, bool>>> found_keys_per_shard(shard_set->size());
@@ -1271,11 +1275,15 @@ void CmdBLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
   parser.NextRange();  // numkeys + keys, handled by the command key spec
   ListDir dir = parser.MapNext("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
 
-  size_t pop_count = 1;
-  parser.Check("COUNT", &pop_count);
+  int64_t count_arg = 1;
+  parser.Check("COUNT", &count_arg);
+  if (!parser.HasError() && (count_arg < 1 || count_arg > UINT32_MAX))
+    return cmd_cntx->SendError(kCountNotGreaterThanZeroErr);
 
   if (!parser.Finalize())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
+
+  uint32_t pop_count = static_cast<uint32_t>(count_arg);
 
   OpResult<StringVec> result;
   auto cb = [&](Transaction* t, EngineShard* shard, string_view key) {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -141,6 +141,13 @@ TEST_F(ListFamilyTest, BLMPopInvalidSyntax) {
   resp = Run({"blmpop", "0.01", "1", kKey1, "LEFT", "COUNT", "boo"});
   EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 
+  // Non-positive count errors immediately, even with an infinite timeout
+  resp = Run({"blmpop", "0", "1", kKey1, "LEFT", "COUNT", "0"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  resp = Run({"blmpop", "0", "1", kKey1, "LEFT", "COUNT", "-1"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
   // Too many arguments
   resp = Run({"blmpop", "0.01", "1", "c", "LEFT", "COUNT", "2", "foo"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
@@ -1331,9 +1338,40 @@ TEST_F(ListFamilyTest, LMPopInvalidSyntax) {
   resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "boo"});
   EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 
+  // COUNT is zero
+  resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "0"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  // COUNT is negative
+  resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "-1"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "-9223372036854775808"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  // COUNT above UINT32_MAX
+  resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "4294967296"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "9223372036854775807"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  // Non-positive count errors even with trailing junk
+  resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "0", "foo"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
   // Too many arguments
   resp = Run({"lmpop", "1", "c", "LEFT", "COUNT", "2", "foo"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
+TEST_F(ListFamilyTest, LMPopCountLargerThanList) {
+  Run({"rpush", "a", "a1", "a2", "a3"});
+
+  // Count above the list size (up to UINT32_MAX) pops the whole list.
+  auto resp = Run({"lmpop", "1", "a", "LEFT", "COUNT", "4294967295"});
+  EXPECT_THAT(resp, RespArray(ElementsAre("a", RespArray(ElementsAre("a1", "a2", "a3")))));
+  EXPECT_THAT(Run({"exists", "a"}), IntArg(0));
 }
 
 TEST_F(ListFamilyTest, LMPop) {
@@ -1451,11 +1489,11 @@ TEST_F(ListFamilyTest, LMPopEdgeCases) {
 
   // Test with COUNT = 0 - should return error
   resp = Run({"lmpop", "1", "list", "LEFT", "COUNT", "0"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("list", RespArray(ElementsAre()))));
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
 
   // Test with negative COUNT - should return error
   resp = Run({"lmpop", "1", "list", "LEFT", "COUNT", "-1"});
-  EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
 }
 
 TEST_F(ListFamilyTest, LMPopDocExample) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -654,15 +654,10 @@ void IntervalVisitor::PopListPack(ZSetFamily::TopNScored sc) {
     Next(zl, &eptr, &sptr);
   }
 
-  int start = 0;
-  if (params_.reverse) {
-    /* If the number of elements to delete is greater than the listpack length,
-     * we set the start to 0 because lpseek fails to search beyond length in reverse */
-    start = (2 * sc > lpLength(zl)) ? 0 : -2 * sc;
-  }
-
-  /* We can finally delete the elements */
-  pv_->SetRObjPtr(lpDeleteRange(zl, start, 2 * sc));
+  /* Cap at the listpack length: 2 * sc overflows uint32 for sc >= 2^31. */
+  unsigned long del_count = std::min<uint64_t>(2 * uint64_t{sc}, lpLength(zl));
+  long start = params_.reverse ? -static_cast<long>(del_count) : 0;
+  pv_->SetRObjPtr(lpDeleteRange(zl, start, del_count));
 }
 
 void IntervalVisitor::PopSkipList(ZSetFamily::TopNScored sc) {
@@ -2442,8 +2437,12 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
   CmdArgParser::Range keys = parser.NextRange();  // numkeys + keys, handled by the key spec.
   bool is_max = parser.MapNext("MAX", true, "MIN", false);
 
-  int pop_count = 1;
-  parser.Check("COUNT", &pop_count);
+  int64_t count_arg = 1;
+  parser.Check("COUNT", &count_arg);
+  if (!parser.HasError() && (count_arg < 1 || count_arg > UINT32_MAX)) {
+    cmd_cntx->SendError(kCountNotGreaterThanZeroErr);
+    return;
+  }
 
   if (!parser.Finalize()) {
     cmd_cntx->SendError(parser.TakeError().MakeReply());
@@ -2537,6 +2536,7 @@ void ZMPopGeneric(CmdArgParser parser, CommandContext* cmd_cntx, bool is_blockin
   DCHECK(key_to_pop.has_value());
 
   // Pop elements from relevant set.
+  uint32_t pop_count = static_cast<uint32_t>(count_arg);
   OpResult<ScoredArray> pop_result =
       ZPopMinMaxInternal(*key_to_pop, FilterShards::YES, pop_count, is_max, cmd_cntx->tx());
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -926,9 +926,59 @@ TEST_F(ZSetFamilyTest, ZMPopInvalidSyntax) {
   resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "boo"});
   EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 
+  // Count is zero.
+  resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "0"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  // Count is negative.
+  resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "-1"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "-9223372036854775808"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  // Count above UINT32_MAX.
+  resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "4294967296"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "9223372036854775807"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  // Non-positive count errors even with trailing junk.
+  resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "0", "foo"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
   // Too many arguments.
   resp = Run({"zmpop", "1", "c", "MAX", "COUNT", "2", "foo"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
+TEST_F(ZSetFamilyTest, ZMPopCountZeroMulti) {
+  auto resp = Run({"multi"});
+  ASSERT_EQ(resp, "OK");
+
+  Run({"zmpop", "1", "a", "MIN", "COUNT", "0"});
+  resp = Run({"exec"});
+  EXPECT_THAT(resp, RespElementsAre(ErrArg("count should be greater than 0")));
+
+  // The connection stays usable after the error.
+  Run({"zadd", "a", "1", "a1"});
+  resp = Run({"zmpop", "1", "a", "MIN"});
+  EXPECT_THAT(resp, ContainsLabeledScoredArray("a", {{"a1", "1"}}));
+}
+
+TEST_F(ZSetFamilyTest, ZMPopCountLargerThanSet) {
+  Run({"zadd", "a", "1", "a1", "2", "a2", "3", "a3"});
+
+  // Count above int32 range must pop the whole set, not truncate.
+  auto resp = Run({"zmpop", "1", "a", "MIN", "COUNT", "2147483648"});
+  EXPECT_THAT(resp, ContainsLabeledScoredArray("a", {{"a1", "1"}, {"a2", "2"}, {"a3", "3"}}));
+  EXPECT_THAT(Run({"exists", "a"}), IntArg(0));
+
+  Run({"zadd", "b", "1", "b1", "2", "b2"});
+  resp = Run({"zmpop", "1", "b", "MIN", "COUNT", "4294967295"});
+  EXPECT_THAT(resp, ContainsLabeledScoredArray("b", {{"b1", "1"}, {"b2", "2"}}));
+  EXPECT_THAT(Run({"exists", "b"}), IntArg(0));
 }
 
 TEST_F(ZSetFamilyTest, ZMPop) {
@@ -1020,6 +1070,13 @@ TEST_F(ZSetFamilyTest, BZMPopInvalidSyntax) {
   // Count number is not uint.
   resp = Run({"bzmpop", "1", "1", "a", "MIN", "COUNT", "boo"});
   EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
+
+  // Non-positive count errors immediately, even with an infinite timeout.
+  resp = Run({"bzmpop", "0", "1", "a", "MIN", "COUNT", "0"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
+
+  resp = Run({"bzmpop", "0", "1", "a", "MIN", "COUNT", "-1"});
+  EXPECT_THAT(resp, ErrArg("count should be greater than 0"));
 
   // Too many arguments.
   resp = Run({"bzmpop", "1", "1", "c", "MAX", "COUNT", "2", "foo"});
@@ -1132,6 +1189,13 @@ TEST_F(ZSetFamilyTest, ZPopMin) {
 
   resp = Run({"zpopmin", "key", "1"});
   ASSERT_THAT(resp, ArrLen(0));
+
+  // Count >= 2^31 must delete the popped elements, not silently keep them.
+  Run({"zadd", "key2", "1", "a", "2", "b"});
+  resp = Run({"zpopmin", "key2", "2147483648"});
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "b", "2"));
+  EXPECT_THAT(Run({"exists", "key2"}), IntArg(0));
 }
 
 TEST_F(ZSetFamilyTest, ZPopMax) {
@@ -1159,6 +1223,13 @@ TEST_F(ZSetFamilyTest, ZPopMax) {
 
   resp = Run({"zpopmax", "key", "1"});
   ASSERT_THAT(resp, ArrLen(0));
+
+  // Count >= 2^31 must delete the popped elements, not silently keep them.
+  Run({"zadd", "key2", "1", "a", "2", "b"});
+  resp = Run({"zpopmax", "key2", "2147483648"});
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "2", "a", "1"));
+  EXPECT_THAT(Run({"exists", "key2"}), IntArg(0));
 }
 
 TEST_F(ZSetFamilyTest, ZAddPopCrash) {


### PR DESCRIPTION
Found while testing Dragonfly as a drop-in backend for the llm-d AI inference framework ([llm-d](https://github.com/llm-d/llm-d)): its batch gateway drives its priority queue and event channels through BZMPOP/ZMPOP/BLMPOP, and the compatibility audit surfaced non-standard COUNT handling in these commands.

Changes:
- ZMPOP/BZMPOP/LMPOP/BLMPOP now reject COUNT <= 0 with "count should be greater than 0". Previously, COUNT 0 replied [key, empty array], which stalls some client libraries for 10+ seconds, and ZMPOP COUNT -1 popped ALL members due to unsigned wrap.
- COUNT is parsed as int64 and clamped to uint32, so values above INT32_MAX work: ZMPOP COUNT 2147483648 no longer fails to parse, and LMPOP COUNT 4294967297 no longer silently truncates to 1.
- PopListPack: 2 * sc overflowed uint32 for sc >= 2^31, turning lpDeleteRange into a no-op: ZPOPMIN key 2147483648 returned elements in the reply but left them in the database. Reachable directly via ZPOPMIN/ZPOPMAX, independent of the parsing fix.
- Blocking variants error immediately instead of blocking on an invalid count; the error is also returned inside MULTI/EXEC without breaking the connection.

Tests: new invalid-count and large-count cases for all four commands plus ZPOPMIN; LMPopEdgeCases previously asserted the buggy replies and is updated.
