### PR TITLE
test(facade): cover shared RESP V2 buffer

### DIFF
--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -25,6 +25,7 @@ helio_cxx_test(reply_builder_test facade_test LABELS DFLY)
 helio_cxx_test(resp_parser_test facade_test LABELS DFLY)
 helio_cxx_test(cmd_arg_parser_test facade_test LABELS DFLY)
 helio_cxx_test(disk_backed_queue_test facade_test LABELS DFLY)
+helio_cxx_test(proactor_read_buffer_test dfly_facade LABELS DFLY)
 
 add_executable(ok_backend ok_main.cc)
 cxx_link(ok_backend dfly_facade)

--- a/src/facade/proactor_read_buffer_test.cc
+++ b/src/facade/proactor_read_buffer_test.cc
@@ -1,0 +1,61 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "facade/proactor_read_buffer.h"
+
+#include <gmock/gmock.h>
+
+#include "base/gtest.h"
+#include "util/fibers/fibers.h"
+
+namespace facade {
+namespace {
+
+// Only one connection may use the shared buffer at a time.
+// Borrow it twice, then confirm the second borrow works only after the first is released.
+TEST(ProactorReadBufferTest, RejectsSecondBorrowUntilFirstIsReleased) {
+  ProactorReadBuffer read_buffer;
+  read_buffer.Init(128);
+
+  auto first_borrow = read_buffer.TryBorrow(1);
+  ASSERT_TRUE(first_borrow);
+  EXPECT_TRUE(read_buffer.in_use());
+  EXPECT_EQ(read_buffer.OwnerConnId(), 1u);
+  EXPECT_FALSE(read_buffer.TryBorrow(2));
+
+  first_borrow.reset();
+  EXPECT_FALSE(read_buffer.in_use());
+  EXPECT_TRUE(read_buffer.TryBorrow(2));
+}
+
+#ifndef NDEBUG
+// Releasing a buffer with unread data would lose that data for the connection.
+// Put one byte in the buffer and check that the release fails.
+TEST(ProactorReadBufferDeathTest, RejectsNonEmptyBufferOnRelease) {
+  EXPECT_DEATH(
+      {
+        ProactorReadBuffer read_buffer;
+        read_buffer.Init(128);
+        auto borrow = read_buffer.TryBorrow(1);
+        borrow->buf().WriteAndCommit("x", 1);
+      },
+      "");
+}
+
+// A buffer borrow must stay in the same fiber that received it.
+// Switch to another fiber and check that the borrow detects the mistake.
+TEST(ProactorReadBufferDeathTest, RejectsFiberSwitchDuringBorrow) {
+  EXPECT_DEATH(
+      {
+        ProactorReadBuffer read_buffer;
+        read_buffer.Init(128);
+        auto borrow = read_buffer.TryBorrow(1);
+        util::fb2::Fiber other("switch_epoch", [] {});
+        other.Join();
+      },
+      "");
+}
+#endif
+
+}  // namespace
+}  // namespace facade

--- a/src/facade/resp_srv_parser_test.cc
+++ b/src/facade/resp_srv_parser_test.cc
@@ -7,6 +7,8 @@
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 
+#include <random>
+
 #include "base/gtest.h"
 #include "base/logging.h"
 
