### PR TITLE
feat(acl): Add JWT validation as an alternative to password AUTH

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -95,7 +95,7 @@ add_library(dragonfly_lib
             ${DF_TIERING_SRCS}
             ${DF_CLUSTER_SRCS}
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
-            acl/validator.cc
+            acl/validator.cc acl/jwt_validator.cc
             sharding.cc cmd_support.cc)
 
 if (DF_ENABLE_MEMORY_TRACKING)
@@ -166,6 +166,7 @@ helio_cxx_test(cuckoo_filter_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_config_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(acl/jwt_validator_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(serializer_base_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(detail/egress_throttle_test dfly_test_lib LABELS DFLY)
@@ -175,7 +176,7 @@ add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  redis_parser_test stream_family_test string_family_test
                  bitops_family_test set_family_test zset_family_test geo_family_test
                  hll_family_test cluster_config_test cluster_family_test acl_family_test
-                 json_family_memory_test)
+                 json_family_memory_test jwt_validator_test)
 
 if (WITH_SEARCH)
   helio_cxx_test(search/search_family_test dfly_test_lib LABELS DFLY)

--- a/src/server/acl/jwt_validator.cc
+++ b/src/server/acl/jwt_validator.cc
@@ -1,0 +1,186 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#include "server/acl/jwt_validator.h"
+
+#include <absl/flags/flag.h>
+#include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
+
+#include <boost/beast/http/string_body.hpp>
+#include <ctime>
+
+#include "base/logging.h"
+#include "core/json/json_object.h"
+#include "util/http/http_client.h"
+
+ABSL_FLAG(std::string, jwt_validate_url, "",
+          "Endpoint used to validate AUTH credentials in JWT mode (see --jwt_validate). "
+          "Format: http://host[:port]/path (plain HTTP, no TLS). The endpoint must reply "
+          "with JSON {\"valid\": bool, \"username\": string, \"exp\": <unix seconds>} "
+          "where `username` names a pre-provisioned ACL user and `exp` (optional) sets "
+          "how long the connection stays authenticated before a reauth is required. "
+          "Expected to be a local/trusted agent (e.g. localhost) reachable without TLS -- "
+          "Dragonfly does not cache validation results itself, so every AUTH is a round "
+          "trip to this endpoint.");
+
+ABSL_FLAG(bool, jwt_validate, false,
+          "Master on/off switch for JWT-mode auth. When true, every AUTH credential is "
+          "sent to --jwt_validate_url for validation instead of being checked against "
+          "the local ACL password store; --jwt_validate_url must already be set (at "
+          "startup) for this to take effect. Runtime-mutable via CONFIG SET, so JWT auth "
+          "can be toggled on/off without a restart once the endpoint is configured.");
+
+ABSL_FLAG(uint32_t, jwt_validate_timeout_ms, 300,
+          "Deadline (ms) for the whole JWT validation HTTP call (connect + request), "
+          "enforced by JwtValidator itself since the underlying HTTP client has no "
+          "built-in timeout. A validator that doesn't respond in time causes AUTH to "
+          "be rejected rather than left waiting indefinitely.");
+
+namespace dfly::acl {
+
+using namespace std;
+using namespace util;
+using http::Client;
+
+namespace {
+
+struct ParsedUrl {
+  string host;
+  string port{"80"};
+  string path{"/"};
+};
+
+optional<ParsedUrl> ParseHttpUrl(string_view url) {
+  constexpr string_view kScheme = "http://";
+  if (!absl::StartsWith(url, kScheme))
+    return nullopt;
+  url.remove_prefix(kScheme.size());
+
+  ParsedUrl out;
+  size_t slash = url.find('/');
+  string_view authority = slash == string_view::npos ? url : url.substr(0, slash);
+  out.path = slash == string_view::npos ? "/" : string(url.substr(slash));
+
+  size_t colon = authority.find(':');
+  if (colon == string_view::npos) {
+    out.host = string(authority);
+  } else {
+    out.host = string(authority.substr(0, colon));
+    out.port = string(authority.substr(colon + 1));
+  }
+  if (out.host.empty())
+    return nullopt;
+
+  uint32_t port_num = 0;
+  if (!absl::SimpleAtoi(out.port, &port_num) || port_num == 0 || port_num >= (1u << 16))
+    return nullopt;
+
+  return out;
+}
+
+}  // namespace
+
+bool JwtValidator::IsEnabled() {
+  if (!absl::GetFlag(FLAGS_jwt_validate))
+    return false;
+  if (absl::GetFlag(FLAGS_jwt_validate_url).empty()) {
+    // Misconfigured: fall back to password auth rather than reject every AUTH.
+    LOG_FIRST_N(ERROR, 1)
+        << "jwt_validate is enabled but jwt_validate_url is empty; falling back to "
+           "password auth until jwt_validate_url is configured (requires a restart)";
+    return false;
+  }
+  return true;
+}
+
+void JwtValidator::SetValidateFuncForTest(
+    std::function<std::optional<ValidationResult>(std::string_view)> f) {
+  validate_override_ = std::move(f);
+}
+
+optional<JwtValidator::ValidationResult> JwtValidator::Validate(string_view token) {
+  if (validate_override_) {
+    return validate_override_(token);
+  }
+
+  const string url = absl::GetFlag(FLAGS_jwt_validate_url);
+  optional<ParsedUrl> parsed = ParseHttpUrl(url);
+  if (!parsed) {
+    LOG_FIRST_N(ERROR, 1) << "jwt_validate_url is set but not a valid http:// URL: " << url;
+    return nullopt;
+  }
+
+  namespace bh = boost::beast::http;
+  using ResponseType = bh::response<bh::string_body>;
+
+  bh::request<bh::string_body> req{bh::verb::post, parsed->path, 11 /*http 1.1*/};
+  req.set(bh::field::host, parsed->host);
+  req.set(bh::field::content_type, "application/json");
+  TmpJson body{jsoncons::json_object_arg};
+  body["token"] = string(token);
+  req.body() = body.to_string();
+  req.prepare_payload();
+
+  ProactorBase* proactor = ProactorBase::me();
+  DCHECK(proactor) << "JwtValidator::Validate must run on a proactor fiber";
+
+  Client client{proactor};
+  // Bounds connect+send+recv (see romange/helio#645); only blocks the calling fiber.
+  client.set_timeout_ms(absl::GetFlag(FLAGS_jwt_validate_timeout_ms));
+
+  std::error_code connect_ec = client.Connect(parsed->host, parsed->port);
+  if (connect_ec) {
+    LOG_EVERY_N(WARNING, 100) << "JWT validation - connection error to " << parsed->host << ":"
+                              << parsed->port << ": " << connect_ec.message();
+    return nullopt;
+  }
+
+  ResponseType res;
+  Client::BoostError send_ec = client.Send(req, &res);
+  if (send_ec) {
+    LOG_EVERY_N(WARNING, 100) << "JWT validation - HTTP request error: " << send_ec.message();
+    return nullopt;
+  }
+
+  if (res.result() != bh::status::ok) {
+    VLOG(1) << "JWT validation - API rejected token, status " << res.result();
+    return nullopt;
+  }
+
+  std::optional<TmpJson> parsed_body = JsonFromString(res.body());
+  if (!parsed_body) {
+    LOG_EVERY_N(WARNING, 100) << "JWT validation - malformed (non-JSON) API response";
+    return nullopt;
+  }
+  if (!parsed_body->contains("valid") || !parsed_body->at("valid").is_bool() ||
+      !parsed_body->at("valid").as_bool()) {
+    return nullopt;
+  }
+  if (!parsed_body->contains("username") || !parsed_body->at("username").is_string()) {
+    LOG_EVERY_N(WARNING, 100) << "JWT validation - API response missing 'username' field";
+    return nullopt;
+  }
+  ValidationResult result{parsed_body->at("username").as_string()};
+
+  // "exp" (optional) determines how long the connection stays authenticated before a
+  // reauth is required (see ConnectionContext::auth_expires_at).
+  if (!parsed_body->contains("exp") || !parsed_body->at("exp").is_int64()) {
+    return result;
+  }
+
+  const int64_t exp_epoch_sec = parsed_body->at("exp").as<int64_t>();
+  const auto exp_wall = chrono::system_clock::from_time_t(static_cast<time_t>(exp_epoch_sec));
+  const auto now_wall = chrono::system_clock::now();
+  if (exp_wall <= now_wall) {
+    // The API says this token is already expired -- treat as an outright rejection.
+    return nullopt;
+  }
+
+  // steady_clock drives the actual expiry check; only the duration is derived from
+  // the API's wall-clock "exp".
+  result.expires_at = chrono::steady_clock::now() + (exp_wall - now_wall);
+  return result;
+}
+
+}  // namespace dfly::acl

--- a/src/server/acl/jwt_validator.h
+++ b/src/server/acl/jwt_validator.h
@@ -1,0 +1,41 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace dfly::acl {
+
+// Delegates JWT validation to an external HTTP API instead of checking a password
+// against the local ACL user registry. Configured via --jwt_validate_url (endpoint)
+// and --jwt_validate (on/off, runtime-mutable). When enabled, every AUTH credential is
+// treated as a JWT and sent to the endpoint; the returned username must map to a
+// pre-provisioned ACL user. No local caching -- every AUTH hits the endpoint directly.
+class JwtValidator {
+ public:
+  struct ValidationResult {
+    std::string username;
+    // Defaults to "never expires"; set only when the API attaches an "exp" to the token.
+    std::chrono::steady_clock::time_point expires_at = std::chrono::steady_clock::time_point::max();
+  };
+
+  // True if --jwt_validate is set AND --jwt_validate_url is non-empty.
+  static bool IsEnabled();
+
+  // Validates `token` against the external API. Returns nullopt on any failure
+  // (invalid/rejected token, timeout, connection error, malformed response).
+  std::optional<ValidationResult> Validate(std::string_view token);
+
+  // Test-only: allows unit tests to bypass the real network call.
+  void SetValidateFuncForTest(std::function<std::optional<ValidationResult>(std::string_view)> f);
+
+ private:
+  std::function<std::optional<ValidationResult>(std::string_view)> validate_override_;
+};
+
+}  // namespace dfly::acl

--- a/src/server/acl/jwt_validator_test.cc
+++ b/src/server/acl/jwt_validator_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#include "server/acl/jwt_validator.h"
+
+#include <absl/flags/declare.h>
+#include <absl/flags/flag.h>
+#include <absl/flags/reflection.h>
+
+#include "base/gtest.h"
+
+ABSL_DECLARE_FLAG(bool, jwt_validate);
+ABSL_DECLARE_FLAG(std::string, jwt_validate_url);
+
+namespace dfly::acl {
+
+using namespace std;
+
+class JwtValidatorTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Flags are process-global; snapshot and restore so tests can freely flip them
+    // without affecting others (gtest doesn't run these in a fresh process each time).
+    saved_validate_ = absl::GetFlag(FLAGS_jwt_validate);
+    saved_validate_url_ = absl::GetFlag(FLAGS_jwt_validate_url);
+  }
+
+  void TearDown() override {
+    absl::SetFlag(&FLAGS_jwt_validate, saved_validate_);
+    absl::SetFlag(&FLAGS_jwt_validate_url, saved_validate_url_);
+  }
+
+ private:
+  bool saved_validate_;
+  string saved_validate_url_;
+};
+
+TEST_F(JwtValidatorTest, IsEnabledFalseWhenFlagOff) {
+  absl::SetFlag(&FLAGS_jwt_validate, false);
+  absl::SetFlag(&FLAGS_jwt_validate_url, "http://localhost:8080/validate");
+  EXPECT_FALSE(JwtValidator::IsEnabled());
+}
+
+TEST_F(JwtValidatorTest, IsEnabledFalseWhenUrlEmpty) {
+  absl::SetFlag(&FLAGS_jwt_validate, true);
+  absl::SetFlag(&FLAGS_jwt_validate_url, "");
+  // Misconfiguration -- must fail closed to "disabled" (falls back to password auth)
+  // rather than crash or treat every AUTH as a JWT with nowhere to validate it.
+  EXPECT_FALSE(JwtValidator::IsEnabled());
+}
+
+TEST_F(JwtValidatorTest, IsEnabledTrueWhenBothSet) {
+  absl::SetFlag(&FLAGS_jwt_validate, true);
+  absl::SetFlag(&FLAGS_jwt_validate_url, "http://localhost:8080/validate");
+  EXPECT_TRUE(JwtValidator::IsEnabled());
+}
+
+TEST_F(JwtValidatorTest, ValidateOverrideBypassesNetwork) {
+  JwtValidator jwt;
+  jwt.SetValidateFuncForTest([](string_view token) -> optional<JwtValidator::ValidationResult> {
+    if (token == "good-token")
+      return JwtValidator::ValidationResult{"alice"};
+    return nullopt;
+  });
+
+  auto ok = jwt.Validate("good-token");
+  ASSERT_TRUE(ok.has_value());
+  EXPECT_EQ(ok->username, "alice");
+  // Default-constructed ValidationResult never expires.
+  EXPECT_EQ(ok->expires_at, chrono::steady_clock::time_point::max());
+
+  auto rejected = jwt.Validate("bad-token");
+  EXPECT_FALSE(rejected.has_value());
+}
+
+TEST_F(JwtValidatorTest, ValidateOverridePropagatesExpiry) {
+  const auto expiry = chrono::steady_clock::now() + chrono::seconds(60);
+  JwtValidator jwt;
+  jwt.SetValidateFuncForTest([&](string_view) -> optional<JwtValidator::ValidationResult> {
+    JwtValidator::ValidationResult result{"bob"};
+    result.expires_at = expiry;
+    return result;
+  });
+
+  auto result = jwt.Validate("whatever");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->username, "bob");
+  EXPECT_EQ(result->expires_at, expiry);
+}
+
+TEST_F(JwtValidatorTest, EachInstanceHasIndependentOverride) {
+  // JwtValidator is intentionally not a singleton (see review discussion) -- confirm two
+  // instances don't share state, since DoAuth constructs a fresh one per AUTH call.
+  JwtValidator jwt_a;
+  jwt_a.SetValidateFuncForTest([](string_view) -> optional<JwtValidator::ValidationResult> {
+    return JwtValidator::ValidationResult{"from_a"};
+  });
+
+  JwtValidator jwt_b;
+  jwt_b.SetValidateFuncForTest([](string_view) -> optional<JwtValidator::ValidationResult> {
+    return JwtValidator::ValidationResult{"from_b"};
+  });
+
+  EXPECT_EQ(jwt_a.Validate("token")->username, "from_a");
+  EXPECT_EQ(jwt_b.Validate("token")->username, "from_b");
+}
+
+}  // namespace dfly::acl

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -7,6 +7,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <cassert>
+#include <chrono>
 
 #include "facade/conn_context.h"
 #include "facade/parsed_command.h"
