### PR TITLE
fix(tests): wait for loading to finish before first write in test_shu…

### DIFF
--- a/tests/dragonfly/shutdown_test.py
+++ b/tests/dragonfly/shutdown_test.py
@@ -27,6 +27,7 @@ class TestGracefulShutdown:
     async def test_shutdown_snapshot_contains_acknowledged_writes(self, df_factory):
         df_server = df_factory.create(dbfilename="dump", **BASIC_ARGS)
         df_server.start()
+        await wait_available_async(df_server.client())
 
         def make_client():
             # One pinned connection, no retries: a lost reply must surface as


### PR DESCRIPTION
`test_shutdown_snapshot_contains_acknowledged_writes` intermittently failed with `BusyLoadingError` on the very first `SET`, right after `df_server.start()`.

Root cause:
`DflyInstance.start()` only waits for the process to open its port, not for the server to leave the `LOADING` state. The test already accounts for this correctly after the *second* `start()` (the post-restart one), calling `wait_available_async` before issuing commands — but the same wait was missing after the first `start()`, so the initial burst of `SET`s could race the server's own startup load phase under CI load.

Fix:
Add the same `wait_available_async` call after the first `start()`, mirroring the pattern already used later in the test.

Fixes #8173.