@@ -134,6 +136,128 @@ TEST_F(RespSrvParserTest, Multi3) {
   ASSERT_EQ(RespSrvParser::OK, Parse("\r\n*3\r\n$3\r\nSET"));
   ASSERT_EQ(2, consumed_);
   EXPECT_THAT(Vec(), ElementsAre("SET", "key:000002273458", "VXK"));
+}
+
+// Parsed arguments remain valid after the input is overwritten.
+TEST_F(RespSrvParserTest, ParsedArgsSurviveSourceBufferOverwrite) {
+  string request = "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
+
+  ASSERT_EQ(RespSrvParser::OK, Parse(request));
+  ASSERT_EQ(request.size(), consumed_);
+  fill(request.begin(), request.end(), '\xCC');
+
+  // Verifies that the parsed arguments are still correct.
+  // This means the parser copied the argument data instead of keeping
+  // references to the original request buffer.
+  EXPECT_THAT(Vec(), ElementsAre("SET", "key", "value"));
+}
+
+// The parser consumes every fragment of an incomplete command.
+TEST_F(RespSrvParserTest, PendingFragmentsAreFullyConsumed) {
+  for (string_view fragment : {"*2\r\n", "$4\r\nECHO\r\n", "$5\r\nhe", "llo"}) {
+    ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(fragment));
+    EXPECT_EQ(fragment.size(), consumed_);
+  }
+
+  ASSERT_EQ(RespSrvParser::OK, Parse("\r\n"));
+  EXPECT_EQ(2, consumed_);
+  EXPECT_THAT(Vec(), ElementsAre("ECHO", "hello"));
+}
+
+// A large bulk value is correctly assembled from small fragments.
+TEST_F(RespSrvParserTest, FragmentedLargeBulkSurvivesSourceBufferReuse) {
+  constexpr size_t kValueSize = 1U << 20;
+  const string value(kValueSize, 'x');
+  const string header = absl::StrCat("*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$", kValueSize, "\r\n");
+  string shared_buffer;
+
+  auto parse = [this, &shared_buffer](string_view fragment) {
+    shared_buffer.assign(fragment);
+    ASSERT_EQ(Parse(shared_buffer), RespSrvParser::INPUT_PENDING);
+    ASSERT_EQ(consumed_, fragment.size());
+    fill(shared_buffer.begin(), shared_buffer.end(), '\xCC');
+  };
+
+  parse(header);
+  for (size_t offset = 0; offset < value.size(); offset += 257) {
+    parse(string_view{value}.substr(offset, min<size_t>(257, value.size() - offset)));
+  }
+
+  ASSERT_EQ(Parse("\r\n"), RespSrvParser::OK);
+  ASSERT_EQ(consumed_, 2u);
+  EXPECT_THAT(Vec(), ElementsAre("SET", "key", value));
+}
+
+// Independent parsers can assemble interleaved command fragments.
+TEST(RespSrvParserSharedBufferTest, AlternatingParsersSurviveSourceBufferReuse) {
+  RespSrvParser first_parser, second_parser;
+  cmn::BackedArguments first_args, second_args;
+  uint32_t consumed = 0;
+  string shared_buffer;
+
+  auto parse = [&shared_buffer, &consumed](RespSrvParser* parser, cmn::BackedArguments* args,
+                                           string_view fragment) {
+    shared_buffer.assign(fragment);
+    RespSrvParser::Buffer buffer{reinterpret_cast<const uint8_t*>(shared_buffer.data()),
+                                 shared_buffer.size()};
+    auto result = parser->Parse(buffer, &consumed, args);
+    EXPECT_EQ(consumed, fragment.size());
+    return result;
+  };
+
+  EXPECT_EQ(parse(&first_parser, &first_args, "*2\r\n$4\r\nECHO\r\n$5\r\nhe"),
+            RespSrvParser::INPUT_PENDING);
+  EXPECT_EQ(parse(&second_parser, &second_args, "*2\r\n$4\r\nECHO\r\n$5\r\nwo"),
+            RespSrvParser::INPUT_PENDING);
+  EXPECT_EQ(parse(&first_parser, &first_args, "llo\r\n"), RespSrvParser::OK);
+  EXPECT_EQ(parse(&second_parser, &second_args, "rld\r\n"), RespSrvParser::OK);
+
+  const auto expected = {pair{&first_args, "hello"}, pair{&second_args, "world"}};
+  for (const auto& [args, value] : expected) {
+    ASSERT_EQ(args->size(), 2u);
+    EXPECT_EQ((*args)[0], "ECHO");
+    EXPECT_EQ((*args)[1], value);
+  }
+}
+
+// Network input can split a command at many different places.
+// Split 100 commands into repeatable random-sized fragments and check they are rebuilt correctly.
+TEST(RespSrvParserSharedBufferTest, SeededFragmentationConsumesAndReassemblesCommands) {
+  mt19937 rng{0x5EED};
+
+  for (unsigned iteration = 0; iteration < 100; ++iteration) {
+    const string value = absl::StrCat("value-", iteration, "-", string(rng() % 256, 'x'));
+    const bool inline_command = (rng() % 2) == 0;
+    const string request = inline_command ? absl::StrCat("ECHO ", value, "\r\n")
+                                          : absl::StrCat("*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$",
+                                                         value.size(), "\r\n", value, "\r\n");
+    RespSrvParser parser;
+    cmn::BackedArguments args;
+    uint32_t consumed = 0;
+
+    for (size_t offset = 0; offset < request.size();) {
+      const size_t fragment_len = min<size_t>(1 + rng() % 31, request.size() - offset);
+      string fragment = request.substr(offset, fragment_len);
+      RespSrvParser::Buffer buffer{reinterpret_cast<const uint8_t*>(fragment.data()),
+                                   fragment.size()};
+      const auto result = parser.Parse(buffer, &consumed, &args);
+      EXPECT_EQ(consumed, fragment.size()) << "iteration=" << iteration;
+      offset += fragment_len;
+      if (offset < request.size())
+        EXPECT_EQ(result, RespSrvParser::INPUT_PENDING) << "iteration=" << iteration;
+      else
+        EXPECT_EQ(result, RespSrvParser::OK) << "iteration=" << iteration;
+    }
+
+    ASSERT_EQ(args.size(), inline_command ? 2u : 3u);
+    EXPECT_EQ(args[0], inline_command ? "ECHO" : "SET");
+    if (inline_command) {
+      EXPECT_EQ(args[1], value);
+    } else {
+      EXPECT_EQ(args[1], "key");
+      EXPECT_EQ(args[2], value);
+    }
+  }
 }
 
 TEST_F(RespSrvParserTest, InvalidMult1) {

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -390,8 +390,12 @@ async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tm
 )
 async def test_shared_read_buffer_interleaved_fragmented_resp(df_server):
     """
-    Verifies that if Client A sends an incomplete command (fragmented across multiple socket writes) and the server's thread
-    switches to handle Client B, Client A's partial state is not corrupted or lost in the shared memory buffer.
+    Client A sends only part of a SET command, stopping in the middle of the value length.
+    Client B then sends a complete command and uses the same shared read buffer.
+
+    When Client A sends the rest of its command, Dragonfly must still remember A's partial
+    command. Both clients then read their own values back, proving that B did not replace A's
+    unfinished input.
     """
     require_shared_resp_io_loop_v2(df_server)
     reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -432,7 +436,13 @@ async def test_shared_read_buffer_interleaved_fragmented_resp(df_server):
     }
 )
 async def test_shared_read_buffer_interleaved_pipelines(df_server):
-    """Concurrent pipelines on one proactor retain each connection's command stream."""
+    """
+    Client A sends half of a large pipeline, then Client B sends a complete pipeline while
+    Client A is still unfinished. Both clients use the same proactor and shared read buffer.
+
+    Each client must receive all of its replies and later read back its own final value. This
+    checks that command bytes from two busy connections are not mixed together.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
     reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -483,7 +493,13 @@ async def test_shared_read_buffer_interleaved_pipelines(df_server):
     }
 )
 async def test_shared_read_buffer_fragmented_large_bulk(df_server):
-    """A fragmented bulk payload survives repeated shared-buffer reuse by another connection."""
+    """
+    Client A sends a 64 KiB value in many small pieces. Between some pieces, Client B sends
+    PING commands, so the shared buffer is used again and again before A's command is complete.
+
+    Dragonfly must keep every piece of A's value in the right order. Reading the value back
+    byte-for-byte shows that no part was lost, changed, or taken from Client B.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
     reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -530,7 +546,13 @@ async def test_shared_read_buffer_fragmented_large_bulk(df_server):
     }
 )
 async def test_shared_read_buffer_split_inline_and_length_lines(df_server):
