### PR TITLE
fix(rdb): keep consumer-group entries_read when loading v2/v3 streams

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1944,7 +1944,7 @@ auto RdbLoaderBase::ReadStreams(int rdbtype) -> io::Result<OpaqueObj> {
     }  // while (consumers_num)
   }    // while (cgroup_num)
 
-  return OpaqueObj{std::move(load_trace), RDB_TYPE_STREAM_LISTPACKS};
+  return OpaqueObj{std::move(load_trace), rdbtype};
 }
 
 auto RdbLoaderBase::ReadRedisModule2() -> io::Result<OpaqueObj> {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -973,6 +973,22 @@ TEST_F(RdbTest, LoadHugeList) {
   EXPECT_GT(metrics.db_stats[0].obj_memory_usage, 20'000'000u);
 }
 
+TEST_F(RdbTest, ReloadKeepsConsumerGroupEntriesRead) {
+  Run({"xadd", "x", "1-0", "f", "v"});
+  Run({"xadd", "x", "2-0", "f", "v"});
+  Run({"xadd", "x", "3-0", "f", "v"});
+  Run({"xgroup", "create", "x", "g", "0"});
+  Run({"xreadgroup", "group", "g", "c", "count", "2", "streams", "x", ">"});
+  auto expected =
+      ElementsAre("name", "g", "consumers", IntArg(1), "pending", IntArg(2), "last-delivered-id",
+                  "2-0", "entries-read", IntArg(2), "lag", IntArg(1));
+  EXPECT_THAT(Run({"xinfo", "groups", "x"}).GetVec()[0].GetVec(), expected);
+
+  ASSERT_EQ(Run({"debug", "reload"}), "OK");
+  // A mid-stream group's entries-read cannot be estimated; it must survive the reload verbatim.
+  EXPECT_THAT(Run({"xinfo", "groups", "x"}).GetVec()[0].GetVec(), expected);
+}
+
 // Tests loading a huge stream, where the stream is loaded in multiple partial
 // reads.
 TEST_F(RdbTest, LoadHugeStream) {


### PR DESCRIPTION
Consumer-group `entries-read`/`lag` were lost on every snapshot load (DEBUG RELOAD, replica full sync, DUMP/RESTORE, COPY) for groups positioned mid-stream, so a master and a freshly synced replica reported different values.

Root cause:
`RdbLoaderBase::ReadStreams` returned the object tagged `RDB_TYPE_STREAM_LISTPACKS` instead of the real `rdbtype`; `CreateStream` then treated a v2/v3 payload as v1 and overwrote the saved `entries_read` with an estimate that is invalid mid-stream.
