### PR TITLE
fix(server): register SORT's STORE destination wherever the option appears

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1018,6 +1018,20 @@ TEST_F(GenericFamilyTest, SortStoreEmptyResult) {
   EXPECT_EQ(0, Run({"exists", "dest"}).GetInt()) << "empty SORT STORE must delete existing key";
 }
 
+TEST_F(GenericFamilyTest, SortStoreNotLastOption) {
+  // STORE may appear anywhere among the options; the destination must still be a transaction
+  // key, otherwise a cross-shard destination is silently never written.
+  Run({"rpush", "src", "b", "a", "c"});
+  for (string_view dst : {"d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8"}) {  // spans all shards
+    Run({"set", dst, "old"});
+    EXPECT_THAT(Run({"sort", "src", "store", dst, "alpha"}), IntArg(3)) << dst;
+    EXPECT_THAT(Run({"lrange", dst, "0", "-1"}), RespArray(ElementsAre("a", "b", "c"))) << dst;
+    EXPECT_THAT(Run({"sort", "src", "alpha", "limit", "0", "2", "store", dst, "desc"}), IntArg(2))
+        << dst;
+    EXPECT_THAT(Run({"lrange", dst, "0", "-1"}), RespArray(ElementsAre("c", "b"))) << dst;
+  }
+}
+
 TEST_F(GenericFamilyTest, SortStoreResetsExpiry) {
   // SORT set STORE dest, where dest has an expiry — dest expiry must be cleared.
   Run({"del", "src", "dest"});

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1849,11 +1849,19 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, const facade::ParsedArgs&
       }
 
       if (name == "SORT") {
-        if (args.size() >= 3) {
-          // SORT key ... STORE destkey
-          string_view opt = args[args.size() - 2];
+        // Options are order-independent, so walk them by arity instead of assuming STORE is the
+        // penultimate argument.
+        for (size_t i = 1; i + 1 < args.size();) {
+          string_view opt = args[i];
           if (absl::EqualsIgnoreCase(opt, "STORE")) {
-            bonus = args.size() - 1;
+            bonus = i + 1;
+            i += 2;
+          } else if (absl::EqualsIgnoreCase(opt, "LIMIT")) {
+            i += 3;
+          } else if (absl::EqualsIgnoreCase(opt, "BY") || absl::EqualsIgnoreCase(opt, "GET")) {
+            i += 2;
+          } else {
+            i += 1;
           }
         }
       }


### PR DESCRIPTION
`SORT src STORE dst <more options>` silently replied `0` and stored nothing when `dst` lived on another shard: the key index only recognised `STORE` as the penultimate argument, so `dst` was not part of the transaction and the store hop never ran on its shard.

DetermineKeys only treated the last argument as SORT's destination when STORE was the penultimate one. For an order such as `SORT src STORE dst ALPHA` the destination was not a transaction key, so a destination on another shard never received the store hop: the command replied 0 and wrote nothing. Walk the options by arity instead (LIMIT 2, BY/GET 1, STORE dst).

Found while reviewing #8190; independent of it.