@@ -368,6 +369,10 @@ class ConnectionContext : public facade::ConnectionContext {
 
   // Username
   std::string authed_username{"default"};
+
+  // Point-in-time expiration of this connection's JWT auth; max() means never expires.
+  std::chrono::steady_clock::time_point auth_expires_at =
+      std::chrono::steady_clock::time_point::max();
 
   // Each entry in the list is a bitfield representing a specific command family,
   // where each bit corresponds to an individual command within that family.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1114,6 +1114,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("timeout");
   config_registry.RegisterMutable("send_timeout");
   config_registry.RegisterMutable("managed_service_info");
+  config_registry.RegisterMutable("jwt_validate");
 #ifdef WITH_SEARCH
   config_registry.RegisterMutable("MAXSEARCHRESULTS");
   config_registry.RegisterMutable("search_query_string_bytes");
@@ -1429,6 +1430,17 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid,
   if (dfly_cntx.req_auth && !dfly_cntx.authenticated) {
     if (cmd_name != "AUTH" && !cid.IsQuit() && !cid.IsReset() && cmd_name != "HELLO") {
       return ErrorReply{"-NOAUTH Authentication required.", facade::kNoAuthErrType};
+    }
+  }
+
+  // JWT-derived auth carries its own expiration contract (see acl::JwtValidator): once
+  // it lapses, we must force a reauth.
+  if (dfly_cntx.authenticated &&
+      dfly_cntx.auth_expires_at != std::chrono::steady_clock::time_point::max() &&
+      dfly_cntx.auth_expires_at <= std::chrono::steady_clock::now()) {
+    if (cmd_name != "AUTH" && !cid.IsQuit() && !cid.IsReset() && cmd_name != "HELLO") {
+      return ErrorReply{"-NOAUTH JWT token expired, please re-authenticate.",
+                        facade::kNoAuthErrType};
     }
   }
 
@@ -2005,6 +2017,7 @@ void Service::Reset(CmdArgParser, CommandContext* cmd_cntx) {
   cntx->authed_username = "default";
   cntx->ns = &namespaces->GetOrInsert("");
   cntx->authenticated = false;
+  cntx->auth_expires_at = std::chrono::steady_clock::time_point::max();
 
   rb->SendSimpleString("RESET");
 }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -52,6 +52,7 @@ extern "C" {
 #include "io/proc_reader.h"
 #include "search/doc_index.h"
 #include "server/acl/acl_commands_def.h"
+#include "server/acl/jwt_validator.h"
 #include "server/acl/user_registry.h"
 #include "server/blocking_controller.h"
 #include "server/command_registry.h"
@@ -2040,7 +2041,23 @@ bool ServerFamily::DoAuth(ConnectionContext* cntx, std::string_view username,
                           std::string_view password) {
   const auto* registry = ServerState::tlocal()->user_registry;
   CHECK(registry);
-  const bool is_authorized = registry->AuthUser(username, password);
+
+  bool is_authorized = false;
+  std::string jwt_username;
+  auto auth_expires_at = std::chrono::steady_clock::time_point::max();
+  if (acl::JwtValidator::IsEnabled()) {
+    acl::JwtValidator jwt;
+    auto claims = jwt.Validate(password);
+    if (claims) {
+      jwt_username = std::move(claims->username);
+      username = jwt_username;
+      is_authorized = registry->IsUserActive(username);
+      auth_expires_at = claims->expires_at;
+    }
+  } else {
+    is_authorized = registry->AuthUser(username, password);
+  }
+
   if (is_authorized) {
     cntx->authed_username = username;
     auto cred = registry->GetCredentials(username);
@@ -2049,6 +2066,7 @@ bool ServerFamily::DoAuth(ConnectionContext* cntx, std::string_view username,
     cntx->pub_sub = std::move(cred.pub_sub);
     cntx->ns = &namespaces->GetOrInsert(cred.ns);
     cntx->authenticated = true;
+    cntx->auth_expires_at = auth_expires_at;
     cntx->acl_db_idx = cred.db;
     if (cred.db == std::numeric_limits<size_t>::max()) {
       cntx->conn_state.db_index = 0;


### PR DESCRIPTION
Delegates JWT validation to an external HTTP API instead of comparing a password hash against the local ACL user registry, so a trusted local agent (e.g. Entra ID validation) can authenticate clients without them ever using a Dragonfly password.

- Add JwtValidator: posts the AUTH credential to --jwt_validate_url and maps the returned username to a pre-provisioned ACL user.
- Add --jwt_validate (runtime-mutable) and --jwt_validate_url (startup-only) flags to enable/configure JWT mode.
- Add ConnectionContext::auth_expires_at to force a reauth once a JWT's own expiry (the API's "exp" field) passes, checked once per dispatched command alongside the existing ACL checks.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
