### PR TITLE
chore: add debug logs for test_replicaof_reject_on_load

### DIFF
--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -683,8 +683,6 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
 
     await c_replica.execute_command("DEBUG POPULATE 2100 key 1000 RAND type set elements 1000")
 
-    replica.stop()
-    replica.start()
     # Disable retries so that BusyLoadingError is raised immediately.
     # redis-py >= 7 retries on ConnectionError by default, and BusyLoadingError
     # inherits from ConnectionError, causing the REPLICAOF to be silently
@@ -692,11 +690,15 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     from redis.backoff import NoBackoff
     from redis.retry import Retry
 
+    replica.stop()
+    replica.start()
     c_replica = replica.client(retry=Retry(NoBackoff(), 0))
 
     @assert_eventually
     async def check_replica_isloading():
         persistence = await c_replica.info("PERSISTENCE")
+        dbsize = await c_replica.dbsize()
+        logging.error(f"loading={persistence['loading']} dbsize={dbsize}")
         assert persistence["loading"] == 1
 
     # If this fails adjust load of DEBUG POPULATE above.


### PR DESCRIPTION
I have been hammering epoll reg tests for some time now and it has not yet failed 🤷 

I switched the order between when we stop/restart the replica and when we import from the python module and as this happens at runtime *maybe* it has an effect. 

This PR was supposed to check the state (dbsize) at each time we check if the datastore is busy loading such that I can understand what is actually happening. 

I am merging this and will follow up when and if it fails. (otherwise the order of import after restart and while the server is loading gave enough room for dragonfly to load the snapshot and by the time we asserted that we were in loading state it was too late.