### PR TITLE
fix: FT.INFO missing-index compatibility

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -2847,7 +2847,7 @@ void CmdFtInfo(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (num_notfound > 0u)
-    return rb->SendError(IndexNotFoundMsg(idx_name));
+    return rb->SendError(absl::StrCat(idx_name, ": no such index"));
 
   DCHECK(infos.front().base_index.schema.fields.size() ==
          infos.back().base_index.schema.fields.size());

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -390,6 +390,10 @@ TEST_F(SearchFamilyTest, CreateDropListIndex) {
   EXPECT_THAT(Run({"ft._list"}), RespElementsAre("idx-3"));
 }
 
+TEST_F(SearchFamilyTest, InfoMissingIndexUsesRedisCompatibleError) {
+  EXPECT_THAT(Run({"FT.INFO", "missing-index"}), ErrArg("missing-index: no such index"));
+}
+
 // Regression for #7953: a zero-field index is a broken state (FT.INFO says "not found" while
 // FT._LIST lists it, and it doesn't survive serialization), so SCHEMA with at least one field
 // must be required unconditionally - not inferred from a heuristic over the skipped tokens.
@@ -401,7 +405,7 @@ TEST_F(SearchFamilyTest, CreateWithoutSchemaKeywordIsError) {
                    "TEXT", "timestamp", "NUMERIC", "SORTABLE"}),
               ErrArg(kMissingSchema));
   EXPECT_THAT(Run({"ft._list"}).GetVec(), testing::IsEmpty());
-  EXPECT_THAT(Run({"ft.info", "idx_ts_test"}), ErrArg("Index with name 'idx_ts_test' not found"));
+  EXPECT_THAT(Run({"ft.info", "idx_ts_test"}), ErrArg("idx_ts_test: no such index"));
 
   // No SCHEMA clause at all, and no field-like tokens either - still rejected, since the
   // resulting index would be just as unusable regardless of how it ended up with zero fields.
@@ -441,7 +445,7 @@ TEST_F(SearchFamilyTest, CreateDropDifferentDatabases) {
 
   // ft.dropindex must work from another database
   EXPECT_EQ(Run({"ft.dropindex", "idx-1"}), "OK");
-  EXPECT_THAT(Run({"ft.info", "idx-1"}), ErrArg("Index with name 'idx-1' not found"));
+  EXPECT_THAT(Run({"ft.info", "idx-1"}), ErrArg("idx-1: no such index"));
 }
 
 TEST_F(SearchFamilyTest, AlterIndex) {


### PR DESCRIPTION
## Summary

Make the missing-index error returned by `FT.INFO` compatible with RedisVL's
index-existence detection.

## Problem

Dragonfly returned `Index with name '<index>' not found` when `FT.INFO` targeted
an absent index. RedisVL 0.26.0 classifies missing indexes using established
Redis Search error fragments such as `no such index` and `index not found`.
Because neither fragment appears contiguously in Dragonfly's wording,
`SearchIndex.exists()` raised `RedisSearchError` instead of returning `False`.
That prevented applications from continuing into their create-if-absent path.

## Root cause

`CmdFtInfo` reused Dragonfly's generic `IndexNotFoundMsg`, whose word order does
not match any missing-index wording recognized by RedisVL.

## Fix

- Return `<index>: no such index` from the missing-index branch of `FT.INFO`.
- Keep the shared `IndexNotFoundMsg` and the responses of `FT.DROPINDEX`,
  `FT.TAGVALS`, and other search commands unchanged.
- Add a focused regression test for the Redis-compatible `FT.INFO` response and
  update the two existing `FT.INFO` missing-index expectations.

## Validation

- Verified the new regression test failed before the production change with the
  old error response and passed after the change.
- Built `search_family_test` successfully.
- Ran all 332 tests from the six test suites in `search_family_test`: 332 passed.
- Ran `git diff --check`: passed.

Fixes #8195
