### PR TITLE
fix: OAH benchmark allocator init

### DIFF
--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -38,17 +38,18 @@ static string KeyOf(OAHPair p) {
   return string{key.view()};
 }
 
+[[maybe_unused]] const bool kThreadLocalAllocatorsInitialized = [] {
+  auto* tlh = mi_heap_get_backing();
+  init_zmalloc_threadlocal(tlh);
+  InitTLStatelessAllocMR(PMR_NS::get_default_resource());
+  return true;
+}();
+
 // Mirrors string_map_test.cc for the OAHMap (OAHTable<OAHPair>) container. The StringMap SdsPair
 // iterator (it->first/it->second) maps to the OAHPair accessor (KeyOf(*it)/it->Value()), and
 // AddOrExchange/Extract return an OwnedOAHPair (RAII, frees on destruction) instead of an SdsEntry.
 class OAHMapTest : public ::testing::Test {
  protected:
-  static void SetUpTestSuite() {
-    auto* tlh = mi_heap_get_backing();
-    init_zmalloc_threadlocal(tlh);
-    InitTLStatelessAllocMR(PMR_NS::get_default_resource());
-  }
-
   void SetUp() override {
     m_ = new OAHMap;
     generator_.seed(0);
@@ -906,7 +907,7 @@ void BM_Shrink(benchmark::State& state) {
     m.Reserve(kGrowTo);
     for (auto& [k, v] : kv)
       m.AddOrUpdate(k, v);
-    CHECK_EQ(m.BucketCount(), kGrowTo);
+    CHECK_EQ(m.BucketCount(), kGrowTo / OAHMap::kOverloadFactor);
     state.ResumeTiming();
     m.Shrink(kShrinkTo);
   }

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -38,14 +38,15 @@ static string KeyOf(OAHEntry e) {
   return string{key.view()};
 }
 
+[[maybe_unused]] const bool kThreadLocalAllocatorsInitialized = [] {
+  auto* tlh = mi_heap_get_backing();
+  init_zmalloc_threadlocal(tlh);
+  InitTLStatelessAllocMR(PMR_NS::get_default_resource());
+  return true;
+}();
+
 class OAHSetTest : public ::testing::Test {
  protected:
-  static void SetUpTestSuite() {
-    auto* tlh = mi_heap_get_backing();
-    init_zmalloc_threadlocal(tlh);
-    InitTLStatelessAllocMR(PMR_NS::get_default_resource());
-  }
-
   void SetUp() override {
     ss_ = new OAHSet;
     generator_.seed(0);
@@ -1427,12 +1428,12 @@ void BM_Grow(benchmark::State& state) {
     state.ResumeTiming();
     for (const auto& str : strs) {
       tmp.Add(str);
-      if (tmp.BucketCount() > elems) {
+      if (tmp.BucketCount() >= elems) {
         break;  // we grew
       }
     }
 
-    CHECK_GT(tmp.BucketCount(), elems);
+    CHECK_EQ(tmp.BucketCount(), elems);
   }
 }
 BENCHMARK(BM_Grow);


### PR DESCRIPTION
Summary: Fixes OAH map/set benchmark setup and capacity expectations.

- Moves allocator initialization from GoogleTest suite setup to translation-unit initialization.
- This ensures the thread-local allocators are ready when registered benchmarks construct OAH containers.
- Updates the map shrink benchmark to account for the table’s two-entry overload factor.
- Adjusts the set growth benchmark to recognize the exact post-growth bucket count.

Technical Notes: The revised checks reflect `Reserve` and automatic growth sizing physical buckets at `kOverloadFactor` of logical entries.