### PR TITLE
fix(cluster): don't abort on client-pause timeout during migration fi…

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -384,7 +384,6 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
       dfly::Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
                   nullptr, ClientPause::ALL, is_pause_in_progress);
 
-  DCHECK(pause_fb_opt);
   if (!pause_fb_opt) {
     auto err = absl::StrCat("Migration finalization time out ", cf_->MyID(), " : ",
                             migration_info_.node_info.id, " attempt ", attempt);


### PR DESCRIPTION
`OutgoingMigration::FinalizeMigration()` crashes debug/test builds with a `DCHECK` failure (SIGABRT) whenever the client-pause step legitimately times out, causing `test_cluster_fuzzymigration` to fail intermittently in CI (#8137).

## Root cause

`FinalizeMigration()` calls `dfly::Pause()` to pause clients during finalization:

```cpp
auto pause_fb_opt = dfly::Pause(...);

DCHECK(pause_fb_opt);
if (!pause_fb_opt) {
  auto err = absl::StrCat("Migration finalization time out ", ...);
  LOG(WARNING) << err;
  SetLastError(std::move(err));
}
```

`dfly::Pause()` returns `std::nullopt` when it can't confirm all in-flight commands paused within `--pause_wait_timeout` (default: **1 second**). The code immediately following the `DCHECK` was already written to handle that case gracefully — log a warning, record the error, and let the caller retry finalization — so a pause timeout is an expected, handled condition, not a programmer error.

The `DCHECK` was added in #5018 purely as a debug aid ("add DCHECK to easier tests debugging"), after the nullopt-handling logic already existed. Under `test_cluster_fuzzymigration`'s heavy concurrent load (20k keys, 10 migration flows), commands can take longer than 1s to finish dispatching, `Pause()` times out, and the `DCHECK` aborts the process — matching the SIGABRT stack in the issue (`OutgoingMigration::FinalizeMigration` → `SyncFb`) and the client-side `Connection refused` (server died mid-test).

## Fix

Remove the `DCHECK`. No behavior change in release builds (`DCHECK` is already a no-op under `NDEBUG`, so this is exactly what release builds do today). Debug/test builds now take the same already-tested fallback path — log a warning and continue finalization on a best-effort basis — instead of crashing.

## Testing

- `tests/dragonfly/cluster_test.py::test_cluster_fuzzymigration` (pre-split location; test now lives in `cluster_migration_resilience_test.py` post-#8118), all 4 parametrized variants including the exact CI-failing combo (`df_seeder_factory0-df_factory0-3-16-20000-10-true`)
- Repeated 20x to cover the timing-dependent race: 80/80 passed
- `pre-commit`/clang-format clean

Fixes #8137
