### PR TITLE
server: Introduce cmd memory scope

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -86,6 +86,10 @@ class CommandId {
     opt_mask_ |= flag;
   }
 
+  bool HasFamily() const {
+    return family_ != kNoFamily;
+  }
+
  protected:
   std::string name_;
 

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -9,15 +9,16 @@
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
-#include <absl/time/clock.h>
 #include <hdr/hdr_histogram.h>
 
-#include "base/bits.h"
+#include <array>
+
 #include "base/flags.h"
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/error.h"
+#include "redis/redis_aux.h"
 #include "server/acl/acl_commands_def.h"
 #include "server/conn_context.h"
 
@@ -126,6 +127,37 @@ CmdLineMapping OriginalToAliasMap() {
 constexpr int64_t kLatencyHistogramMinValue = 1;        // Minimum value in usec
 constexpr int64_t kLatencyHistogramMaxValue = 1000000;  // Maximum value in usec (1s)
 constexpr int32_t kLatencyHistogramPrecision = 2;
+
+constexpr int kNoCommandMemoryType = -1;
+
+constexpr auto kFamilyToType = std::to_array<int>({
+    kNoCommandMemoryType,  // core
+    kNoCommandMemoryType,  // server
+    kNoCommandMemoryType,  // generic
+    OBJ_LIST,              // list
+    OBJ_STRING,            // string
+#ifdef WITH_COLLECTION_CMDS
+    OBJ_SET,     // set
+    OBJ_HASH,    // hash
+    OBJ_ZSET,    // sorted_set
+    OBJ_STREAM,  // stream
+#endif
+#ifdef WITH_EXTENSION_CMDS
+    OBJ_ZSET,          // geo
+    OBJ_STRING,        // bitmap
+    OBJ_STRING,        // hyperloglog
+    OBJ_SBF,           // bloom
+    OBJ_CMS,           // cms
+    OBJ_TOPK,          // topk
+    OBJ_CUCKOOFILTER,  // cuckoo_filter
+    OBJ_JSON,          // json
+#endif
+#ifdef WITH_SEARCH
+    kNoCommandMemoryType,  // search
+#endif
+    kNoCommandMemoryType,  // cluster
+    kNoCommandMemoryType,  // acl
+});
 
 }  // namespace
 
@@ -364,6 +396,11 @@ absl::flat_hash_map<std::string, hdr_histogram*> CommandRegistry::LatencyMap() c
     cmd_latencies.insert({absl::AsciiStrToLower(cmd_name), cmd.GetLatencyHist()});
   }
   return cmd_latencies;
