### PR TITLE
fix(list): set plain-node size from value length in QList::Replace

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -876,7 +876,10 @@ void QList::Replace(Iterator it, std::string_view elem) {
       zfree(node->entry);
       uint8_t* new_entry = (uint8_t*)zmalloc(sz);
       memcpy(new_entry, elem.data(), sz);
-      malloc_size_ += NodeSetEntry(node, new_entry);
+      // Plain nodes hold raw bytes; size is the value length, not lpBytes() of a listpack header.
+      malloc_size_ += ssize_t(sz) - ssize_t(node->sz);
+      node->entry = new_entry;
+      node->sz = sz;
       CoolOff(node, node_id);
     } else {
       Insert(it, elem, AFTER);

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -321,6 +321,17 @@ TEST_F(QListTest, PushPlain) {
   EXPECT_THAT(items, ElementsAre(val));
 }
 
+TEST_F(QListTest, ReplacePlainWithPlain) {
+  // Replacing a large (plain-node) element with another large element must set node->sz from the
+  // value length, not by parsing a listpack header out of the raw plain bytes.
+  string a(9000, 'a'), b(9000, 'b');
+  ql_.Push(a, QList::HEAD);
+  ASSERT_TRUE(ql_.Replace(0, b));
+  auto it = ql_.GetIterator(0);
+  ASSERT_TRUE(it.Valid());
+  EXPECT_EQ(b, it.Get().view());
+}
+
 TEST_F(QListTest, GetNum) {
   ql_.Push("1251977", QList::HEAD);
   QList::Iterator it = ql_.GetIterator(QList::HEAD);

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -582,6 +582,14 @@ TEST_F(ListFamilyTest, Lset) {
   ASSERT_EQ(Run({"rpop", kKey1}), "foo");
   Run({"rpush", kKey2, "a"});
   ASSERT_THAT(Run({"lset", kKey2, "1", "foo"}), ErrArg("index out of range"));
+
+  // LSET of a large (plain-node) element over another large element must not corrupt the node.
+  string big_a(9000, 'a'), big_b(9000, 'b');
+  Run({"rpush", kKey3, big_a});
+  ASSERT_EQ(Run({"lset", kKey3, "0", big_b}), "OK");
+  EXPECT_EQ(Run({"lindex", kKey3, "0"}), big_b);
+  Run({"debug", "reload"});
+  EXPECT_EQ(Run({"lindex", kKey3, "0"}), big_b);
 }
 
 TEST_F(ListFamilyTest, LPop) {


### PR DESCRIPTION
`LSET` of a >listpack-size element over another large element corrupted the plain node's size, crashing the server on the next read/pop or snapshot (SIGSEGV in debug, silent heap corruption in release). Since `LSET` is journaled, a replica corrupted identically.

Root cause:
`QList::Replace` plain-node branch used `NodeSetEntry`, which sets `node->sz = lpBytes(entry)` - valid only for listpack nodes. A plain node holds raw bytes, so `lpBytes` read a bogus size.

Changes:
- Set `node->sz` from the value length in the plain-node `Replace` path.
- Unit regression `QListTest.ReplacePlainWithPlain`; command-level `LSET` + `DEBUG RELOAD` case.
