### PR TITLE
[do not review] chore: debug cluster fuzzy migration

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2106,6 +2106,42 @@ string Connection::DebugInfo() const {
   return info;
 }
 
+#ifndef NDEBUG
+string Connection::DebugCheckpointState() const {
+  const bool queued = any_of(dispatch_q_.begin(), dispatch_q_.end(),
+                             [](const MessageHandle& m) { return m.IsCheckPoint(); });
+  const bool deferred = !deferred_checkpoints_.empty();
+  const bool in_flight = HasInFlightCommands();
+
+  if (!queued && !deferred)
+    return {};  // nothing outstanding on this connection
+
+  string info = "{cause=";
+  if (queued && !in_flight) {
+    // Still sitting in dispatch_q_ despite nothing async pending - the control path itself isn't
+    // draining, not a checkpoint-release problem at all.
+    absl::StrAppend(&info, "dropped");
+  } else if (deferred && !in_flight) {
+    // The release condition already holds, yet ReleaseDeferredCheckpoints() wasn't called even
+    // though it sits right next to this check. Direct proof of a leak, no timing needed.
+    absl::StrAppend(&info, "leaked");
+  } else if (deferred && in_flight && parsed_head_ && parsed_head_->CanReply()) {
+    // The transaction's own completion flag is already set, but our dispatch bookkeeping never
+    // consumed it. Not slow - stuck.
+    absl::StrAppend(&info, "livelock");
+  } else {
+    // The in-flight command genuinely hasn't finished yet. Real contention/latency, not a bug in
+    // this mechanism.
+    absl::StrAppend(&info, "executing");
+  }
+  absl::StrAppend(&info, ", queued=", queued, ", deferred=", deferred_checkpoints_.size(),
+                  ", in_flight=", in_flight, ", rechecks=", inflight_recheck_misses_,
+                  ", can_reply=", parsed_head_ ? parsed_head_->CanReply() : false,
+                  ", park=", static_cast<unsigned>(fiber_park_spot_), "}");
+  return info;
+}
+#endif
+
 bool Connection::ProcessAdminMessage(MessageHandle* msg, AsyncOperations* async_op) {
   // Guard: Automatically subtract stats when this scope exits (via return or exception).
   absl::Cleanup stats_guard = [this, msg] { UpdateDispatchStats(*msg, false /* subtract */); };
@@ -3981,6 +4017,10 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
     // run has drained.
     if (!HasInFlightCommands()) {
       ReleaseDeferredCheckpoints();
+#ifndef NDEBUG
+    } else if (!deferred_checkpoints_.empty()) {
+      ++inflight_recheck_misses_;
+#endif
     }
 
     // A protocol error detected by parse-in-proactor (which runs in the recv callback and cannot

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -313,6 +313,24 @@ class Connection : public util::Connection {
   // Get quick debug info for logs
   std::string DebugInfo() const;
 
+#ifndef NDEBUG
+  // Debug-only diagnostic for a DispatchTracker/CLIENT PAUSE checkpoint that hasn't released on
+  // this connection. Classifies the stall as one of:
+  //  - "dropped": the checkpoint never reached the deferral handler (still queued or lost).
+  //  - "leaked": HasInFlightCommands() already false but a deferred checkpoint is still held -
+  //    the release call was skipped despite its condition being satisfied.
+  //  - "livelock": the in-flight command's own completion flag (CanReply()) is already set, but
+  //    this connection's dispatch bookkeeping never consumed it.
+  //  - "executing": the in-flight command genuinely hasn't finished yet (real contention/latency,
+  //    not a bug in this mechanism).
+  // Returns an empty string if there is nothing outstanding on this connection.
+  std::string DebugCheckpointState() const;
+#else
+  std::string DebugCheckpointState() const {
+    return {};
+  }
+#endif
+
   bool IsHttp() const;
 
   static void UpdateFromFlags();                          // Set values from flags
@@ -664,6 +682,14 @@ class Connection : public util::Connection {
   // - Assumption: usually this vectors holds 0-1 entries, and at any given (extreme) point of time,
   // the number of deferred checkpoints is minimal (<10, no inlined vector required).
   std::vector<util::fb2::BlockingCounter> deferred_checkpoints_;
+
+#ifndef NDEBUG
+  // Debug-only counter for DebugCheckpointState(): incremented every main-loop pass that finds a
+  // deferred checkpoint still waiting on HasInFlightCommands() to clear. A high count over a short
+  // external wait rules out scheduler starvation for this connection - its loop kept running and
+  // kept re-checking, the in-flight command just hadn't finished (or its completion was missed).
+  uint32_t inflight_recheck_misses_ = 0;
+#endif
 
   // how many bytes of the current request have been consumed
   size_t request_consumed_bytes_ = 0;

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -10,6 +10,8 @@
 #include "base/logging.h"
 #include "cluster_family.h"
 #include "cluster_utility.h"
+#include "facade/dragonfly_connection.h"
+#include "facade/dragonfly_listener.h"
 #include "facade/socket_utils.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
@@ -30,6 +32,32 @@ using namespace facade;
 using namespace util;
 
 namespace dfly::cluster {
+
+namespace {
+
+#ifndef NDEBUG
+// Debug-only: called when a client pause times out waiting for connections to finish
+// dispatching. Walks every connection on the given listeners and, for any that still owe a
+// DispatchTracker checkpoint, logs Connection::DebugCheckpointState()'s causal classification
+// (dropped / leaked / livelock / executing) so the log already has the answer without needing to
+// reproduce and attach a debugger. No-op (empty body) in non-debug builds.
+void DumpCheckpointDiagnostics(absl::Span<facade::Listener* const> listeners) {
+  for (auto* listener : listeners) {
+    listener->TraverseConnections([](unsigned, util::Connection* conn) {
+      auto* fconn = static_cast<facade::Connection*>(conn);
+      string state = fconn->DebugCheckpointState();
+      if (!state.empty()) {
+        LOG(WARNING) << "pause-timeout diagnostic: " << fconn->DebugInfo() << " " << state;
+      }
+    });
+  }
+}
+#else
+void DumpCheckpointDiagnostics(absl::Span<facade::Listener* const>) {
+}
+#endif
+
+}  // namespace
 
 class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
  public:
@@ -384,6 +412,11 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
       dfly::Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
                   nullptr, ClientPause::ALL, is_pause_in_progress);
 
+  if (!pause_fb_opt) {
+    // Dump before the DCHECK below can abort - this is the one build (debug) where both are
+    // compiled in, and the DCHECK must not shadow the diagnostic that explains it.
+    DumpCheckpointDiagnostics(server_family_->GetNonPriviligedListeners());
+  }
   DCHECK(pause_fb_opt);
   if (!pause_fb_opt) {
     auto err = absl::StrCat("Migration finalization time out ", cf_->MyID(), " : ",

--- a/tests/dragonfly/__init__.py
+++ b/tests/dragonfly/__init__.py
@@ -14,14 +14,27 @@ def dfly_multi_test_args(*args):
 class PortPicker:
     """A simple port manager to allocate available ports for tests"""
 
+    MIN_PORT = 5555
+    # Kept below the kernel's ephemeral port range (starts at 32768 by default on Linux, see
+    # /proc/sys/net/ipv4/ip_local_port_range). A long-running repeat job that never wraps its
+    # counter eventually climbs into that range and starts racing the OS's own automatic port
+    # allocator for outbound connections, causing spurious "Address already in use" bind failures.
+    MAX_PORT = 30000
+
     def __init__(self):
-        self.next_port = 5555
+        self.next_port = self.MIN_PORT
 
     def get_available_port(self):
         while not self.is_port_available(self.next_port):
-            self.next_port += 1
+            self._advance()
+        port = self.next_port
+        self._advance()
+        return port
+
+    def _advance(self):
         self.next_port += 1
-        return self.next_port - 1
+        if self.next_port > self.MAX_PORT:
+            self.next_port = self.MIN_PORT
 
     def is_port_available(self, port):
         import socket

--- a/tests/dragonfly/cluster_test_utils.py
+++ b/tests/dragonfly/cluster_test_utils.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import socket
 from binascii import crc_hqx
 from dataclasses import dataclass
 
@@ -12,13 +13,26 @@ from .instance import DflyInstance
 from .utility import tick_timer
 
 BASE_PORT = 30001
+# Kept below the kernel's ephemeral port range (starts at 32768 by default on Linux, see
+# /proc/sys/net/ipv4/ip_local_port_range). Without a ceiling this counter marches straight past
+# that boundary in a long repeat run and starts racing the OS's own automatic port allocator for
+# outbound connections, causing spurious "Address already in use" bind failures.
+MAX_PORT = 32000
+
+
+def _is_port_available(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("localhost", port)) != 0
 
 
 def monotonically_increasing_port_number():
     port = BASE_PORT
     while True:
-        yield port
-        port = port + 1
+        if _is_port_available(port):
+            yield port
+        port += 1
+        if port > MAX_PORT:
+            port = BASE_PORT
 
 
 # Create a generator object


### PR DESCRIPTION
DO NOT REVIEW -- I will discard this.

Hypothesis:

1. Checkpoint is starved so we have a form of a livelock (we ignore it from ioloopv2 due to some corner case)
2. CI is genuinely slow -> we will just increase the timeout