### PR TITLE
fix(traffic): preserve V2 parse-time logging (fixes #8120)

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -283,6 +283,8 @@ struct TrafficLogger {
   // matching `listener_type_` produce records; others are skipped on the hot path.
   // Set once when the file is opened, cleared in ResetLocked().
   Connection::ListenerType listener_type = Connection::ListenerType::MAIN_RESP;
+  // Commands parsed before this cycle do not belong to the current recording.
+  uint64_t start_logging_cycle = 0;
 
   void ResetLocked();
   // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -296,6 +298,7 @@ void TrafficLogger::ResetLocked() {
     log_file.reset();
   }
   listener_type = Connection::ListenerType::MAIN_RESP;
+  start_logging_cycle = 0;
 }
 
 // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -330,7 +333,8 @@ thread_local uint32 pipeline_wait_batch_usec = absl::GetFlag(FLAGS_pipeline_wait
 // we fail to open a file). `listener_type` is only committed after the file is
 // successfully opened so the logger's state stays consistent on failure.
 Connection::StartTrafficResult OpenTrafficLogger(string_view base_path,
-                                                 Connection::ListenerType listener_type) {
+                                                 Connection::ListenerType listener_type,
+                                                 uint64_t start_logging_cycle) {
   using Res = Connection::StartTrafficResult;
   unique_lock lk{tl_traffic_logger.mutex};
   if (tl_traffic_logger.log_file)
@@ -345,6 +349,8 @@ Connection::StartTrafficResult OpenTrafficLogger(string_view base_path,
     LOG(ERROR) << "Error opening a file " << path << " for traffic logging: " << file.error();
     return Res::kOpenFailed;
   }
+  // Publish the common parser-time boundary before exposing an active logger.
+  tl_traffic_logger.start_logging_cycle = start_logging_cycle;
   tl_traffic_logger.log_file = unique_ptr<io::WriteFile>{file.value()};
   tl_traffic_logger.listener_type = listener_type;
 #else
@@ -2727,8 +2733,9 @@ void Connection::RequestAsyncMigration(util::fb2::ProactorBase* dest, bool force
 }
 
 Connection::StartTrafficResult Connection::StartTrafficLogging(string_view path,
-                                                               ListenerType listener_type) {
-  return OpenTrafficLogger(path, listener_type);
+                                                               ListenerType listener_type,
+                                                               uint64_t start_logging_cycle) {
+  return OpenTrafficLogger(path, listener_type, start_logging_cycle);
 }
 
 void Connection::StopTrafficLogging() {
@@ -3006,6 +3013,10 @@ bool Connection::ShouldLogTrafficV2() const {
 }
 
 void Connection::LogTrafficV2(ParsedCommand* cmd) {
+  if (cmd->parsed_cycle < tl_traffic_logger.start_logging_cycle)
+    // Skip logging commands that were parsed before traffic logging was started.
+    return;
+
   LogTraffic(id_, cmd->has_unparsed_input, *cmd, service_->GetContextInfo(cc_.get()));
 }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -292,9 +292,11 @@ class Connection : public util::Connection {
   // Starts traffic logging in the calling thread. Must be a proactor thread.
   // Each thread creates its own log file containing requests from connections on
   // that thread whose listener type equals `listener_type`. Exactly one listener
-  // kind per recording — mixing protocols in a single file is not supported.
+  // kind per recording — mixing protocols in a single file is not supported. All
+  // threads in a recording session receive the same `start_logging_cycle`.
   static StartTrafficResult StartTrafficLogging(std::string_view base_path,
-                                                ListenerType listener_type);
+                                                ListenerType listener_type,
+                                                uint64_t start_logging_cycle);
 
   // Stops traffic logging in this thread. A noop if the thread is not logging.
   static void StopTrafficLogging();
@@ -557,7 +559,8 @@ class Connection : public util::Connection {
   // V2: Returns true if the connection is currently logging traffic to a file.
   bool ShouldLogTrafficV2() const;
 
-  // V2: A helper function to log a single command to a file.
+  // V2: Records a command only while logging is active at dispatch and it was parsed after the
+  // current logger started. STOP can therefore suppress a command parsed while logging was active.
   void LogTrafficV2(ParsedCommand* cmd);
 
   // V2 vectorized squash phase: dispatch the run starting at parsed_to_execute_ through

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1153,20 +1153,21 @@ void DebugCmd::LogTraffic(CmdArgParser parser, CommandContext* cmd_cntx) {
   std::atomic<unsigned> already_logging{0};
   std::atomic<unsigned> open_failed{0};
   std::string path_str(path);
-  shard_set->pool()->AwaitFiberOnAll(
-      [path_str, listener_type, &started_new, &already_logging, &open_failed](auto*) {
-        switch (Connection::StartTrafficLogging(path_str, listener_type)) {
-          case Connection::StartTrafficResult::kStarted:
-            started_new.fetch_add(1, std::memory_order_relaxed);
-            break;
-          case Connection::StartTrafficResult::kAlreadyLogging:
-            already_logging.fetch_add(1, std::memory_order_relaxed);
-            break;
-          case Connection::StartTrafficResult::kOpenFailed:
-            open_failed.fetch_add(1, std::memory_order_relaxed);
-            break;
-        }
-      });
+  uint64_t start_logging_cycle = base::CycleClock::Now();
+  shard_set->pool()->AwaitFiberOnAll([path_str, listener_type, start_logging_cycle, &started_new,
+                                      &already_logging, &open_failed](auto*) {
+    switch (Connection::StartTrafficLogging(path_str, listener_type, start_logging_cycle)) {
+      case Connection::StartTrafficResult::kStarted:
+        started_new.fetch_add(1, std::memory_order_relaxed);
+        break;
+      case Connection::StartTrafficResult::kAlreadyLogging:
+        already_logging.fetch_add(1, std::memory_order_relaxed);
+        break;
+      case Connection::StartTrafficResult::kOpenFailed:
+        open_failed.fetch_add(1, std::memory_order_relaxed);
+        break;
+    }
+  });
 
   unsigned started = started_new.load(std::memory_order_relaxed);
   unsigned refused = already_logging.load(std::memory_order_relaxed);

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -300,18 +300,32 @@ async def test_debug_traffic_records_pipeline_in_dispatch_order(df_server, tmp_p
 
 @dfly_args({"enable_resp_io_loop_v2": "true", "proactor_threads": 1})
 @pytest.mark.exclude_epoll
-@pytest.mark.skip("Fails constantly")
 async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tmp_path):
-    """V2 logging records queued commands and does not preempt proactor parsing."""
+    """Validates that V2 logging keeps parser-time eligibility while deferring writes from proactor parsing."""
     client = df_server.client()
     log_prefix = tmp_path / "traffic-proactor"
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
 
     try:
-        # The SET is queued behind the blocking command before logging starts.
+        writer.write(b"CLIENT ID\r\n")
+        await writer.drain()
+        client_id = int((await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=2))[1:-2])
+
+        # This SET arrives before logging starts, so it must not be recorded even though execution
+        # is delayed behind BLPOP until after START.
         writer.write(b"BLPOP traffic:block 0\r\nSET traffic:queued before-start\r\n")
         await writer.drain()
-        await asyncio.sleep(0.05)
+
+        @assert_eventually(timeout=2)
+        async def wait_for_pipeline_to_parse():
+            connection = parse_client_list(
+                await client.execute_command("CLIENT LIST ID", client_id)
+            )
+            assert len(connection) == 1
+            assert int(connection[0].get("pipeline", 0)) >= 2
+
+        # This assertion proves both commands were parsed and queued before the test sends "DEBUG TRAFFIC START"
+        await wait_for_pipeline_to_parse()
 
         assert await client.execute_command("DEBUG", "TRAFFIC", "START", str(log_prefix)) == "OK"
 
@@ -337,7 +351,10 @@ async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tm
         parts
         for _, parts in _read_traffic_log_records(log_prefix.with_name("traffic-proactor-000.bin"))
     ]
-    assert [b"SET", b"traffic:queued", b"before-start"] in logged_commands
+
+    # The queued SET was parsed before DEBUG TRAFFIC START, so delayed execution must not add it
+    # retroactively to the log. The later SET was parsed after START, so it is expected to be logged.
+    assert [b"SET", b"traffic:queued", b"before-start"] not in logged_commands
     assert [b"SET", b"traffic:proactor", b"one"] in logged_commands
 
 


### PR DESCRIPTION
Give every traffic logger the same START cycle, so V2 eligibility remains
stable when a queued connection migrates between proactors. Record only
commands parsed at or after that boundary, while keeping file writes off
the parser path.

Re-enable the V2 integration test with a CLIENT LIST parse barrier, and
change its expected log contents: a command parsed before START but
dispatched afterward must not be recorded.

Fixes https://github.com/dragonflydb/dragonfly/issues/8120 - test
test_debug_traffic_v2_parse_in_proactor_does_not_preempt.