### PR TITLE
tests: Skip cache reclamation for v2 io loop

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2669,6 +2669,9 @@ async def test_pipeline_cache_only_async_squashed_dispatches(df_factory):
 # shrink (because it's underutilized).
 @dfly_args({"proactor_threads": 1})
 async def test_pipeline_cache_size(df_server: DflyInstance):
+    # tracking issue: https://github.com/dragonflydb/dragonfly/issues/8163
+    if is_resp_io_loop_v2(df_server):
+        pytest.skip("V2 does not have reclamation yet")
     # Start 1 client.
     good = df_server.client()
     bad = df_server.client()


### PR DESCRIPTION
Skip the cache reclamation test for io loop v2. The pool is only shrunk on v1 code path so the test does not work on v2.

This avoids errors such as https://github.com/dragonflydb/dragonfly/actions/runs/32845946101/job/97795525730#step:7:1578

```
      @assert_eventually(timeout=2)
      async def wait_for_pipeline_cache_shrink():
          await push_pipeline()
          await good.set("foo", "bar")
          good_info = await good.info()
  >       assert good_info["pipeline_cache_bytes"] < old_pipeline_cache_bytes
  E       assert 10560 < 10560
```

tracking issue https://github.com/dragonflydb/dragonfly/issues/8163
the skip may be removed once cache reclamation is introduced, or remain permanently in case it is not relevant for v2