### PR TITLE
fix(generic): TTL of a logically expired key returns -2 instead of aborting

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -988,9 +988,11 @@ OpResult<uint64_t> OpExpireTime(Transaction* t, EngineShard* shard, string_view 
   if (!it->first.HasExpire())
     return OpStatus::SKIPPED;
 
-  int64_t ttl_ms = it->first.GetExpireTime();
-  DCHECK_GT(ttl_ms, 0);  // Otherwise FindReadOnly would return null.
-  return ttl_ms;
+  int64_t expire_ms = it->first.GetExpireTime();
+  // Expiry may be disabled (CLIENT PAUSE, replica): a key past its deadline is logically gone.
+  if (expire_ms <= int64_t(t->GetDbContext().time_now_ms))
+    return OpStatus::KEY_NOTFOUND;
+  return expire_ms;
 }
 
 // OpMove touches multiple databases (op_args.db_idx, target_db), so it assumes it runs

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -34,6 +34,18 @@ namespace dfly {
 
 class GenericFamilyTest : public BaseFamilyTest {};
 
+TEST_F(GenericFamilyTest, TtlOfExpiredKeyDuringPause) {
+  // CLIENT PAUSE disables expiry; a key past its deadline is logically gone, not a negative TTL.
+  Run({"set", "k", "v", "px", "10"});
+  Run({"client", "pause", "5000", "write"});
+  AdvanceTime(300);
+  EXPECT_THAT(Run({"pttl", "k"}), IntArg(-2));
+  EXPECT_THAT(Run({"ttl", "k"}), IntArg(-2));
+  EXPECT_THAT(Run({"expiretime", "k"}), IntArg(-2));
+  EXPECT_THAT(Run({"pexpiretime", "k"}), IntArg(-2));
+  Run({"client", "unpause"});
+}
+
 TEST_F(GenericFamilyTest, Expire) {
   Run({"set", "key", "val"});
 


### PR DESCRIPTION
While CLIENT PAUSE (or a replica without replica_delete_expired) disables expiry, FindReadOnly hands back a key that is already past its deadline. OpTtl then computed a negative TTL and hit DCHECK_GT(ttl_ms, 0), aborting the server; release builds returned the negative value through OpResult<uint64_t> as a huge bogus TTL. Treat such a key as missing in OpExpireTime, which covers TTL/PTTL/EXPIRETIME/PEXPIRETIME at once.