-    """RESP parser state, rather than bytes in the shared buffer, carries split command lines."""
+    """
+    Client A splits PING in the middle of its command name, first as an inline command and then
+    as a RESP array command. Client B runs a complete PING between A's two writes.
+
+    The parser must remember that Client A had started a command even after Client B used the
+    shared buffer. Both forms of A's split PING must still return PONG.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
     reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -569,8 +591,11 @@ async def test_shared_read_buffer_split_inline_and_length_lines(df_server):
 )
 async def test_shared_read_buffer_drains_silent_pipeline(df_server):
     """
-    Tests how the server handles a large wave of commands sent all at once, purposely exceeding the
-    1024-byte limit of the server's shared read buffer.
+    The client sends 1,024 PING commands in one write. The input is much larger than the 1 KiB
+    shared read buffer, and the client sends no more bytes afterward.
+
+    Dragonfly must keep draining the socket and reusing the buffer until it handles every command.
+    Receiving all 1,024 PONG replies proves it does not stop after the first buffer-sized chunk.
     """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -595,10 +620,11 @@ async def test_shared_read_buffer_drains_silent_pipeline(df_server):
 )
 async def test_shared_read_buffer_setup_bytes_handoff(df_server):
     """
-    A basic sanity check for protocol setup. When a connection is established, initial
-    bytes may be consumed during protocol detection. This test ensures those setup bytes
-    are successfully handed off to the shared read buffer without being lost, allowing
-    the very first command to execute correctly.
+    A new connection may read some bytes while Dragonfly decides how to set up its protocol.
+    Those early bytes must be passed into the shared V2 read path instead of being dropped.
+
+    The first command on the connection is PING. Getting PONG proves the setup code handed its
+    bytes to the shared buffer correctly.
     """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -623,10 +649,12 @@ async def test_shared_read_buffer_setup_bytes_handoff(df_server):
 )
 async def test_shared_read_buffer_overflow_copy_metric(df_server):
     """
-    Verifies that when a pipeline hits the strict queue limit (pipeline_queue_limit=1),
-    the server safely copies the unparsed, remaining bytes out of the shared read buffer
-    to prevent data loss. We confirm this fallback mechanism triggered by checking that
-    the 'dragonfly_shared_buf_overflow_copies' metric increments.
+    A blocking BLPOP is followed by many PING commands while the pipeline queue is limited to one
+    command. The remaining PING bytes cannot stay in the shared buffer because another connection
+    may need that buffer.
+
+    Dragonfly must copy those remaining bytes to connection-owned memory. The test checks that the
+    copy metric increases, then unblocks BLPOP and receives both its reply and every queued PONG.
     """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -668,7 +696,13 @@ async def test_shared_read_buffer_overflow_copy_metric(df_server):
     }
 )
 async def test_shared_read_buffer_blocking_command_releases_borrow(df_server):
-    """A callback can parse after BLPOP blocks without pinning the shared buffer."""
+    """
+    One client sends BLPOP followed by SET. BLPOP waits for a list value, but SET arrives while
+    that wait is still active.
+
+    Dragonfly must not keep the shared read buffer locked by the waiting BLPOP. It must parse the
+    later SET, then run it after BLPOP is unblocked. The final GET confirms that SET was preserved.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     client = df_server.client()
@@ -699,7 +733,13 @@ async def test_shared_read_buffer_blocking_command_releases_borrow(df_server):
     }
 )
 async def test_shared_read_buffer_multi_exec_split(df_server):
-    """A transaction split at a RESP boundary retains its connection-owned parser state."""
+    """
+    Client A starts a transaction and sends only `EX` from the final EXEC command. Client B sends
+    PING before Client A sends the remaining `EC` bytes.
+
+    The transaction and parser state must stay with Client A while Client B uses the shared buffer.
+    Client A must receive the normal MULTI, QUEUED, and EXEC replies and then read the saved value.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
     reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -735,7 +775,13 @@ async def test_shared_read_buffer_multi_exec_split(df_server):
     }
 )
 async def test_shared_read_buffer_protocol_error_closes_connection(df_server):
-    """A parser failure discards shared-buffer residue, replies, and closes only that client."""
+    """
+    One client first proves it is healthy with PING, then sends an invalid RESP array header.
+    Dragonfly must return a protocol error, discard any input left for that connection, and close it.
+
+    A second client then sends PING on the same proactor. Its success proves bad input from the
+    first client did not damage the shared buffer or break other connections.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     healthy_client = df_server.client()
@@ -769,7 +815,13 @@ async def test_shared_read_buffer_protocol_error_closes_connection(df_server):
     }
 )
 async def test_shared_read_buffer_backpressure_recovers_without_new_write(df_server):
-    """Overflow input drains after backpressure relief without another client write."""
+    """
+    The client sends more PING commands than the tiny pipeline limits allow. Dragonfly must save
+    the unread commands and wait for backpressure to be removed.
+
+    The test raises the limits without writing any new bytes to that client. All PONG replies must
+    still arrive, proving the saved input wakes up and continues on its own.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     admin = df_server.client()
@@ -806,7 +858,13 @@ async def test_shared_read_buffer_backpressure_recovers_without_new_write(df_ser
     }
 )
 async def test_shared_read_buffer_backpressure_keeps_server_responsive(df_server):
-    """A throttled shared connection preserves overflow while another client still makes progress."""
+    """
+    One client is blocked in BLPOP and has many PING commands waiting behind it. The small pipeline
+    limits force Dragonfly to save the waiting input outside the shared buffer.
+
+    While that client is stuck, a second admin client must still answer PING quickly. After lifting
+    the limits and unblocking BLPOP, the first client must receive all of its saved replies.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     admin = df_server.client()
@@ -844,7 +902,13 @@ async def test_shared_read_buffer_backpressure_keeps_server_responsive(df_server
     }
 )
 async def test_shared_read_buffer_reset_and_pause(df_server):