+}
+
+int TypeForFamily(size_t family) {
+  DCHECK_LT(family, kFamilyToType.size());
+  return kFamilyToType[family];
 }
 
 absl::flat_hash_map<std::string, CmdCallStats> CommandRegistry::NamedCallStats(

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -386,4 +386,8 @@ class CommandRegistry {
   std::optional<uint32_t> acl_category_;  // category of family currently being built
 };
 
+// Returns the object type for tracked command family, or -1 for families which have no one specific
+// type. family must come from a CommandId registered by CommandRegistry.
+int TypeForFamily(size_t family);
+
 }  // namespace dfly

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -20,6 +20,7 @@ extern "C" {
 #include "facade/dragonfly_listener.h"
 #include "facade/error.h"
 #include "facade/facade_test.h"
+#include "redis/redis_aux.h"
 #include "server/command_registry.h"
 #include "server/main_service.h"
 #include "server/test_utils.h"
@@ -1193,6 +1194,49 @@ TEST_F(DflyEngineTest, ListenerAcceptLoopDistribution) {
   for (facade::Listener* listener : listeners)
     accept_proactors.insert(listener->socket()->proactor());
   EXPECT_EQ(kListeners, accept_proactors.size());
+}
+
+TEST_F(DflyEngineTest, TypeForFamilyMatchesRegisteredCommands) {
+  constexpr int kNoTrackedType = -1;
+  const auto* registry = service_->mutable_registry();
+
+  auto expect_type = [registry](string_view cmd, int type) {
+    const auto* cid = registry->Find(cmd);
+    ASSERT_NE(cid, nullptr);
+    ASSERT_TRUE(cid->HasFamily());
+    EXPECT_EQ(TypeForFamily(cid->GetFamily()), type);
+  };
+
+  expect_type("QUIT", kNoTrackedType);
+  expect_type("INFO", kNoTrackedType);
+  expect_type("DEL", kNoTrackedType);
+  expect_type("LPUSH", OBJ_LIST);
+  expect_type("SET", OBJ_STRING);
+
+#ifdef WITH_COLLECTION_CMDS
+  expect_type("SADD", OBJ_SET);
+  expect_type("HSET", OBJ_HASH);
+  expect_type("ZADD", OBJ_ZSET);
+  expect_type("XADD", OBJ_STREAM);
+#endif
+
+#ifdef WITH_EXTENSION_CMDS
+  expect_type("GEOADD", OBJ_ZSET);
+  expect_type("SETBIT", OBJ_STRING);
+  expect_type("PFADD", OBJ_STRING);
+  expect_type("BF.ADD", OBJ_SBF);
+  expect_type("CMS.INITBYDIM", OBJ_CMS);
+  expect_type("TOPK.RESERVE", OBJ_TOPK);
+  expect_type("CF.RESERVE", OBJ_CUCKOOFILTER);
+  expect_type("JSON.SET", OBJ_JSON);
+#endif
+
+#ifdef WITH_SEARCH
+  expect_type("FT.CREATE", kNoTrackedType);
+#endif
+
+  expect_type("CLUSTER", kNoTrackedType);
+  expect_type("ACL", kNoTrackedType);
 }
 
 class DflyCommandAliasTest : public DflyEngineTest {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1149,9 +1149,12 @@ void EngineShard::CacheStats() {
   last_mem_params_ = {used_mem};
 }
 
+size_t EngineShard::UsedMemoryWithoutSearch() const {
+  return mi_resource_.used() + zmalloc_used_memory_tl + SmallString::UsedThreadLocal();
+}
+
 size_t EngineShard::UsedMemory() const {
-  return mi_resource_.used() + zmalloc_used_memory_tl + SmallString::UsedThreadLocal() +
-         search_indices()->GetUsedMemory();
+  return UsedMemoryWithoutSearch() + search_indices()->GetUsedMemory();
 }
 
 bool EngineShard::ShouldThrottleForTiering() const {
@@ -1292,6 +1295,14 @@ EngineShard::CompactTableStats EngineShard::CompactTable(double threshold, DbInd
   }
 
   return stats;
+}
+
+void EngineShard::AddTypeMemDelta(size_t type, int64_t delta) {
+  if (delta == 0)
+    return;
+
+  DCHECK_LT(type, type_mem_delta_.size());
+  type_mem_delta_[type] += delta;
 }
 
 }  // namespace dfly

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -4,11 +4,14 @@
 
 #pragma once
 
+#include <array>
+
 #include "core/intent_lock.h"
 #include "core/mi_memory_resource.h"
 #include "core/page_usage/page_usage_stats.h"
 #include "core/task_queue.h"
 #include "core/tx_queue.h"
+#include "redis/redis_aux.h"
 #include "server/common_types.h"
 #include "util/sliding_counter.h"
 
@@ -19,6 +22,8 @@ namespace dfly {
 class EngineShardSet;
 class TieredStorage;
 class ShardDocIndices;
+
+using TypeMemDeltas = std::array<int64_t, OBJ_TYPE_MAX>;
 
 class EngineShard {
   friend class EngineShardSet;
@@ -127,8 +132,11 @@ class EngineShard {
     return stats_;
   }
 
-  // Calculate memory used by shard by summing multiple sources
+  // Calculate memory used by shard by summing multiple sources.
   size_t UsedMemory() const;
+
+  // Calculate memory used by local shard allocators, excluding search index memory.
+  size_t UsedMemoryWithoutSearch() const;
 
   TieredStorage* tiered_storage() {
     return tiered_storage_.get();
@@ -245,6 +253,12 @@ class EngineShard {
 
   // Merge underutilized buddy-segment pairs in the dash table.
   CompactTableStats CompactTable(double threshold, DbIndex db_idx);
+
+  void AddTypeMemDelta(size_t type, int64_t delta);
+
+  const TypeMemDeltas& type_mem_delta() const {
+    return type_mem_delta_;
+  }
 
  private:
   struct DefragTaskState {
@@ -368,6 +382,8 @@ class EngineShard {
   using Counter = util::SlidingCounter<7>;
 
   Counter counter_[COUNTER_TOTAL];
+
+  TypeMemDeltas type_mem_delta_ = {};
 
   static __thread EngineShard* shard_;
 };

--- a/src/server/memory_scope.h
+++ b/src/server/memory_scope.h
@@ -1,0 +1,34 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cstdint>
+
+namespace dfly {
+
+class MemoryScope {
+ public:
+  explicit MemoryScope(int obj_type);
+
+  MemoryScope(const MemoryScope&) = delete;
+  MemoryScope& operator=(const MemoryScope&) = delete;
+
+  void Suspend();
+  void Resume();
+
+  ~MemoryScope();
+
+ private:
+  void Checkpoint(int64_t used_memory);
+
+  int obj_type_;
+  int64_t mem_baseline_ = 0;
+
+  int64_t delta_ = 0;
+
+  bool suspended_ = false;
+};
+
+}  // namespace dfly

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -8,21 +8,23 @@
 
 #include <memory>
 
+#include "absl/cleanup/cleanup.h"
 #include "base/flags.h"
 #include "base/logging.h"
 #include "facade/facade_stats.h"
 #include "facade/op_status.h"
-#include "redis/redis_aux.h"
 #include "server/blocking_controller.h"
 #include "server/command_registry.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/journal/journal.h"
+#include "server/memory_scope.h"
 #include "server/namespaces.h"
 #include "server/server_state.h"
 
 ABSL_FLAG(uint32_t, tx_queue_warning_len, 96,
           "Length threshold for warning about long transaction queue");
+ABSL_FLAG(bool, disable_scope_based_mem_track, false, "Turn off scope based memory metric");
 
 namespace dfly {
 
@@ -80,6 +82,35 @@ std::string FormatTp(Transaction::time_point tp) {
 
 uint16_t trans_id(const Transaction* ptr) {
   return (intptr_t(ptr) >> 8) & 0xFFFF;
+}
+
+thread_local MemoryScope* tl_mem_scope = nullptr;
+
+void MemTrackerHook(fb2::FiberSwitchHookEvent event) noexcept {
+  DCHECK_NE(tl_mem_scope, nullptr);
+
+  using enum fb2::FiberSwitchHookEvent;
+  switch (event) {
+    case SUSPEND:
+      tl_mem_scope->Suspend();
+      break;
+    case RESUME:
+      tl_mem_scope->Resume();
+      break;
+  }
+}
+
+template <typename Func> auto WithHook(int obj_type, Func func) {
+  MemoryScope scope(obj_type);
+  const auto prev_hook = ThisFiber::SetSwitchHook({MemTrackerHook});
+  // there is probably no prev. hook but restore just in case
+  auto cleanup = absl::MakeCleanup([prev_hook] { ThisFiber::SetSwitchHook(prev_hook); });
+  return func();
+}
+
+int ObjectType(const CommandId* cid) {
+  static const bool kTrackScopeMem = !absl::GetFlag(FLAGS_disable_scope_based_mem_track);
+  return kTrackScopeMem && cid && cid->HasFamily() ? TypeForFamily(cid->GetFamily()) : -1;
 }
 
 }  // namespace
@@ -683,7 +714,10 @@ void Transaction::RunCallback(EngineShard* shard) {
 
   RunnableResult result;
   try {
-    result = (*cb_ptr_)(this, shard);
+    if (const int obj_typ = ObjectType(cid_); obj_typ >= 0)
+      result = WithHook(obj_typ, [&] { return (*cb_ptr_)(this, shard); });
+    else
+      result = (*cb_ptr_)(this, shard);
 
     if (unique_shard_cnt_ == 1) {
       cb_ptr_.reset();  // We can do it because only a single thread runs the callback.
@@ -1525,7 +1559,10 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   // An escaping exception would skip the cleanup below and leave the EXEC reply incomplete.
   RunnableResult result;
   try {
-    result = cb(this, shard);
+    if (const int obj_typ = ObjectType(cid_); obj_typ >= 0)
+      result = WithHook(obj_typ, [&] { return cb(this, shard); });
+    else
+      result = cb(this, shard);
   } catch (std::bad_alloc&) {
     LOG_EVERY_T(ERROR, 1) << " out of memory";
     result = OpStatus::OUT_OF_MEMORY;
@@ -1871,6 +1908,63 @@ std::vector<Transaction::PerShardCache>& Transaction::TLTmpSpace::GetShardIndex(
   for (auto& v : shard_cache)
     v.Clear();
   return shard_cache;
+}
+
+namespace {
+
+int64_t TrackedMemory() {
+  const EngineShard* shard = EngineShard::tlocal();
+  // Full search index memory accounting scans all indices. Keep command-scope sampling O(1).
+  const int64_t used_memory = shard->UsedMemoryWithoutSearch();
+
+  const DbSlice* db_slice = nullptr;
+  if (const Transaction* tx = shard->running_tx(); tx != nullptr)
+    db_slice = &tx->GetDbSlice(shard->shard_id());
+  // for unit tests which do not run in transactions
+  else if (namespaces != nullptr)
+    db_slice = &namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
+
+  return used_memory - db_slice->table_memory();
+}
+
+}  // namespace
+
+MemoryScope::MemoryScope(int obj_type) : obj_type_(obj_type), mem_baseline_(TrackedMemory()) {
+  DCHECK_GE(obj_type_, 0);
+  DCHECK_EQ(tl_mem_scope, nullptr);
+  tl_mem_scope = this;
+}
+
+void MemoryScope::Suspend() {
+  DCHECK_EQ(tl_mem_scope, this);
+  DCHECK(!suspended_);
+
+  Checkpoint(TrackedMemory());
+  suspended_ = true;
+}
+
+void MemoryScope::Resume() {
+  DCHECK_EQ(tl_mem_scope, this);
+  DCHECK(suspended_);
+
+  mem_baseline_ = TrackedMemory();
+  suspended_ = false;
+}
+
+MemoryScope::~MemoryScope() {
+  DCHECK_EQ(tl_mem_scope, this);
+  DCHECK(!suspended_);
+
+  Checkpoint(TrackedMemory());
+  tl_mem_scope = nullptr;
+
+  EngineShard::tlocal()->AddTypeMemDelta(obj_type_, delta_);
+}
+
+void MemoryScope::Checkpoint(int64_t used_memory) {
+  DCHECK(!suspended_);
+  delta_ += used_memory - mem_baseline_;
+  mem_baseline_ = used_memory;
 }
 
 }  // namespace dfly

--- a/src/server/transaction_test.cc
+++ b/src/server/transaction_test.cc
@@ -15,6 +15,7 @@
 #include "server/db_slice.h"
 #include "server/engine_shard.h"
 #include "server/engine_shard_set.h"
+#include "server/memory_scope.h"
 #include "server/namespaces.h"
 #include "server/server_state.h"
 #include "util/fibers/pool.h"
@@ -421,6 +422,82 @@ TEST_F(TransactionTest, LazyLockDisjointKeyMarkedOutOfOrder) {
 
   ASSERT_TRUE(v_done.WaitFor(5s)) << "V was never run after Z concluded";
   fb_v.Join();
+}
+
+namespace {
+
+TypeMemDeltas DeltaDiff(const TypeMemDeltas& before, const TypeMemDeltas& after) {
+  TypeMemDeltas diffs = after;
+  for (size_t i = 0; i < before.size(); ++i)
+    diffs[i] -= before[i];
+  return diffs;
+}
+
+void AllButOneDeltaIs(const TypeMemDeltas& deltas, size_t pos, int64_t expected) {
+  ASSERT_GT(deltas.size(), pos);
+  for (size_t i = 0; i < deltas.size(); ++i)
+    if (i == pos)
+      ASSERT_EQ(deltas[i], expected);
+    else
+      ASSERT_EQ(deltas[i], 0);
+}
+
+template <typename F> auto WithMemTrack(int obj_type, F f) {
+  MemoryScope scope(obj_type);
+  return f();
+}
+
+}  // namespace
+
+TEST_F(TransactionTest, DeltaChanges) {
+  OnShard(0, [] {
+    const auto shard = EngineShard::tlocal();
+    const auto mr = shard->memory_resource();
+    void* p = nullptr;
+    const auto before = shard->type_mem_delta();
+    WithMemTrack(OBJ_STRING, [&] { p = mr->allocate(1024); });
+    AllButOneDeltaIs(DeltaDiff(before, shard->type_mem_delta()), OBJ_STRING, 1024);
+    mr->deallocate(p, 1024);
+  });
+}
+
+TEST_F(TransactionTest, DeltaAllocAndFree) {
+  OnShard(0, [] {
+    const auto shard = EngineShard::tlocal();
+    const auto mr = shard->memory_resource();
+    void* p = mr->allocate(1024);
+    const auto before = shard->type_mem_delta();
+    WithMemTrack(OBJ_LIST, [&] { mr->deallocate(p, 1024); });
+    AllButOneDeltaIs(DeltaDiff(before, shard->type_mem_delta()), OBJ_LIST, -1024);
+  });
+}
+
+TEST_F(TransactionTest, DeltaSuspendResume) {
+  OnShard(0, [] {
+    const auto shard = EngineShard::tlocal();
+    const auto mr = shard->memory_resource();
+
+    const auto before = shard->type_mem_delta();
+    void* p = nullptr;
+    void* q = nullptr;
+
+    {
+      MemoryScope scope_for_string{OBJ_STRING};
+      p = mr->allocate(1024);
+
+      scope_for_string.Suspend();
+
+      q = mr->allocate(128);
+
+      scope_for_string.Resume();
+    }
+
+    const auto diff = DeltaDiff(before, shard->type_mem_delta());
+    AllButOneDeltaIs(diff, OBJ_STRING, 1024);
+
+    mr->deallocate(p, 1024);
+    mr->deallocate(q, 128);
+  });
 }
 
 }  // namespace dfly


### PR DESCRIPTION
A new RAII based class is introduced called MemoryScope. It calculates the change in memory (shard used memory - table memory) across its lifetime.

The scope cooperates with helio, when a fiber is suspended, tracking is also suspended and resumed using fiber hooks.

Memory delta calculated is stored on a new field of engine shard, which is an array. The index of the array represents object type so that we have per type memory delta.

To keep the PR small the metric is not exposed yet. In next PRs the metric will be exposed, and generic command families and especially delete command will use local scope objects to track memory.

---

There is also a new flag to turn off this scope mechanism: `disable_scope_based_mem_track`. The memory tracking is __enabled__ by default. It has to be explicitly disabled if needed.

---

It does not yet include search index memory usage. Since that is calculated by walking over multiple data structures. In future PRs we can add counters for this usage, and then include it back. 

https://github.com/dragonflydb/dragonfly/pull/7794 contains a rough working implementation of the eventual code, where deletes, generic commands etc are handled using scopes.