### PR TITLE
tests: enable fixed Valkey stream TCL tests and add the pubsub suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,10 +259,10 @@ jobs:
           name: regression_logs
           path: /tmp/failed/*
 
-      - name: Run Valkey TCL stream tests
-        # Same gating as the regression tests above: runs the upstream Valkey stream TCL suites
-        # (unit/type/stream[-cgroups]) in external-server mode against the just-built binary,
-        # on both Debug and Release. continue-on-error keeps it a canary for now — flip to a
+      - name: Run Valkey TCL tests
+        # Same gating as the regression tests above: runs the upstream Valkey TCL suites
+        # (unit/type/stream[-cgroups], unit/pubsub) in external-server mode against the just-built
+        # binary, on both Debug and Release. continue-on-error keeps it a canary for now — flip to a
         # blocking step once proven stable in CI. See tests/dragonfly/valkey_tcl/README.md.
         if: matrix.container == 'ubuntu-dev:24' && matrix.sanitizers == 'NoSanitizers' && github.event_name != 'push'
         continue-on-error: true

--- a/tests/dragonfly/valkey_tcl/README.md
+++ b/tests/dragonfly/valkey_tcl/README.md
@@ -1,16 +1,15 @@
-# Valkey TCL stream tests on Dragonfly
+# Valkey TCL stream and pubsub tests on Dragonfly
 
 Runs the upstream [Valkey](https://github.com/valkey-io/valkey) TCL test suite (the
 classic Redis-era tests) against Dragonfly in **external-server mode** — the harness
 connects to an already-running Dragonfly over `--host/--port` instead of spawning a
-server. Currently scoped to the two stream suites:
-`unit/type/stream` and `unit/type/stream-cgroups`.
+server. Currently scoped to `unit/type/stream`, `unit/type/stream-cgroups` and `unit/pubsub`.
 
 ## Layout
 
 ```
 tests/dragonfly/valkey_tcl/
-├── sync-valkey-tcl-tests.sh   # clone Valkey @ pinned SHA → copy harness + stream files (committed)
+├── sync-valkey-tcl-tests.sh   # clone Valkey @ pinned SHA → copy harness + test files (committed)
 ├── run-stream-tests.sh        # start Dragonfly + run the harness with the skiplist (committed)
 ├── skiplist.txt               # documented, tracked list of known-failing tests (committed)
 ├── README.md                  # this file (committed)
@@ -24,7 +23,7 @@ mirroring `tests/dragonfly/valkey_search/`.
 
 ```bash
 cd tests/dragonfly/valkey_tcl
-./sync-valkey-tcl-tests.sh                       # sync harness + stream tests (pinned SHA)
+./sync-valkey-tcl-tests.sh                       # sync harness + tests (pinned SHA)
 ./run-stream-tests.sh ../../../build-dbg/dragonfly   # start DF + run suites
 ```
 
@@ -53,7 +52,7 @@ the bucket comments of `skiplist.txt` itself.
 
 ## CI
 
-Runs as the `Run Valkey TCL stream tests` step of the `build` job in
+Runs as the `Run Valkey TCL tests` step of the `build` job in
 `.github/workflows/ci.yml`, right after the Python regression tests and under the same
 gating (`ubuntu-dev:24` + `NoSanitizers`, both Debug and Release), against the just-built
 binary. The step installs `tcl`/`redis-tools`, syncs the harness, and runs the suites.

--- a/tests/dragonfly/valkey_tcl/run-stream-tests.sh
+++ b/tests/dragonfly/valkey_tcl/run-stream-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run the Valkey stream TCL suites against a Dragonfly binary in external-server mode.
+# Run the Valkey stream and pubsub TCL suites against a Dragonfly binary in external-server mode.
 # Exits 0 only if every non-skipped test passes (harness returns 1 on any failure).
 #
 # Usage: ./run-stream-tests.sh <path-to-dragonfly-binary> [port]
@@ -118,6 +118,7 @@ timeout --kill-after=30 900 tclsh tests/test_helper.tcl \
   --host 127.0.0.1 --port "$PORT" \
   --single unit/type/stream \
   --single unit/type/stream-cgroups \
+  --single unit/pubsub \
   --tags "-needs:debug -needs:repl -external:skip -large-memory" \
   --skipfile "$CLEAN_SKIP" \
   --timeout 120 \

--- a/tests/dragonfly/valkey_tcl/skiplist.txt
+++ b/tests/dragonfly/valkey_tcl/skiplist.txt
@@ -1,11 +1,11 @@
-# Known-failing Valkey stream tests on Dragonfly, skipped so the suite is a green
+# Known-failing Valkey stream/pubsub tests on Dragonfly, skipped so the suite is a green
 # regression gate over the passing subset. One test name per line (a line starting
 # with '/' is treated as a regexp by the harness). Comments (#) and blank lines are
 # stripped before the list is passed to --skipfile.
 #
 # Each entry is a tracked gap, NOT a permanent exclusion — remove it once fixed.
 # Validated against Valkey unstable @ 79fc841577be18d5e789f741ca92a4157e8315fa.
-# Baseline PoC (truncated partial run before the wake fixes): 65 pass / 27 fail.
+# Baseline (main @ b6c22ce5e): streams 96 pass / 0 fail, pubsub 20 pass / 0 fail.
 
 # --- Missing runtime CONFIG `stream-node-max-entries` (test setup fails) ---
 XADD with MAXLEN option and the '~' argument
@@ -34,12 +34,6 @@ XSETID cannot set the offset to less than the length
 # --- Blocking XREAD not registered as a blocked client (wait_for_blocked_clients timeout) ---
 XREAD with same stream name multiple times should work
 XREAD + multiple XADD inside transaction
-Blocking XREAD for stream that ran dry (issue #5299)
-# Woken blocking XREAD replies an empty set ({x {}}) instead of the newly added entry.
-XREAD streamID edge (blocking)
-
-# --- Ran-dry XREADGROUP replies {stream {}} instead of nil (issue #5299 shape) ---
-Blocking XREADGROUP for stream that ran dry (issue #5299)
 
 # --- Blocked-client accounting: INFO lacks `total_blocking_keys`(+`_on_nokey`); multi-client ---
 # blocked-count scenarios don't converge. NOTE: these tests abort mid-way and LEAK blocked
@@ -59,15 +53,7 @@ XGROUP CREATE: with ENTRIESREAD parameter
 # --- XGROUP SETID rejects the `-` special id ---
 PEL NACK reassignment after XGROUP SETID event
 
-# --- HANGS: blocked XREADGROUP is not woken when the key is mutated (BLOCK 0). ---
-# A group-blocked client is not woken by DEL/SET(retype)/FLUSHALL/SWAPDB, so `$rd read`
-# blocks forever. These MUST stay skipped or the whole run wedges. Remove once
-# wake-on-key-invalidation for blocked XREADGROUP lands.
-# (XGROUP DESTROY and RENAME *do* wake correctly.)
-Blocking XREADGROUP: key deleted
-Blocking XREADGROUP: key type changed with SET
-Blocking XREADGROUP: key type changed with transaction
-Blocking XREADGROUP: flushed DB
+# --- SWAPDB is not implemented (`ERR unknown command`) ---
 Blocking XREADGROUP: swapped DB, key doesn't exist
 Blocking XREADGROUP: swapped DB, key is not a stream
 
@@ -88,3 +74,26 @@ XCLAIM can claim PEL items from another consumer
 XREAD and XREADGROUP against wrong parameter
 XAUTOCLAIM COUNT must be > 0
 XAUTOCLAIM with out of range count
+
+# ===================================== unit/pubsub =====================================
+
+# --- CLIENT REPLY OFF|SKIP unsupported ---
+PubSub messages with CLIENT REPLY OFF
+
+# --- notify-keyspace-events: only the Ex class is supported, CONFIG SET rejects the rest ---
+Keyspace notifications: we receive keyspace notifications
+Keyspace notifications: we receive keyevent notifications
+Keyspace notifications: we can receive both kind of events
+Keyspace notifications: we are able to mask events
+Keyspace notifications: general events test
+Keyspace notifications: list events test
+Keyspace notifications: set events test
+Keyspace notifications: zset events test
+Keyspace notifications: hash events test
+Keyspace notifications: stream events test
+Keyspace notifications: evicted events
+Keyspace notifications: test CONFIG GET/SET of event flags
+Keyspace notifications: new key test
+
+# --- UNSUBSCRIBE is rejected inside MULTI ---
+unsubscribe inside multi, and publish to self

--- a/tests/dragonfly/valkey_tcl/sync-valkey-tcl-tests.sh
+++ b/tests/dragonfly/valkey_tcl/sync-valkey-tcl-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Sync the Valkey TCL test harness + stream test files into ./upstream (gitignored),
+# Sync the Valkey TCL test harness + stream/pubsub test files into ./upstream (gitignored),
 # pinned to a specific revision. Mirrors tests/dragonfly/valkey_search/sync-valkey-search-tests.sh.
 #
 # Usage: ./sync-valkey-tcl-tests.sh [<git-sha-or-tag>]
@@ -29,6 +29,7 @@ cp -r "$TMP/tests/helpers"                        "$DEST/tests/"
 cp -r "$TMP/tests/assets"                         "$DEST/tests/"
 cp    "$TMP/tests/unit/type/stream.tcl"           "$DEST/tests/unit/type/"
 cp    "$TMP/tests/unit/type/stream-cgroups.tcl"   "$DEST/tests/unit/type/"
+cp    "$TMP/tests/unit/pubsub.tcl"                "$DEST/tests/unit/"
 echo "$REV" > "$DEST/TESTED_REVISION.txt"
 
-echo "Done. Synced harness + $(ls "$DEST"/tests/unit/type | wc -l) stream test file(s) to $DEST"
+echo "Done. Synced harness + $(find "$DEST/tests/unit" -name "*.tcl" | wc -l) test file(s) to $DEST"


### PR DESCRIPTION
Re-probed the Valkey TCL suites on current main after the expired-event, SET past-expiry and blocked-XREADGROUP wake fixes landed: 7 skiplisted stream tests now pass, the "hangs" bucket is gone, and `unit/pubsub` runs green over 20 tests with a 15-entry skiplist.

Changes:
- skiplist: drop the 7 passing stream tests (ran-dry x2, streamID edge, key deleted / retyped / retyped in MULTI / flushed DB); the two "swapped DB" tests fail cleanly with `unknown command SWAPDB` instead of hanging and move to their own bucket.
- Add `unit/pubsub` to the sync script and the run script. Skipped: `CLIENT REPLY OFF` (1), `notify-keyspace-events` classes beyond `Ex` (13), `UNSUBSCRIBE` inside MULTI (1). `unit/pubsubshard` is tagged `external:skip` upstream and is not runnable in external mode.
