### PR TITLE
server: Initialize cmd family during clone for alias

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -100,8 +100,9 @@ class CommandId {
   // Acl categories
   uint32_t acl_categories_;
   // Acl commands indices
-  size_t family_;
-  uint64_t bit_index_;
+  static constexpr size_t kNoFamily = std::numeric_limits<size_t>::max();
+  size_t family_ = kNoFamily;
+  uint64_t bit_index_ = 0;
 };
 
 }  // namespace facade

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -197,6 +197,8 @@ CommandId::~CommandId() {
 CommandId CommandId::Clone(const std::string_view name) const {
   CommandId cloned =
       CommandId{name.data(), opt_mask_, arity_, first_key_, last_key_, acl_categories_};
+  cloned.SetFamily(GetFamily());
+  cloned.SetBitIndex(GetBitIndex());
   cloned.handler_ = handler_;
   cloned.opt_mask_ = opt_mask_ | CO::HIDDEN;
   cloned.acl_categories_ = acl_categories_;


### PR DESCRIPTION
Also set sentinel values as default, if not set explicitly. 

Required for another child PR https://github.com/dragonflydb/dragonfly/pull/8151