### PR TITLE
feat(facade): share the RESP V2 read buffer

### DIFF
--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(dfly_parser_lib redis_parser.cc resp_expr.cc resp_parser.cc
 cxx_link(dfly_parser_lib base strings_lib redis_lib)
 
 add_library(dfly_facade dragonfly_listener.cc dragonfly_connection.cc facade.cc
+            proactor_read_buffer.cc
             memcache_parser.cc reply_builder.cc op_status.cc parsed_command.cc service_interface.cc
             reply_capture.cc cmd_arg_parser.cc tls_helpers.cc socket_utils.cc disk_backed_queue.cc)
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -189,6 +189,8 @@ constexpr size_t kMaxHttpProbeLen = 1024;
 constexpr size_t kMinSharedReadBufferLen = kMaxHttpProbeLen;
 constexpr size_t kHttpProbeAppendBytes = 128;
 
+// Access from connection execution paths via GetSharedReadBuffer() to reload TLS after a
+// possible proactor migration.
 thread_local ProactorReadBuffer tl_shared_read_buf;
 
 void SendProtocolError(RespSrvParser::Result pres, SinkReplyBuilder* builder) {
@@ -677,6 +679,14 @@ ConnectionStats& __attribute__((noinline)) GetLocalConnStats() {
   return tl_facade_stats->conn_stats;
 }
 
+// See GetLocalConnStats() above. Connection fibers can migrate between proactors, so reload this
+// thread-local buffer after every possible migration point.
+ProactorReadBuffer& __attribute__((noinline)) GetSharedReadBuffer() {
+  asm volatile("");
+
+  return tl_shared_read_buf;
+}
+
 thread_local uint32_t max_busy_read_cycles_cached = UINT32_MAX;
 thread_local const size_t max_client_iobuf_len_cached = GetFlag(FLAGS_max_client_iobuf_len);
 thread_local const uint32_t iobuf_min_shrink_interval_sec_cached =
@@ -895,33 +905,36 @@ void Connection::Init(unsigned io_threads) {
     }
   }
 
-  if (GetFlag(FLAGS_enable_shared_read_buffer)) {
+  if (GetFlag(FLAGS_enable_shared_read_buffer) && GetFlag(FLAGS_enable_resp_io_loop_v2)) {
     const size_t capacity = GetFlag(FLAGS_shared_read_buffer_len);
-    LOG(INFO) << "Shared RESP V2 read buffer enabled: " << capacity << " bytes per proactor, "
-              << capacity * io_threads << " bytes across " << io_threads << " proactors";
+    LOG(INFO) << "Shared RESP V2 read buffer enabled with a requested capacity of " << capacity
+              << " bytes per proactor, " << capacity * io_threads << " bytes across " << io_threads
+              << " proactors";
   } else {
     LOG(INFO) << "Shared RESP V2 read buffer disabled";
   }
 }
 
 void Connection::InitThreadLocal() {
-  if (!GetFlag(FLAGS_enable_shared_read_buffer)) {
-    return;
+  if (GetFlag(FLAGS_enable_shared_read_buffer) && GetFlag(FLAGS_enable_resp_io_loop_v2)) {
+    // Protocol detection first reads into the connection's private buffer. Those bytes are moved
+    // into the shared buffer before normal RESP V2 reads begin, so the shared buffer must be large
+    // enough to hold everything collected during detection.
+    const size_t shared_read_buffer_len = GetFlag(FLAGS_shared_read_buffer_len);
+    CHECK_GE(shared_read_buffer_len, kMinSharedReadBufferLen)
+        << "--shared_read_buffer_len is too small";
+    tl_shared_read_buf.Init(shared_read_buffer_len);
+    ReadBufTracker::Update(0, tl_shared_read_buf.Capacity(), 0,
+                           ReadBufTracker::kReasonProactorSharedReadBuffer);
   }
-
-  // FLAGS_enable_shared_read_buffer is true:
-  // Protocol detection first reads into the connection's private buffer. Those bytes are moved
-  // into the shared buffer before normal RESP V2 reads begin, so the shared buffer must be large
-  // Enough to hold everything collected during detection.
-  const size_t shared_read_buffer_len = GetFlag(FLAGS_shared_read_buffer_len);
-  CHECK_GE(shared_read_buffer_len, kMinSharedReadBufferLen)
-      << "--shared_read_buffer_len is too small";
-  tl_shared_read_buf.Init(shared_read_buffer_len);
-  ReadBufTracker::Update(0, tl_shared_read_buf.Capacity(), 0,
-                         ReadBufTracker::kReasonProactorSharedReadBuffer);
 }
 
 void Connection::ShutdownThreadLocal() {
+  if (tl_shared_read_buf.IsInitialized()) {
+    ReadBufTracker::Update(tl_shared_read_buf.Capacity(), 0, 0,
+                           ReadBufTracker::kReasonProactorSharedReadBuffer);
+    tl_shared_read_buf.Reset();
+  }
   pipeline_req_pool_.clear();
 }
 
@@ -1202,11 +1215,11 @@ void Connection::HandleRequests() {
                    (protocol_ == Protocol::REDIS && GetFlag(FLAGS_enable_resp_io_loop_v2));
       pipeline_squashing_v2_ =
           ioloop_v2_ && GetFlag(FLAGS_enable_pipeline_squashing_v2) && protocol_ == Protocol::REDIS;
-      // Initialization order invariant: tl_shared_read_buf must be initialized here if
-      // enable_shared_read_buffer is true.
+      // Initialization order invariant: the proactor shared buffer must exist when this
+      // connection uses it.
       shared_read_buf_enabled_ =
           ioloop_v2_ && protocol_ == Protocol::REDIS && GetFlag(FLAGS_enable_shared_read_buffer);
-      CHECK(!shared_read_buf_enabled_ || tl_shared_read_buf.IsInitialized())
+      CHECK(!shared_read_buf_enabled_ || GetSharedReadBuffer().IsInitialized())
           << "Shared read buffer was not initialized on this proactor";
 
       socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
@@ -1427,8 +1440,8 @@ io::Result<bool> Connection::CheckForHttpProto() {
                                           GetFlag(FLAGS_enable_resp_io_loop_v2) &&
                                           GetFlag(FLAGS_enable_shared_read_buffer);
   if (may_use_shared_read_buffer) {  // V2 Resp with shared read buffer enabled.
-    CHECK(tl_shared_read_buf.IsInitialized());
-    probe_limit = std::min(probe_limit, tl_shared_read_buf.Capacity());
+    CHECK(GetSharedReadBuffer().IsInitialized());
+    probe_limit = std::min(probe_limit, GetSharedReadBuffer().Capacity());
   }
 
   size_t last_len = 0;
@@ -3713,7 +3726,7 @@ void Connection::MoveInputToOverflow(io::IoBuf& input_buf) {
   if (input_buf.InputLen() == 0)
     return;
   CHECK(!overflow_buf_);
-  CHECK_LE(input_buf.InputLen(), tl_shared_read_buf.Capacity());
+  CHECK_LE(input_buf.InputLen(), GetSharedReadBuffer().Capacity());
 
   // TODO: Optimize overflow-buffer memory management, e.g. by retaining or pooling allocations.
 
@@ -3757,10 +3770,11 @@ void Connection::FinalizeSharedInput(io::IoBuf& input_buf, bool discard) {
 
 size_t Connection::GetUnreadInputLen() const {
   if (shared_read_buf_enabled_) {  // shared buffer
-    if (tl_shared_read_buf.OwnerConnId() == id_) {
+    auto& shared_read_buf = GetSharedReadBuffer();
+    if (shared_read_buf.OwnerConnId() == id_) {
       // shared buffer is borrowed by me
       DCHECK(!overflow_buf_);
-      return tl_shared_read_buf.InputLen();
+      return shared_read_buf.InputLen();
     }
     // shared buffer not borrowed, only overflow buffer counts
     return overflow_buf_ ? overflow_buf_->InputLen() : 0;
@@ -3776,12 +3790,13 @@ Connection::ParserStatus Connection::ReadAndParseShared(bool from_proactor_callb
   if (IsOverPipelineLimit())
     return NEED_MORE;
 
-  auto borrow = tl_shared_read_buf.TryBorrow(id_);
+  auto& shared_read_buf = GetSharedReadBuffer();
+  auto borrow = shared_read_buf.TryBorrow(id_);
   if (!borrow) {
     // This cannot occur when a borrow never suspends; terminate on the internal invariant failure.
     // Set it as an IO error and not as a client protocol error.
     LOG(DFATAL) << CONN_ID << "Shared read buffer is already borrowed by "
-                << tl_shared_read_buf.OwnerConnId();
+                << shared_read_buf.OwnerConnId();
     io_ec_ = make_error_code(errc::operation_canceled);
     pending_input_ = false;
     return NEED_MORE;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -20,7 +20,6 @@
 #include "base/flag_utils.h"
 #include "base/flags.h"
 #include "base/histogram.h"
-#include "base/io_buf.h"
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "common/heap_size.h"
@@ -29,12 +28,14 @@
 #include "facade/facade_types.h"
 #include "facade/memcache_parser.h"
 #include "facade/op_status.h"
+#include "facade/proactor_read_buffer.h"
 #include "facade/redis_parser.h"
 #include "facade/reply_builder.h"
 #include "facade/resp_srv_parser.h"
 #include "facade/service_interface.h"
 #include "facade/socket_utils.h"
 #include "io/file.h"
+#include "io/io_buf.h"
 #include "strings/human_readable.h"
 #include "util/fiber_socket_base.h"
 #include "util/fibers/fibers.h"
@@ -152,6 +153,12 @@ ABSL_FLAG(bool, enable_memcache_io_loop_v2, true,
 ABSL_FLAG(bool, enable_resp_io_loop_v2, false,
           "Enable the event-driven IoLoopV2 for non-TLS RESP connections.");
 
+ABSL_FLAG(bool, enable_shared_read_buffer, true,
+          "Use one read buffer per proactor for eligible RESP IoLoopV2 connections.");
+
+ABSL_FLAG(strings::MemoryBytesFlag, shared_read_buffer_len, 1u << 15,
+          "Capacity of the per-proactor RESP IoLoopV2 shared read buffer.");
+
 ABSL_FLAG(bool, enable_pipeline_squashing_v2, true,
           "Enable vectorized pipeline squashing for the V2 dispatch loop. Groups consecutive "
           "single-shard pipeline commands by shard and executes them in parallel.");
@@ -178,6 +185,12 @@ namespace {
 // reaches soft_limit * kPubSubHardMultiplier.
 constexpr uint32_t kPubSubHardMultiplier = 4;
 
+constexpr size_t kMaxHttpProbeLen = 1024;
+constexpr size_t kMinSharedReadBufferLen = kMaxHttpProbeLen;
+constexpr size_t kHttpProbeAppendBytes = 128;
+
+thread_local ProactorReadBuffer tl_shared_read_buf;
+
 void SendProtocolError(RespSrvParser::Result pres, SinkReplyBuilder* builder) {
   constexpr string_view res = "-ERR Protocol error: "sv;
   if (pres == RespSrvParser::BAD_BULKLEN) {
@@ -201,14 +214,24 @@ bool MatchHttp11Line(string_view line) {
 // To use it as RAII object, call the ctor, or if the update should be immediate, call
 // ReadBufTracker::Update() directly.
 struct ReadBufTracker {
-  static constexpr string_view kReasonHttpProbe = "http_probe";
-  static constexpr string_view kReasonConnectionSetup = "connection_setup";
-  static constexpr string_view kReasonNeedMoreInput = "need_more_input";
-  static constexpr string_view kReasonLowUsage = "low_usage";
-  static constexpr string_view kReasonReceiveIdle = "receive_idle";
-  static constexpr string_view kReasonRegister = "register";
-  static constexpr string_view kReasonUnregister = "unregister";
-  static constexpr string_view kReasonRecvProvidedBuffers = "recv_provided_buffers";
+  // Private per-connection io_buf_ capacity changes.
+  static constexpr string_view kReasonPrivateHttpProbe = "private_http_probe";
+  static constexpr string_view kReasonPrivateConnectionFlowReserve =
+      "private_connection_flow_reserve";
+  static constexpr string_view kReasonPrivateNeedMoreInput = "private_need_more_input";
+  static constexpr string_view kReasonPrivateLowUsageShrink = "private_low_usage_shrink";
+  static constexpr string_view kReasonPrivateReceiveIdleShrink = "private_receive_idle_shrink";
+  static constexpr string_view kReasonPrivateProvidedBufferReceive =
+      "private_provided_buffer_receive";
+
+  // Connection-owned capacity: private io_buf_ plus an optional overflow_buf_.
+  static constexpr string_view kReasonConnectionCapacityRegister = "connection_capacity_register";
+  static constexpr string_view kReasonConnectionCapacityUnregister =
+      "connection_capacity_unregister";
+  static constexpr string_view kReasonConnectionOverflowBuffer = "connection_overflow_buffer";
+
+  // Shared read-buffer capacity is counted once per proactor, not once per connection.
+  static constexpr string_view kReasonProactorSharedReadBuffer = "proactor_shared_read_buffer";
 
   explicit ReadBufTracker(const io::IoBuf& io_buf, uint32_t conn_id,
                           string_view capacity_change_reason)
@@ -871,6 +894,35 @@ void Connection::Init(unsigned io_threads) {
       exit(-1);
     }
   }
+
+  if (GetFlag(FLAGS_enable_shared_read_buffer)) {
+    const size_t capacity = GetFlag(FLAGS_shared_read_buffer_len);
+    LOG(INFO) << "Shared RESP V2 read buffer enabled: " << capacity << " bytes per proactor, "
+              << capacity * io_threads << " bytes across " << io_threads << " proactors";
+  } else {
+    LOG(INFO) << "Shared RESP V2 read buffer disabled";
+  }
+}
+
+void Connection::InitThreadLocal() {
+  if (!GetFlag(FLAGS_enable_shared_read_buffer)) {
+    return;
+  }
+
+  // FLAGS_enable_shared_read_buffer is true:
+  // Protocol detection first reads into the connection's private buffer. Those bytes are moved
+  // into the shared buffer before normal RESP V2 reads begin, so the shared buffer must be large
+  // Enough to hold everything collected during detection.
+  const size_t shared_read_buffer_len = GetFlag(FLAGS_shared_read_buffer_len);
+  CHECK_GE(shared_read_buffer_len, kMinSharedReadBufferLen)
+      << "--shared_read_buffer_len is too small";
+  tl_shared_read_buf.Init(shared_read_buffer_len);
+  ReadBufTracker::Update(0, tl_shared_read_buf.Capacity(), 0,
+                         ReadBufTracker::kReasonProactorSharedReadBuffer);
+}
+
+void Connection::ShutdownThreadLocal() {
+  pipeline_req_pool_.clear();
 }
 
 void Connection::Shutdown() {
@@ -1150,6 +1202,12 @@ void Connection::HandleRequests() {
                    (protocol_ == Protocol::REDIS && GetFlag(FLAGS_enable_resp_io_loop_v2));
       pipeline_squashing_v2_ =
           ioloop_v2_ && GetFlag(FLAGS_enable_pipeline_squashing_v2) && protocol_ == Protocol::REDIS;
+      // Initialization order invariant: tl_shared_read_buf must be initialized here if
+      // enable_shared_read_buffer is true.
+      shared_read_buf_enabled_ =
+          ioloop_v2_ && protocol_ == Protocol::REDIS && GetFlag(FLAGS_enable_shared_read_buffer);
+      CHECK(!shared_read_buf_enabled_ || tl_shared_read_buf.IsInitialized())
+          << "Shared read buffer was not initialized on this proactor";
 
       socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
       switch (protocol_) {
@@ -1359,10 +1417,33 @@ io::Result<bool> Connection::CheckForHttpProto() {
     return false;
   }
 
+  size_t probe_limit = kMaxHttpProbeLen;
+
+  // Protocol detection reads into the private buffer, which may already contain real protocol
+  // input. If this connection later uses the shared RESP V2 buffer, those unread bytes are moved to
+  // overflow_buf_ and must fit in the shared buffer. Limit each Recv to the remaining space so the
+  // final read can fill, but cannot exceed, the bound. This is done by limiting the probe_limit.
+  const bool may_use_shared_read_buffer = (protocol_ == Protocol::REDIS) &&
+                                          GetFlag(FLAGS_enable_resp_io_loop_v2) &&
+                                          GetFlag(FLAGS_enable_shared_read_buffer);
+  if (may_use_shared_read_buffer) {  // V2 Resp with shared read buffer enabled.
+    CHECK(tl_shared_read_buf.IsInitialized());
+    probe_limit = std::min(probe_limit, tl_shared_read_buf.Capacity());
+  }
+
   size_t last_len = 0;
   auto* peer = socket_.get();
   do {
+    CHECK_LT(io_buf_.InputLen(), probe_limit);
+
+    // A receive must fit both the private buffer's available append space and the remaining
+    // protocol-probe allowance. The private buffer can be smaller than the remaining allowance
+    // while it grows across probe reads.
     auto buf = io_buf_.AppendBuffer();
+    const size_t read_len = std::min(buf.size(), probe_limit - io_buf_.InputLen());
+    buf = buf.first(read_len);
+
+    // Make sure there is append space for the next Recv() call:
     DCHECK(!buf.empty());
 
     const uint64_t io_buf_generation = io_buf_.generation();
@@ -1397,13 +1478,15 @@ io::Result<bool> Connection::CheckForHttpProto() {
       return MatchHttp11Line(ib);
     }
     last_len = io_buf_.InputLen();
-    const size_t previous_capacity = io_buf_.Capacity();
-    {
-      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonHttpProbe);
-      io_buf_.EnsureCapacity(128);
+    if (last_len < probe_limit) {
+      const size_t previous_capacity = io_buf_.Capacity();
+      {
+        ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonPrivateHttpProbe);
+        io_buf_.EnsureCapacity(std::min(kHttpProbeAppendBytes, probe_limit - last_len));
+      }
+      UpdateIoBufCapacityChange(previous_capacity);
     }
-    UpdateIoBufCapacityChange(previous_capacity);
-  } while (last_len < 1024);
+  } while (last_len < probe_limit);
 
   return false;
 }
@@ -1426,7 +1509,11 @@ void Connection::ConnectionFlow() {
 
   // At the start we read from the socket to determine the HTTP/Memstore protocol.
   // Therefore we may already have some data in the buffer.
-  if (io_buf_.InputLen() > 0) {
+  if (shared_read_buf_enabled_ && io_buf_.InputLen() > 0) {
+    // Preserve probe bytes for the first shared read/parse pass, which restores and parses them (No
+    // need to explicitly parse here).
+    MoveInputToOverflow(io_buf_);
+  } else if (io_buf_.InputLen() > 0) {
     phase_ = PROCESS;
     if (redis_parser_ && !ioloop_v2_) {
       parse_status = ParseRedis(io_buf_, 10000, /*enqueue_only=*/false);
@@ -1440,7 +1527,7 @@ void Connection::ConnectionFlow() {
   // Main loop.
   if (parse_status != ERROR && !ec) {
     {
-      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonConnectionSetup);
+      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonPrivateConnectionFlowReserve);
       io_buf_.EnsureCapacity(64);
     }
     variant<error_code, Connection::ParserStatus> res;
@@ -2426,10 +2513,6 @@ Connection::WeakRef Connection::Borrow() {
   return {self_, unsigned(socket_->proactor()->GetPoolIndex()), id_};
 }
 
-void Connection::ShutdownThreadLocal() {
-  pipeline_req_pool_.clear();
-}
-
 bool Connection::IsCurrentlyDispatching() const {
   if (!cc_)
     return false;
@@ -2893,19 +2976,28 @@ void Connection::DecreaseConnStats() {
   conn_stats.pipeline_queue_bytes -= parsed_cmd_q_bytes_;
 }
 
+size_t Connection::GetReadBufCapacity() const {
+  // Overflow input is connection-owned while shared input is accounted once per proactor.
+  const size_t overflow_buf_capacity = overflow_buf_ ? overflow_buf_->Capacity() : 0;
+  DCHECK(!overflow_buf_ || (overflow_buf_capacity > 0u));
+  return io_buf_.Capacity() + overflow_buf_capacity;
+}
+
 void Connection::RegisterReadBufCapacity() {
   DCHECK(tl_facade_stats);
   DCHECK(!read_buf_capacity_registered_);
-  // Registration includes setting the flag and adding the current buffer capacity.
-  ReadBufTracker::Update(0, io_buf_.Capacity(), id_, ReadBufTracker::kReasonRegister);
+
+  ReadBufTracker::Update(0, GetReadBufCapacity(), id_,
+                         ReadBufTracker::kReasonConnectionCapacityRegister);
   read_buf_capacity_registered_ = true;
 }
 
 void Connection::UnregisterReadBufCapacity() {
   DCHECK(tl_facade_stats);
   DCHECK(read_buf_capacity_registered_);
-  // Unregistration includes clearing the flag and subtracting the current buffer capacity.
-  ReadBufTracker::Update(io_buf_.Capacity(), 0, id_, ReadBufTracker::kReasonUnregister);
+
+  ReadBufTracker::Update(GetReadBufCapacity(), 0, id_,
+                         ReadBufTracker::kReasonConnectionCapacityUnregister);
   read_buf_capacity_registered_ = false;
 }
 
@@ -3116,7 +3208,7 @@ Connection::ExecuteBatchResult Connection::ExecuteBatch() {
       // if we squashed any commands, continue the loop to check if there are
       // non-squashable commands to process.
       DVLOG(2) << CONN_ID << "Squashing pipeline " << dispatch_waiting_count_ << " commands "
-               << pending_input_ << " " << io_buf_.InputLen();
+               << pending_input_ << " " << GetUnreadInputLen();
 
       if (SquashPipelineV2()) {
         // - This helps with throughput. Explanation:
@@ -3124,7 +3216,7 @@ Connection::ExecuteBatchResult Connection::ExecuteBatch() {
         //   By breaking now we give the io-loop a chance to add more commands to the pipeline.
         // - Skip the break when parse-in-proactor is on: the proactor already parsed those bytes
         //   into the queue during the squash wait, so keep squashing in place instead.
-        if (!pipeline_parse_in_proactor_cached && (pending_input_ || io_buf_.InputLen() > 0))
+        if (!pipeline_parse_in_proactor_cached && (pending_input_ || GetUnreadInputLen() > 0))
           break;
         continue;
       }
@@ -3497,14 +3589,34 @@ bool ConnectionRef::operator==(const ConnectionRef& other) const {
 void Connection::OnRecvNotification(const util::FiberSocketBase::RecvNotification& n) {
   DVLOG(2) << CONN_ID << "OnRecvNotification: io_buf_ input_len=" << io_buf_.InputLen()
            << " pending_input=" << pending_input_;
+  const uint64_t start_epoch = fb2::FiberSwitchEpoch();
+  const uint64_t initial_read_count = GetLocalConnStats().io_read_cnt;
   ProcessRecvNotification(n);
 
-  if (!IsOverPipelineLimit()) {
+  auto parse_in_proactor = [this](auto&& parse_cb) {
+    size_t cmds_before = parsed_cmd_q_len_;
+    ParserStatus status = parse_cb();
+    if (parsed_cmd_q_len_ > cmds_before)
+      ++GetLocalConnStats().proactor_parse;
+    // The recv callback cannot return a status. If parsing hit a protocol error, flag it so
+    // IoLoopV2 surfaces ParserStatus::ERROR and sends the protocol-error reply.
+    if (status == ERROR)
+      proactor_parse_error_ = true;
+    DVLOG(1) << CONN_ID << "Parse-in-proactor added " << (parsed_cmd_q_len_ - cmds_before)
+             << " commands, pq_len=" << parsed_cmd_q_len_;
+  };
+  auto can_parse_in_proactor = [this] {
+    return pipeline_parse_in_proactor_cached && (fiber_park_spot_ == FiberParkSpot::kSquashHop ||
+                                                 fiber_park_spot_ == FiberParkSpot::kSendReply ||
+                                                 fiber_park_spot_ == FiberParkSpot::kSimpleHop);
+  };
+
+  if (shared_read_buf_enabled_ && can_parse_in_proactor()) {
+    // TODO: Bound callback read/parse work to prevent a busy connection from starving the proactor.
+    parse_in_proactor([this] { return ReadAndParseShared(/*from_proactor_callback=*/true); });
+  } else if (!shared_read_buf_enabled_ && !IsOverPipelineLimit()) {
     // Drain the socket while the fiber is suspended (no-op when io_buf_ is full / no append room).
-    const size_t before = io_buf_.InputLen();
     ReadPendingInput();
-    if (io_buf_.InputLen() > before)
-      ++GetLocalConnStats().proactor_reads;
 
     // Parse In Proactor: parse newly-read bytes while the fiber is parked, so the next batch is
     // already larger on resume. Enabled only at parks where the parser is idle AND the fiber waits
@@ -3512,24 +3624,16 @@ void Connection::OnRecvNotification(const util::FiberSocketBase::RecvNotificatio
     // overlaps real work. Parks that run nothing in parallel (e.g. a self-preemption yield) are
     // excluded - offloading them buys nothing.
     // - Calling ParseRedis() with max_busy_cycles==0: proactor's callbacks must not suspend.
-    if (pipeline_parse_in_proactor_cached &&
-        (fiber_park_spot_ == FiberParkSpot::kSquashHop ||
-         fiber_park_spot_ == FiberParkSpot::kSendReply ||
-         fiber_park_spot_ == FiberParkSpot::kSimpleHop) &&
-        redis_parser_ && (io_buf_.InputLen() > 0)) {
-      size_t cmds_before = parsed_cmd_q_len_;
-      ParserStatus st = ParseRedis(io_buf_, 0, /*enqueue_only=*/true);
-      if (parsed_cmd_q_len_ > cmds_before)
-        ++GetLocalConnStats().proactor_parse;
-      // The recv callback cannot return a status. If parsing hit a protocol error, flag it so
-      // IoLoopV2 surfaces ParserStatus::ERROR and sends the protocol-error reply.
-      if (st == ERROR)
-        proactor_parse_error_ = true;
-      DVLOG(1) << CONN_ID << "Parse-in-proactor added " << (parsed_cmd_q_len_ - cmds_before)
-               << " commands, pq_len=" << parsed_cmd_q_len_;
+    if (can_parse_in_proactor() && redis_parser_ && (io_buf_.InputLen() > 0)) {
+      parse_in_proactor([this] { return ParseRedis(io_buf_, 0, /*enqueue_only=*/true); });
     }
   }
 
+  if (GetLocalConnStats().io_read_cnt > initial_read_count)
+    ++GetLocalConnStats().proactor_reads;
+
+  // No preemption is allowed in proactor callbacks.
+  DCHECK_EQ(fb2::FiberSwitchEpoch(), start_epoch);
   io_event_.notify();
 }
 
@@ -3548,9 +3652,10 @@ void Connection::ProcessRecvNotification(const util::FiberSocketBase::RecvNotifi
 
     pending_input_ = true;
   } else if (std::holds_alternative<io::MutableBytes>(n.read_result)) {  // provided buffer.
+    CHECK(!shared_read_buf_enabled_);
     io::MutableBytes buf = std::get<io::MutableBytes>(n.read_result);
     {
-      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonRecvProvidedBuffers);
+      ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonPrivateProvidedBufferReceive);
       io_buf_.WriteAndCommit(buf.data(), buf.size());
     }
     last_interaction_ = time(nullptr);
@@ -3568,11 +3673,175 @@ void Connection::ProcessRecvNotification(const util::FiberSocketBase::RecvNotifi
   }
 }
 
+bool Connection::HandleTryRecvResult(const io::Result<size_t>& result) {
+  if (result) {
+    if (*result > 0)
+      // read some bytes
+      return true;
+
+    // EOF (*result == 0) - the peer closed the connection.
+    io_ec_ = make_error_code(errc::connection_aborted);
+    pending_input_ = false;
+    return false;
+  }
+
+  // error case
+  const std::error_code ec = result.error();
+  if ((ec == errc::resource_unavailable_try_again) || (ec == errc::operation_would_block)) {
+    pending_input_ = false;
+  } else if (ec != errc::device_or_resource_busy) {
+    io_ec_ = ec;
+  }
+  return false;
+}
+
+void Connection::RecordRecvBytes(size_t bytes) {
+  DCHECK(tl_facade_stats);
+  auto& conn_stats = tl_facade_stats->conn_stats;
+
+  conn_stats.io_read_bytes += bytes;
+  ++conn_stats.io_read_cnt;
+
+  local_stats_.net_bytes_in += bytes;
+  ++local_stats_.read_cnt;
+
+  last_interaction_ = time(nullptr);
+  io_buf_last_read_time_ = last_interaction_;
+}
+
+void Connection::MoveInputToOverflow(io::IoBuf& input_buf) {
+  if (input_buf.InputLen() == 0)
+    return;
+  CHECK(!overflow_buf_);
+  CHECK_LE(input_buf.InputLen(), tl_shared_read_buf.Capacity());
+
+  // TODO: Optimize overflow-buffer memory management, e.g. by retaining or pooling allocations.
+
+  // copy input_buf unconsumed bytes to overflow_buf_ and clear input_buf. Then update
+  // ReadBufTracker.                    .
+  overflow_buf_ = make_unique<io::IoBuf>(input_buf.InputLen());
+  overflow_buf_->WriteAndCommit(input_buf.InputBuffer().data(), input_buf.InputLen());
+  input_buf.Clear();
+  if (read_buf_capacity_registered_) {
+    ReadBufTracker::Update(0, overflow_buf_->Capacity(), id_,
+                           ReadBufTracker::kReasonConnectionOverflowBuffer);
+  }
+}
+
+void Connection::RestoreOverflowToInput(io::IoBuf& input_buf) {
+  CHECK(overflow_buf_);
+  CHECK_EQ(input_buf.InputLen(), 0u);
+  DCHECK_GT(overflow_buf_->InputLen(), 0u);
+  CHECK_LE(overflow_buf_->InputLen(), input_buf.AppendLen());
+
+  // copy overflow_buf_ unconsumed bytes to input_buf and clear overflow_buf_. Then update
+  // ReadBufTracker.
+  input_buf.WriteAndCommit(overflow_buf_->InputBuffer().data(), overflow_buf_->InputLen());
+  if (read_buf_capacity_registered_) {
+    ReadBufTracker::Update(overflow_buf_->Capacity(), 0, id_,
+                           ReadBufTracker::kReasonConnectionOverflowBuffer);
+  }
+  overflow_buf_.reset();
+}
+
+void Connection::FinalizeSharedInput(io::IoBuf& input_buf, bool discard) {
+  CHECK(!overflow_buf_);
+  if (!discard && (input_buf.InputLen() > 0)) {
+    MoveInputToOverflow(input_buf);
+    // Keep this below increment outside MoveInputToOverflow,  since the above helper is also used
+    // during connection setup.
+    ++GetLocalConnStats().shared_buf_overflow_copies;
+  }
+  input_buf.Clear();
+}
+
+size_t Connection::GetUnreadInputLen() const {
+  if (shared_read_buf_enabled_) {  // shared buffer
+    if (tl_shared_read_buf.OwnerConnId() == id_) {
+      // shared buffer is borrowed by me
+      DCHECK(!overflow_buf_);
+      return tl_shared_read_buf.InputLen();
+    }
+    // shared buffer not borrowed, only overflow buffer counts
+    return overflow_buf_ ? overflow_buf_->InputLen() : 0;
+  }
+  return io_buf_.InputLen();  // private buffer
+}
+
+Connection::ParserStatus Connection::ReadAndParseShared(bool from_proactor_callback) {
+  DCHECK(shared_read_buf_enabled_);
+  if (!pending_input_ && GetUnreadInputLen() == 0)
+    // nothing to read and nothing to parse
+    return NEED_MORE;
+  if (IsOverPipelineLimit())
+    return NEED_MORE;
+
+  auto borrow = tl_shared_read_buf.TryBorrow(id_);
+  if (!borrow) {
+    // This cannot occur when a borrow never suspends; terminate on the internal invariant failure.
+    // Set it as an IO error and not as a client protocol error.
+    LOG(DFATAL) << CONN_ID << "Shared read buffer is already borrowed by "
+                << tl_shared_read_buf.OwnerConnId();
+    io_ec_ = make_error_code(errc::operation_canceled);
+    pending_input_ = false;
+    return NEED_MORE;
+  }
+
+  const uint64_t borrow_start = CycleClock::Now();
+  io::IoBuf& input_buf = borrow->buf();
+
+  if (overflow_buf_) {
+    RestoreOverflowToInput(input_buf);
+  }
+
+  // Drain until EAGAIN, EOF, error, or backpressure.
+  ParserStatus status = NEED_MORE;
+  while (!IsOverPipelineLimit()) {
+    if (input_buf.InputLen() > 0) {
+      status = ParseRedis(input_buf, 0, /*enqueue_only=*/true);
+      if (status == ERROR) {
+        break;
+      }
+
+      // The parser stashes incomplete tokens internally, so unread bytes here only remain when
+      // backpressure stops parsing (backpressure) - retain that suffix outside the shared buffer.
+      if (input_buf.InputLen() > 0)
+        break;
+
+      // Reset the consumed buffer so the next socket read can use its full capacity. This allows a
+      // pipeline larger than one shared-buffer capacity to be read in successive chunks.
+      input_buf.Clear();
+    }
+
+    if (!pending_input_)
+      break;
+    io::Result<size_t> result = socket_->TryRecv(input_buf.AppendBuffer());
+    if (!HandleTryRecvResult(result)) {
+      break;
+    }
+
+    input_buf.CommitWrite(*result);
+    RecordRecvBytes(*result);
+  }
+
+  // A parser or socket error discards unparsed residue before returning the shared buffer.
+  const bool io_or_parser_error = (status == ERROR) || io_ec_;
+  FinalizeSharedInput(input_buf, io_or_parser_error);
+
+  auto& conn_stats = GetLocalConnStats();
+  const uint64_t borrow_cycles = CycleClock::Now() - borrow_start;
+  if (from_proactor_callback)
+    conn_stats.shared_buf_borrow_cycles_callback += borrow_cycles;
+  else
+    conn_stats.shared_buf_borrow_cycles_fiber += borrow_cycles;
+  return status;
+}
+
 void Connection::ReadPendingInput() {
   if (!pending_input_)
     return;
 
-  // Drain available socket data into io_buf_.
+  // Drain available socket data into buf.
   io::MutableBytes buf = io_buf_.AppendBuffer();
   // pending_input_ lifecycle in this drain loop (see TlsSocket::TryRecv contract in tls_socket.h):
   // - Positive read: possibly short, not a "drained" signal - keep looping without clearing it. If
@@ -3585,34 +3854,15 @@ void Connection::ReadPendingInput() {
   bool done_read = false;
   while (!buf.empty()) {
     io::Result<size_t> res = socket_->TryRecv(buf);
-    if (!res) {
-      auto ec = res.error();
-      if (ec == errc::resource_unavailable_try_again || ec == errc::operation_would_block) {
-        pending_input_ = false;
-      } else if (ec != errc::device_or_resource_busy) {
-        io_ec_ = ec;
-      }
-      break;
-    }
-
-    if (*res == 0) {
-      io_ec_ = make_error_code(errc::connection_aborted);  // *res == 0, clean EOF
-      pending_input_ = false;
+    if (!HandleTryRecvResult(res)) {
       break;
     }
 
     DVLOG(1) << CONN_ID << "Read " << *res << " bytes from socket";
 
-    auto& conn_stats = tl_facade_stats->conn_stats;
     size_t commit_sz = *res;
-    conn_stats.io_read_bytes += commit_sz;
-    local_stats_.net_bytes_in += commit_sz;
-
-    ++conn_stats.io_read_cnt;
-    ++local_stats_.read_cnt;
-
-    last_interaction_ = time(nullptr);
     io_buf_.CommitWrite(commit_sz);
+    RecordRecvBytes(commit_sz);
     done_read = true;
     buf = io_buf_.AppendBuffer();
   }
@@ -3624,6 +3874,8 @@ void Connection::ReadPendingInput() {
 
 void Connection::MaybeAdjustIoBufCapacity(ParserStatus parse_status, bool reached_capacity) {
   DCHECK_NE(parse_status, ERROR);
+  if (shared_read_buf_enabled_)
+    return;
 
   // A completed parse can reuse its existing allocation - only an incomplete request needs more
   // input before it can make progress.
@@ -3647,7 +3899,7 @@ void Connection::MaybeAdjustIoBufCapacity(ParserStatus parse_status, bool reache
       }
       if (target_capacity > capacity) {
         {
-          ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonNeedMoreInput);
+          ReadBufTracker tracker(io_buf_, id_, ReadBufTracker::kReasonPrivateNeedMoreInput);
           io_buf_.Reserve(target_capacity);
         }
         UpdateIoBufCapacityChange(capacity);
@@ -3726,7 +3978,7 @@ void Connection::MaybeShrinkIoBufOnLowUsage() {
   if (io_buf_high_watermark_ < half_capacity) {  // shrink
     const size_t target_capacity =
         std::max({half_capacity, absl::bit_ceil(io_buf_.InputLen()), kMinReadSize});
-    ShrinkIoBufTo(target_capacity, ReadBufTracker::kReasonLowUsage);
+    ShrinkIoBufTo(target_capacity, ReadBufTracker::kReasonPrivateLowUsageShrink);
     return;
   }
 
@@ -3737,7 +3989,7 @@ void Connection::MaybeShrinkIoBufOnLowUsage() {
 }
 
 bool Connection::MaybeShrinkIoBufOnReceiveIdle() {
-  if (!ioloop_v2_ || (iobuf_min_shrink_interval_sec_cached == 0)) {
+  if (!ioloop_v2_ || shared_read_buf_enabled_ || (iobuf_min_shrink_interval_sec_cached == 0)) {
     return false;
   }
 
@@ -3751,7 +4003,7 @@ bool Connection::MaybeShrinkIoBufOnReceiveIdle() {
   if ((idle_for >= iobuf_min_shrink_interval_sec_cached) && IsIoBufShrinkSafe() &&
       CanShrinkIoBuf(now)) {
     return ShrinkIoBufTo(std::max(io_buf_.Capacity() / 2, kMinReadSize),
-                         ReadBufTracker::kReasonReceiveIdle);
+                         ReadBufTracker::kReasonPrivateReceiveIdleShrink);
   }
 
   return false;
@@ -3762,7 +4014,7 @@ void Connection::MaybeEnableRecvMultishot() {
   if (fb2::ProactorBase::me()->GetKind() == fb2::ProactorBase::Kind::IOURING) {
     auto* up = static_cast<fb2::UringProactor*>(fb2::ProactorBase::me());
     // Only enable if the buffer ring is configured and we aren't using TLS
-    if (up->BufRingEntrySize(kRecvSockGid) > 0 && !is_tls_) {
+    if (up->BufRingEntrySize(kRecvSockGid) > 0 && !is_tls_ && !shared_read_buf_enabled_) {
       static_cast<fb2::UringSocket*>(socket_.get())->EnableRecvMultishot();
       pending_input_ = false;
     }
@@ -3793,8 +4045,11 @@ bool Connection::HasControlEvent() const {
   // Control events warrant leaving any park, independent of new socket input or pipeline memory:
   // a reply became ready, control-plane messages are queued (dispatch_q_), the socket errored or
   // closed (io_ec_), or a thread migration is pending and actionable.
+
+  // A callback parse error must wake the V2 fiber even if the callback did not read more input.
+  // So we must include proactor_parse_error_.
   return (parsed_head_ && parsed_head_->CanReply()) || !dispatch_q_.empty() || io_ec_ ||
-         IsReadyToMigrate();
+         proactor_parse_error_ || IsReadyToMigrate();
 }
 
 bool Connection::ShouldWakeIdle() const {
@@ -3803,7 +4058,7 @@ bool Connection::ShouldWakeIdle() const {
 
   // On top of the control events, the idle park also wakes for incoming data and for a head command
   // that is now ready to run.
-  return io_buf_.InputLen() > 0 || pending_input_ || HasCommandToExecute() || HasControlEvent();
+  return GetUnreadInputLen() > 0 || pending_input_ || HasCommandToExecute() || HasControlEvent();
 }
 
 bool Connection::DrainControlPath(uint32_t quota) {
@@ -3934,7 +4189,14 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       current_wait_.emplace(parsed_head_, &cmd_completion_waiter);
     }
 
-    ReadPendingInput();
+    if (shared_read_buf_enabled_) {
+      parse_status = ReadAndParseShared(/*from_proactor_callback=*/false);
+      if (ERROR == parse_status) {
+        break;
+      }
+    } else {
+      ReadPendingInput();
+    }
 
     // Idle park: flush and sleep only when the fiber is truly idle (ShouldWakeIdle() is false).
     // When synchronous commands (e.g. PUBLISH) are pipelined, ExecuteBatch processes them
@@ -3961,17 +4223,30 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       continue;
     }
 
+    // Drain-only path (execute and reply without parsing):
+    // Drain already-queued commands to free memory. If the pipeline memory limit is exceeded, park
+    // the fiber until another connection relieves the pressure (May return immediately; Empty
+    // queues are never over the limit, ensuring admin commands can always parse).
+    //
+    // We enter this path under two distinct modes:
+    // * Shared Buffer Mode:
+    //   Read-parse and execute-reply operations should be strictly split. Parsing
+    //   already occurred while this connection owned the borrowed buffer. Any
+    //   retained input resides in `overflow_buf_` and must not be passed to the
+    //   `io_buf_` parser here.
+    // * Private Buffer Mode:
+    //   Entered either because there is no new input to parse, or because pipeline
+    //   backpressure prevents further parsing (which would only grow the queue).
     bool over_limit = IsOverPipelineLimit();
-    if (io_buf_.InputLen() == 0 || over_limit) {
-      // Drain-only path: either there is no new input to parse, or we are over the pipeline memory
-      // limit (parsing would only grow the queue further). Either way, drain queued commands to
-      // free memory instead of parsing. When over the limit, also park until another connection
-      // relieves the pressure. (Empty queues are never over the limit, so admin commands can still
-      // parse.)
+    if (shared_read_buf_enabled_ || (io_buf_.InputLen() == 0) || over_limit) {
       DrainQueuedCommands();
       if (over_limit)
         ParkOnBackpressure(&backpressure_waiter);
-      parse_status = NEED_MORE;
+
+      // ReadAndParseShared already supplied this iteration's status. Private buffer mode did not
+      // parse here, so report that it requires more input for capacity bookkeeping below.
+      if (!shared_read_buf_enabled_)
+        parse_status = NEED_MORE;
     } else {
       // Input available and under budget: parse, execute, reply.
       parse_status = RunParsePath();
@@ -4039,6 +4314,9 @@ void ResetStats() {
   cstats.io_read_bytes = 0;
   cstats.proactor_reads = 0;
   cstats.proactor_parse = 0;
+  cstats.shared_buf_overflow_copies = 0;
+  cstats.shared_buf_borrow_cycles_callback = 0;
+  cstats.shared_buf_borrow_cycles_fiber = 0;
   cstats.iobuf_capacity_change_cnt = 0;
 
   tl_facade_stats->reply_stats = {};

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1432,10 +1432,8 @@ io::Result<bool> Connection::CheckForHttpProto() {
 
   size_t probe_limit = kMaxHttpProbeLen;
 
-  // Protocol detection reads into the private buffer, which may already contain real protocol
-  // input. If this connection later uses the shared RESP V2 buffer, those unread bytes are moved to
-  // overflow_buf_ and must fit in the shared buffer. Limit each Recv to the remaining space so the
-  // final read can fill, but cannot exceed, the bound. This is done by limiting the probe_limit.
+  // If shared V2 will be used, limit the the private probe so unread bytes fit in the shared
+  // buffer.
   const bool may_use_shared_read_buffer = (protocol_ == Protocol::REDIS) &&
                                           GetFlag(FLAGS_enable_resp_io_loop_v2) &&
                                           GetFlag(FLAGS_enable_shared_read_buffer);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -153,7 +153,7 @@ ABSL_FLAG(bool, enable_memcache_io_loop_v2, true,
 ABSL_FLAG(bool, enable_resp_io_loop_v2, false,
           "Enable the event-driven IoLoopV2 for non-TLS RESP connections.");
 
-ABSL_FLAG(bool, enable_shared_read_buffer, true,
+ABSL_FLAG(bool, enable_shared_read_buffer, false,
           "Use one read buffer per proactor for eligible RESP IoLoopV2 connections.");
 
 ABSL_FLAG(strings::MemoryBytesFlag, shared_read_buffer_len, 1u << 15,

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -92,6 +92,7 @@ std::string FormatClientInfo(const ClientInfo& ci);
 class Connection : public util::Connection {
  public:
   static void Init(unsigned io_threads);
+  static void InitThreadLocal();
   static void Shutdown();
   static void ShutdownThreadLocal();
 
@@ -389,8 +390,47 @@ class Connection : public util::Connection {
   // provided the buffer ring is configured and the connection is not using TLS.
   void MaybeEnableRecvMultishot();
 
-  // Drains currently available bytes from socket into io_buf_ using non-blocking reads.
+  // Drains currently available socket bytes into the private V2 input buffer without suspending.
   void ReadPendingInput();
+
+  // Borrows the shared buffer for this proactor, reads available RESP V2 data from the socket, and
+  // parses the data while the borrow is held. Set from_proactor_callback=true when calling from
+  // proactor. Before the borrow is released, any input that could not be parsed because of
+  // backpressure is copied to overflow_buf_.
+  ParserStatus ReadAndParseShared(bool from_proactor_callback);
+
+  // Copies the unread part of `input_buf` into the connection-owned overflow_buf_ and then clears
+  // `input_buf`. The source buffer is empty when the function returns. overflow_buf_ is allocated
+  // only if input remains.
+  void MoveInputToOverflow(io::IoBuf& input_buf);
+
+  // Copies all unread overflow input into `input_buf`. The caller must provide a buffer with:
+  // 1) Nothing to consume in (i.e., InputLen() == 0) and
+  // 2) Enough space to append the overflow buffer input (i.e., AppendLen() >=
+  // overflow_buf_->InputLen()).
+  // overflow_buf_ is released after the copy.
+  void RestoreOverflowToInput(io::IoBuf& input_buf);
+
+  // Finalizes `input_buf` before the shared-buffer borrow ends. When `discard` is true, unread
+  // input in the shared buffer and any existing overflow_buf_ are discarded. Otherwise, unread
+  // input is copied to overflow_buf_ for processing during a later borrow. The shared buffer is
+  // empty when the function returns.
+  void FinalizeSharedInput(io::IoBuf& input_buf, bool discard);
+
+  // Returns this connection's unread input. In shared-buffer mode, it reads the active shared
+  // buffer only when this connection owns the borrow; otherwise it returns overflow_buf_ input.
+  size_t GetUnreadInputLen() const;
+
+  // Handles the result of a non-blocking receive in `result`. On EAGAIN/EWOULDBLOCK, it clears
+  // pending_input_ to mark the connection as waiting indefinitely for the next receive notification
+  // instead of polling the socket. It records EOF or a non-retryable error in the connection state
+  // and returns true only when `result` contains a positive number of bytes that the caller may
+  // commit to its input buffer.
+  bool HandleTryRecvResult(const io::Result<size_t>& result);
+
+  // Adds `bytes` to the receive counters for this connection and its current proactor. It also
+  // updates the last-interaction time and the timestamp used by private-buffer resizing.
+  void RecordRecvBytes(size_t bytes);
 
   // Grows the buffer when parsing needs more data, or evaluates low-usage shrinking otherwise.
   // `parse_status` is the parser result; `reached_capacity` marks the preceding read filled it.
@@ -511,8 +551,14 @@ class Connection : public util::Connection {
 
   void IncreaseConnStats();
   void DecreaseConnStats();
+
+  // Registers or unregisters the two connection-owned read buffers: io_buf_ and overflow_buf_.
+  // The shared per-proactor buffer capacity is registered separately and is not this connection's
+  // responsibility. GetReadBufCapacity is a helper.
   void RegisterReadBufCapacity();
   void UnregisterReadBufCapacity();
+  size_t GetReadBufCapacity() const;
+
   void BreakOnce(uint32_t ev_mask);
 
   // The read buffer with read data that needs to be parsed and processed.
@@ -825,6 +871,9 @@ class Connection : public util::Connection {
       // ParserStatus::ERROR to close the connection and send the protocol-error reply.
       bool proactor_parse_error_ : 1;
 
+      // Shared read buffer: only valid for RESP IoLoop V2 connections.
+      bool shared_read_buf_enabled_ : 1;
+
       bool request_shutdown_ : 1;  // set when the connection is requested to shutdown
     };
   };
@@ -835,6 +884,10 @@ class Connection : public util::Connection {
   // executing inside ProcessAdminMessage's std::visit, or 0 when none is in progress. Used by the
   // slow-subscriber protection policy to detect a Pub/Sub send that has been blocked too long.
   uint64_t async_op_start_cycle_ = 0;
+
+  // V2 with shared read buffer: Raw RESP suffix retained by parser when shared-buffer parsing stops
+  // at backpressure.
+  std::unique_ptr<io::IoBuf> overflow_buf_;
 };
 
 }  // namespace facade

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -23,7 +23,7 @@ using namespace std;
 constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
-  static_assert(kSizeConnStats == 336);
+  static_assert(kSizeConnStats == 360);
 
   ADD(read_buf_capacity);
   ADD(connection_memory_bytes);
@@ -59,6 +59,9 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(pipeline_dispatch_flush_count);
   ADD(proactor_reads);
   ADD(proactor_parse);
+  ADD(shared_buf_overflow_copies);
+  ADD(shared_buf_borrow_cycles_callback);
+  ADD(shared_buf_borrow_cycles_fiber);
   ADD(pubsub_backpressure);
 
   return *this;

--- a/src/facade/facade_stats.h
+++ b/src/facade/facade_stats.h
@@ -98,6 +98,11 @@ struct ConnectionStats {
   // callback.
   uint64_t proactor_parse = 0;
 
+  // Local validation metrics for the V2 shared read-buffer path.
+  uint64_t shared_buf_overflow_copies = 0;
+  uint64_t shared_buf_borrow_cycles_callback = 0;
+  uint64_t shared_buf_borrow_cycles_fiber = 0;
+
   // Pub/Sub back-pressure / slow-subscriber protection counters.
   PubsubBackpressureStats pubsub_backpressure;
 

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -674,7 +674,10 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   OkService service(pool);
 
   Connection::Init(pool->size());
-  pool->Await([](auto*) { tl_facade_stats = new FacadeStats; });
+  pool->Await([](auto*) {
+    tl_facade_stats = new FacadeStats;
+    Connection::InitThreadLocal();
+  });
 
   // Create a FiberQueue per shard and start a consumer fiber draining it on the owning
   // proactor thread. The queue and its consumer fiber both live on that thread, so cross-thread

--- a/src/facade/proactor_read_buffer.cc
+++ b/src/facade/proactor_read_buffer.cc
@@ -1,0 +1,90 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "facade/proactor_read_buffer.h"
+
+#include <utility>
+
+#include "base/logging.h"
+#include "util/fibers/fibers.h"
+
+namespace facade {
+
+ProactorReadBuffer::ScopedBorrow::ScopedBorrow(ProactorReadBuffer* read_buffer)
+    : proactor_read_buffer_(read_buffer) {
+  DCHECK(proactor_read_buffer_);
+}
+
+ProactorReadBuffer::ScopedBorrow& ProactorReadBuffer::ScopedBorrow::operator=(
+    ScopedBorrow&& other) noexcept {
+  if (this != &other) {
+    Release();
+    proactor_read_buffer_ = std::exchange(other.proactor_read_buffer_, nullptr);
+  }
+  return *this;
+}
+
+void ProactorReadBuffer::ScopedBorrow::Release() {
+  if (!proactor_read_buffer_)
+    // This is possible by definition since the ScopedBorrow might be moved from.
+    return;
+
+  auto& io_buf = *proactor_read_buffer_->io_buf_;
+  CHECK(proactor_read_buffer_->in_use_);
+  DCHECK_EQ(io_buf.InputLen(), 0u);
+  DCHECK_EQ(io_buf.AppendLen(), io_buf.Capacity());
+  DCHECK_EQ(io_buf.Capacity(), proactor_read_buffer_->capacity_);
+  DCHECK_EQ(util::fb2::FiberSwitchEpoch(), proactor_read_buffer_->switch_epoch_);
+  io_buf.Clear();
+  proactor_read_buffer_->in_use_ = false;
+  proactor_read_buffer_->owner_conn_id_ = ProactorReadBuffer::kNoOwner;
+  proactor_read_buffer_ = nullptr;
+}
+
+void ProactorReadBuffer::Init(size_t capacity) {
+  CHECK(!io_buf_);  // can init only once.
+  CHECK_GT(capacity, 0u);
+  // Construct the IoBuf in-place and keep the capacity_ for later verification.
+  io_buf_.emplace(capacity);
+  capacity_ = capacity;
+}
+
+size_t ProactorReadBuffer::Capacity() const {
+  DCHECK(io_buf_);
+  return io_buf_->Capacity();
+}
+
+bool ProactorReadBuffer::in_use() const {
+  DCHECK(io_buf_);
+  return in_use_;
+}
+
+size_t ProactorReadBuffer::InputLen() const {
+  DCHECK(io_buf_);
+  return io_buf_->InputLen();
+}
+
+uint64_t ProactorReadBuffer::OwnerConnId() const {
+  DCHECK(io_buf_);
+  return owner_conn_id_;
+}
+
+std::optional<ProactorReadBuffer::ScopedBorrow> ProactorReadBuffer::TryBorrow(uint32_t conn_id) {
+  CHECK(io_buf_);
+
+  // An in-use buffer is reported to the caller so it can fail safely instead of corrupting input.
+  if (in_use_)
+    return std::nullopt;
+
+  DCHECK_EQ(io_buf_->InputLen(), 0u);
+  DCHECK_EQ(io_buf_->AppendLen(), io_buf_->Capacity());
+  DCHECK_EQ(io_buf_->Capacity(), capacity_);
+
+  in_use_ = true;
+  owner_conn_id_ = conn_id;
+  switch_epoch_ = util::fb2::FiberSwitchEpoch();
+  return ScopedBorrow{this};
+}
+
+}  // namespace facade

--- a/src/facade/proactor_read_buffer.cc
+++ b/src/facade/proactor_read_buffer.cc
@@ -25,6 +25,11 @@ ProactorReadBuffer::ScopedBorrow& ProactorReadBuffer::ScopedBorrow::operator=(
   return *this;
 }
 
+io::IoBuf& ProactorReadBuffer::ScopedBorrow::buf() {
+  assert(proactor_read_buffer_);
+  return *proactor_read_buffer_->io_buf_;
+}
+
 void ProactorReadBuffer::ScopedBorrow::Release() {
   if (!proactor_read_buffer_)
     // This is possible by definition since the ScopedBorrow might be moved from.
@@ -45,9 +50,17 @@ void ProactorReadBuffer::ScopedBorrow::Release() {
 void ProactorReadBuffer::Init(size_t capacity) {
   CHECK(!io_buf_);  // can init only once.
   CHECK_GT(capacity, 0u);
-  // Construct the IoBuf in-place and keep the capacity_ for later verification.
+  // IoBuf may round capacity up. Keep its actual allocation for later verification.
   io_buf_.emplace(capacity);
-  capacity_ = capacity;
+  capacity_ = io_buf_->Capacity();
+}
+
+void ProactorReadBuffer::Reset() {
+  DCHECK(!in_use_);
+  io_buf_.reset();
+  capacity_ = 0;
+  owner_conn_id_ = kNoOwner;
+  switch_epoch_ = 0;
 }
 
 size_t ProactorReadBuffer::Capacity() const {

--- a/src/facade/proactor_read_buffer.h
+++ b/src/facade/proactor_read_buffer.h
@@ -1,0 +1,94 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <utility>
+
+#include "io/io_buf.h"
+
+namespace facade {
+
+// Owns the one reusable RESP V2 receive buffer for a proactor thread. The buffer may be borrowed
+// by only one connection at a time and must be empty when returned.
+class ProactorReadBuffer {
+ public:
+  // RAII ownership guard: holds exclusive access to the shared buffer. Returning or destroying the
+  // borrow verifies that no fiber switch occurred and resets the buffer before another connection
+  // can use it.
+  class ScopedBorrow {
+   public:
+    // Non-copyable, move-only. Moving transfers ownership to the destination borrow.
+    ScopedBorrow(const ScopedBorrow&) = delete;
+    ScopedBorrow& operator=(const ScopedBorrow&) = delete;
+    ScopedBorrow(ScopedBorrow&& other) noexcept
+        : proactor_read_buffer_(std::exchange(other.proactor_read_buffer_, nullptr)) {
+    }
+    ScopedBorrow& operator=(ScopedBorrow&& other) noexcept;
+    ~ScopedBorrow() {
+      Release();
+    }
+
+    io::IoBuf& buf() {
+      return *proactor_read_buffer_->io_buf_;
+    }
+
+   private:
+    friend class ProactorReadBuffer;
+    explicit ScopedBorrow(ProactorReadBuffer* read_buffer);
+
+    // Validates the active borrow, clears its buffer, and makes it available to another connection.
+    // Calling Release() on a moved-from borrow is a no-op (since the ownership has moved to another
+    // owner).
+    void Release();
+
+    ProactorReadBuffer* proactor_read_buffer_ = nullptr;
+  };
+
+  void Init(size_t capacity);
+  bool IsInitialized() const {
+    return io_buf_.has_value();
+  }
+
+  size_t Capacity() const;
+
+  bool in_use() const;
+
+  size_t InputLen() const;
+
+  // Should be used for diagnostics only. For correctness, use in_use().
+  uint64_t OwnerConnId() const;
+
+  // Creates an RAII guard for exclusive use of the shared buffer by `conn_id`.
+  // Returns nullopt when another connection is already using it. The guard records the current
+  // fiber-switch epoch. When the guard is destroyed, it verifies that no fiber switch occurred and
+  // makes the buffer available for another connection without deallocating it.
+  std::optional<ScopedBorrow> TryBorrow(uint32_t conn_id);
+
+ private:
+  std::optional<io::IoBuf> io_buf_;
+
+  // Source of truth for the active-borrow state. false exactly when the buffer is available.
+  bool in_use_ = false;
+
+  // Client ID recorded by the active borrow, or kNoOwner while the buffer is available.
+  // Can be also 0 too (theoretically) since client IDs start at 1 but held in uint32_t which may
+  // wrap around.
+  static constexpr uint64_t kNoOwner = std::numeric_limits<uint64_t>::max();
+  uint64_t owner_conn_id_ = kNoOwner;
+
+  // The configured size of io_buf_, in bytes. Init() sets this value. The code checks that this
+  // size does not change while a connection is using io_buf_.
+  size_t capacity_ = 0;
+
+  // Fiber-switch epoch captured when ownership begins. Release verifies it is unchanged, proving
+  // the exclusive shared-buffer borrow did not suspend.
+  uint64_t switch_epoch_ = 0;
+};
+
+}  // namespace facade

--- a/src/facade/proactor_read_buffer.h
+++ b/src/facade/proactor_read_buffer.h
@@ -34,9 +34,7 @@ class ProactorReadBuffer {
       Release();
     }
 
-    io::IoBuf& buf() {
-      return *proactor_read_buffer_->io_buf_;
-    }
+    io::IoBuf& buf();
 
    private:
     friend class ProactorReadBuffer;
@@ -51,6 +49,7 @@ class ProactorReadBuffer {
   };
 
   void Init(size_t capacity);
+  void Reset();
   bool IsInitialized() const {
     return io_buf_.has_value();
   }
@@ -82,8 +81,8 @@ class ProactorReadBuffer {
   static constexpr uint64_t kNoOwner = std::numeric_limits<uint64_t>::max();
   uint64_t owner_conn_id_ = kNoOwner;
 
-  // The configured size of io_buf_, in bytes. Init() sets this value. The code checks that this
-  // size does not change while a connection is using io_buf_.
+  // The actual size of io_buf_, in bytes. Init() stores the rounded capacity allocated by IoBuf.
+  // The code checks that this size does not change while a connection is using io_buf_.
   size_t capacity_ = 0;
 
   // Fiber-switch epoch captured when ownership begins. Release verifies it is unchanged, proving

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1179,6 +1179,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
       [&](uint32_t index, ProactorBase* pb) { sharding::InitThreadLocals(shard_set->size()); });
 
   shard_set->pool()->AwaitBrief([](unsigned, auto*) {
+    facade::Connection::InitThreadLocal();
     facade::Connection::UpdateFromFlags();
     UpdateFromFlagsOnThread();
     UpdateSchedulerFlagsOnThread();

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -325,8 +325,6 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
   AppendMetricWithoutLabels("shared_buf_overflow_copies_total", "Shared V2 overflow copies",
                             conn_stats.shared_buf_overflow_copies, MetricType::COUNTER,
                             &resp->body());
-  // fix A5
-  // Convert only after aggregation so individual sub-microsecond borrows contribute to the total.
   AppendMetricWithoutLabels("shared_buf_borrow_callback_usec_total",
                             "Shared V2 callback borrow duration",
                             base::CycleClock::ToUsec(conn_stats.shared_buf_borrow_cycles_callback),

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -322,6 +322,18 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
   AppendMetricWithoutLabels("proactor_parse_total",
                             "V2 OnRecv parses that enqueued at least one command",
                             conn_stats.proactor_parse, MetricType::COUNTER, &resp->body());
+  AppendMetricWithoutLabels("shared_buf_overflow_copies_total", "Shared V2 overflow copies",
+                            conn_stats.shared_buf_overflow_copies, MetricType::COUNTER,
+                            &resp->body());
+  // fix A5
+  // Convert only after aggregation so individual sub-microsecond borrows contribute to the total.
+  AppendMetricWithoutLabels("shared_buf_borrow_callback_usec_total",
+                            "Shared V2 callback borrow duration",
+                            base::CycleClock::ToUsec(conn_stats.shared_buf_borrow_cycles_callback),
+                            MetricType::COUNTER, &resp->body());
+  AppendMetricWithoutLabels("shared_buf_borrow_fiber_usec_total", "Shared V2 fiber borrow duration",
+                            base::CycleClock::ToUsec(conn_stats.shared_buf_borrow_cycles_fiber),
+                            MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("net_input_bytes_total", "", conn_stats.io_read_bytes,
                             MetricType::COUNTER, &resp->body());
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2720,6 +2720,7 @@ IOBUF_WAIT_TIMEOUT_SEC = 6
     {
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
@@ -2763,6 +2764,7 @@ async def test_iobuf_shrinks_when_receive_idle(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
@@ -2800,6 +2802,7 @@ async def test_iobuf_regrows_after_receive_idle_shrink(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         "iobuf_min_shrink_interval_sec": 0,
     }
@@ -2828,6 +2831,7 @@ async def test_iobuf_does_not_shrink_when_disabled(df_server: DflyInstance):
 @dfly_args(
     {
         "proactor_threads": 1,
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
@@ -2873,6 +2877,7 @@ async def test_iobuf_shrinks_from_active_path(df_server: DflyInstance):
 @dfly_args(
     {
         "proactor_threads": 1,
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
@@ -2904,6 +2909,7 @@ async def test_iobuf_shrinks_from_complete_parse(df_server: DflyInstance):
 @dfly_args(
     {
         "proactor_threads": 1,
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         "iobuf_min_shrink_interval_sec": IOBUF_MIN_SHRINK_INTERVAL_SEC,
     }
@@ -2943,6 +2949,7 @@ async def test_iobuf_high_usage_defers_active_shrink(df_server: DflyInstance):
     {
         "proactor_threads": 1,
         "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "false",
         "max_client_iobuf_len": 4096,
         # Needs a longer configured shrink interval so it can prove that after the first shrink
         # a second shrink does not occur during the cooldown window.


### PR DESCRIPTION
Add a ProactorReadBuffer that lets eligible RESP V2 connections borrow one shared input buffer per proactor. This establishes the lifecycle needed to reduce per-connection retained read-buffer memory once the private buffer is released. It is primarily a memory-saving change, not a throughput optimization.

We expect a large memory reduction for workloads with many open connections. For example, a server with 25K client connections on 32 CPUs would use about 800 MB for 25K private 32KB buffers. With one shared buffer per proactor, this should drop to less than 1 MB after the private buffers are released. Note: The reduction will materialize only on following PRs, when the private buffer is released and stays unused.

The design is limited to the event-driven RESP V2 loop. Applying it to RESP V1 would require invasive changes to V1's connection and read lifecycle, so V1 keeps its private input buffer.

Track shared-buffer ownership, per-connection overflow input, and borrow duration through facade stats and metrics. Preserve bytes read during protocol detection by moving them into overflow storage before shared parsing begins.

Metrics:
- Add `shared_buf_overflow_copies_total` to count copies into connection-owned overflow storage.
- Add `shared_buf_borrow_callback_usec_total` and `shared_buf_borrow_fiber_usec_total` to measure shared-buffer borrow time in callbacks and fibers.

Configuration:
- Add `enable_shared_read_buffer` to enable or disable the shared RESP V2 read buffer.
- Add `shared_read_buffer_len` to configure its per-proactor capacity.

Validation:
- Exercised repeatedly in local stress runs and in this PR, with all runs passing.
- A follow-up PR will add dedicated regression coverage for fragmented requests, overflow ownership, pipelining, backpressure, TLS, Unix, admin, and connection-accounting cases.

Known follow-up work:
- Protocol detection still uses a private buffer whose allocation is retained after detection.
- The private buffer is still fully allocated during normal RESP V2 operation, so the expected memory gain is not realized yet. Its smart pointer still needs to be reset after the shared buffer takes over.
- Overflow storage grows dynamically per connection and does not use a reuse pool.
- Shared-buffer borrowing has no fairness mechanism or quotas.
- Run ASAN and UBSAN coverage for this new lifecycle.