-    """RESET and CLIENT PAUSE do not retain the buffer across their control-path waits."""
+    """
+    This test runs commands that change connection state or make writes wait: RESET and CLIENT
+    PAUSE. Both paths must release the shared read buffer before they wait or change state.
+
+    The PING after RESET must work on the same connection. The SET sent during the write pause must
+    also complete and store its value once the pause finishes.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     admin = df_server.client()
@@ -877,7 +941,13 @@ async def test_shared_read_buffer_reset_and_pause(df_server):
     }
 )
 async def test_shared_read_buffer_migrates_backpressured_overflow(df_server):
-    """A connection retains shared-buffer overflow safely while migrating between proactors."""
+    """
+    A named client blocks in BLPOP and has many PING commands saved because of the small pipeline
+    limits. The test then moves that client to the other proactor thread.
+
+    The saved input belongs to the connection, not to the old thread's shared buffer. After the
+    move, lifting the limits and unblocking BLPOP must produce the list reply and all PONG replies.
+    """
     require_shared_resp_io_loop_v2(df_server)
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
     admin = df_server.client()
@@ -915,7 +985,13 @@ async def test_shared_read_buffer_migrates_backpressured_overflow(df_server):
 
 
 async def test_shared_read_buffer_tls_fragmented(df_factory):
-    """Fragmented TLS plaintext is reassembled on the shared V2 path while another client runs."""
+    """
+    A TLS client sends an 8 KiB SET command in 137-byte pieces. TLS must first turn encrypted
+    network bytes into normal RESP bytes before the shared V2 parser can use them.
+
+    Another TLS client sends PING while the first request is incomplete. The final GET must return
+    the whole value, proving shared-buffer handling also works for fragmented TLS input.
+    """
     server = df_factory.create(
         enable_resp_io_loop_v2="true",
         enable_shared_read_buffer="true",
@@ -954,7 +1030,13 @@ async def test_shared_read_buffer_tls_fragmented(df_factory):
 
 
 async def test_shared_read_buffer_unix_and_admin_connections(df_factory, tmp_dir):
-    """Shared V2 selection works for Unix-domain and admin RESP listeners."""
+    """
+    The shared V2 path is available through more than the normal TCP port. This test starts both a
+    Unix-domain socket and the separate admin RESP port with shared buffering enabled.
+
+    A PING through each listener must return successfully. That proves both listener types choose
+    and work with the shared V2 read path.
+    """
     server = df_factory.create(
         enable_resp_io_loop_v2="true",
         enable_shared_read_buffer="true",
@@ -978,7 +1060,14 @@ async def test_shared_read_buffer_unix_and_admin_connections(df_factory, tmp_dir
 
 
 async def test_shared_read_buffer_accounting_1000_connections(df_factory):
-    """The aggregate read-buffer metric accounts for shared and direct client buffers."""
+    """
+    The server opens 1,000 client connections with shared buffering enabled, then asks for memory
+    use through both INFO and the Prometheus metrics endpoint.
+
+    The two reported totals should match except for the small direct buffer used by the metrics
+    request itself. This checks that shared buffers are counted once and client buffers are counted
+    correctly at larger connection counts.
+    """
     server = df_factory.create(
         enable_resp_io_loop_v2="true",
         enable_shared_read_buffer="true",
@@ -1017,7 +1106,14 @@ async def test_shared_read_buffer_accounting_1000_connections(df_factory):
 )
 @pytest.mark.exclude_epoll
 async def test_shared_read_buffer_excludes_uring_multishot(df_server):
-    """Shared V2 reads must not consume io_uring provided buffers when a ring is available."""
+    """
+    On systems with an io_uring buffer ring, normal reads can use buffers supplied by io_uring.
+    Shared V2 reads must use their own shared buffer instead, because the two buffer systems have
+    different ownership rules.
+
+    After a small PING pipeline, the test checks that no receive call used an io_uring provided
+    buffer. It skips cleanly when the host has no io_uring buffer ring.
+    """
     require_shared_resp_io_loop_v2(df_server)
     if not any(
         "Registered a bufring" in Path(log_file).read_text() for log_file in df_server.log_files

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -9,6 +9,7 @@ import struct
 import subprocess
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from threading import Thread
 from typing import Awaitable, Callable
 
@@ -32,6 +33,7 @@ from .instance import DflyInstance, DflyInstanceFactory
 from .utility import assert_eventually, parse_client_list, tick_timer
 
 BASE_PORT = 1111
+TLS_CERTIFICATES_DIR = Path(__file__).parents[2] / "helio" / "util" / "tls" / "certificates"
 
 
 def is_resp_io_loop_v2(server: DflyInstance) -> bool:
@@ -45,6 +47,15 @@ def is_resp_io_loop_v2(server: DflyInstance) -> bool:
         server.has_arg("enable_resp_io_loop_v2")
         and server.args.get("enable_resp_io_loop_v2") != "false"
     )
+
+
+def require_shared_resp_io_loop_v2(server: DflyInstance) -> None:
+    if (
+        not is_resp_io_loop_v2(server)
+        or not server.has_arg("enable_shared_read_buffer")
+        or server.args.get("enable_shared_read_buffer") == "false"
+    ):
+        pytest.skip("requires the RESP V2 shared read buffer")
 
 
 @dataclass(frozen=True)
@@ -298,10 +309,18 @@ async def test_debug_traffic_records_pipeline_in_dispatch_order(df_server, tmp_p
     ]
 
 
-@dfly_args({"enable_resp_io_loop_v2": "true", "proactor_threads": 1})
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
 @pytest.mark.exclude_epoll
 async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tmp_path):
-    """Validates that V2 logging keeps parser-time eligibility while deferring writes from proactor parsing."""
+    """Shared V2 callback parsing records traffic without retaining the shared buffer."""
+    require_shared_resp_io_loop_v2(df_server)
     client = df_server.client()
     log_prefix = tmp_path / "traffic-proactor"
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
@@ -341,6 +360,9 @@ async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tm
         assert b"traffic:block" in first_response
         assert b"unblock" in first_response
         assert second_response == b"+OK\r\n"
+        writer.write(b"PING\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readuntil(b"+PONG\r\n"), timeout=2) == b"+PONG\r\n"
         assert await client.execute_command("DEBUG", "TRAFFIC", "STOP") == "OK"
     finally:
         writer.close()
@@ -356,6 +378,664 @@ async def test_debug_traffic_v2_parse_in_proactor_does_not_preempt(df_server, tm
     # retroactively to the log. The later SET was parsed after START, so it is expected to be logged.
     assert [b"SET", b"traffic:queued", b"before-start"] not in logged_commands
     assert [b"SET", b"traffic:proactor", b"one"] in logged_commands
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_interleaved_fragmented_resp(df_server):
+    """
+    Verifies that if Client A sends an incomplete command (fragmented across multiple socket writes) and the server's thread
+    switches to handle Client B, Client A's partial state is not corrupted or lost in the shared memory buffer.
+    """
+    require_shared_resp_io_loop_v2(df_server)
+    reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
+    reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        # Split client A inside its bulk-length line, then let client B overwrite the shared buffer.
+        writer_a.write(b"*3\r\n$3\r\nSET\r\n$5\r\nalpha\r\n$")
+        await writer_a.drain()
+        await asyncio.sleep(0)
+
+        writer_b.write(b"SET beta two\r\n")
+        await writer_b.drain()
+        assert await asyncio.wait_for(reader_b.readuntil(b"\r\n"), timeout=2) == b"+OK\r\n"
+
+        writer_a.write(b"3\r\none\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(reader_a.readuntil(b"\r\n"), timeout=2) == b"+OK\r\n"
+
+        writer_a.write(b"GET alpha\r\n")
+        writer_b.write(b"GET beta\r\n")
+        await writer_a.drain()
+        await writer_b.drain()
+        assert await asyncio.wait_for(reader_a.readexactly(9), timeout=2) == b"$3\r\none\r\n"
+        assert await asyncio.wait_for(reader_b.readexactly(9), timeout=2) == b"$3\r\ntwo\r\n"
+    finally:
+        writer_a.close()
+        writer_b.close()
+        await writer_a.wait_closed()
+        await writer_b.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_interleaved_pipelines(df_server):
+    """Concurrent pipelines on one proactor retain each connection's command stream."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
+    reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        command_count = 128
+        pipeline_a = b"".join(
+            f"SET shared:a:{index} value-a-{index}\r\n".encode() for index in range(command_count)
+        )
+        pipeline_b = b"".join(
+            f"SET shared:b:{index} value-b-{index}\r\n".encode() for index in range(command_count)
+        )
+
+        # Leave A's first pipeline incomplete while B uses the same proactor's shared buffer.
+        split_at = len(pipeline_a) // 2
+        writer_a.write(pipeline_a[:split_at])
+        await writer_a.drain()
+        await asyncio.sleep(0)
+        writer_b.write(pipeline_b)
+        await writer_b.drain()
+        writer_a.write(pipeline_a[split_at:])
+        await writer_a.drain()
+
+        expected = b"+OK\r\n" * command_count
+        assert await asyncio.wait_for(reader_a.readexactly(len(expected)), timeout=5) == expected
+        assert await asyncio.wait_for(reader_b.readexactly(len(expected)), timeout=5) == expected
+
+        writer_a.write(b"GET shared:a:127\r\n")
+        writer_b.write(b"GET shared:b:127\r\n")
+        await writer_a.drain()
+        await writer_b.drain()
+        assert await asyncio.wait_for(reader_a.readuntil(b"\r\n"), timeout=2) == b"$11\r\n"
+        assert await asyncio.wait_for(reader_a.readexactly(13), timeout=2) == b"value-a-127\r\n"
+        assert await asyncio.wait_for(reader_b.readuntil(b"\r\n"), timeout=2) == b"$11\r\n"
+        assert await asyncio.wait_for(reader_b.readexactly(13), timeout=2) == b"value-b-127\r\n"
+    finally:
+        writer_a.close()
+        writer_b.close()
+        await writer_a.wait_closed()
+        await writer_b.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_fragmented_large_bulk(df_server):
+    """A fragmented bulk payload survives repeated shared-buffer reuse by another connection."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
+    reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
+    value = bytes(index % 251 for index in range(64 * 1024))
+    request_header = b"*3\r\n$3\r\nSET\r\n$17\r\nshared:large-bulk\r\n$65536\r\n"
+
+    try:
+        # Send a partial bulk, then repeatedly let B occupy the proactor between A's fragments.
+        writer_a.write(request_header)
+        await writer_a.drain()
+        for offset in range(0, len(value), 257):
+            writer_a.write(value[offset : offset + 257])
+            await writer_a.drain()
+            if offset % (257 * 8) == 0:
+                writer_b.write(b"PING\r\n")
+                await writer_b.drain()
+                assert (
+                    await asyncio.wait_for(reader_b.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+                )
+        writer_a.write(b"\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(reader_a.readuntil(b"\r\n"), timeout=5) == b"+OK\r\n"
+
+        writer_a.write(b"GET shared:large-bulk\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(reader_a.readuntil(b"\r\n"), timeout=5) == b"$65536\r\n"
+        assert (
+            await asyncio.wait_for(reader_a.readexactly(len(value) + 2), timeout=5)
+            == value + b"\r\n"
+        )
+    finally:
+        writer_a.close()
+        writer_b.close()
+        await writer_a.wait_closed()
+        await writer_b.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_split_inline_and_length_lines(df_server):
+    """RESP parser state, rather than bytes in the shared buffer, carries split command lines."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
+    reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        writer_a.write(b"PI")
+        await writer_a.drain()
+        writer_b.write(b"PING\r\n")
+        await writer_b.drain()
+        assert await asyncio.wait_for(reader_b.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+        writer_a.write(b"NG\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(reader_a.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+
+        writer_a.write(b"*1\r\n$4\r\nPI")
+        await writer_a.drain()
+        writer_b.write(b"PING\r\n")
+        await writer_b.drain()
+        assert await asyncio.wait_for(reader_b.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+        writer_a.write(b"NG\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(reader_a.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+    finally:
+        writer_a.close()
+        writer_b.close()
+        await writer_a.wait_closed()
+        await writer_b.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_drains_silent_pipeline(df_server):
+    """
+    Tests how the server handles a large wave of commands sent all at once, purposely exceeding the
+    1024-byte limit of the server's shared read buffer.
+    """
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        command_count = 1024
+        writer.write(b"PING\r\n" * command_count)
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(7 * command_count), timeout=1) == (
+            b"+PONG\r\n" * command_count
+        )
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_setup_bytes_handoff(df_server):
+    """
+    A basic sanity check for protocol setup. When a connection is established, initial
+    bytes may be consumed during protocol detection. This test ensures those setup bytes
+    are successfully handed off to the shared read buffer without being lost, allowing
+    the very first command to execute correctly.
+    """
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        writer.write(b"PING\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "pipeline_queue_limit": 1,
+        "pipeline_buffer_limit": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_overflow_copy_metric(df_server):
+    """
+    Verifies that when a pipeline hits the strict queue limit (pipeline_queue_limit=1),
+    the server safely copies the unparsed, remaining bytes out of the shared read buffer
+    to prevent data loss. We confirm this fallback mechanism triggered by checking that
+    the 'dragonfly_shared_buf_overflow_copies' metric increments.
+    """
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        command_count = 128
+        writer.write(b"BLPOP shared:overflow 0\r\n" + b"PING\r\n" * command_count)
+        await writer.drain()
+
+        @assert_eventually(timeout=2)
+        async def overflow_was_preserved():
+            metrics = await df_server.metrics()
+            assert metrics["dragonfly_shared_buf_overflow_copies"].samples[0].value > 0
+
+        await overflow_was_preserved()
+        admin = df_server.client()
+        try:
+            assert await admin.lpush("shared:overflow", "unblock") == 1
+        finally:
+            await admin.aclose()
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=5) == b"*2\r\n"
+        blocking_reply_tail = b"$15\r\nshared:overflow\r\n$7\r\nunblock\r\n"
+        assert await asyncio.wait_for(reader.readexactly(len(blocking_reply_tail)), timeout=5) == (
+            blocking_reply_tail
+        )
+        assert await asyncio.wait_for(reader.readexactly(7 * command_count), timeout=5) == (
+            b"+PONG\r\n" * command_count
+        )
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_blocking_command_releases_borrow(df_server):
+    """A callback can parse after BLPOP blocks without pinning the shared buffer."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    client = df_server.client()
+    try:
+        # SET is parsed while the connection is blocked in BLPOP, so it exercises callback parsing.
+        writer.write(b"BLPOP shared:block 0\r\nSET shared:after-block value\r\n")
+        await writer.drain()
+        await asyncio.sleep(0.05)
+        assert await client.lpush("shared:block", "unblock") == 1
+
+        first_reply = await asyncio.wait_for(_read_resp_frame(reader), timeout=2)
+        assert b"shared:block" in first_reply
+        assert b"unblock" in first_reply
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=2) == b"+OK\r\n"
+        assert await client.get("shared:after-block") == "value"
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await client.aclose()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_multi_exec_split(df_server):
+    """A transaction split at a RESP boundary retains its connection-owned parser state."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader_a, writer_a = await asyncio.open_connection("127.0.0.1", df_server.port)
+    reader_b, writer_b = await asyncio.open_connection("127.0.0.1", df_server.port)
+    try:
+        writer_a.write(b"MULTI\r\nSET shared:tx value\r\nEX")
+        await writer_a.drain()
+        writer_b.write(b"PING\r\n")
+        await writer_b.drain()
+        assert await asyncio.wait_for(reader_b.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+
+        writer_a.write(b"EC\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(_read_resp_frame(reader_a), timeout=2) == b"+OK\r\n"
+        assert await asyncio.wait_for(_read_resp_frame(reader_a), timeout=2) == b"+QUEUED\r\n"
+        assert await asyncio.wait_for(_read_resp_frame(reader_a), timeout=2) == b"*1\r\n+OK\r\n"
+
+        writer_a.write(b"GET shared:tx\r\n")
+        await writer_a.drain()
+        assert await asyncio.wait_for(_read_resp_frame(reader_a), timeout=2) == b"$5\r\nvalue\r\n"
+    finally:
+        writer_a.close()
+        writer_b.close()
+        await writer_a.wait_closed()
+        await writer_b.wait_closed()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_protocol_error_closes_connection(df_server):
+    """A parser failure discards shared-buffer residue, replies, and closes only that client."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    healthy_client = df_server.client()
+    try:
+        writer.write(b"PING\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=2) == b"+PONG\r\n"
+
+        writer.write(b"*x\r\n")
+        await writer.drain()
+        error = await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=2)
+        assert error.startswith(b"-ERR Protocol error")
+        assert await asyncio.wait_for(reader.read(), timeout=2) == b""
+
+        # The next borrower on the same proactor must still receive and parse normally.
+        assert await healthy_client.ping() is True
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await healthy_client.aclose()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "pipeline_queue_limit": 1,
+        "pipeline_buffer_limit": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_backpressure_recovers_without_new_write(df_server):
+    """Overflow input drains after backpressure relief without another client write."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    admin = df_server.client()
+    try:
+        command_count = 128
+        writer.write(b"BLPOP shared:recovery 0\r\n" + b"PING\r\n" * command_count)
+        await writer.drain()
+        await asyncio.sleep(0.05)
+
+        # Waking a parked shared-buffer fiber must restore and process its preserved suffix.
+        await admin.config_set("pipeline_queue_limit", command_count + 1)
+        await admin.config_set("pipeline_buffer_limit", 1024 * 1024)
+        assert await admin.lpush("shared:recovery", "unblock") == 1
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=5) == (
+            b"*2\r\n$15\r\nshared:recovery\r\n$7\r\nunblock\r\n"
+        )
+        assert await asyncio.wait_for(reader.readexactly(7 * command_count), timeout=5) == (
+            b"+PONG\r\n" * command_count
+        )
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await admin.aclose()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "pipeline_queue_limit": 1,
+        "pipeline_buffer_limit": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_backpressure_keeps_server_responsive(df_server):
+    """A throttled shared connection preserves overflow while another client still makes progress."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    admin = df_server.client()
+    try:
+        writer.write(b"BLPOP shared:responsive 0\r\n" + b"PING\r\n" * 128)
+        await writer.drain()
+
+        @assert_eventually(timeout=2)
+        async def overflow_was_preserved():
+            metrics = await df_server.metrics()
+            assert metrics["dragonfly_shared_buf_overflow_copies"].samples[0].value > 0
+
+        await overflow_was_preserved()
+        assert await asyncio.wait_for(admin.ping(), timeout=1) is True
+
+        await admin.config_set("pipeline_queue_limit", 1024)
+        await admin.config_set("pipeline_buffer_limit", 1024 * 1024)
+        assert await admin.lpush("shared:responsive", "unblock") == 1
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=5) == (
+            b"*2\r\n$17\r\nshared:responsive\r\n$7\r\nunblock\r\n"
+        )
+        assert await asyncio.wait_for(reader.readexactly(7 * 128), timeout=5) == b"+PONG\r\n" * 128
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await admin.aclose()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    }
+)
+async def test_shared_read_buffer_reset_and_pause(df_server):
+    """RESET and CLIENT PAUSE do not retain the buffer across their control-path waits."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    admin = df_server.client()
+    try:
+        writer.write(b"CLIENT SETNAME shared-reset\r\nRESET\r\nPING\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=2) == b"+OK\r\n"
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=2) == b"+RESET\r\n"
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=2) == b"+PONG\r\n"
+
+        assert await admin.execute_command("CLIENT", "PAUSE", "50", "WRITE") == "OK"
+        writer.write(b"SET shared:pause value\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(_read_resp_frame(reader), timeout=2) == b"+OK\r\n"
+        assert await admin.get("shared:pause") == "value"
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await admin.aclose()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "pipeline_queue_limit": 1,
+        "pipeline_buffer_limit": "1024",
+        "proactor_threads": 2,
+    }
+)
+async def test_shared_read_buffer_migrates_backpressured_overflow(df_server):
+    """A connection retains shared-buffer overflow safely while migrating between proactors."""
+    require_shared_resp_io_loop_v2(df_server)
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    admin = df_server.client()
+    try:
+        writer.write(b"CLIENT SETNAME shared-overflow\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=2) == b"+OK\r\n"
+        writer.write(b"BLPOP shared:migrate-overflow 0\r\n" + b"PING\r\n" * 128)
+        await writer.drain()
+
+        @assert_eventually(timeout=2)
+        async def overflow_was_preserved():
+            metrics = await df_server.metrics()
+            assert metrics["dragonfly_shared_buf_overflow_copies"].samples[0].value > 0
+
+        await overflow_was_preserved()
+        client_info = parse_client_list(await admin.execute_command("CLIENT LIST"))
+        migrant = next(client for client in client_info if client["name"] == "shared-overflow")
+        current_tid = int(migrant["tid"])
+        assert await admin.execute_command("CLIENT", "MIGRATE", migrant["id"], 1 - current_tid) == 1
+
+        await admin.config_set("pipeline_queue_limit", 1024)
+        await admin.config_set("pipeline_buffer_limit", 1024 * 1024)
+        assert await admin.lpush("shared:migrate-overflow", "unblock") == 1
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=5) == b"*2\r\n"
+        blocking_reply_tail = b"$23\r\nshared:migrate-overflow\r\n$7\r\nunblock\r\n"
+        assert await asyncio.wait_for(reader.readexactly(len(blocking_reply_tail)), timeout=5) == (
+            blocking_reply_tail
+        )
+        assert await asyncio.wait_for(reader.readexactly(7 * 128), timeout=5) == b"+PONG\r\n" * 128
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await admin.aclose()
+
+
+async def test_shared_read_buffer_tls_fragmented(df_factory):
+    """Fragmented TLS plaintext is reassembled on the shared V2 path while another client runs."""
+    server = df_factory.create(
+        enable_resp_io_loop_v2="true",
+        enable_shared_read_buffer="true",
+        shared_read_buffer_len=1024,
+        proactor_threads=1,
+        tls=None,
+        tls_cert_file=str(TLS_CERTIFICATES_DIR / "server-cert.pem"),
+        tls_key_file=str(TLS_CERTIFICATES_DIR / "server-key.pem"),
+        requirepass="shared-tls-password",
+    )
+    server.start()
+    require_shared_resp_io_loop_v2(server)
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.port, ssl=ssl_ctx)
+    other = server.client(password="shared-tls-password", ssl=True, ssl_cert_reqs=None)
+    value = b"x" * 8192
+    request = b"*3\r\n$3\r\nSET\r\n$10\r\ntls:shared\r\n$8192\r\n" + value + b"\r\n"
+    try:
+        writer.write(b"AUTH shared-tls-password\r\n")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=2) == b"+OK\r\n"
+        for offset in range(0, len(request), 137):
+            writer.write(request[offset : offset + 137])
+            await writer.drain()
+            if offset == 0:
+                assert await other.ping() is True
+        assert await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=5) == b"+OK\r\n"
+        assert await other.get("tls:shared") == "x" * 8192
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await other.aclose()
+        server.stop()
+
+
+async def test_shared_read_buffer_unix_and_admin_connections(df_factory, tmp_dir):
+    """Shared V2 selection works for Unix-domain and admin RESP listeners."""
+    server = df_factory.create(
+        enable_resp_io_loop_v2="true",
+        enable_shared_read_buffer="true",
+        shared_read_buffer_len=1024,
+        proactor_threads=1,
+        port=BASE_PORT,
+        admin_port=BASE_PORT + 1,
+        unixsocket="./shared.sock",
+    )
+    server.start()
+    require_shared_resp_io_loop_v2(server)
+    unix_client = aioredis.Redis(unix_socket_path=tmp_dir / "shared.sock", decode_responses=True)
+    admin_client = server.admin_client()
+    try:
+        assert await unix_client.ping() is True
+        assert await admin_client.ping() is True
+    finally:
+        await unix_client.aclose()
+        await admin_client.aclose()
+        server.stop()
+
+
+async def test_shared_read_buffer_accounting_1000_connections(df_factory):
+    """The aggregate read-buffer metric accounts for shared and direct client buffers."""
+    server = df_factory.create(
+        enable_resp_io_loop_v2="true",
+        enable_shared_read_buffer="true",
+        shared_read_buffer_len=1024,
+        proactor_threads=1,
+    )
+    server.start()
+    require_shared_resp_io_loop_v2(server)
+    clients = [server.client() for _ in range(1000)]
+    try:
+        await asyncio.gather(*(client.ping() for client in clients))
+        info_bytes = int((await clients[0].info("clients"))["client_read_buffer_bytes"])
+        metrics = await server.metrics()
+        metric_bytes = next(
+            sample.value
+            for sample in metrics["dragonfly_memory_by_class_bytes"].samples
+            if sample.labels["class"] == "client_read_buffer"
+        )
+        # The /metrics request is itself a direct connection while the metric is serialized. Its
+        # minimum receive buffer is 256 bytes, but it is not present in the preceding INFO snapshot.
+        assert metric_bytes == info_bytes + 256
+        assert info_bytes >= 1024
+    finally:
+        await asyncio.gather(*(client.aclose() for client in clients))
+        server.stop()
+
+
+@dfly_args(
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+        "uring_recv_buffer_cnt": 8,
+    }
+)
+@pytest.mark.exclude_epoll
+async def test_shared_read_buffer_excludes_uring_multishot(df_server):
+    """Shared V2 reads must not consume io_uring provided buffers when a ring is available."""
+    require_shared_resp_io_loop_v2(df_server)
+    if not any(
+        "Registered a bufring" in Path(log_file).read_text() for log_file in df_server.log_files
+    ):
+        pytest.skip("io_uring buffer rings are unavailable on this host")
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    admin = df_server.client()
+    try:
+        writer.write(b"PING\r\n" * 128)
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(7 * 128), timeout=5) == b"+PONG\r\n" * 128
+        stats = await admin.info("stats")
+        assert int(stats["connection_recv_provided_calls"]) == 0
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await admin.aclose()
 
 
 @dfly_args(
@@ -3050,13 +3730,25 @@ async def test_pipeline_overlimit(df_factory: DflyInstanceFactory):
         await task
 
 
-@dfly_args(
+@dfly_multi_test_args(
     {
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
-        "pipeline_buffer_limit": "1024",
+        # One parsed command can use more than 1 KiB. The queue limit drives this test.
+        "pipeline_buffer_limit": "1mb",
         "enable_resp_io_loop_v2": "true",
-    }
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+    },
+    {
+        "proactor_threads": 4,
+        "pipeline_queue_limit": 10,
+        # One parsed command can use more than 1 KiB. The queue limit drives this test.
+        "pipeline_buffer_limit": "1mb",
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "false",
+        "shared_read_buffer_len": "1024",
+    },
 )
 async def test_pipeline_backpressure_v2_correctness(df_server: DflyInstance):
     """Verify that V2 backpressure throttles without corrupting responses."""
@@ -3701,13 +4393,27 @@ async def test_tls_partial_header_read(
 
 
 @dfly_multi_test_args(
-    {"enable_resp_io_loop_v2": "false", "proactor_threads": 1},
-    {"enable_resp_io_loop_v2": "true", "proactor_threads": 1},
+    {
+        "enable_resp_io_loop_v2": "false",
+        "enable_shared_read_buffer": "false",
+        "proactor_threads": 1,
+    },
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "false",
+        "proactor_threads": 1,
+    },
+    {
+        "enable_resp_io_loop_v2": "true",
+        "enable_shared_read_buffer": "true",
+        "shared_read_buffer_len": "1024",
+        "proactor_threads": 1,
+    },
 )
 async def test_tls_full_duplex_large_pipeline(
     df_factory, with_ca_tls_server_args, with_tls_client_args
 ):
-    """Regression test for TLS support in the V2 (single-fiber) IoLoop.
+    """Regression test for TLS support in V1, private V2, and shared-buffer V2.
 
     Streams a large pipeline of ECHO commands (large request AND large reply payloads) over a
     single TLS connection using true full-duplex I/O: a writer task keeps sending while a reader
@@ -3719,6 +4425,8 @@ async def test_tls_full_duplex_large_pipeline(
     """
     server = df_factory.create(**with_ca_tls_server_args)
     server.start()
+    if is_resp_io_loop_v2(server) and server.args.get("enable_shared_read_buffer") == "true":
+        require_shared_resp_io_loop_v2(server)
 
     # The server verifies client certs (tls_ca_cert_file is set), so present the client cert chain.
     # We deliberately do NOT verify the server cert here (its CN won't match 127.0.0.1), so no CA


### PR DESCRIPTION
This is a follow-up test coverage to feat(facade): share the RESP V2 read buffer.

Note: 
- Shared buffer is a base (shim) to provided buffer, and can also be used in production kernels under 6.12 and when using epoll.
- ASan, UBSAn and fuzzing are not part of this commit.

**GoogleTest:**
1) Add GoogleTest coverage in proactor_read_buffer_test.cc for exclusive borrowing, empty-buffer release, and preventing borrows from crossing a fiber switch.
2) Extend resp_srv_parser_test.cc with source-reuse and fixed-seed fragmentation coverage for inline, multibulk, and large bulk requests.

**Regression Tests/pytest:**
Add integration coverage for interleaved clients, pipeline backpressure and overflow recovery, blocking commands, migration, protocol errors, RESET/PAUSE, DEBUG TRAFFIC, TLS, Unix/admin listeners, accounting, and io_uring provided-buffer exclusion.

Use explicit V1/V2 and shared-buffer settings so private and shared buffer behavior are tested independently.
