### PR TITLE
test(replication): disable failing CI test test_replicaof_reject_on_load

### DIFF
--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -672,6 +672,9 @@ async def test_replica_reconnections_after_network_disconnect(
         await assert_replica_reconnections(replica, initial_reconnects_count)
 
 
+@pytest.mark.skip(
+    reason="Has been failing in CI for a long time. See https://github.com/dragonflydb/dragonfly/issues/5662."
+)
 @pytest.mark.debug_only
 @dfly_args({"proactor_threads": 2})
 async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):


### PR DESCRIPTION
Skip test_replicaof_reject_on_load because it has failed in CI for a long time. Track the underlying issue in:
https://github.com/dragonflydb/dragonfly/issues/5662.

