### PR TITLE
fix: test_big_huge_streaming_restart

### DIFF
--- a/tests/dragonfly/replication_specific_test.py
+++ b/tests/dragonfly/replication_specific_test.py
@@ -516,9 +516,9 @@ async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
 @dfly_args(
     {
         "proactor_threads": 2,
-        "serialization_max_chunk_size": 5000,
+        # 4mb is around 500 chunks
+        "serialization_max_chunk_size": 4194304,
         "compression_mode": "0",
-        "proactor_busy_poll_usec": 500,
     }
 )
 async def test_big_huge_streaming_restart(df_factory: DflyInstanceFactory, tagged_chunks):


### PR DESCRIPTION
The issue is that with `tagged_chunks=true` we ended up splitting the two keys into 400k chunks! The solution is to split them in 4mb (around 480) which does not affect the test semantics but reduces the actual load significantly. 