### PR TITLE
fix(replication): bound RESP client parser against unbounded allocation

### DIFF
--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -6,12 +6,20 @@
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 
+#include <algorithm>
+
 #include "base/logging.h"
 #include "common/heap_size.h"
 
 namespace facade {
 
 using namespace std;
+
+// Cap upfront array reservation so a wire count can't force one giant allocation.
+constexpr uint32_t kMaxArrReserve = 1024;
+
+// Cap client-mode aggregate nesting so many nested headers can't accumulate memory.
+constexpr uint32_t kMaxDepth = 64;
 
 auto RedisParser::Parse(Buffer str, uint32_t* consumed, RespExpr::Vec* res) -> Result {
   DCHECK(!str.empty());
@@ -311,8 +319,11 @@ auto RedisParser::ConsumeArrayLen(Buffer str) -> ResultConsumed {
   }
 
   if (state_ == MAP_LEN_S) {
-    // Map starts with %N followed by an array of 2*N elements.
-    // Even elements are keys, odd elements are values.
+    // Guard len*2 against overflow.
+    if (len > max_arr_len_ / 2) {
+      LOG(WARNING) << "Multibulk len is too large " << len;
+      return {BAD_ARRAYLEN, res.second};
+    }
     len *= 2;
   }
 
@@ -343,13 +354,18 @@ auto RedisParser::ConsumeArrayLen(Buffer str) -> ResultConsumed {
     return {OK, res.second};
   }
 
+  if (parse_stack_.size() >= kMaxDepth) {
+    LOG(WARNING) << "Nesting is too deep";
+    return {BAD_ARRAYLEN, res.second};
+  }
+
   if (state_ == PARSE_ARG_S) {
     DCHECK(!server_mode_);
 
     cached_expr_->emplace_back(RespExpr::ARRAY);
     stash_.emplace_back(new RespExpr::Vec());
     RespExpr::Vec* arr = stash_.back().get();
-    arr->reserve(len);
+    arr->reserve(std::min<size_t>(len, kMaxArrReserve));
     cached_expr_->back().u = arr;
     cached_expr_ = arr;
   }

--- a/src/facade/redis_parser.h
+++ b/src/facade/redis_parser.h
@@ -34,7 +34,10 @@ class RedisParser {
 
   explicit RedisParser(Mode mode = Mode::SERVER, uint32_t max_arr_len = UINT32_MAX,
                        uint64_t max_bulk_len = UINT64_MAX)
-      : server_mode_(mode == Mode::SERVER), max_arr_len_(max_arr_len), max_bulk_len_(max_bulk_len) {
+      : server_mode_(mode == Mode::SERVER),
+        max_arr_len_(max_arr_len),
+        // bulk_len_ is uint32_t; clamp so an accepted length can't truncate.
+        max_bulk_len_(max_bulk_len > UINT32_MAX ? UINT32_MAX : max_bulk_len) {
   }
 
   /**

--- a/src/facade/redis_parser_test.cc
+++ b/src/facade/redis_parser_test.cc
@@ -212,6 +212,57 @@ TEST_F(RedisParserTest, Hierarchy) {
   ASSERT_THAT(args_, ElementsAre(ArrLen(1), ArrLen(1)));
 }
 
+// The CLIENT-mode parser used by replication / protocol client must bound wire-declared
+// lengths so a peer cannot force a huge allocation.
+
+static RedisParser::Result ParseOnce(RedisParser* parser, string_view s) {
+  uint32_t consumed = 0;
+  RespExpr::Vec args;
+  return parser->Parse(RedisParser::Buffer{reinterpret_cast<const uint8_t*>(s.data()), s.size()},
+                       &consumed, &args);
+}
+
+TEST(RedisParserBoundTest, RejectsHugeNestedArray) {
+  RedisParser parser(RedisParser::CLIENT, /*max_arr_len=*/65536);
+  EXPECT_EQ(RedisParser::BAD_ARRAYLEN, ParseOnce(&parser, "*1\r\n*2000000000\r\n"));
+}
+
+// %N expands to 2N elements; rejected before the doubling can overflow.
+TEST(RedisParserBoundTest, RejectsHugeMapWithoutOverflow) {
+  RedisParser parser(RedisParser::CLIENT, /*max_arr_len=*/65536);
+  EXPECT_EQ(RedisParser::BAD_ARRAYLEN, ParseOnce(&parser, "%9223372036854775807\r\n"));
+}
+
+TEST(RedisParserBoundTest, RejectsHugeBulk) {
+  RedisParser parser(RedisParser::CLIENT, /*max_arr_len=*/65536, /*max_bulk_len=*/1u << 20);
+  EXPECT_EQ(RedisParser::BAD_ARRAYLEN, ParseOnce(&parser, "*1\r\n$2000000000\r\n"));
+}
+
+// Even with unbounded limits the upfront reserve stays capped.
+TEST_F(RedisParserTest, NestedArrayReserveIsCapped) {
+  parser_.SetClientMode();
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("*1\r\n*2000000000\r\n"));
+  ASSERT_EQ(1u, parser_.stash_size());
+  EXPECT_LE(parser_.stash().back()->capacity(), 1u << 20)
+      << "reserved " << parser_.stash().back()->capacity() << " elements";
+}
+
+// Many nested aggregate headers with no elements must be rejected, not accumulated.
+TEST_F(RedisParserTest, RejectsDeepNesting) {
+  parser_.SetClientMode();
+  string s;
+  for (int i = 0; i < 1000; ++i)
+    s += "*2\r\n";
+  EXPECT_EQ(RedisParser::BAD_ARRAYLEN, Parse(s));
+}
+
+// A bulk length that overflows the 32-bit internal counter is rejected, not truncated,
+// even when a >4 GiB bulk limit is configured.
+TEST(RedisParserBoundTest, RejectsBulkLenAboveUint32) {
+  RedisParser parser(RedisParser::CLIENT, /*max_arr_len=*/65536, /*max_bulk_len=*/UINT64_MAX);
+  EXPECT_EQ(RedisParser::BAD_ARRAYLEN, ParseOnce(&parser, "*1\r\n$5000000000\r\n"));
+}
+
 TEST_F(RedisParserTest, InvalidMult1) {
   ASSERT_EQ(RedisParser::BAD_BULKLEN, Parse("*2\r\n$3\r\nFOO\r\nBAR\r\n"));
 }

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -45,6 +45,8 @@ ABSL_DECLARE_FLAG(std::string, tls_cert_file);
 ABSL_DECLARE_FLAG(std::string, tls_key_file);
 ABSL_DECLARE_FLAG(std::string, tls_ca_cert_file);
 ABSL_DECLARE_FLAG(std::string, tls_ca_cert_dir);
+ABSL_DECLARE_FLAG(uint32_t, max_multi_bulk_len);
+ABSL_DECLARE_FLAG(uint64_t, max_bulk_len);
 
 namespace dfly {
 
@@ -468,8 +470,12 @@ error_code ProtocolClient::SendCommandAndReadResponse(string_view command) {
 }
 
 void ProtocolClient::ResetParser(RedisParser::Mode mode) {
-  // We accept any length for the parser because it has been approved by the master.
-  parser_.reset(new RedisParser(mode));
+  // Bound the parser so a peer cannot force a huge allocation. SERVER mode mirrors an
+  // upstream master's commands, whose arg count can exceed our client cap.
+  uint32_t max_arr_len = GetFlag(FLAGS_max_multi_bulk_len);
+  if (mode == RedisParser::Mode::SERVER && max_arr_len < (1u << 20))
+    max_arr_len = 1u << 20;
+  parser_.reset(new RedisParser(mode, max_arr_len, GetFlag(FLAGS_max_bulk_len)));
 }
 
 uint64_t ProtocolClient::LastIoTime() const {


### PR DESCRIPTION
The CLIENT-mode RedisParser used by the replication / protocol client was built with unbounded limits (max_arr_len=UINT32_MAX, max_bulk_len=UINT64_MAX). A malicious or on-path master/peer could send a nested array with a ~2e9 inner count, making ConsumeArrayLen reserve() a multi-gigabyte vector -> std::bad_alloc -> the replica aborts (DoS). The client-facing path was already bounded.

- protocol_client: ResetParser now builds a bounded parser from the existing --max_multi_bulk_len / --max_bulk_len flags. SERVER mode (mirroring an upstream master's commands, whose arg count can exceed our client cap) uses a looser array bound of max(flag, 1<<20).
- redis_parser: guard the map len*2 doubling against signed-integer overflow by rejecting before the multiply.
- redis_parser: cap the upfront array reserve; the vector still grows to the bounded length as elements arrive.

Adds parser tests for the array/map/bulk bounds and the reserve cap.

Fixes #8183