### PR TITLE
fix(stream): Validate all streams before mutating group state in XREADGROUP

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1284,6 +1284,7 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
 OpResult<RecordVec> OpRange(const OpArgs& op_args, string_view key, const RangeOpts& opts) {
   // It's write because we add a NACK. Relevant to XReadGroup only
   const bool is_write_command = opts.group;
+  DCHECK(!is_write_command || opts.consumer);
   auto& db_slice = op_args.GetDbSlice();
   DbSlice::ItAndUpdater it;
   const CompactObj* cobj;
@@ -1493,6 +1494,11 @@ vector<RecordVec> OpRead(const OpArgs& op_args, const ShardArgs& shard_args, con
 
     // We skip, group can be empty after waking up from a blocked read
     if (!sitem.group && opts.read_group) {
+      continue;
+    }
+
+    // We skip, consumers can be unresolved from FindOrAddGroupConsumers.
+    if (sitem.group && !sitem.consumer) {
       continue;
     }
 
@@ -1855,6 +1861,23 @@ streamConsumer* FindOrAddConsumer(string_view name, streamCG* cg, uint64_t now_m
   }
 
   return consumer;
+}
+
+// Creates the group consumer for every requested key on this shard.
+void FindOrAddGroupConsumers(const OpArgs& op_args, const ShardArgs& keys, ReadOpts* opts) {
+  for (string_view key : keys) {
+    StreamIDsItem& sitem = opts->stream_ids.at(key);
+    if (!sitem.group || sitem.consumer)
+      continue;
+    auto res = op_args.GetDbSlice().FindMutable(op_args.db_cntx, key, OBJ_STREAM);
+    if (!res)
+      continue;
+    StreamMemTracker tracker;
+    sitem.is_consumer_new = false;
+    sitem.consumer = FindOrAddConsumer(opts->consumer_name, sitem.group,
+                                       op_args.db_cntx.time_now_ms, &sitem.is_consumer_new);
+    tracker.UpdateStreamSize(res->it->second);
+  }
 }
 
 constexpr uint8_t kClaimForce = 1 << 0;
@@ -3260,7 +3283,9 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
     }
 
     if (is_single_shard) {
-      if (have_entries.load(memory_order_relaxed)) {
+      if (have_entries.load(memory_order_relaxed) && !err) {
+        if (read_group)
+          FindOrAddGroupConsumers(op_args, tx->GetShardArgs(es->shard_id()), &*opts);
         fastread_prefetched = OpRead(tx->GetOpArgs(es), tx->GetShardArgs(es->shard_id()), *opts);
         if (read_group) {
           size_t index = 0;
@@ -3271,9 +3296,11 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
           }
         }
       } else {
-        // We didn't read any entries but we might added new consumers
-        for (auto key : tx->GetShardArgs(es->shard_id())) {
-          JournalConsumerCreationIfNeeded(op_args, *opts, key);
+        if (!err && read_group) {
+          FindOrAddGroupConsumers(op_args, tx->GetShardArgs(es->shard_id()), &*opts);
+          for (auto key : tx->GetShardArgs(es->shard_id())) {
+            JournalConsumerCreationIfNeeded(op_args, *opts, key);
+          }
         }
         return {OpStatus::OK, Transaction::RunnableResult::AVOID_CONCLUDING};
       }
@@ -3287,8 +3314,20 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(**err);
   }
 
-  if (!have_entries.load(memory_order_relaxed))
+  if (!have_entries.load(memory_order_relaxed)) {
+    // Cross-shard, create consumers before blocking.
+    if (read_group && !is_single_shard) {
+      auto register_cb = [&](Transaction* t, EngineShard* shard) {
+        auto op_args = t->GetOpArgs(shard);
+        FindOrAddGroupConsumers(op_args, t->GetShardArgs(shard->shard_id()), &*opts);
+        for (auto key : t->GetShardArgs(shard->shard_id()))
+          JournalConsumerCreationIfNeeded(op_args, *opts, key);
+        return OpStatus::OK;
+      };
+      tx->Execute(register_cb, false);
+    }
     return XReadBlock(&*opts, tx, cmd_cntx->rb(), cmd_cntx->server_conn_cntx());
+  }
 
   vector<vector<RecordVec>> xread_resp;
   if (is_single_shard && have_entries.load(memory_order_relaxed)) {
@@ -3298,6 +3337,9 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
     auto read_cb = [&](Transaction* t, EngineShard* shard) {
       ShardId sid = shard->shard_id();
       auto op_args = tx->GetOpArgs(shard);
+      if (read_group) {
+        FindOrAddGroupConsumers(op_args, t->GetShardArgs(sid), &*opts);
+      }
       xread_resp[sid] = OpRead(op_args, t->GetShardArgs(sid), *opts);
       if (read_group) {
         size_t index = 0;
@@ -3993,15 +4035,9 @@ void CmdXRevRange(CmdArgParser parser, CommandContext* cmd_cntx) {
   XRangeGeneric(key, end, start, parser.UnparsedArgs(), true, cmd_cntx);
 }
 
-// If opts.read_group is true then this is a WRITE command. We don't however journal the consumer
-// creation, only the side effects later on from the scheduled callbacks.
 variant<bool, facade::ErrorReply> HasEntries2(const OpArgs& op_args, string_view skey,
                                               ReadOpts* opts) {
-  const bool is_write_command = opts->read_group;
   auto& db_slice = op_args.GetDbSlice();
-
-  DbSlice::ItAndUpdater it;
-  const CompactObj* cobj;
 
   auto error = [&](auto res_it) -> variant<bool, facade::ErrorReply> {
     if (res_it.status() == OpStatus::WRONG_TYPE)
@@ -4012,18 +4048,11 @@ variant<bool, facade::ErrorReply> HasEntries2(const OpArgs& op_args, string_view
     return false;
   };
 
-  if (is_write_command) {
-    auto res = db_slice.FindMutable(op_args.db_cntx, skey, OBJ_STREAM);
-    if (!res)
-      return error(std::move(res));
-    it = std::move(*res);
-    cobj = &it.it->second;
-  } else {
-    auto res = db_slice.FindReadOnly(op_args.db_cntx, skey, OBJ_STREAM);
-    if (!res)
-      return error(res);
-    cobj = &(*res)->second;
-  }
+  auto res = db_slice.FindReadOnly(op_args.db_cntx, skey, OBJ_STREAM);
+  if (!res)
+    return error(res);
+
+  const CompactObj* cobj = &(*res)->second;
 
   stream* s = GetReadOnlyStream(*cobj);
 
@@ -4037,23 +4066,17 @@ variant<bool, facade::ErrorReply> HasEntries2(const OpArgs& op_args, string_view
   // Check requested
   auto& requested_sitem = opts->stream_ids.at(skey);
 
-  // Look up group consumer if needed
-  streamCG* group = nullptr;
-  streamConsumer* consumer = nullptr;
-  if (is_write_command) {
-    group = StreamLookupCG(s, WrapSds(opts->group_name));
+  // Look up the group, but not the consumer: consumer creation is a mutation and must wait until
+  // the caller knows every requested stream is valid.
+  if (opts->read_group) {
+    streamCG* group = StreamLookupCG(s, WrapSds(opts->group_name));
     if (!group)
       return facade::ErrorReply{
           NoGroupOrKey(skey, opts->group_name, " in XREADGROUP with GROUP option")};
 
-    StreamMemTracker tracker;
-    requested_sitem.is_consumer_new = false;
-    consumer = FindOrAddConsumer(opts->consumer_name, group, op_args.db_cntx.time_now_ms,
-                                 &requested_sitem.is_consumer_new);
-    tracker.UpdateStreamSize(it.it->second);
-
     requested_sitem.group = group;
-    requested_sitem.consumer = consumer;
+    // Consumer create needs to be done after all streams have been validated.
+    requested_sitem.consumer = nullptr;
 
     // If '>' is not provided, consumer PEL is used. So don't need to block.
     if (requested_sitem.id.val.ms != UINT64_MAX || requested_sitem.id.val.seq != UINT64_MAX) {

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -317,6 +317,58 @@ TEST_F(StreamFamilyTest, XReadGroup) {
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 }
 
+// A multi-stream XREADGROUP where one stream is valid and another has no matching key/group
+// must return NOGROUP without mutating any state on the valid stream: no PEL insertion, no new
+// consumer, and no advance of last-delivered-id. Both single shard and cross shard are tested.
+TEST_F(StreamFamilyTest, XReadGroupMultiStreamErrorDoesNotMutateState) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  struct Case {
+    string_view name;
+    bool same_shard;
+  };
+
+  const vector<Case> cases = {
+      {"same-shard", true},
+      {"cross-shard", false},
+  };
+
+  for (const Case& tc : cases) {
+    SCOPED_TRACE(tc.name);
+
+    const string good = absl::StrCat(tc.name, "-good");
+    string missing;
+    for (unsigned i = 0; missing.empty(); ++i) {
+      string candidate = absl::StrCat(tc.name, "-missing-", i);
+      const bool collocated = Shard(candidate, shard_set->size()) == Shard(good, shard_set->size());
+      if (collocated == tc.same_shard)
+        missing = std::move(candidate);
+    }
+
+    Run({"XGROUP", "CREATE", good, "g", "0", "MKSTREAM"});
+    Run({"XADD", good, "1-0", "f", "v"});
+
+    // "missing" has no key at all, so this must fail with NOGROUP for it.
+    auto resp = Run({"XREADGROUP", "GROUP", "g", "c", "STREAMS", good, missing, ">", ">"});
+    EXPECT_THAT(resp, ErrArg(absl::StrCat("No such key '", missing,
+                                          "' or consumer group 'g' in XREADGROUP with GROUP "
+                                          "option")));
+
+    // Entry 1-0 must not have leaked into the group/consumer PEL.
+    auto pending = Run({"XPENDING", good, "g"});
+    EXPECT_THAT(pending.GetVec()[0], IntArg(0))
+        << "entry 1-0 leaked into the PEL despite the NOGROUP error";
+
+    // Consumer "c" must not have been created, and last-delivered-id must not have advanced.
+    auto group_info = Run({"XINFO", "GROUPS", good});
+    ASSERT_THAT(group_info, ArrLen(1));
+    EXPECT_THAT(
+        group_info.GetVec()[0].GetVec(),
+        ElementsAre("name", "g", "consumers", IntArg(0), "pending", IntArg(0), "last-delivered-id",
+                    "0-0", "entries-read", kMatchNil, "lag", IntArg(1)));
+  }
+}
+
 TEST_F(StreamFamilyTest, XReadGroupConsumerNamedStreams) {
   Run({"XADD", "COUNT", "1-0", "field", "value"});
   Run({"XGROUP", "CREATE", "COUNT", "grp1", "0"});


### PR DESCRIPTION
Multi-stream XREADGROUP created consumers, inserted PEL entries and advanced the 
group's last-delivered-id on valid streams before noticing another stream failed validation.
The client got NOGROUP while owning an entry it never received.

HasEntries2 now only validates. Consumer creation moved to FindOrAddGroupConsumers, 
which runs after every requested stream has been validated.

Fixes #8070

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
