### PR TITLE
fix(generic): require every EXPIRE flag to hold instead of any one of them

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -11,6 +11,12 @@ Indices (say in GETRANGE and SETRANGE commands) should be signed 32 bit integers
 SORT does not take any locale into account.
 
 ## Expiry ranges.
+
+### EXPIRE flags
+EXPIRE, PEXPIRE, EXPIREAT and PEXPIREAT accept NX together with GT or LT: the expiry is set when
+the key has none, otherwise GT or LT alone decides. Redis rejects these combinations as
+incompatible.
+
 Expirations are limited to 8 years. For commands with millisecond precision like PEXPIRE or PSETEX,
 expirations greater than 2^28ms are quietly rounded to the nearest second losing precision of less than 0.001%.
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1277,20 +1277,23 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
   }
 
   int64_t current_cmp = numeric_limits<int64_t>::max();  // inf if no expiry is set
-  bool satisfied = params.expire_options == ExpireFlags::EXPIRE_ALWAYS;
-
-  if (prime_it->first.HasExpire()) {
+  const bool has_expire = prime_it->first.HasExpire();
+  if (has_expire)
     current_cmp = prime_it->first.GetExpireTime();
-    satisfied |= (params.expire_options & ExpireFlags::EXPIRE_XX);
-  } else {
-    satisfied |= (params.expire_options & ExpireFlags::EXPIRE_NX);
+
+  // Every given flag must hold. Exception: NX with GT/LT (deliberate extension) sets the
+  // expiry when there is none, otherwise GT/LT alone decides.
+  int32_t opts = params.expire_options;
+  if ((opts & ExpireFlags::EXPIRE_NX) &&
+      (opts & (ExpireFlags::EXPIRE_GT | ExpireFlags::EXPIRE_LT))) {
+    opts = has_expire ? opts & ~ExpireFlags::EXPIRE_NX : int32_t{ExpireFlags::EXPIRE_ALWAYS};
   }
-
-  satisfied |= (params.expire_options & ExpireFlags::EXPIRE_LT) && (abs_msec < current_cmp);
-  satisfied |= (params.expire_options & ExpireFlags::EXPIRE_GT) && (abs_msec > current_cmp);
-
-  if (!satisfied)
+  if (((opts & ExpireFlags::EXPIRE_XX) && !has_expire) ||
+      ((opts & ExpireFlags::EXPIRE_NX) && has_expire) ||
+      ((opts & ExpireFlags::EXPIRE_LT) && !(abs_msec < current_cmp)) ||
+      ((opts & ExpireFlags::EXPIRE_GT) && !(abs_msec > current_cmp))) {
     return OpStatus::SKIPPED;
+  }
 
   // If we update and the new value is already expired, delete the key
   // Already-expired new value: delete; the caller emits the expired event after journaling.

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1250,8 +1250,9 @@ ExpireArgs ParseExpireArgs(CmdArgParser* parser) {
   auto args = kGrammar.Apply(parser);
   parser->Finalize("Unsupported option: ");
 
+  // NX with GT/LT is allowed as a deliberate extension, see docs/differences.md.
   if ((args.flags & ExpireFlags::EXPIRE_NX) && (args.flags & ExpireFlags::EXPIRE_XX))
-    parser->ReportCustom("NX and XX options at the same time are not compatible");
+    parser->ReportCustom("NX and XX, GT or LT options at the same time are not compatible");
   if ((args.flags & ExpireFlags::EXPIRE_GT) && (args.flags & ExpireFlags::EXPIRE_LT))
     parser->ReportCustom("GT and LT options at the same time are not compatible");
   return args;

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -46,6 +46,47 @@ TEST_F(GenericFamilyTest, TtlOfExpiredKeyDuringPause) {
   Run({"client", "unpause"});
 }
 
+TEST_F(GenericFamilyTest, ExpireFlagsAreAnded) {
+  // Every given flag must hold; one passing flag must not override another that fails.
+  Run({"set", "foo", "bar", "ex", "50"});
+  EXPECT_THAT(Run({"expire", "foo", "100", "XX", "LT"}), IntArg(0));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(50));
+
+  Run({"set", "foo", "bar", "ex", "200"});
+  EXPECT_THAT(Run({"expire", "foo", "100", "XX", "GT"}), IntArg(0));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(200));
+
+  Run({"set", "foo", "bar"});
+  EXPECT_THAT(Run({"expire", "foo", "200", "LT", "XX"}), IntArg(0));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(-1));
+
+  Run({"set", "foo", "bar", "ex", "50"});
+  EXPECT_THAT(Run({"expire", "foo", "100", "XX", "GT"}), IntArg(1));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(100));
+
+  EXPECT_THAT(Run({"expire", "foo", "10", "NX", "XX"}),
+              ErrArg("NX and XX, GT or LT options at the same time are not compatible"));
+}
+
+TEST_F(GenericFamilyTest, ExpireNxWithComparison) {
+  // Deliberate extension: NX with GT/LT sets the expiry when there is none, else GT/LT decides.
+  Run({"set", "foo", "bar"});
+  EXPECT_THAT(Run({"expire", "foo", "5", "NX", "GT"}), IntArg(1));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(5));
+  EXPECT_THAT(Run({"expire", "foo", "3", "NX", "GT"}), IntArg(0));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(5));
+  EXPECT_THAT(Run({"expire", "foo", "7", "NX", "GT"}), IntArg(1));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(7));
+
+  Run({"persist", "foo"});
+  EXPECT_THAT(Run({"expire", "foo", "10", "NX", "LT"}), IntArg(1));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(10));
+  EXPECT_THAT(Run({"expire", "foo", "20", "NX", "LT"}), IntArg(0));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(10));
+  EXPECT_THAT(Run({"expire", "foo", "4", "NX", "LT"}), IntArg(1));
+  EXPECT_THAT(Run({"ttl", "foo"}), IntArg(4));
+}
+
 TEST_F(GenericFamilyTest, Expire) {
   Run({"set", "key", "val"});
 
@@ -160,7 +201,7 @@ TEST_F(GenericFamilyTest, ExpireOptions) {
   // NX and XX are mutually exclusive
   Run({"set", "key", "val"});
   auto resp = Run({"expire", "key", "3600", "NX", "XX"});
-  ASSERT_THAT(resp, ErrArg("NX and XX options at the same time are not compatible"));
+  ASSERT_THAT(resp, ErrArg("NX and XX, GT or LT options at the same time are not compatible"));
 
   // GT and LT are mutually exclusive
   resp = Run({"expire", "key", "3600", "GT", "LT"});
@@ -239,17 +280,6 @@ TEST_F(GenericFamilyTest, ExpireOptions) {
   EXPECT_THAT(resp, IntArg(0));
   resp = Run({"ttl", "key"});
   EXPECT_THAT(resp.GetInt(), 101);
-
-  // NX with GT, first sets expiry, updates only to larger values
-  Run({"persist", "key"});
-  Run({"expire", "key", "5", "NX", "GT"});
-  EXPECT_THAT(Run({"ttl", "key"}), IntArg(5));
-
-  Run({"expire", "key", "3", "NX", "GT"});
-  EXPECT_THAT(Run({"ttl", "key"}), IntArg(5));
-
-  Run({"expire", "key", "7", "NX", "GT"});
-  EXPECT_THAT(Run({"ttl", "key"}), IntArg(7));
 }
 
 TEST_F(GenericFamilyTest, ExpireAtOptions) {
@@ -260,7 +290,7 @@ TEST_F(GenericFamilyTest, ExpireAtOptions) {
   Run({"set", "key", "val"});
   // NX and XX are mutually exclusive
   auto resp = Run({"expireat", "key", "3600", "NX", "XX"});
-  ASSERT_THAT(resp, ErrArg("NX and XX options at the same time are not compatible"));
+  ASSERT_THAT(resp, ErrArg("NX and XX, GT or LT options at the same time are not compatible"));
 
   // GT and LT are mutually exclusive
   resp = Run({"expireat", "key", "3600", "GT", "LT"});
@@ -325,7 +355,7 @@ TEST_F(GenericFamilyTest, PExpireOptions) {
   // NX and XX are mutually exclusive
   Run({"set", "key", "val"});
   auto resp = Run({"pexpire", "key", "3600", "NX", "XX"});
-  ASSERT_THAT(resp, ErrArg("NX and XX options at the same time are not compatible"));
+  ASSERT_THAT(resp, ErrArg("NX and XX, GT or LT options at the same time are not compatible"));
 
   // GT and LT are mutually exclusive
   resp = Run({"pexpire", "key", "3600", "GT", "LT"});
@@ -389,7 +419,7 @@ TEST_F(GenericFamilyTest, PExpireAtOptions) {
   Run({"set", "key", "val"});
   // NX and XX are mutually exclusive
   auto resp = Run({"pexpireat", "key", "3600", "NX", "XX"});
-  ASSERT_THAT(resp, ErrArg("NX and XX options at the same time are not compatible"));
+  ASSERT_THAT(resp, ErrArg("NX and XX, GT or LT options at the same time are not compatible"));
 
   // GT and LT are mutually exclusive
   resp = Run({"pexpireat", "key", "3600", "GT", "LT"});


### PR DESCRIPTION
`EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT` with several flags applied the change if *any* flag held, so `XX LT` could raise a TTL, `XX GT` lower it, and `LT XX` add a TTL to a persistent key.

The `NX GT`/`NX LT` combinations stay as designed in #6203: one command instead of a Lua script - set the expiry when the key has none, otherwise the comparison decides. Upstream can't express this in a single command (`GT` alone never sets a TTL on a persistent key) and rejects the combination outright, so no upstream-valid workload changes behavior. Now documented in `docs/differences.md`.

- `DbSlice::UpdateExpire`: every given flag must hold; `NX` with `GT`/`LT` keeps the extension semantics
- `ParseExpireArgs`: only `NX XX` is rejected (upstream error text, matches the valkey test)
- Tests: `ExpireFlagsAreAnded` for conjunctive combos, `ExpireNxWithComparison` pins the extension

Found by valkey `expire.tcl` (`EXPIRE with LT and XX option ...`).
