### PR TITLE
fix(stream): XPENDING with an unknown consumer returns an empty list

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2331,7 +2331,7 @@ OpResult<ClaimInfo> OpAutoClaim(const OpArgs& op_args, string_view key, const Cl
 
 struct PendingOpts {
   string_view group_name;
-  string_view consumer_name;
+  std::optional<string_view> consumer_name;
   ParsedStreamId start;
   ParsedStreamId end;
   int64_t min_idle_time = 0;
@@ -2446,8 +2446,10 @@ OpResult<PendingResult> OpPending(const OpArgs& op_args, string_view key, const 
   RETURN_ON_BAD_STATUS(cgroup_res);
 
   streamConsumer* consumer = nullptr;
-  if (!opts.consumer_name.empty()) {
-    consumer = StreamLookupConsumer(cgroup_res->cg, WrapSds(opts.consumer_name));
+  if (opts.consumer_name) {
+    consumer = StreamLookupConsumer(cgroup_res->cg, WrapSds(*opts.consumer_name));
+    if (!consumer)
+      return PendingResult{PendingExtendedResultList{}};  // an unknown consumer owns nothing
   }
 
   PendingResult result;

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -1301,6 +1301,10 @@ TEST_F(StreamFamilyTest, XPending) {
                   RespArray(ElementsAre("1-1", "alice", ArgType(RespExpr::INT64), IntArg(1))),
                   RespArray(ElementsAre("1-2", "alice", ArgType(RespExpr::INT64), IntArg(1))))));
 
+  // An unknown consumer owns nothing: empty, not the whole group PEL.
+  EXPECT_THAT(Run({"xpending", "foo", "group", "-", "+", "10", "nobody"}), ArrLen(0));
+  EXPECT_THAT(Run({"xpending", "foo", "group", "-", "+", "10", ""}), ArrLen(0));
+
   // only return a single entry
   resp = Run({"xpending", "foo", "group", "-", "+", "1"});
   EXPECT_THAT(resp.GetVec()[0].GetVec(),

--- a/tests/dragonfly/valkey_tcl/skiplist.txt
+++ b/tests/dragonfly/valkey_tcl/skiplist.txt
@@ -65,11 +65,6 @@ XGROUP DESTROY should unblock XREADGROUP with -NOGROUP
 # --- XCLAIM with trimming: needs `config set stream-node-max-entries` (two tests share this name) ---
 XCLAIM with trimming
 
-# --- XPENDING ignores the <consumer> filter argument ---
-# `XPENDING key group - + 10 consumer2` returns other consumers' entries instead of an
-# empty array (live-verified), so the pre-claim asserts fail.
-XCLAIM can claim PEL items from another consumer
-
 # --- Error-message text differs from Valkey (assert_error exact-match) ---
 XREAD and XREADGROUP against wrong parameter
 XAUTOCLAIM COUNT must be > 0


### PR DESCRIPTION
`XPENDING key group start end count <consumer>` ignored the consumer filter when the consumer was not registered in the group and returned the whole group PEL. Recovery logic that runs `XPENDING ... myconsumer` -> `XCLAIM` from a fresh consumer would claim other consumers' entries. Upstream replies with an empty array for an unknown consumer.