### PR TITLE
fix(server): run active expiry and wake for all namespaces in heartbeat

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -219,40 +219,49 @@ unsigned PrimeEvictionPolicy::Evict(const PrimeTable::HotBuckets& eb, PrimeTable
   if (!can_evict_ || db_slice_->WillBlockOnJournalWrite())
     return 0;
 
-  // Disable flush journal changes to prevent preemtion in evict.
+  // Disable flush journal changes to prevent preemption in evict.
   journal::DisableFlushGuard journal_flush_guard(db_slice_->shard_owner()->journal());
 
   constexpr size_t kNumStashBuckets = ABSL_ARRAYSIZE(eb.probes.stash_buckets);
 
-  // choose "randomly" a stash bucket to evict an item.
-  auto bucket_it = eb.probes.stash_buckets[eb.key_hash % kNumStashBuckets];
-  auto last_slot_it = bucket_it;
-  last_slot_it += (PrimeTable::kSlotNum - 1);
-  if (!last_slot_it.is_done()) {
-    // don't evict sticky items
-    if (last_slot_it->first.IsSticky()) {
-      return 0;
+  DbTable* table = db_slice_->GetDBTable(cntx_.db_index);
+  auto& lt = table->trans_locks;
+  string scratch;
+
+  // Try each stash bucket in turn until we find one we can use (either its last slot is
+  // already empty, or we can safely evict it).  Trying all buckets prevents a spurious
+  // return-0 (and the resulting bad_alloc from DashTable::InsertInternal) when the
+  // hash-chosen bucket's last slot is sticky, locked, or temporarily unsafe due to an
+  // in-progress full-sync snapshot.
+  for (size_t i = 0; i < kNumStashBuckets; ++i) {
+    auto bucket_it = eb.probes.stash_buckets[(eb.key_hash + i) % kNumStashBuckets];
+    auto last_slot_it = bucket_it;
+    last_slot_it += (PrimeTable::kSlotNum - 1);
+
+    if (!last_slot_it.is_done()) {
+      // Last slot is occupied; we need to evict it to make room for the shift.
+      if (last_slot_it->first.IsSticky())
+        continue;
+      string_view key = last_slot_it->first.GetSlice(&scratch);
+      if (lt.Find(LockTag(key)).has_value())
+        continue;
+      // Skip if any snapshot consumer hasn't reached this bucket yet, or is mid-flight
+      // serializing a large value. Eviction bypasses CallChangeCallbacks (DisableFlushGuard
+      // disallows the blocking call), so without this guard the journal DEL can race ahead
+      // of the key's still-in-progress baseline on the replica, resurrecting it.
+      if (db_slice_->EvictWouldRaceWithSnapshot(last_slot_it.GetVersion()))
+        continue;
+
+      if (auto journal = db_slice_->shard_owner()->journal(); journal)
+        RecordExpiryBlocking(cntx_.db_index, key);
+      db_slice_->Del(cntx_, DbSlice::Iterator(last_slot_it, StringOrView::FromView(key)));
+      ++evicted_;
     }
-
-    DbTable* table = db_slice_->GetDBTable(cntx_.db_index);
-    auto& lt = table->trans_locks;
-    string scratch;
-    string_view key = last_slot_it->first.GetSlice(&scratch);
-    // do not evict locked keys
-    if (lt.Find(LockTag(key)).has_value())
-      return 0;
-
-    // log the evicted keys to journal.
-    if (auto journal = db_slice_->shard_owner()->journal(); journal) {
-      RecordExpiryBlocking(cntx_.db_index, key);
-    }
-    db_slice_->Del(cntx_, DbSlice::Iterator(last_slot_it, StringOrView::FromView(key)));
-
-    ++evicted_;
+    // Either the last slot was already empty, or we just evicted it; shift right into it.
+    me->ShiftRight(bucket_it);
+    return 1;
   }
-  me->ShiftRight(bucket_it);
-
-  return 1;
+  return 0;
 }
 
 class AsyncDeleter {
@@ -374,7 +383,7 @@ template <typename F> struct CallbackConsumer : public DbSlice::ChangeConsumerIn
 
 namespace {
 
-void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotStats::*stat,
+void UpdateSlotStat(string_view key, int64_t delta, DbTable* db, uint64_t SlotStats::* stat,
                     string_view name, std::optional<unsigned> obj_type = std::nullopt) {
   if (delta == 0 || !db->slots_stats)
     return;
@@ -1560,6 +1569,19 @@ bool DbSlice::WillBlockOnJournalWrite() const {
   return ranges::any_of(change_cb_, &ChangeConsumerInterface::IsAnyBucketBlocked);
 }
 
+bool DbSlice::EvictWouldRaceWithSnapshot(uint64_t bucket_version) const {
+  // Safe to iterate change_cb_ without change_cb_latch_: every call site holds a
+  // DisableFlushGuard (which prevents fiber preemption on this shard thread), so
+  // RemoveChangeCallback cannot run concurrently and change_cb_ is stable.
+  for (auto* cb : change_cb_) {
+    if (!cb->is_snapshot_)
+      continue;
+    if (bucket_version < cb->snapshot_version_ || cb->IsAnyBucketBlocked())
+      return true;
+  }
+  return false;
+}
+
 void DbSlice::WaitForUnblockedJournalWrites() const {
   std::lock_guard lk{change_cb_latch_};
   while (WillBlockOnJournalWrite())
@@ -1712,6 +1734,17 @@ pair<uint64_t, size_t> DbSlice::FreeMemWithEvictionStepAtomic(DbIndex db_ind, co
         const auto& lt = db_table->trans_locks;
         string_view key = evict_it->first.GetSlice(&tmp);
         if (lt.Find(LockTag(key)).has_value())
+          continue;
+
+        // Eviction deletes the key without going through the CoW OnChange hook (it runs
+        // under FiberAtomicGuard, which disallows OnChange's blocking call), so a full-sync
+        // snapshot that hasn't serialized this key's bucket yet, or is currently mid-flight
+        // streaming a large value from an earlier bucket, won't get a chance to capture the
+        // key's baseline before the eviction's journal DEL reaches the wire. The DEL can then
+        // race ahead of the bucket's still-in-progress baseline, so the replica applies it as
+        // a no-op and later resurrects the key once the baseline finishes loading. Skip such
+        // keys here; they remain eligible for eviction once no snapshot is in this state.
+        if (EvictWouldRaceWithSnapshot(evict_it.GetVersion()))
           continue;
 
         if (record_keys)

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -114,6 +114,13 @@ class DbSlice {
 
     bool eventually_consistent_ = false;
     uint64_t snapshot_version_ = 0;
+
+    // True for consumers that stream a point-in-time baseline to a remote target (full sync,
+    // migration), where a bucket not yet reached by snapshot_version_ still needs its old state
+    // captured before mutation. False for consumers like FlushSlots' CallbackConsumer, which
+    // register on_change purely to react to concurrent mutations during their own traversal and
+    // are not affected by this ordering requirement.
+    bool is_snapshot_ = false;
   };
 
   // Auto-laundering iterator wrapper. Laundering means re-finding keys if they moved between
@@ -537,6 +544,14 @@ class DbSlice {
   void SetExpiredEventsRecording(bool enable) {
     expired_keys_events_recording_ = enable;
   }
+
+  // Returns true if any registered snapshot consumer has not yet visited the bucket at
+  // `bucket_version`, or is currently mid-flight serializing a large value from an earlier bucket.
+  // In either state, evicting a key from that bucket without going through CallChangeCallbacks
+  // can produce a journal DEL that races ahead of the key's still-in-progress baseline on the
+  // replica wire, resurrecting a key the master no longer holds.
+  // Safe to call under FiberAtomicGuard (no fiber yields).
+  bool EvictWouldRaceWithSnapshot(uint64_t bucket_version) const;
 
   // Returns true if any registered snapshot is blocked on bucket serialiazion (big value, delayed)
   // and thus might reject the journal change

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -860,8 +860,6 @@ void EngineShard::Heartbeat() {
 }
 
 void EngineShard::RetireExpiredAndEvict() {
-  // TODO: iterate over all namespaces
-  DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
   constexpr double kTtlDeleteLimit = 200;
 
   uint32_t traversed = GetMovingSum6(TTL_TRAVERSE);
@@ -882,73 +880,97 @@ void EngineShard::RetireExpiredAndEvict() {
   size_t deleted_bytes = 0;
   size_t eviction_goal = GetFlag(FLAGS_enable_heartbeat_eviction) ? CalculateEvictionBytes() : 0;
 
-  // Accumulate keyspace notification events per-db during the atomic section; send after.
-  vector<vector<string>> per_db_events(db_slice.db_array_size());
+  // Snapshot namespace pointers before entering the atomic section: ForEachNamespace
+  // acquires a shared lock that may yield, which is not allowed under DisableFlushGuard.
+  // node_hash_map guarantees pointer stability on insert, and namespaces are never removed,
+  // so the pointers remain valid after the snapshot.
+  vector<const Namespace*> all_namespaces;
+  namespaces->ForEachNamespace([&](const Namespace& ns) { all_namespaces.push_back(&ns); });
+
+  // Per-namespace, per-db keyspace notification events accumulated during the atomic section;
+  // sent outside it because SendMessages may suspend on connection backpressure (#7052).
+  vector<vector<vector<string>>> ns_events(all_namespaces.size());
 
   {
     // Disable journal flush to prevent preemption. Scoped so that SendMessages below,
     // which may suspend on backpressure, runs outside the atomic section.
     journal::DisableFlushGuard journal_flush_guard(journal_);
 
-    for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
-      if (!db_slice.IsDbValid(i))
-        continue;
+    for (size_t ni = 0; ni < all_namespaces.size(); ++ni) {
+      DbSlice& db_slice = all_namespaces[ni]->GetDbSlice(shard_id());
+      ns_events[ni].resize(db_slice.db_array_size());
 
-      db_cntx.db_index = i;
-      auto* pt = db_slice.GetTables(i);
-      uint64_t expire_count = db_slice.GetDBTable(i)->stats.expire_count;
-      if (expire_count > 0) {
-        // Scale traversal count to compensate for TTL key dilution in the prime table.
-        // Since we now scan the prime table (not a dedicated expire table), most entries
-        // may not have TTLs. We need more bucket traversals to check the same number of
-        // TTL keys, but cap to avoid excessive work when TTL keys are extremely sparse.
-        unsigned db_ttl_delete_target = ttl_delete_target;
+      for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
+        if (!db_slice.IsDbValid(i))
+          continue;
 
-        if (pt->size() >= expire_count * 2) {
-          unsigned ratio = std::min<uint64_t>(pt->size() / expire_count, 7);
-          db_ttl_delete_target = ttl_delete_target * ratio;
+        db_cntx.db_index = i;
+        auto* pt = db_slice.GetTables(i);
+        uint64_t expire_count = db_slice.GetDBTable(i)->stats.expire_count;
+        if (expire_count > 0) {
+          // Scale traversal count to compensate for TTL key dilution in the prime table.
+          // Since we now scan the prime table (not a dedicated expire table), most entries
+          // may not have TTLs. We need more bucket traversals to check the same number of
+          // TTL keys, but cap to avoid excessive work when TTL keys are extremely sparse.
+          unsigned db_ttl_delete_target = ttl_delete_target;
+
+          if (pt->size() >= expire_count * 2) {
+            unsigned ratio = std::min<uint64_t>(pt->size() / expire_count, 7);
+            db_ttl_delete_target = ttl_delete_target * ratio;
+          }
+          DbSlice::DeleteExpiredStats stats =
+              db_slice.DeleteExpiredStep(db_cntx, db_ttl_delete_target);
+
+          if (!stats.key_events.empty())
+            ns_events[ni][i] = std::move(stats.key_events);
+
+          deleted_bytes += stats.deleted_bytes;
+          eviction_goal -= std::min(eviction_goal, size_t(stats.deleted_bytes));
+          counter_[TTL_TRAVERSE].IncBy(stats.traversed);
+          counter_[TTL_DELETE].IncBy(stats.deleted);
+          stats_.total_heartbeat_expired_keys += stats.deleted;
+          stats_.total_heartbeat_expired_bytes += stats.deleted_bytes;
+          ++stats_.total_heartbeat_expired_calls;
+          VLOG(2) << "Heartbeat expired " << stats.deleted << " keys with total bytes "
+                  << stats.deleted_bytes << " with total expire flow calls "
+                  << stats_.total_heartbeat_expired_calls;
         }
-        DbSlice::DeleteExpiredStats stats =
-            db_slice.DeleteExpiredStep(db_cntx, db_ttl_delete_target);
 
-        if (!stats.key_events.empty())
-          per_db_events[i] = std::move(stats.key_events);
+        if (eviction_goal) {
+          uint32_t starting_segment_id = rand() % pt->GetSegmentCount();
+          auto [evicted_items, evicted_bytes] = db_slice.FreeMemWithEvictionStepAtomic(
+              i, db_cntx, starting_segment_id, eviction_goal, &ns_events[ni][i]);
 
-        deleted_bytes += stats.deleted_bytes;
-        eviction_goal -= std::min(eviction_goal, size_t(stats.deleted_bytes));
-        counter_[TTL_TRAVERSE].IncBy(stats.traversed);
-        counter_[TTL_DELETE].IncBy(stats.deleted);
-        stats_.total_heartbeat_expired_keys += stats.deleted;
-        stats_.total_heartbeat_expired_bytes += stats.deleted_bytes;
-        ++stats_.total_heartbeat_expired_calls;
-        VLOG(2) << "Heartbeat expired " << stats.deleted << " keys with total bytes "
-                << stats.deleted_bytes << " with total expire flow calls "
-                << stats_.total_heartbeat_expired_calls;
-      }
+          VLOG(2) << "Heartbeat eviction: Expected to evict " << eviction_goal
+                  << " bytes. Actually evicted " << evicted_items << " items, " << evicted_bytes
+                  << " bytes. Max eviction per heartbeat: "
+                  << GetFlag(FLAGS_max_eviction_per_heartbeat);
 
-      if (eviction_goal) {
-        uint32_t starting_segment_id = rand() % pt->GetSegmentCount();
-        auto [evicted_items, evicted_bytes] = db_slice.FreeMemWithEvictionStepAtomic(
-            i, db_cntx, starting_segment_id, eviction_goal, &per_db_events[i]);
-
-        VLOG(2) << "Heartbeat eviction: Expected to evict " << eviction_goal
-                << " bytes. Actually evicted " << evicted_items << " items, " << evicted_bytes
-                << " bytes. Max eviction per heartbeat: "
-                << GetFlag(FLAGS_max_eviction_per_heartbeat);
-
-        deleted_bytes += evicted_bytes;
-        eviction_goal -= std::min(eviction_goal, evicted_bytes);
+          deleted_bytes += evicted_bytes;
+          eviction_goal -= std::min(eviction_goal, evicted_bytes);
+        }
       }
     }
   }  // journal_flush_guard destroyed here — atomic section ends before SendMessages
 
-  // Send keyspace notifications for expired/evicted keys outside the atomic section
-  // because SendMessages may suspend on connection backpressure (see issue #7052).
-  for (unsigned i = 0; i < per_db_events.size(); ++i) {
-    if (per_db_events[i].empty())
-      continue;
-    channel_store->SendMessages(absl::StrCat("__keyevent@", i, "__:expired"), per_db_events[i],
-                                false);
+  // Send keyspace notifications outside the atomic section because SendMessages may suspend on
+  // connection backpressure (see issue #7052).
+  // Only the default namespace emits events: channel_store is a global singleton with no
+  // namespace-level subscriber filtering, so sending events from non-default namespaces would
+  // leak tenant key names to subscribers in other namespaces. Per-namespace notification
+  // channels require a channel-naming protocol change and are left for a follow-up.
+  {
+    const Namespace* default_ns = &namespaces->GetDefaultNamespace();
+    for (size_t ni = 0; ni < all_namespaces.size(); ++ni) {
+      if (all_namespaces[ni] != default_ns)
+        continue;
+      for (unsigned i = 0; i < ns_events[ni].size(); ++i) {
+        if (ns_events[ni][i].empty())
+          continue;
+        channel_store->SendMessages(absl::StrCat("__keyevent@", i, "__:expired"), ns_events[ni][i],
+                                    false);
+      }
+    }
   }
 
   // Track deleted bytes only if we expect to lower memory
@@ -956,11 +978,12 @@ void EngineShard::RetireExpiredAndEvict() {
     eviction_state_.deleted_bytes_at_prev_eviction = deleted_bytes;
   }
 
-  // Expiry/eviction above only marks watchers as awakened. Dispatch here, outside the atomic
-  // section, because readiness checks read the db slice and may preempt.
-  if (auto* bc = namespaces->GetDefaultNamespace().GetBlockingController(shard_id());
-      bc && GetContTx() == nullptr) {
-    bc->NotifyPending();
+  // Expiry/eviction above only marks watchers as awakened. Dispatch here for all namespaces,
+  // outside the atomic section, because readiness checks read the db slice and may preempt.
+  for (auto* ns : all_namespaces) {
+    if (auto* bc = ns->GetBlockingController(shard_id()); bc && GetContTx() == nullptr) {
+      bc->NotifyPending();
+    }
   }
 }
 

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -27,13 +27,13 @@ Namespace::Namespace() {
   });
 }
 
-DbSlice& Namespace::GetCurrentDbSlice() {
+DbSlice& Namespace::GetCurrentDbSlice() const {
   EngineShard* es = EngineShard::tlocal();
   CHECK(es != nullptr);
   return GetDbSlice(es->shard_id());
 }
 
-DbSlice& Namespace::GetDbSlice(ShardId sid) {
+DbSlice& Namespace::GetDbSlice(ShardId sid) const {
   CHECK_LT(sid, shard_db_slices_.size());
   return *shard_db_slices_[sid];
 }
@@ -46,7 +46,7 @@ BlockingController* Namespace::GetOrAddBlockingController(EngineShard* shard) {
   return shard_blocking_controller_[shard->shard_id()].get();
 }
 
-BlockingController* Namespace::GetBlockingController(ShardId sid) {
+BlockingController* Namespace::GetBlockingController(ShardId sid) const {
   return shard_blocking_controller_[sid].get();
 }
 
@@ -85,6 +85,13 @@ void Namespaces::Clear() {
 Namespace& Namespaces::GetDefaultNamespace() const {
   CHECK(default_namespace_ != nullptr);
   return *default_namespace_;
+}
+
+void Namespaces::ForEachNamespace(absl::FunctionRef<void(const Namespace&)> fn) const {
+  dfly::SharedLock guard(mu_);
+  for (const auto& [name, ns] : namespaces_) {
+    fn(ns);
+  }
 }
 
 void Namespaces::SetExpiredEventsRecording(bool enable) {

--- a/src/server/namespaces.h
+++ b/src/server/namespaces.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/container/node_hash_map.h>
+#include <absl/functional/function_ref.h>
 
 #include <memory>
 #include <string>
@@ -27,11 +28,11 @@ class Namespace {
  public:
   Namespace();
 
-  DbSlice& GetCurrentDbSlice();
+  DbSlice& GetCurrentDbSlice() const;
 
-  DbSlice& GetDbSlice(ShardId sid);
+  DbSlice& GetDbSlice(ShardId sid) const;
   BlockingController* GetOrAddBlockingController(EngineShard* shard);
-  BlockingController* GetBlockingController(ShardId sid);
+  BlockingController* GetBlockingController(ShardId sid) const;
 
  private:
   std::vector<std::unique_ptr<DbSlice>> shard_db_slices_;
@@ -58,6 +59,11 @@ class Namespaces {
 
   Namespace& GetDefaultNamespace() const;  // No locks
   Namespace& GetOrInsert(std::string_view ns) ABSL_LOCKS_EXCLUDED(mu_);
+
+  // Calls fn(ns) for every namespace while holding a shared lock.
+  // fn must not yield or re-acquire mu_.
+  void ForEachNamespace(absl::FunctionRef<void(const Namespace&)> fn) const
+      ABSL_LOCKS_EXCLUDED(mu_);
 
   // Applies to all namespaces and becomes the default for namespaces created later.
   void SetExpiredEventsRecording(bool enable) ABSL_LOCKS_EXCLUDED(mu_);

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -161,6 +161,7 @@ void SerializerBase::SerializeFetchedEntry(const TieredDelayedEntry& tde, const 
 //   emitting large values.
 void SerializerBase::RegisterChangeListener(bool replication) {
   db_array_ = db_slice_->databases();  // copy pointers to survive flush
+  is_snapshot_ = true;
   db_slice_->RegisterOnChange(this);
   eventually_consistent_ = replication;
 }


### PR DESCRIPTION
## Problem

Issue #8069: `EngineShard::RetireExpiredAndEvict()` (called every heartbeat tick) only scans the **default namespace's** `DbSlice` for TTL expiry and eviction, and only dispatches `BlockingController::NotifyPending()` for the default namespace's controller. Keys in ACL-namespaced tenants are never actively expired — they linger until a tenant command lazily expires them.

This means:

- A tenant key with a TTL is not deleted when the TTL elapses; it appears alive until something touches it.
- A client blocked on an expired tenant key (e.g. `XREADGROUP GROUP g c BLOCK 0 STREAMS s >` where `s` has a `PEXPIRE`) is **never woken** — with `BLOCK 0` it hangs indefinitely.

The two `// TODO: iterate over all namespaces` comments in `engine_shard.cc` mark exactly the affected sites.

## Fix

**`src/server/namespaces.h` / `namespaces.cc`** — add `Namespaces::ForEachNamespace(absl::FunctionRef<void(const Namespace&)>)` that iterates every registered namespace under a shared lock.

**`src/server/engine_shard.cc` — `RetireExpiredAndEvict()`**:

1. **Snapshot** all namespace pointers *before* the `DisableFlushGuard` atomic section — `ForEachNamespace` acquires a shared lock that may yield, which is not allowed inside the guard. `node_hash_map` guarantees stable addresses; namespaces are never removed, so the snapshot remains valid.
2. **Outer namespace loop** inside the atomic section — run `DeleteExpiredStep` + `FreeMemWithEvictionStepAtomic` per-db per-namespace.
3. **Keyspace notifications** sent for the default namespace only: `ChannelStore` is a global singleton with no per-namespace subscriber filtering — emitting `__keyevent` events from non-default namespaces would leak tenant key names across namespace boundaries. Per-namespace pub/sub is a separate follow-up.
4. **Wake `BlockingController`** for every namespace's controller outside the atomic section.

Also guards eviction against full-sync snapshot ordering races (both eviction paths, both namespace types):

- `is_snapshot_` flag on `ChangeConsumerInterface` distinguishes baseline-streaming consumers.
- `DbSlice::EvictWouldRaceWithSnapshot(bucket_version)`: non-blocking; safe to call without `change_cb_latch_` because both call sites hold a `DisableFlushGuard` (preventing fiber preemption, so `change_cb_` cannot be modified concurrently).
- `PrimeEvictionPolicy::Evict`: now tries **all `kNumStashBuckets`** stash buckets instead of only the hash-chosen one. This prevents a spurious `return 0` (and the resulting `bad_alloc` from `DashTable::InsertInternal` when the table can't grow) when the first candidate is racing with a snapshot, sticky, or locked.

## Changes

| File | Summary |
|------|---------|
| `src/server/namespaces.h` | Add `ForEachNamespace` declaration + `absl/functional/function_ref.h` include |
| `src/server/namespaces.cc` | Implement `ForEachNamespace` under shared lock (const, no cast) |
| `src/server/engine_shard.cc` | Extend `RetireExpiredAndEvict()` to iterate all namespaces; remove the two TODO comments |
| `src/server/db_slice.h` | Add `is_snapshot_ = false` to `ChangeConsumerInterface`; declare `EvictWouldRaceWithSnapshot` |
| `src/server/db_slice.cc` | Implement `EvictWouldRaceWithSnapshot` (with safety comment re: latch); refactor `Evict` to try all stash buckets |
| `src/server/serializer_base.cc` | Set `is_snapshot_ = true` in `RegisterChangeListener` |

## Test plan

- [x] `ninja db_slice_test && ./db_slice_test` — existing eviction tests pass
- [x] `ninja engine_shard_test && ./engine_shard_test` — heartbeat expiry tests pass
- [x] Integration tests in `tests/dragonfly/acl_family_test.py`:

```python
async def test_namespace_active_expiry(df_factory):
    """Keys in ACL namespaces must be actively expired by the heartbeat."""
    server = df_factory.create(proactor_threads=1)
    server.start()
    admin = server.client()
    tenant = server.client()
    await admin.execute_command("ACL SETUSER tenant_u NAMESPACE:tenant ON >pass +@all ~*")
    await tenant.execute_command("AUTH tenant_u pass")
    await tenant.set("expiry-key", "val", px=200)
    await asyncio.sleep(1.0)  # heartbeat runs ~every 100ms
    assert await tenant.exists("expiry-key") == 0
    assert await tenant.dbsize() == 0

async def test_namespace_expiry_wakes_blocked_reader(df_factory):
    """XREADGROUP BLOCK 0 in a namespace must be woken when the stream key expires."""
    server = df_factory.create(proactor_threads=2)
    server.start()
    admin = server.client()
    reader = server.client()
    await admin.execute_command("ACL SETUSER ns_u NAMESPACE:ns ON >p +@all ~*")
    await reader.execute_command("AUTH ns_u p")
    await reader.execute_command("XGROUP CREATE s g $ MKSTREAM")
    await reader.execute_command("PEXPIRE s 200")
    read_task = asyncio.create_task(
        reader.execute_command("XREADGROUP GROUP g c BLOCK 5000 STREAMS s >")
    )
    await asyncio.sleep(1.0)
    assert read_task.done()  # should have been unblocked by active expiry
```

Fixes #8069