### PR TITLE
fix(stream): Report XREADGROUP errors in argument order, not shard order

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3109,28 +3109,38 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     return rb->SendError("-NOGROUP the consumer group this client was blocked on no longer exists");
   };
 
+  vector<OpStatus> key_status(opts->stream_ids.size(), OpStatus::OK);
+
   // Re-resolves the streams owned by a single shard. The cached streamCG* predates the wake: the
-  // waking transaction can drop the group or replace the key. Returns INVALID_VALUE for a missing
-  // stream or group, WRONG_TYPE if the key was replaced by another type.
+  // waking transaction can drop the group or replace the key. Records INVALID_VALUE for a missing
+  // stream or group, WRONG_TYPE if the key was replaced by another type, at that key's argument
+  // position.
   auto validate_shard_keys = [&](const OpArgs& op_args, const ShardArgs& keys) {
-    OpStatus status = OpStatus::OK;
-    for (string_view skey : keys) {
+    // Status of first error in shard's keys or OK if none.
+    OpStatus first_found_key_error = OpStatus::OK;
+    for (auto arg_it = keys.begin(); arg_it != keys.end(); ++arg_it) {
+      const string_view skey = *arg_it;
+      const size_t pos = arg_it.index() - opts->streams_arg;
       auto res_it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, skey, OBJ_STREAM);
       if (!res_it.ok()) {
-        if (status == OpStatus::OK) {
-          status = res_it.status() == OpStatus::WRONG_TYPE ? OpStatus::WRONG_TYPE
-                                                           : OpStatus::INVALID_VALUE;
-        }
+        OpStatus key_err = res_it.status() == OpStatus::WRONG_TYPE ? OpStatus::WRONG_TYPE
+                                                                   : OpStatus::INVALID_VALUE;
+        key_status[pos] = key_err;
+        if (first_found_key_error == OpStatus::OK)
+          first_found_key_error = key_err;
         continue;
       }
 
       StreamIDsItem& stream_item = opts->stream_ids.at(skey);
       stream_item.group =
           StreamLookupCG(GetReadOnlyStream((*res_it)->second), WrapSds(opts->group_name));
-      if (!stream_item.group && status == OpStatus::OK)
-        status = OpStatus::INVALID_VALUE;
+      if (!stream_item.group) {
+        key_status[pos] = OpStatus::INVALID_VALUE;
+        if (first_found_key_error == OpStatus::OK)
+          first_found_key_error = OpStatus::INVALID_VALUE;
+      }
     }
-    return status;
+    return first_found_key_error;
   };
 
   // While we were blocked any of the watched streams could have been deleted, retyped or lost its
