### PR TITLE
fix(facade): reclaim V2 pipeline cache

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -714,7 +714,8 @@ class PipelineCacheSizeTracker {
     const auto now = absl::Now();
     const auto elapsed = now - last_check_;
     min_ = std::min(min_, pipeline_sz);
-    if (elapsed < absl::Milliseconds(10)) {
+    constexpr auto kPipelineCacheReclamationInterval = absl::Milliseconds(10);
+    if (elapsed < kPipelineCacheReclamationInterval) {
       return false;
     }
 
@@ -3173,6 +3174,8 @@ Connection::ExecuteBatchResult Connection::ExecuteBatch() {
   if (parsed_to_execute_ == nullptr) {
     return ExecuteBatchResult::kSuccess;  // no errors.
   }
+
+  ShrinkPipelinePool();
 
   ConnectionMemoryTracker memory_tracker(this);
   absl::Cleanup batch_guard = [this] { reply_builder_->SetBatchMode(false); };

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2669,9 +2669,6 @@ async def test_pipeline_cache_only_async_squashed_dispatches(df_factory):
 # shrink (because it's underutilized).
 @dfly_args({"proactor_threads": 1})
 async def test_pipeline_cache_size(df_server: DflyInstance):
-    # tracking issue: https://github.com/dragonflydb/dragonfly/issues/8163
-    if is_resp_io_loop_v2(df_server):
-        pytest.skip("V2 does not have reclamation yet")
     # Start 1 client.
     good = df_server.client()
     bad = df_server.client()


### PR DESCRIPTION
Reclaim unused cached ParsedCommand entries during V2 batch execution so the cache does not retain memory forever.

Enable the pipeline cache regression test to cover V2 reclamation.
