### PR TITLE
fix(set): do not abort SRANDMEMBER on a zero-member set

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -964,6 +964,8 @@ OpStatus OpRandMember(const OpArgs& op_args, std::string_view key, int count,
   const PrimeValue& pv = find_res.value()->second;
 
   const std::uint32_t size = pv.Size();
+  if (size == 0)  // only a RESTOREd payload can yield this; NonUniquePicksGenerator(0) CHECKs
+    return OpStatus::OK;
   const bool picks_are_unique = count >= 0;
   // Widen to int64_t before std::abs: for count == INT_MIN, std::abs(count) on an int is UB
   // (the magnitude isn't representable in int). The magnitude fits in int64_t and uint32_t.

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -215,6 +215,16 @@ TEST_F(SetFamilyTest, SPop) {
   EXPECT_THAT(Run({"spop", "xlarge", "2", "3"}), ErrArg("syntax error"));
 }
 
+TEST_F(SetFamilyTest, SRandMemberRestoredEmptySet) {
+  // RESTORE currently accepts a zero-member set; SRANDMEMBER on it must not abort.
+  uint8_t payload[] = {0x02, 0x00, 0x0b, 0x00, 0x53, 0x11, 0x84, 0x73, 0x66, 0x16, 0xd0, 0x61};
+  std::string_view dump(reinterpret_cast<const char*>(payload), sizeof(payload));
+  ASSERT_EQ(Run({"restore", "es", "0", dump}), "OK");
+  EXPECT_THAT(Run({"srandmember", "es", "-1"}), ArrLen(0));
+  EXPECT_THAT(Run({"srandmember", "es", "2"}), ArrLen(0));
+  EXPECT_THAT(Run({"srandmember", "es"}), ArgType(RespExpr::NIL));
+}
+
 TEST_F(SetFamilyTest, SRandMember) {
   // Test IntSet
   Run({"sadd", "x", "1", "2", "3"});


### PR DESCRIPTION
`RESTORE` of a zero-member set payload is accepted and yields a present empty set; `SRANDMEMBER key -N` on it hit a hard `CHECK` in `NonUniquePicksGenerator` and aborted the server (release too).

Adjacent to #6999, which guarded the lazy-expiry path only. Rejecting empty collections at `RESTORE` time is a follow-up.
