### PR TITLE
fix(server): guard policy-based eviction against full-sync snapshot race

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -219,40 +219,49 @@ unsigned PrimeEvictionPolicy::Evict(const PrimeTable::HotBuckets& eb, PrimeTable
   if (!can_evict_ || db_slice_->WillBlockOnJournalWrite())
     return 0;
 
-  // Disable flush journal changes to prevent preemtion in evict.
+  // Disable flush journal changes to prevent preemption in evict.
   journal::DisableFlushGuard journal_flush_guard(db_slice_->shard_owner()->journal());
 
   constexpr size_t kNumStashBuckets = ABSL_ARRAYSIZE(eb.probes.stash_buckets);
 
-  // choose "randomly" a stash bucket to evict an item.
-  auto bucket_it = eb.probes.stash_buckets[eb.key_hash % kNumStashBuckets];
-  auto last_slot_it = bucket_it;
-  last_slot_it += (PrimeTable::kSlotNum - 1);
-  if (!last_slot_it.is_done()) {
-    // don't evict sticky items
-    if (last_slot_it->first.IsSticky()) {
-      return 0;
+  DbTable* table = db_slice_->GetDBTable(cntx_.db_index);
+  auto& lt = table->trans_locks;
+  string scratch;
+
+  // Try each stash bucket in turn until we find one we can use (either its last slot is
+  // already empty, or we can safely evict it).  Trying all buckets prevents a spurious
+  // return-0 (and the resulting bad_alloc from DashTable::InsertInternal) when the
+  // hash-chosen bucket's last slot is sticky, locked, or temporarily unsafe due to an
+  // in-progress full-sync snapshot.
+  for (size_t i = 0; i < kNumStashBuckets; ++i) {
+    auto bucket_it = eb.probes.stash_buckets[(eb.key_hash + i) % kNumStashBuckets];
+    auto last_slot_it = bucket_it;
+    last_slot_it += (PrimeTable::kSlotNum - 1);
+
+    if (!last_slot_it.is_done()) {
+      // Last slot is occupied; we need to evict it to make room for the shift.
+      if (last_slot_it->first.IsSticky())
+        continue;
+      string_view key = last_slot_it->first.GetSlice(&scratch);
+      if (lt.Find(LockTag(key)).has_value())
+        continue;
+      // Skip if any snapshot consumer hasn't reached this bucket yet, or is mid-flight
+      // serializing a large value. Eviction bypasses CallChangeCallbacks (DisableFlushGuard
+      // disallows the blocking call), so without this guard the journal DEL can race ahead
+      // of the key's still-in-progress baseline on the replica, resurrecting it.
+      if (db_slice_->EvictWouldRaceWithSnapshot(last_slot_it.GetVersion()))
+        continue;
+
+      if (auto journal = db_slice_->shard_owner()->journal(); journal)
+        RecordExpiryBlocking(cntx_.db_index, key);
+      db_slice_->Del(cntx_, DbSlice::Iterator(last_slot_it, StringOrView::FromView(key)));
+      ++evicted_;
     }
-
-    DbTable* table = db_slice_->GetDBTable(cntx_.db_index);
-    auto& lt = table->trans_locks;
-    string scratch;
-    string_view key = last_slot_it->first.GetSlice(&scratch);
-    // do not evict locked keys
-    if (lt.Find(LockTag(key)).has_value())
-      return 0;
-
-    // log the evicted keys to journal.
-    if (auto journal = db_slice_->shard_owner()->journal(); journal) {
-      RecordExpiryBlocking(cntx_.db_index, key);
-    }
-    db_slice_->Del(cntx_, DbSlice::Iterator(last_slot_it, StringOrView::FromView(key)));
-
-    ++evicted_;
+    // Either the last slot was already empty, or we just evicted it; shift right into it.
+    me->ShiftRight(bucket_it);
+    return 1;
   }
-  me->ShiftRight(bucket_it);
-
-  return 1;
+  return 0;
 }
 
 class AsyncDeleter {
@@ -374,7 +383,7 @@ template <typename F> struct CallbackConsumer : public DbSlice::ChangeConsumerIn
 
 namespace {
 
-void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotStats::*stat,
+void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotStats::* stat,
                     string_view name, std::optional<unsigned> obj_type = std::nullopt) {
   if (delta == 0 || !db->slots_stats)
     return;
@@ -1560,6 +1569,19 @@ bool DbSlice::WillBlockOnJournalWrite() const {
   return ranges::any_of(change_cb_, &ChangeConsumerInterface::IsAnyBucketBlocked);
 }
 
+bool DbSlice::EvictWouldRaceWithSnapshot(uint64_t bucket_version) const {
+  // Safe to iterate change_cb_ without change_cb_latch_: every call site holds a
+  // DisableFlushGuard (which prevents fiber preemption on this shard thread), so
+  // RemoveChangeCallback cannot run concurrently and change_cb_ is stable.
+  for (auto* cb : change_cb_) {
+    if (!cb->is_snapshot_)
+      continue;
+    if (bucket_version < cb->snapshot_version_ || cb->IsAnyBucketBlocked())
+      return true;
+  }
+  return false;
+}
+
 void DbSlice::WaitForUnblockedJournalWrites() const {
   std::lock_guard lk{change_cb_latch_};
   while (WillBlockOnJournalWrite())
@@ -1712,6 +1734,17 @@ pair<uint64_t, size_t> DbSlice::FreeMemWithEvictionStepAtomic(DbIndex db_ind, co
         const auto& lt = db_table->trans_locks;
         string_view key = evict_it->first.GetSlice(&tmp);
         if (lt.Find(LockTag(key)).has_value())
+          continue;
+
+        // Eviction deletes the key without going through the CoW OnChange hook (it runs
+        // under FiberAtomicGuard, which disallows OnChange's blocking call), so a full-sync
+        // snapshot that hasn't serialized this key's bucket yet, or is currently mid-flight
+        // streaming a large value from an earlier bucket, won't get a chance to capture the
+        // key's baseline before the eviction's journal DEL reaches the wire. The DEL can then
+        // race ahead of the bucket's still-in-progress baseline, so the replica applies it as
+        // a no-op and later resurrects the key once the baseline finishes loading. Skip such
+        // keys here; they remain eligible for eviction once no snapshot is in this state.
+        if (EvictWouldRaceWithSnapshot(evict_it.GetVersion()))
           continue;
 
         if (record_keys)

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -114,6 +114,13 @@ class DbSlice {
 
     bool eventually_consistent_ = false;
     uint64_t snapshot_version_ = 0;
+
+    // True for consumers that stream a point-in-time baseline to a remote target (full sync,
+    // migration), where a bucket not yet reached by snapshot_version_ still needs its old state
+    // captured before mutation. False for consumers like FlushSlots' CallbackConsumer, which
+    // register on_change purely to react to concurrent mutations during their own traversal and
+    // are not affected by this ordering requirement.
+    bool is_snapshot_ = false;
   };
 
   // Auto-laundering iterator wrapper. Laundering means re-finding keys if they moved between
@@ -537,6 +544,14 @@ class DbSlice {
   void SetExpiredEventsRecording(bool enable) {
     expired_keys_events_recording_ = enable;
   }
+
+  // Returns true if any registered snapshot consumer has not yet visited the bucket at
+  // `bucket_version`, or is currently mid-flight serializing a large value from an earlier bucket.
+  // In either state, evicting a key from that bucket without going through CallChangeCallbacks
+  // can produce a journal DEL that races ahead of the key's still-in-progress baseline on the
+  // replica wire, resurrecting a key the master no longer holds.
+  // Safe to call under FiberAtomicGuard (no fiber yields).
+  bool EvictWouldRaceWithSnapshot(uint64_t bucket_version) const;
 
   // Returns true if any registered snapshot is blocked on bucket serialiazion (big value, delayed)
   // and thus might reject the journal change

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -161,6 +161,7 @@ void SerializerBase::SerializeFetchedEntry(const TieredDelayedEntry& tde, const 
 //   emitting large values.
 void SerializerBase::RegisterChangeListener(bool replication) {
   db_array_ = db_slice_->databases();  // copy pointers to survive flush
+  is_snapshot_ = true;
   db_slice_->RegisterOnChange(this);
   eventually_consistent_ = replication;
 }


### PR DESCRIPTION
## Problem

Issue #8128: eviction can delete a key mid-full-sync before its baseline is captured, causing the replica to retain keys the master already evicted.

**The race (large values only):**

1. Full-sync snapshot serializes large key K — value spans multiple wire chunks.
2. Between chunks the "bucket blocked" flag is released momentarily.
3. An eviction fiber runs, sees no blocked bucket, calls `DbSlice::Del()` for K — bypassing `CallChangeCallbacks()` (which is disallowed under `DisableFlushGuard`).
4. The journal `DEL` lands on the wire _before_ the remaining baseline chunks of K.
5. On the replica: `DEL` is a no-op (K not yet loaded). Remaining chunks arrive → K is resurrected. Keyspace diverges.

Two call sites share this gap:
- **Path 1** — `DbSlice::FreeMemWithEvictionStepAtomic` (heartbeat-driven)
- **Path 2** — `PrimeEvictionPolicy::Evict` (inline during DashTable inserts, triggered when `CanGrow()` returns false)

PR #8109 addresses Path 1. This PR covers both paths with the same approach.

## Fix

Add `DbSlice::EvictWouldRaceWithSnapshot(uint64_t bucket_version)` — a non-blocking helper that returns `true` if any full-sync snapshot consumer:
- has not yet visited the bucket at `bucket_version` (`bucket_version < cb->snapshot_version_`), or
- is currently mid-flight serializing a large value (`cb->IsAnyBucketBlocked()`).

**Safety note:** both call sites hold a `DisableFlushGuard` (which prevents fiber preemption on the shard thread), so `change_cb_` cannot be modified concurrently. No `change_cb_latch_` acquisition is needed in `EvictWouldRaceWithSnapshot`; the invariant is documented in the implementation.

Both eviction paths call this check after the lock guard and skip the candidate key if it returns true. Skipped keys remain eligible for eviction on the next heartbeat tick or DashTable insert attempt.

**Path 2 OOM fix:** `PrimeEvictionPolicy::Evict` previously picked a single stash bucket and returned `0` if that slot was sticky, locked, or racing with a snapshot. `DashTable::InsertInternal` treats `0` as eviction failure and throws `bad_alloc` when `CanGrow()` is also false. The fix: try **all `kNumStashBuckets`** stash buckets in sequence and return `0` only when every candidate is unavailable, which restores the pre-fix OOM probability.

The `is_snapshot_` flag on `ChangeConsumerInterface` distinguishes snapshot consumers (where baseline-before-journal ordering is required) from other consumers like `FlushSlots::CallbackConsumer`.

## Changes

| File | Summary |
|------|---------|
| `src/server/db_slice.h` | Add `is_snapshot_ = false` to `ChangeConsumerInterface`; declare `EvictWouldRaceWithSnapshot` |
| `src/server/db_slice.cc` | Implement `EvictWouldRaceWithSnapshot` (with safety comment re: latch); guard `FreeMemWithEvictionStepAtomic`; refactor `Evict` to try all stash buckets |
| `src/server/serializer_base.cc` | Set `is_snapshot_ = true` in `RegisterChangeListener` |

## Test plan

- [x] `ninja db_slice_test && ./db_slice_test` — existing eviction tests pass
- [x] `ninja replication_test && ./replication_test --gtest_filter=*Eviction*` — replication eviction tests pass

Fixes #8128
Related: #8109