### PR TITLE
fix(search): reject FT.CREATE NUMERIC BLOCKSIZE 0 (divide-by-zero)

### DIFF
--- a/src/core/search/range_tree.cc
+++ b/src/core/search/range_tree.cc
@@ -76,7 +76,10 @@ template <typename MapT> auto FindRangeBlockImpl(MapT& entries, double value) {
 }  // namespace
 
 RangeTree::RangeTree(PMR_NS::memory_resource* mr, size_t max_range_block_size)
-    : max_range_block_size_(max_range_block_size), entries_(mr) {
+    // A zero block size is used as a divisor in Builder::Populate; fall back to the default.
+    : max_range_block_size_(max_range_block_size ? max_range_block_size
+                                                 : kDefaultMaxRangeBlockSize),
+      entries_(mr) {
   // The tree has at least always a block with a negative infinity bound, so that any new insertion
   // goes at least somewhere
   CreateEmptyBlock(-std::numeric_limits<double>::infinity());

--- a/src/core/search/range_tree_test.cc
+++ b/src/core/search/range_tree_test.cc
@@ -628,6 +628,24 @@ TEST_F(RangeTreeTest, DiscreteIntialization) {
   EXPECT_EQ(result.size(), 4u);
 }
 
+TEST_F(BuilderTest, ZeroBlockSizeDoesNotDivideByZero) {
+  RangeTree tree{PMR_NS::get_default_resource(), 0};
+  RangeTree::Builder builder;
+
+  std::vector<RangeTree::Entry> entries;
+  entries.reserve(20);
+  for (size_t i = 0; i < 20; i++)
+    entries.emplace_back(i, double(i));
+  for (auto [id, v] : entries)
+    builder.Add(id, v);
+
+  builder.Populate(&tree, RenewableQuota::Unlimited());
+
+  rng::sort(entries, {}, &RangeTree::Entry::first);
+  auto all_values = tree.Range(-1000, +1000);
+  EXPECT_TRUE(rng::equal(all_values.Take(), entries | std::views::keys));
+}
+
 // Benchmark tree insertion performance with set of discrete values
 static void BM_DiscreteInsertion(benchmark::State& state) {
   RangeTree tree{PMR_NS::get_default_resource()};

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -204,7 +204,10 @@ constexpr auto kTextParamsGrammar =
 
 search::SchemaField::NumericParams ParseNumericParams(CmdArgParser* parser) {
   search::SchemaField::NumericParams params{};
-  parser->Check("BLOCKSIZE", &params.block_size);
+  // A zero block size divides by zero when the numeric range tree is built.
+  if (parser->Check("BLOCKSIZE"))
+    params.block_size =
+        parser->Next<facade::Positive<size_t>>("BLOCKSIZE must be a positive integer");
   return params;
 }
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -4074,6 +4074,18 @@ TEST_F(SearchFamilyTest, BlockSizeOptionFtCreate) {
   EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2", "doc:3"));
 }
 
+TEST_F(SearchFamilyTest, BlockSizeZeroRejected) {
+  Run({"HSET", "doc:a", "n", "7"});
+
+  EXPECT_THAT(Run({"FT.CREATE", "idx0", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "n",
+                   "NUMERIC", "BLOCKSIZE", "0"}),
+              ErrArg("BLOCKSIZE"));
+
+  EXPECT_THAT(Run({"FT.CREATE", "idx1", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "n",
+                   "NUMERIC", "BLOCKSIZE", "1"}),
+              "OK");
+}
+
 TEST_F(SearchFamilyTest, AggregateWithLoadFromJoinSimple) {
   Run({"ft.create", "idx1", "ON", "HASH", "SCHEMA", "num1", "NUMERIC", "num2", "NUMERIC"});
   Run({"ft.create", "idx2", "ON", "HASH", "SCHEMA", "num3", "NUMERIC", "num4", "NUMERIC"});


### PR DESCRIPTION
`FT.CREATE ... NUMERIC BLOCKSIZE 0` set the numeric range-block size to zero, which is used as a divisor in `RangeTree::Builder::Populate` - dividing by zero when the index is built over already-present numeric documents. This crashes with SIGFPE on x86_64 (an infinite build loop on aarch64, where integer divide-by-zero is silent).

Found by the AFL++ long fuzzing campaign (resp-tiering leg):
https://github.com/dragonflydb/dragonfly/actions/runs/32825932471/job/97733818227

Changes:
- **Reject at parse** (`search_family.cc`): `FT.CREATE ... BLOCKSIZE 0` now returns `-ERR BLOCKSIZE must be a positive integer`, via the existing `Positive<size_t>` validator (same path as `WEIGHT` / `EPSILON`).
- **Defense-in-depth** (`range_tree.cc`): a zero block size in the `RangeTree` constructor falls back to the default block size, so the core can never divide by zero.
- **Tests** (red before the fix, green after):
  - `range_tree_test.cc` - `BuilderTest.ZeroBlockSizeDoesNotDivideByZero`
  - `search_family_test.cc` - `SearchFamilyTest.BlockSizeZeroRejected`