@@ -3140,17 +3150,13 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
   // It cannot be folded into the action hop: waiting for sibling shards from inside a transaction
   // callback stalls the shard and can deadlock two interleaved multi shard readers.
   if (opts->read_group && tx->GetUniqueShardCnt() > 1) {
-    // Indexed by shard id; each shard writes only its own slot.
-    vector<OpStatus> validation_status(shard_set->size(), OpStatus::OK);
-
     auto validate_cb = [&](Transaction* t, EngineShard* shard) {
-      const ShardId sid = shard->shard_id();
-      validation_status[sid] = validate_shard_keys(t->GetOpArgs(shard), t->GetShardArgs(sid));
+      validate_shard_keys(t->GetOpArgs(shard), t->GetShardArgs(shard->shard_id()));
       return OpStatus::OK;
     };
     tx->Execute(validate_cb, false);
 
-    for (OpStatus status : validation_status) {
+    for (OpStatus status : key_status) {
       if (status == OpStatus::OK)
         continue;
 
@@ -3266,8 +3272,8 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
   if (!opts)
     return;
 
-  // Determine if streams have entries or any error occured
-  AggregateValue<optional<facade::ErrorReply>> err;
+  // Key errors, indexed by their position in the command arguments.
+  vector<optional<facade::ErrorReply>> key_errors(opts->stream_ids.size());
   atomic_bool have_entries = false;
   auto* tx = cmd_cntx->tx();
   // With a single shard we can call OpRead in a single hop, falling back to
@@ -3277,15 +3283,21 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
 
   auto cb = [&](auto* tx, auto* es) -> Transaction::RunnableResult {
     auto op_args = tx->GetOpArgs(es);
-    for (string_view skey : tx->GetShardArgs(es->shard_id())) {
-      if (auto res = HasEntries2(op_args, skey, &*opts); holds_alternative<facade::ErrorReply>(res))
-        err = get<facade::ErrorReply>(res);
-      else if (holds_alternative<bool>(res) && get<bool>(res))
+    bool error = false;
+    ShardArgs shard_args = tx->GetShardArgs(es->shard_id());
+    for (auto arg_it = shard_args.begin(); arg_it != shard_args.end(); ++arg_it) {
+      string_view skey = *arg_it;
+      if (auto res = HasEntries2(op_args, skey, &*opts);
+          holds_alternative<facade::ErrorReply>(res)) {
+        key_errors[arg_it.index() - opts->streams_arg] = get<facade::ErrorReply>(res);
+        error = true;
+      } else if (holds_alternative<bool>(res) && get<bool>(res)) {
         have_entries.store(true, memory_order_relaxed);
+      }
     }
 
     if (is_single_shard) {
-      if (have_entries.load(memory_order_relaxed) && !err) {
+      if (have_entries.load(memory_order_relaxed) && !error) {
         if (read_group)
           FindOrAddGroupConsumers(op_args, tx->GetShardArgs(es->shard_id()), &*opts);
         fastread_prefetched = OpRead(tx->GetOpArgs(es), tx->GetShardArgs(es->shard_id()), *opts);
@@ -3298,7 +3310,7 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
           }
         }
       } else {
-        if (!err && read_group) {
+        if (!error && read_group) {
           FindOrAddGroupConsumers(op_args, tx->GetShardArgs(es->shard_id()), &*opts);
           for (auto key : tx->GetShardArgs(es->shard_id())) {
             JournalConsumerCreationIfNeeded(op_args, *opts, key);
@@ -3311,9 +3323,18 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
   };
   tx->Execute(cb, is_single_shard);
 
+  // Iterate over key_errors to find the first error, if exists, and report it.
+  optional<facade::ErrorReply> err;
+  for (auto& key_err : key_errors) {
+    if (key_err) {
+      err = std::move(key_err);
+      break;
+    }
+  }
+
   if (err) {
     tx->Conclude();
-    return cmd_cntx->SendError(**err);
+    return cmd_cntx->SendError(*err);
   }
 
   if (!have_entries.load(memory_order_relaxed)) {

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -916,6 +916,54 @@ TEST_F(StreamFamilyTest, XReadGroupBlockMultiStreamRevalidatesStreams) {
   }
 }
 
+// For multi-shard XREADGROUP, the reported error must come from the first invalid key in
+// STREAMS argument order, regardless of shard assignment or validation order.
+TEST_F(StreamFamilyTest, XReadGroupErrorFollowsArgumentOrder) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  // Find a key that maps to a specific shard.
+  auto find_key_on_shard = [&](string_view prefix, ShardId target_shard) {
+    for (unsigned i = 0;; ++i) {
+      string candidate = absl::StrCat(prefix, "-", i);
+      if (Shard(candidate, shard_set->size()) == target_shard)
+        return candidate;
+    }
+  };
+
+  const string key_on_shard1 = find_key_on_shard("nb-shard1", 1);  // 1st: missing key
+  const string key_on_shard0 = find_key_on_shard("nb-shard0", 0);  // 2nd: wrong type
+
+  Run({"SET", key_on_shard0, "value"});
+
+  // The first key is missing and the second has the wrong type. The error must come from
+  // the first key, even though it is on the higher shard ID.
+  auto resp =
+      Run({"XREADGROUP", "GROUP", "group", "c", "STREAMS", key_on_shard1, key_on_shard0, ">", ">"});
+  EXPECT_THAT(resp, ErrArg("No such key"));
+
+  const string blocked_key_on_shard1 = find_key_on_shard("blk-shard1", 1);
+  const string blocked_key_on_shard0 = find_key_on_shard("blk-shard0", 0);
+  Run({"XGROUP", "CREATE", blocked_key_on_shard1, "group", "0", "MKSTREAM"});
+  Run({"XGROUP", "CREATE", blocked_key_on_shard0, "group", "0", "MKSTREAM"});
+
+  // The first key becomes WRONGTYPE and the second loses its group (NOGROUP). The first
+  // key's error must be reported, regardless of shard validation order.
+  RespExpr blocked_resp;
+  auto reader = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    blocked_resp = Run({"XREADGROUP", "GROUP", "group", "c", "BLOCK", "0", "STREAMS",
+                        blocked_key_on_shard1, blocked_key_on_shard0, ">", ">"});
+  });
+  ASSERT_TRUE(WaitUntilCondition([&] { return IsConnBlocked("IO1"); }, 500ms));
+
+  Run({"MULTI"});
+  Run({"XGROUP", "DESTROY", blocked_key_on_shard0, "group"});
+  Run({"SET", blocked_key_on_shard1, "value"});
+  Run({"EXEC"});
+
+  reader.Join();
+  EXPECT_THAT(blocked_resp, ErrArg("WRONGTYPE"));
+}
+
 TEST_F(StreamFamilyTest, XReadGroupBlockLazyExpireDuringWakeDoesNotCrash) {
   Run({"XGROUP", "CREATE", "s", "g", "0", "MKSTREAM"});
 


### PR DESCRIPTION
Multi-key XREADGROUP reported whichever shard's error was found first instead of the 
first invalid key in STREAMS order.

- Non-blocking path: replaced a racy AggregateValue (first shard fiber to write won) with
  a per-key error slot indexed by argument position.

- Blocked/woken path: replaced shard-id-ordered validation status with the same per-key
  indexing, reusing the existing ShardArgs index() pattern.

Fixes #8072

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
