### PR TITLE
chore: disable epoll test_replicaof_reject_on_load

### DIFF
--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -673,6 +673,7 @@ async def test_replica_reconnections_after_network_disconnect(
 
 
 @pytest.mark.debug_only
+@pytest.mark.exclude_epoll  # epoll sockets/file reads behave differently, load finishes too fast
 @dfly_args({"proactor_threads": 2})
 async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     master = df_factory.create()


### PR DESCRIPTION
I am disabling it on epoll. The two proactors behave differently on file reads and epoll asynchronity is emulated (and the consequence is snapshot loads faster as file reads are more aggressive) 