### PR TITLE
fix(tests): use FLUSHALL SYNC in test_rss_oom_ratio to stop RSS-drop …

### DIFF
--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -170,11 +170,7 @@ async def test_rss_oom_ratio(df_factory: DflyInstanceFactory, admin_port):
         with pytest.raises(redis.exceptions.ConnectionError):
             await client.ping()
 
-    # flush to free memory. Plain flushall() (and even flushall(asynchronous=False) in redis-py)
-    # only sends "FLUSHALL" without the SYNC keyword, which Dragonfly runs asynchronously and
-    # detaches the decommit fibers (see ServerFamily::Drakarys) -- RSS then drops on its own
-    # schedule and can race the rss_compare(False) timeout below under CI load. FLUSHALL SYNC
-    # blocks until the decommit finishes, matching the pattern used by test_rss_used_mem_gap above.
+    # Wait for decommit
     await new_client.execute_command("FLUSHALL", "SYNC")
 
     await rss_compare(False)

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -170,8 +170,12 @@ async def test_rss_oom_ratio(df_factory: DflyInstanceFactory, admin_port):
         with pytest.raises(redis.exceptions.ConnectionError):
             await client.ping()
 
-    # flush to free memory
-    await new_client.flushall()
+    # flush to free memory. Plain flushall() (and even flushall(asynchronous=False) in redis-py)
+    # only sends "FLUSHALL" without the SYNC keyword, which Dragonfly runs asynchronously and
+    # detaches the decommit fibers (see ServerFamily::Drakarys) -- RSS then drops on its own
+    # schedule and can race the rss_compare(False) timeout below under CI load. FLUSHALL SYNC
+    # blocks until the decommit finishes, matching the pattern used by test_rss_used_mem_gap above.
+    await new_client.execute_command("FLUSHALL", "SYNC")
 
     await rss_compare(False)
     await asyncio.sleep(0.5)  # Wait for another RSS heartbeat update in Dragonfly


### PR DESCRIPTION
Fixes flaky test_rss_oom_ratio (#7690).

new_client.flushall() sends a bare FLUSHALL command, which Dragonfly
runs asynchronously (decommit fibers are detached, see
ServerFamily::Drakarys in src/server/server_family.cc). The test's
next check (rss_compare(False)) only allowed 5 seconds for RSS to drop
below the threshold, but stress-testing shows decommit of ~270MB can take
8-10 seconds. This exact gotcha is already documented in a comment on the
neighboring test_rss_used_mem_gap test in the same file, which correctly
uses FLUSHALL SYNC -- test_rss_oom_ratio just missed it.

## Test plan
- [x] pytest tests/dragonfly/memory_test.py -k test_rss_oom_ratio -v -- 2/2 passed
- [x] Same test looped 10x per parametrization (--count=10) -- 20/20 passed,
      with several runs showing 8-10s decommit times that would have failed
      the old 5s timeout, confirming the fix addresses the actual race

issue:
#7690