### PR TITLE
feat(server): add TYPE, USER, SKIPME, MAXAGE filters to CLIENT KILL

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -327,6 +327,10 @@ class Connection : public util::Connection {
     return time(nullptr) - last_interaction_;
   }
 
+  time_t GetCreationTime() const {
+    return creation_time_;
+  }
+
   unsigned GetSendWaitTimeSec() const;
 
   Phase phase() const {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -650,7 +650,7 @@ void ClientKill(facade::ParsedArgs args, absl::Span<facade::Listener*> listeners
     } else {
       return cmd_cntx->SendError(kSyntaxErr);
     }
-  } else if (args.size() % 2 != 0) {
+  } else if (args.size() == 0 || args.size() % 2 != 0) {
     return cmd_cntx->SendError(kSyntaxErr);
   } else {
     for (size_t i = 0; i < args.size(); i += 2) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -635,49 +635,105 @@ void ClientId(facade::ParsedArgs args, CommandContext* cmd_cntx) {
 
 void ClientKill(facade::ParsedArgs args, absl::Span<facade::Listener*> listeners,
                 ServerFamily* server_family, CommandContext* cmd_cntx) {
-  std::function<bool(facade::Connection * conn)> evaluator;
+  optional<string_view> addr_filter;
+  optional<string_view> laddr_filter;
+  optional<uint32_t> id_filter;
+  optional<ClientListType> type_filter;
+  optional<string_view> user_filter;
+  optional<int64_t> maxage_filter;
+  bool skipme = true;
 
   if (args.size() == 1) {
     string_view ip_port = args[0];
     if (ip_port.find(':') != ip_port.npos) {
-      evaluator = [ip_port](facade::Connection* conn) {
-        return conn->RemoteEndpointStr() == ip_port;
-      };
+      addr_filter = ip_port;
+    } else {
+      return cmd_cntx->SendError(kSyntaxErr);
     }
-  } else if (args.size() == 2) {
-    string filter_type = absl::AsciiStrToUpper(args[0]);
-    string_view filter_value = args[1];
-    if (filter_type == "ADDR") {
-      evaluator = [filter_value](facade::Connection* conn) {
-        return conn->RemoteEndpointStr() == filter_value;
-      };
-    } else if (filter_type == "LADDR") {
-      evaluator = [filter_value](facade::Connection* conn) {
-        return conn->LocalBindStr() == filter_value;
-      };
-    } else if (filter_type == "ID") {
-      uint32_t id;
-      if (absl::SimpleAtoi(filter_value, &id)) {
-        if (server_family->IsMasterLinkClientId(id)) {
-          return cmd_cntx->SendError("Cannot kill master link; use REPLICAOF NO ONE");
-        }
-        evaluator = [id](facade::Connection* conn) { return conn->GetClientId() == id; };
+  } else if (args.size() % 2 != 0) {
+    return cmd_cntx->SendError(kSyntaxErr);
+  } else {
+    for (size_t i = 0; i < args.size(); i += 2) {
+      string filter_key = absl::AsciiStrToUpper(args[i]);
+      string_view filter_value = args[i + 1];
+
+      if (filter_key == "ADDR") {
+        addr_filter = filter_value;
+      } else if (filter_key == "LADDR") {
+        laddr_filter = filter_value;
+      } else if (filter_key == "ID") {
+        uint32_t id;
+        if (!absl::SimpleAtoi(filter_value, &id))
+          return cmd_cntx->SendError(kSyntaxErr);
+        id_filter = id;
+      } else if (filter_key == "TYPE") {
+        if (absl::EqualsIgnoreCase(filter_value, "normal"))
+          type_filter = ClientListType::kNormal;
+        else if (absl::EqualsIgnoreCase(filter_value, "master"))
+          type_filter = ClientListType::kMaster;
+        else if (absl::EqualsIgnoreCase(filter_value, "replica") ||
+                 absl::EqualsIgnoreCase(filter_value, "slave"))
+          type_filter = ClientListType::kReplica;
+        else if (absl::EqualsIgnoreCase(filter_value, "pubsub"))
+          type_filter = ClientListType::kPubsub;
+        else
+          return cmd_cntx->SendError(StrCat("Unknown client type '", filter_value, "'"));
+      } else if (filter_key == "USER") {
+        user_filter = filter_value;
+      } else if (filter_key == "SKIPME") {
+        if (absl::EqualsIgnoreCase(filter_value, "yes"))
+          skipme = true;
+        else if (absl::EqualsIgnoreCase(filter_value, "no"))
+          skipme = false;
+        else
+          return cmd_cntx->SendError(kSyntaxErr);
+      } else if (filter_key == "MAXAGE") {
+        int64_t age;
+        if (!absl::SimpleAtoi(filter_value, &age) || age < 0)
+          return cmd_cntx->SendError(kSyntaxErr);
+        maxage_filter = age;
+      } else {
+        return cmd_cntx->SendError(kSyntaxErr);
       }
     }
-    // TODO: Add support for KILL USER/TYPE/SKIPME
   }
 
-  if (!evaluator) {
-    return cmd_cntx->SendError(kSyntaxErr);
+  if (id_filter && server_family->IsMasterLinkClientId(*id_filter)) {
+    return cmd_cntx->SendError("Cannot kill master link; use REPLICAOF NO ONE");
   }
 
+  const uint32_t self_id = cmd_cntx->conn()->GetClientId();
   const bool is_admin_request = cmd_cntx->conn()->IsPrivileged();
+  const time_t now = time(nullptr);
+
+  auto evaluator = [&](facade::Connection* conn) -> bool {
+    if (skipme && conn->GetClientId() == self_id)
+      return false;
+    if (addr_filter && conn->RemoteEndpointStr() != *addr_filter)
+      return false;
+    if (laddr_filter && conn->LocalBindStr() != *laddr_filter)
+      return false;
+    if (id_filter && conn->GetClientId() != *id_filter)
+      return false;
+    if (type_filter && ClassifyConnection(conn) != *type_filter)
+      return false;
+    if (user_filter) {
+      auto* base_cntx = conn->cntx();
+      if (!base_cntx)
+        return false;
+      auto* dfly_cntx = static_cast<ConnectionContext*>(base_cntx);
+      if (dfly_cntx->authed_username != *user_filter)
+        return false;
+    }
+    if (maxage_filter && (now - conn->GetCreationTime()) < *maxage_filter)
+      return false;
+    return true;
+  };
 
   atomic<uint32_t> killed_connections = 0;
   atomic<uint32_t> kill_errors = 0;
 
   auto cb = [&](unsigned idx, ProactorBase* p) mutable {
-    // Step 1 aggregate the per thread connections from all listeners
     std::vector<facade::Connection::WeakRef> connections;
     auto traverse_cb = [&](unsigned idx, util::Connection* conn) {
       facade::Connection* dconn = static_cast<facade::Connection*>(conn);
@@ -693,7 +749,6 @@ void ClientKill(facade::ParsedArgs args, absl::Span<facade::Listener*> listeners
       listener->TraverseConnectionsOnThread(traverse_cb, UINT32_MAX, nullptr);
     }
 
-    // Step 2 kill the clients
     for (auto& tcon : connections) {
       facade::Connection* conn = tcon.Get();
       if (conn && conn->socket()->proactor()->GetPoolIndex() == p->GetPoolIndex()) {
@@ -3104,7 +3159,7 @@ string ServerFamily::FormatInfoMetrics(
       if (show) {
         size_t total = stats.events.hits + stats.events.misses;
         double hit_ratio =
-            (total > 0) ? static_cast<double>(stats.events.hits) / (total)*100.0 : 0.0;
+            (total > 0) ? static_cast<double>(stats.events.hits) / (total) * 100.0 : 0.0;
         string val = StrCat("keys=", stats.key_count, ",expires=", stats.expire_count,
                             ",hits=", stats.events.hits, ",misses=", stats.events.misses,
                             ",hit_ratio=", absl::StrFormat("%.2f", hit_ratio),

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -164,6 +164,10 @@ async def test_client_kill_filters(df_factory):
         with pytest.raises(ResponseError):
             await admin_client.execute_command("CLIENT KILL TYPE badtype")
 
+        # Test zero-argument CLIENT KILL: must return syntax error, not kill everyone
+        with pytest.raises(ResponseError):
+            await admin_client.execute_command("CLIENT KILL")
+
         # Test MAXAGE 0: connections with age >= 0 (all connections) should be killed
         c4 = instance.client(retry=Retry(NoBackoff(), 0))
         await c4.ping()

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -116,6 +116,69 @@ async def test_client_kill(df_factory):
                 await client_conn.ping()
 
 
+async def test_client_kill_filters(df_factory):
+    with df_factory.create(port=1115, admin_port=1116) as instance:
+        instance: DflyInstance
+        from redis.asyncio.retry import Retry
+        from redis.backoff import NoBackoff
+
+        admin_client = instance.admin_client()
+        await admin_client.ping()
+
+        # Test TYPE normal: kill all normal connections
+        c1 = instance.client(retry=Retry(NoBackoff(), 0))
+        c2 = instance.client(retry=Retry(NoBackoff(), 0))
+        await c1.ping()
+        await c2.ping()
+
+        killed = await admin_client.execute_command("CLIENT KILL TYPE normal")
+        assert killed >= 2
+
+        @assert_eventually(timeout=10)
+        async def assert_normals_killed():
+            assert len(await admin_client.execute_command("CLIENT LIST")) == 1
+
+        await assert_normals_killed()
+        await c1.aclose()
+        await c2.aclose()
+
+        # Test USER filter: kill connections by username (all connect as "default")
+        c3 = instance.client(retry=Retry(NoBackoff(), 0))
+        await c3.ping()
+
+        killed = await admin_client.execute_command("CLIENT KILL USER default TYPE normal")
+        assert killed >= 1
+
+        @assert_eventually(timeout=10)
+        async def assert_user_killed():
+            assert len(await admin_client.execute_command("CLIENT LIST")) == 1
+
+        await assert_user_killed()
+        await c3.aclose()
+
+        # Test SKIPME yes (default): admin should not kill itself
+        killed = await admin_client.execute_command("CLIENT KILL SKIPME yes TYPE pubsub")
+        assert killed == 0  # no pubsub connections, and self is skipped
+
+        # Test invalid TYPE value
+        with pytest.raises(ResponseError):
+            await admin_client.execute_command("CLIENT KILL TYPE badtype")
+
+        # Test MAXAGE 0: connections with age >= 0 (all connections) should be killed
+        c4 = instance.client(retry=Retry(NoBackoff(), 0))
+        await c4.ping()
+
+        killed = await admin_client.execute_command("CLIENT KILL MAXAGE 0 TYPE normal")
+        assert killed >= 1
+
+        @assert_eventually(timeout=10)
+        async def assert_maxage_killed():
+            assert len(await admin_client.execute_command("CLIENT LIST")) == 1
+
+        await assert_maxage_killed()
+        await c4.aclose()
+
+
 async def test_scan(async_client: aioredis.Redis):
     """
     make sure that the scan command is working with python


### PR DESCRIPTION
## Summary

- `CLIENT KILL` previously supported only `ADDR`, `LADDR`, and `ID` filters
- Adds Redis 2.8+ compatible filters: `TYPE`, `USER`, `SKIPME` (default: yes), and `MAXAGE`
- Multiple filters combine with AND logic, matching Redis behavior
- Adds `GetCreationTime()` accessor to `facade::Connection` for the `MAXAGE` check

## Changes

- `src/facade/dragonfly_connection.h`: add `GetCreationTime()` public accessor
- `src/server/server_family.cc`: replace `ClientKill()` single-pair parser with a loop-based
  multi-filter parser; removes the explicit `TODO: Add support for KILL USER/TYPE/SKIPME`
- `tests/dragonfly/server_family_test.py`: add `test_client_kill_filters` covering TYPE, USER,
  SKIPME, MAXAGE, and invalid-type error

## Test plan

- [ ] `test_client_kill` — existing LADDR test still passes
- [ ] `test_client_kill_filters` — new TYPE/USER/SKIPME/MAXAGE coverage

