### PR TITLE
refactor: improve OAHMap performance

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(dfly_core allocation_tracker.cc bloom.cc topk.cc compact_object.cc c
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc stream_node.cc task_queue.cc
     tx_queue.cc string_set.cc string_map.cc tiering_types.cc top_keys.cc
     detail/bitpacking.cc detail/listpack_wrap.cc detail/listpack.cc
-    oah_entry.cc oah_pair.cc oah_ptr.cc oah_set.cc oah_table.cc)
+    oah_entry.cc oah_map.cc oah_pair.cc oah_ptr.cc oah_set.cc oah_table.cc)
 
 cxx_link(dfly_core base dfly_search_core dfly_page_usage fibers2 jsonpath
     absl::flat_hash_map absl::str_format absl::random_random redis_lib

--- a/src/core/oah_map.cc
+++ b/src/core/oah_map.cc
@@ -1,0 +1,38 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/oah_map.h"
+
+#include <absl/random/random.h>
+
+#include <algorithm>
+
+namespace dfly {
+
+void OAHMap::RandomPairsUnique(unsigned count, std::vector<std::string>& keys,
+                               std::vector<std::string>& vals, bool with_value) {
+  const unsigned total = SizeSlow();
+  count = std::min(count, total);
+
+  keys.reserve(keys.size() + count);
+  if (with_value)
+    vals.reserve(vals.size() + count);
+
+  static thread_local absl::InsecureBitGen rng;
+  unsigned index = 0;
+  unsigned remaining = count;
+  for (auto it = begin(), it_end = end(); remaining && it != it_end; ++it, ++index) {
+    const double threshold = double(remaining) / (total - index);
+    if (absl::Uniform(rng, 0.0, 1.0) <= threshold) {
+      OAHPair pair = *it;
+      const oah::key::Decoded key = DecodeKey(pair);
+      keys.emplace_back(key.view());
+      if (with_value)
+        vals.emplace_back(pair.Value());
+      --remaining;
+    }
+  }
+}
+
+}  // namespace dfly

--- a/src/core/oah_map.h
+++ b/src/core/oah_map.h
@@ -24,29 +24,23 @@ class OAHMap : public OAHTable<OAHPair> {
   // Returns true if added, false if an existing field was updated.
   bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX,
                    bool keepttl = false) {
-    const ASCIIStr key(field);
-    TaggedPtr new_tp = MakePair(key.content(), key.len(), value,
-                                ComputeTtl(key.content(), key.len(), ttl_sec, keepttl));
-    return AddPairImpl(key.content(), key.len(), new_tp, /*replace=*/true, nullptr);
+    return AddOrUpdateImpl({.key = ASCIIStr(field), .value = value, .ttl_sec = ttl_sec}, keepttl);
   }
 
   // Returns false (no update) if the field already exists.
   bool AddOrSkip(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX) {
-    const ASCIIStr key(field);
-    return AddPairImpl(key.content(), key.len(), MakePair(key.content(), key.len(), value, ttl_sec),
-                       /*replace=*/false, nullptr);
+    return AddPairImpl<AddMode::kSkip>(
+        {.key = ASCIIStr(field), .value = value, .ttl_sec = ttl_sec});
   }
 
   // Like AddOrUpdate but on update returns the previous entry (RAII-owned; freed on destruction);
   // empty if a new field was added.
   OwnedOAHPair AddOrExchange(std::string_view field, std::string_view value,
                              uint32_t ttl_sec = UINT32_MAX, bool keepttl = false) {
-    const ASCIIStr key(field);
-    TaggedPtr new_tp = MakePair(key.content(), key.len(), value,
-                                ComputeTtl(key.content(), key.len(), ttl_sec, keepttl));
-    TaggedPtr old_tp = 0;
-    AddPairImpl(key.content(), key.len(), new_tp, /*replace=*/true, &old_tp);
-    return OwnedOAHPair(old_tp);
+    TaggedPtr previous = 0;
+    AddOrUpdateImpl({.key = ASCIIStr(field), .value = value, .ttl_sec = ttl_sec}, keepttl,
+                    &previous);
+    return OwnedOAHPair(previous);
   }
 
   std::optional<std::string_view> GetValue(std::string_view field) {
@@ -105,63 +99,54 @@ class OAHMap : public OAHTable<OAHPair> {
   // Selects up to `count` unique live pairs via single-pass threshold sampling (Algorithm S),
   // mirroring StringMap::RandomPairsUnique. Only the picked pairs are copied.
   void RandomPairsUnique(unsigned count, std::vector<std::string>& keys,
-                         std::vector<std::string>& vals, bool with_value) {
-    unsigned total = SizeSlow();
-    if (count > total)
-      count = total;
-
-    keys.reserve(keys.size() + count);
-    if (with_value)
-      vals.reserve(vals.size() + count);
-
-    static thread_local absl::InsecureBitGen rng;
-    unsigned index = 0, remaining = count;
-    for (auto it = begin(), it_end = end(); remaining && it != it_end; ++it, ++index) {
-      double threshold = double(remaining) / (total - index);
-      if (absl::Uniform(rng, 0.0, 1.0) <= threshold) {
-        OAHPair e = *it;
-        const oah::key::Decoded key = DecodeKey(e);
-        keys.emplace_back(key.view());
-        if (with_value)
-          vals.emplace_back(e.Value());
-        --remaining;
-      }
-    }
-  }
+                         std::vector<std::string>& vals, bool with_value);
 
  private:
-  uint32_t ComputeTtl(std::string_view content, uint32_t len, uint32_t ttl_sec, bool keepttl) {
-    if (keepttl && !entries_.empty()) {
-      auto it = Find(content, len);
-      if (it != end() && it.HasExpiry() && it.ExpiryTime() > time_now_)
-        return it.ExpiryTime() - time_now_;
-    }
-    return ttl_sec;
+  enum class AddMode { kReplace, kKeepTtl, kSkip };
+
+  struct AddParams {
+    const ASCIIStr key;
+    const std::string_view value;
+    const uint32_t ttl_sec;
+  };
+
+  bool AddOrUpdateImpl(const AddParams& params, bool keepttl, TaggedPtr* previous_out = nullptr) {
+    if (keepttl)
+      return AddPairImpl<AddMode::kKeepTtl>(params, previous_out);
+    return AddPairImpl<AddMode::kReplace>(params, previous_out);
   }
 
-  // Creates a pair blob for key/value with a relative ttl, flagging expiry use.
-  TaggedPtr MakePair(std::string_view content, uint32_t len, std::string_view value, uint32_t ttl) {
-    if (ttl != UINT32_MAX)
+  TaggedPtr MakePair(const AddParams& params, uint32_t ttl_sec, uint64_t shifted_ext_hash) {
+    if (ttl_sec != UINT32_MAX)
       expiration_used_ = true;
-    return OAHPair::Create(content, len, value, EntryTTL(ttl));
+    TaggedPtr ptr =
+        OAHPair::Create(params.key.content(), params.key.len(), params.value, EntryTTL(ttl_sec));
+    OAHPair pair(ptr);
+    pair.SetShiftedExtHash(shifted_ext_hash);
+    return ptr;
   }
 
-  // Map insertion core. On a live duplicate: replace=false destroys new_tp; replace=true swaps it
-  // in, returning the old TaggedPtr via *old_out (or destroying it when null). Returns true only on
-  // a fresh insert.
-  bool AddPairImpl(std::string_view content, uint32_t len, TaggedPtr new_tp, bool replace,
-                   TaggedPtr* old_out) {
+  // Map insertion core. Normal replacements retain the preallocated hot path, while duplicate
+  // skips and KEEPTTL replacements defer allocation until this probe resolves the existing entry.
+  template <AddMode kMode>
+  bool AddPairImpl(const AddParams& params, TaggedPtr* previous_out = nullptr) {
+    TaggedPtr new_pair = 0;
+    size_t new_pair_alloc_size = 0;
+
     TryGrow();
     assert(Capacity() >= kDisplacementSize);
 
-    uint64_t hash = Hash(content);
+    uint64_t hash = Hash(params.key.content());
     auto bucket_id = BucketId(hash, capacity_log_);
     oah::PrefetchRead(entries_.data() + bucket_id);
 
     const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
     const uint64_t shifted_ext_hash = ext_hash << oah::kExtHashShift;
-    OAHPair(new_tp).SetShiftedExtHash(shifted_ext_hash);
-    const size_t entry_alloc_size = OAHPair(new_tp).AllocSize();
+
+    if constexpr (kMode == AddMode::kReplace) {
+      new_pair = MakePair(params, params.ttl_sec, shifted_ext_hash);
+      new_pair_alloc_size = OAHPair(new_pair).AllocSize();
+    }
 
     const uint32_t ext_bid = GetExtensionPoint(bucket_id);
     oah::PrefetchRead(At(ext_bid).Raw());
@@ -172,45 +157,55 @@ class OAHMap : public OAHTable<OAHPair> {
     TaggedPtr* base = entries_.data();
     for (uint32_t cand_bits = masks.candidates; cand_bits; cand_bits &= cand_bits - 1) {
       TaggedPtr* cell = &base[bucket_id + std::countr_zero(cand_bits)];
-      if (OAHPair(*cell).KeyMatches(content, len)) {
+      if (OAHPair(*cell).KeyMatches(params.key.content(), params.key.len())) {
         matched = cell;
         break;
       }
     }
     if (!matched && At(ext_bid).IsVector())
-      matched = ProbeExtensionVector(ext_bid, content, len, ext_hash);
+      matched = ProbeExtensionVector(ext_bid, params.key.content(), params.key.len(), ext_hash);
 
     if (matched) {
       OAHPair dup(*matched);
       ExpireIfNeeded(dup);
       if (!dup.Empty()) {
-        if (!replace) {
-          OAHPair::Destroy(new_tp);
+        if constexpr (kMode == AddMode::kSkip) {
+          return false;
+        } else {
+          if constexpr (kMode == AddMode::kKeepTtl) {
+            uint32_t ttl = params.ttl_sec;
+            if (dup.HasExpiry())
+              ttl = dup.GetExpiry() - time_now_;
+            new_pair = MakePair(params, ttl, shifted_ext_hash);
+            new_pair_alloc_size = OAHPair(new_pair).AllocSize();
+          }
+
+          obj_alloc_used_ -= dup.AllocSize();
+          TaggedPtr previous = dup.Release();
+          if (previous_out)
+            *previous_out = previous;
+          else
+            OAHPair::Destroy(previous);
+          obj_alloc_used_ += new_pair_alloc_size;
+          *matched = new_pair;
           return false;
         }
-        obj_alloc_used_ -= dup.AllocSize();
-        TaggedPtr old_tp = dup.Release();
-        if (old_out)
-          *old_out = old_tp;
-        else
-          OAHPair::Destroy(old_tp);
-        obj_alloc_used_ += entry_alloc_size;
-        *matched = new_tp;
-        return false;  // updated, not newly added
       }
-      // Reuse the just-reaped expired cell in place.
-      obj_alloc_used_ += entry_alloc_size;
-      ++size_;
-      *matched = new_tp;
-      return true;
     }
 
-    obj_alloc_used_ += entry_alloc_size;
+    if constexpr (kMode != AddMode::kReplace) {
+      new_pair = MakePair(params, params.ttl_sec, shifted_ext_hash);
+      new_pair_alloc_size = OAHPair(new_pair).AllocSize();
+    }
+
+    obj_alloc_used_ += new_pair_alloc_size;
     ++size_;
-    if (masks.empties) {
-      At(bucket_id + std::countr_zero(masks.empties)).Assign(new_tp);
+    if (matched) {  // reuse the just-reaped expired cell
+      *matched = new_pair;
+    } else if (masks.empties) {
+      At(bucket_id + std::countr_zero(masks.empties)).Assign(new_pair);
     } else {
-      ptr_vectors_alloc_used_ += At(ext_bid).InsertNonEmpty(new_tp);  // window full
+      ptr_vectors_alloc_used_ += At(ext_bid).InsertNonEmpty(new_pair);  // window full
     }
     return true;
   }

--- a/src/core/oah_map_test.cc
+++ b/src/core/oah_map_test.cc
@@ -135,6 +135,17 @@ TEST_F(OAHMapTest, Basic) {
   EXPECT_FALSE(m_->GetValue("missing").has_value());
 }
 
+TEST_F(OAHMapTest, AddOrSkipDuplicateDoesNotEnableExpiration) {
+  EXPECT_TRUE(m_->AddOrUpdate("field", "old-value"));
+  ASSERT_FALSE(m_->ExpirationUsed());
+  const size_t obj_alloc = m_->ObjMallocUsed();
+
+  EXPECT_FALSE(m_->AddOrSkip("field", string(4096, 'x'), 10));
+  EXPECT_EQ(m_->GetValue("field"), std::optional{"old-value"sv});
+  EXPECT_EQ(m_->ObjMallocUsed(), obj_alloc);
+  EXPECT_FALSE(m_->ExpirationUsed());
+}
+
 TEST_F(OAHMapTest, ShrinkToMinimumBuckets) {
   m_->Reserve(1);
   EXPECT_EQ(m_->BucketCount(), OAHMap::kMinBucketCount);
@@ -640,6 +651,32 @@ TEST_F(OAHMapTest, AddOrExchange) {
   EXPECT_EQ(it.ExpiryTime(), 200u);
 }
 
+TEST_F(OAHMapTest, AddOrExchangeKeepTtl) {
+  m_->set_time(10);
+  EXPECT_TRUE(m_->AddOrUpdate("field", "old-value", 30));
+
+  auto previous = m_->AddOrExchange("field", "new-value", 5, true);
+  ASSERT_TRUE(previous);
+  EXPECT_EQ(previous.pair().Value(), "old-value"sv);
+  EXPECT_EQ(previous.pair().GetExpiry(), 40u);
+
+  auto current = m_->Find("field");
+  ASSERT_NE(current, m_->end());
+  EXPECT_EQ(current->Value(), "new-value"sv);
+  EXPECT_TRUE(current.HasExpiry());
+  EXPECT_EQ(current.ExpiryTime(), 40u);
+
+  // An expired pair is treated as absent and its TTL is not retained.
+  m_->set_time(40);
+  auto expired = m_->AddOrExchange("field", "replacement", UINT32_MAX, true);
+  EXPECT_FALSE(expired);
+  current = m_->Find("field");
+  ASSERT_NE(current, m_->end());
+  EXPECT_EQ(current->Value(), "replacement"sv);
+  EXPECT_FALSE(current.HasExpiry());
+  EXPECT_EQ(m_->UpperBoundSize(), 1u);
+}
+
 TEST_F(OAHMapTest, Extract) {
   // Non-existing key: empty owner, map unchanged.
   m_->AddOrUpdate("f1", "v1");
@@ -807,6 +844,70 @@ void BM_AddOrUpdate(benchmark::State& state) {
 BENCHMARK(BM_AddOrUpdate)
     ->ArgNames({"elements", "KeySize"})
     ->ArgsProduct({{1000, 10000, 100000}, {10, 100, 1000}});
+
+void BM_UpdateExisting(benchmark::State& state) {
+  vector<pair<string, string>> kv;
+  mt19937 generator(0);
+  OAHMap map;
+  const unsigned elems = state.range(0);
+  const unsigned key_size = state.range(1);
+  for (size_t i = 0; i < elems; ++i) {
+    kv.emplace_back(random_string(generator, key_size), random_string(generator, key_size));
+    map.AddOrUpdate(kv.back().first, "initial");
+  }
+
+  while (state.KeepRunning()) {
+    for (const auto& [key, value] : kv)
+      benchmark::DoNotOptimize(map.AddOrUpdate(key, value));
+  }
+  state.SetItemsProcessed(state.iterations() * elems);
+}
+BENCHMARK(BM_UpdateExisting)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000}, {10, 100}});
+
+void BM_UpdateExistingKeepTtl(benchmark::State& state) {
+  vector<pair<string, string>> kv;
+  mt19937 generator(0);
+  OAHMap map;
+  const unsigned elems = state.range(0);
+  const unsigned key_size = state.range(1);
+  map.set_time(100);
+  for (size_t i = 0; i < elems; ++i) {
+    kv.emplace_back(random_string(generator, key_size), random_string(generator, key_size));
+    map.AddOrUpdate(kv.back().first, "initial", 1000);
+  }
+
+  while (state.KeepRunning()) {
+    for (const auto& [key, value] : kv)
+      benchmark::DoNotOptimize(map.AddOrUpdate(key, value, UINT32_MAX, true));
+  }
+  state.SetItemsProcessed(state.iterations() * elems);
+}
+BENCHMARK(BM_UpdateExistingKeepTtl)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000}, {10, 100}});
+
+void BM_AddOrSkipExisting(benchmark::State& state) {
+  vector<pair<string, string>> kv;
+  mt19937 generator(0);
+  OAHMap map;
+  const unsigned elems = state.range(0);
+  const unsigned key_size = state.range(1);
+  for (size_t i = 0; i < elems; ++i) {
+    kv.emplace_back(random_string(generator, key_size), random_string(generator, key_size));
+    map.AddOrUpdate(kv.back().first, "initial");
+  }
+
+  while (state.KeepRunning()) {
+    for (const auto& [key, value] : kv)
+      benchmark::DoNotOptimize(map.AddOrSkip(key, value));
+  }
+  state.SetItemsProcessed(state.iterations() * elems);
+}
+BENCHMARK(BM_AddOrSkipExisting)
+    ->ArgNames({"elements", "KeySize"})
+    ->ArgsProduct({{1000, 10000}, {10, 100}});
 
 void BM_Erase(benchmark::State& state) {
   vector<pair<string, string>> kv;


### PR DESCRIPTION
Summary: This refactor improves OAHMap update-path efficiency while preserving map semantics.

Changes:

- Introduces insertion modes for replace, keep-TTL, and skip-existing operations.
- Defers pair allocation for duplicate `AddOrSkip` and keep-TTL updates.
- Keeps eager allocation for normal replacement updates.
- Preserves cached extended-hash setup and allocation accounting in the new paths.
- Moves `RandomPairsUnique` out of the header into `oah_map.cc`.
- Adds the new implementation file to the `dfly_core` CMake target.
- Adds coverage for duplicate skip expiry behavior and exchange with retained TTL.
- Adds benchmarks for existing-entry update, keep-TTL update, and skip paths.