### PR TITLE
fix(server): Fix journal omit breaking on stash bucket

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -755,7 +755,7 @@ struct DashTable<_Key, _Value, Policy>::BucketSet {
 
   DashTable* owner_;
   uint32_t seg_id_;
-  uint8_t limit_;  // if larger than ids, then it is just the prefix 1..limit
+  uint8_t limit_;  // number of entries: 1 or 2 values from ids_ or all possible buckets
   std::array<uint8_t, 2> ids_;
 };
 

--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -723,6 +723,16 @@ struct DashTable<_Key, _Value, Policy>::BucketSet {
            });
   }
 
+  bool ContainsStashBucket() const {
+    if (limit_ > ids_.size())
+      return limit_ > DashTable::kBucketNum;
+
+    for (unsigned i = 0; i < limit_; ++i)
+      if (ids_[i] >= DashTable::kBucketNum)
+        return true;
+    return false;
+  }
+
   bool operator==(const BucketSet& other) const {
     return owner_ == other.owner_ && seg_id_ == other.seg_id_ && limit_ == other.limit_ &&
            ids_[0] == other.ids_[0] && ids_[1] == other.ids_[1];
@@ -745,7 +755,7 @@ struct DashTable<_Key, _Value, Policy>::BucketSet {
 
   DashTable* owner_;
   uint32_t seg_id_;
-  uint8_t limit_;
+  uint8_t limit_;  // if larger than ids, then it is just the prefix 1..limit
   std::array<uint8_t, 2> ids_;
 };
 

--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -1353,6 +1353,14 @@ void Segment<Key, Value, Policy>::Split(HFunc&& hfn, Segment* dest_right, MoveCb
     stash.ForEachSlot(std::move(cb));
     stash.ClearSlots(invalid_mask);
   }
+
+  // Propagate parent version - the version is never expected to magically decrease (drop to 0)
+  if constexpr (kUseVersion) {
+    for (unsigned i = 0; i < kBucketNum; ++i) {
+      if (dest_right->bucket_[i].IsEmpty())
+        dest_right->bucket_[i].SetVersion(bucket_[i].GetVersion());
+    }
+  }
 }
 
 template <typename Key, typename Value, typename Policy>

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -2157,6 +2157,11 @@ bool DbSlice::IsOmittableWrite(const Context& cntx, const ChangeReq& req) {
   if (!journal_omit_redundant_writes_)
     return false;
 
+  // Stash entries can be moved backwards relative to the cursor by TryMoveFromStash,
+  // breaking our reachability assumption. We must serialize now
+  if (req.ContainsStashBucket())
+    return false;
+
   bool omit_update = false;
   if (cntx.is_omittable_operation && change_cb_.size() == 1) {
     auto gv = [](PrimeTable::bucket_iterator it) { return it.GetVersion(); };

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -108,6 +108,7 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
     std::pair<unsigned, unsigned> delay_lat_us = {0, 100};
     bool start_paused = false;
     bool block_on_update = false;
+    bool eventually_consistent = false;
   };
 
   TestDriver(Params params, DbSlice* slice, ExecutionState* cntx, CommandRegistry* reg)
@@ -176,7 +177,7 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   }
 
   void Start() {
-    SerializerBase::RegisterChangeListener(false);
+    SerializerBase::RegisterChangeListener(params_.eventually_consistent);
     journal::StartInThread();
     journal_id_ = journal::RegisterConsumer(this);
 
@@ -392,30 +393,62 @@ class SerializerBaseTest : public BaseFamilyTest {
   std::optional<TestDriver> driver_;
 };
 
-// Check that basic serialization of debug populate is successful and fullfils all driver asserts
-TEST_F(SerializerBaseTest, StaticDebugPopulate) {
+class SerializerBaseParamTest : public SerializerBaseTest,
+                                public testing::WithParamInterface<bool> {};
+
+INSTANTIATE_TEST_SUITE_P(WithAppender, SerializerBaseParamTest, testing::Bool());
+
+// Snapshots a populated DB while a writer inserts new (omittable) keys.
+// With an appender it also runs non-omittable APPENDs
+TEST_P(SerializerBaseParamTest, StaticWithSetAndAppend) {
+  driver_params.eventually_consistent = true;
+
+  const bool with_appender = GetParam();
   const size_t kKeys = 10000;
+  const size_t kNew = 30000;
+
   Run({"DEBUG", "POPULATE", std::to_string(kKeys)});
   Start();
 
-  // Issue appends at the same time
   std::atomic_bool running = true;
-  auto worker = pp_->at(0)->LaunchFiber([&] {
-    for (unsigned i = 0; running.load(std::memory_order_relaxed) && i < kKeys; i++) {
-      Run("W1", {"APPEND", absl::StrCat("key:", i), "D"});
+  util::fb2::Fiber appender;
+  if (with_appender) {
+    appender = pp_->at(0)->LaunchFiber([&] {
+      for (unsigned i = 0; running.load(std::memory_order_relaxed) && i < kKeys; i++) {
+        Run("W2", {"APPEND", absl::StrCat("key:", i), "D"});
+        util::ThisFiber::Yield();
+      }
+    });
+  }
+  auto setter = pp_->at(0)->LaunchFiber([&] {
+    for (unsigned i = 0; running.load(std::memory_order_relaxed) && i < kNew; i++) {
+      Run("W1", {"SET", absl::StrCat("newkey:", i), "v"});
       util::ThisFiber::Yield();
     }
   });
 
-  // Finish and join worker
-  auto [stats, baselines, _] = Finish();
+  // Wait for the traversal loop to finish while the writers are still running, then finalize.
+  Change([](TestDriver& d) { d.Wait(); });
   running = false;
-  worker.Join();
+  if (with_appender)
+    appender.Join();
+  setter.Join();
+  auto [stats, baselines, journal_writes] = Finish();
 
-  // Expect serialized keys
-  EXPECT_EQ(stats.keys_serialized, kKeys);
+  // Pre-existing keys always exist and must be strictly covered by a baseline (emitted before any
+  // journal write by the ordering invariant).
   for (unsigned i = 0; i < kKeys; i++)
     EXPECT_TRUE(baselines.contains(absl::StrCat("key:", i)));
+
+  // New keys are inserted mid-sweep, so a surviving one must be covered by a baseline or a journal
+  // write; a key omitted past the cursor by a split would be missing from both.
+  for (unsigned i = 0; i < kNew; i++) {
+    auto key = absl::StrCat("newkey:", i);
+    if (Run({"EXISTS", key}).GetInt() == 1) {
+      EXPECT_TRUE(baselines.contains(key) || journal_writes.contains(key))
+          << "silently lost " << key;
+    }
+  }
 }
 
 // Check serialization of lists is successful with parallel additions to list.


### PR DESCRIPTION
Fixes #8153 

Two bugs: 

1. Versions are not propagated in the dash table splitting - there was just a todo comment
2. We can't omit stash buckets as values from stash buckets can be brough back to regular buckets and thus travel "backwards" relative to the cursor