### PR TITLE
fix: don't abort on in-flight OnChange serialization when unregistering snapshot listener

### DIFF
--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -166,10 +166,11 @@ void SerializerBase::RegisterChangeListener(bool replication) {
 }
 
 void SerializerBase::UnregisterChangeListener() {
-  DCHECK(!IsAnyBucketBlocked());
   if (snapshot_version_ > 0)
     if (!db_slice_->UnregisterOnChange(this))
       LOG(DFATAL) << "UnregisterOnChange failed for snapshot_version_ " << snapshot_version_;
+  // No OnChange is in flight after unregistering, so leftover deps can only be leaks.
+  DCHECK(!IsAnyBucketBlocked());
 }
 
 bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator it,

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -105,6 +105,8 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   struct Params {
     float delay_prob = 0.0;
     std::pair<unsigned, unsigned> delay_lat_us = {0, 100};
+    bool start_paused = false;
+    bool block_on_update = false;
   };
 
   TestDriver(Params params, DbSlice* slice, ExecutionState* cntx, CommandRegistry* reg)
@@ -198,6 +200,8 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   // subdriver for delayed entries
   TestDelayDriver delay_driver_;
 
+  util::fb2::Done on_update_entered_, on_update_release_, resume_traversal_;
+
   // Number of delayed entries currently enqueued.
   unsigned delayed_enqueued_ = 0;
 
@@ -206,6 +210,9 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
 };
 
 void TestDriver::Loop() {
+  if (params_.start_paused)
+    resume_traversal_.Wait();
+
   for (DbIndex snapshot_db_indx = 0; snapshot_db_indx < db_array_.size(); ++snapshot_db_indx) {
     if (!base_cntx_->IsRunning())
       return;
@@ -263,6 +270,11 @@ void TestDriver::ConsumeJournalChange(const journal::JournalChangeItem& item) {
 
 unsigned TestDriver::SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_iterator it,
                                            bool on_update) {
+  if (on_update && params_.block_on_update) {
+    on_update_entered_.Notify();
+    on_update_release_.Wait();
+  }
+
   unsigned serialized = 0;
   for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
     DCHECK_EQ(it.GetVersion(), snapshot_version_);
@@ -298,6 +310,10 @@ class SerializerBaseTest : public BaseFamilyTest {
 
   void Change(auto cb) {
     pp_->at(0)->Await([this, cb] { cb(*driver_); });
+  }
+
+  void CancelCntx() {
+    pp_->at(0)->Await([this] { cntx_.ReportCancelError(); });
   }
 
   TestDriver::Params driver_params;
@@ -493,6 +509,30 @@ TEST_F(SerializerBaseTest, DelayedEvicted) {
 
   // Currently we write baselines before eviction
   EXPECT_EQ(baselines.size(), kKeys + 1);
+}
+
+// Cancelling mid-sync must not let UnregisterChangeListener observe a bucket latch still held
+// by an OnChange serialization suspended inside the Increment..Decrement window.
+TEST_F(SerializerBaseTest, UnregisterWaitsForInflightOnChange) {
+  driver_params = {.start_paused = true, .block_on_update = true};
+
+  Run({"DEBUG", "POPULATE", "100"});
+  Start();
+
+  auto writer = pp_->at(0)->LaunchFiber([&] { Run("W1", {"APPEND", "key:1", "D"}); });
+  Change([](TestDriver& d) { d.on_update_entered_.Wait(); });
+
+  CancelCntx();
+  Change([](TestDriver& d) { d.resume_traversal_.Notify(); });
+  Change([](TestDriver&) {
+    for (unsigned i = 0; i < 20; ++i)
+      util::ThisFiber::Yield();
+  });
+
+  Change([](TestDriver& d) { d.on_update_release_.Notify(); });
+
+  writer.Join();
+  Finish();
 }
 
 }  // namespace dfly


### PR DESCRIPTION
`SerializerBase::UnregisterChangeListener` ran `DCHECK(!IsAnyBucketBlocked())` before `UnregisterOnChange`, racing OnChange callbacks that legally hold a bucket latch while suspended on a chunk flush into a stalled replication socket. When the master breaks a stalled full sync (`replication_timeout`), the snapshot fiber early-returns from traversal and can reach the DCHECK while a writer's OnChange is still latched - SIGABRT in debug builds. This is the cause of all 2026 failures of `test_replication_timeout_on_full_sync` (the 2025 failures in the issue were a different, older bug on the replica side).

Changes:
- Unregister first, assert after: `UnregisterOnChange` waits on `change_cb_latch_`, which covers the whole OnChange invocation, so afterward leftover deps can only be genuine leaks and the DCHECK becomes a real invariant.
- Add a deterministic regression test that parks an OnChange fiber inside the latch window and cancels mid-sync; pre-fix it aborts with the exact CI signature.

Fixes #4538
