### PR TITLE
chore(server): remove DEBUG COMPRESSION, HuffmanCheckTask, and deprecate --huffman_table

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -5,17 +5,12 @@
 
 #include "core/detail/gen_utils.h"
 
-#define HUF_STATIC_LINKING_ONLY
-
 extern "C" {
-#include "huff/hist.h"
-#include "huff/huf.h"
 #include "redis/redis_aux.h"
 }
 
 #include <absl/cleanup/cleanup.h>
 #include <absl/random/random.h>
-#include <absl/strings/escaping.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <lz4.h>
@@ -28,7 +23,6 @@ extern "C" {
 
 #include "base/flags.h"
 #include "base/logging.h"
-#include "core/huff_coder.h"
 #include "core/qlist.h"
 #include "core/sorted_map.h"
 #include "core/string_map.h"
@@ -265,115 +259,6 @@ void DoSegmentHist(EngineShard* shard, ConnectionContext* cntx, SegmentInfo* inf
       ThisFiber::Yield();
     }
   }
-}
-
-struct HufHist {
-  static constexpr unsigned kMaxSymbol = 255;
-  array<unsigned, kMaxSymbol + 1> hist;  // histogram of symbols.
-  unsigned max_symbol = 0;               // what is the max symbol of the histogram.
-
-  HufHist() {
-    hist.fill(0);
-  }
-
-  void Merge(const HufHist& other) {
-    max_symbol = std::max(max_symbol, other.max_symbol);
-    for (unsigned i = 0; i <= max_symbol; ++i) {
-      hist[i] += other.hist[i];
-    }
-  }
-
-  unsigned MaxFreqCount() const;
-};
-
-unsigned HufHist::MaxFreqCount() const {
-  unsigned max_freq = 0;
-  for (unsigned i = 0; i < kMaxSymbol; ++i) {
-    if (hist[i] > max_freq) {
-      max_freq = hist[i];
-    }
-  }
-  return max_freq;
-}
-
-constexpr unsigned kMaxFreqPerShard = 1U << 20;
-constexpr unsigned kMaxFreqTotal = static_cast<unsigned>((1U << 31) * 0.9);
-
-void DoComputeHist(CompactObjType type, EngineShard* shard, ConnectionContext* cntx,
-                   HufHist* dest) {
-  auto& db_slice = cntx->ns->GetDbSlice(shard->shard_id());
-  DbTable* dbt = db_slice.GetDBTable(cntx->db_index());
-  CHECK(dbt);
-
-  PrimeTable::Cursor cursor;
-  unsigned steps = 0;
-  string scratch;
-  // Sample up to kMaxHuffLen bytes per string so the trained huffman table matches the byte
-  // distribution of the data that EncodeString will actually compress.
-  constexpr size_t kMaxLen = CompactObj::kMaxHuffLen;
-  PrimeTable& table = dbt->prime;
-
-  do {
-    cursor = table.Traverse(cursor, [&](PrimeIterator it) {
-      scratch.clear();
-      ++steps;
-      if (type == kInvalidCompactObjType) {  // KEYSPACE
-        if (it->first.MallocUsed() > 0) {
-          it->first.GetString(&scratch);
-        }
-      } else if (type == OBJ_STRING && it->second.ObjType() == OBJ_STRING) {
-        if (it->second.MallocUsed() > 0) {
-          it->second.GetString(&scratch);
-        }
-      } else if (type == OBJ_ZSET && it->second.ObjType() == OBJ_ZSET) {
-        container_utils::IterateSortedSet(
-            it->second, [&](container_utils::ContainerEntry entry, double) {
-              ++steps;
-              if (entry.IsString()) {
-                HIST_add(dest->hist.data(), entry.data(), entry.size());
-              }
-              return true;
-            });
-      } else if (type == OBJ_LIST && it->second.ObjType() == OBJ_LIST) {
-        container_utils::IterateList(it->second, [&](container_utils::ContainerEntry entry) {
-          ++steps;
-          if (entry.IsString()) {
-            HIST_add(dest->hist.data(), entry.data(), entry.size());
-          }
-          return true;
-        });
-      } else if (type == OBJ_HASH && it->second.ObjType() == OBJ_HASH) {
-        container_utils::IterateMap(it->second, [&](container_utils::ContainerEntry key,
-                                                    container_utils::ContainerEntry value) {
-          ++steps;
-          if (key.IsString()) {
-            HIST_add(dest->hist.data(), key.data(), key.size());
-          }
-          if (value.IsString()) {
-            HIST_add(dest->hist.data(), value.data(), value.size());
-          }
-          return true;
-        });
-      }
-
-      if (!scratch.empty()) {
-        size_t len = std::min(scratch.size(), kMaxLen);
-        HIST_add(dest->hist.data(), scratch.data(), len);
-      }
-    });
-
-    if (steps >= 40000) {
-      if (dest->MaxFreqCount() > kMaxFreqPerShard) {
-        break;
-      }
-
-      steps = 0;
-      ThisFiber::Yield();
-    }
-  } while (cursor);
-  dest->max_symbol = HufHist::kMaxSymbol;
-  while (dest->max_symbol && dest->hist[dest->max_symbol] == 0)
-    --dest->max_symbol;
 }
 
 ObjInfo InspectOp(ConnectionContext* cntx, string_view key) {
@@ -724,11 +609,6 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "    Stop traffic logging started by a previous TRAFFIC START.",
         "RECVSIZE [<tid> | ENABLE | DISABLE]",
         "    Prints the histogram of the received request sizes on the given thread",
-        "COMPRESSION [IMPORT <bintable> | EXPORT | SET <bintable>] [type]",
-        "    Estimate the compressibility of values of the given type. if no type is given, ",
-        "    checks compressibility of keys. If IN is specified, then the provided ",
-        "    bintable is used to check compressibility. If OUT is specified, then ",
-        "    the serialized table is printed as well",
         "IOSTATS [PS]",
         "    Prints IO stats per thread. If PS is specified, prints thread-level stats ",
         "    per second.",
@@ -820,10 +700,6 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   if (subcmd == "VALUES" && parser.HasNext()) {
     return Values(parser, cmd_cntx);
   }
-  if (subcmd == "COMPRESSION") {
-    return Compression(parser, cmd_cntx);
-  }
-
   if (subcmd == "IOSTATS") {
     return IOStats(parser, cmd_cntx);
   }
@@ -1604,145 +1480,6 @@ void DebugCmd::Values(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   }
 
   return cmd_cntx->SendError(kSyntaxErr);
-}
-
-static size_t PostProcessHist(HufHist* dest) {
-  size_t total_freq = 0;
-  auto& hist = dest->hist;
-  unsigned max_freq = 0;
-
-  for (unsigned i = 0; i <= HufHist::kMaxSymbol; i++) {
-    // raw_size may count less characters than the actual size because
-    // we may cut the counting early.
-    total_freq += hist[i];
-    if (hist[i] == 0) {
-      hist[i] = 1;  // Avoid zero frequency symbols.
-    }
-  }
-
-  if (total_freq > kMaxFreqTotal) {
-    // huffman encoder has a bug with frequencies too high, so we scale down everything
-    // to avoid overflow.
-    double scale = static_cast<double>(max_freq) / kMaxFreqTotal;
-    for (unsigned i = 0; i <= HufHist::kMaxSymbol; i++) {
-      hist[i] = unsigned(hist[i] / scale);
-      if (hist[i] == 0) {
-        hist[i] = 1;  // Avoid zero frequency symbols.
-      }
-    }
-  }
-  return total_freq;
-}
-
-void DebugCmd::Compression(CmdArgParser parser, CommandContext* cmd_cntx) {
-  CompactObjType type = kInvalidCompactObjType;
-  string bintable;
-  bool print_bintable = false;
-
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (parser.Check("SET", &bintable)) {
-    RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
-
-    // SET <bintable> [type]
-    string raw;
-    atomic_bool succeed = absl::Base64Unescape(bintable, &raw);
-    if (succeed) {
-      CompactObj::HuffmanDomain domain = CompactObj::HUFF_KEYS;
-      if (parser.HasNext()) {
-        string_view type_str = parser.Next();
-        type = ObjTypeFromString(type_str);
-        if (type != OBJ_STRING) {  // Currently only string type is supported.
-          return cmd_cntx->SendError(kSyntaxErr);
-        }
-        domain = CompactObj::HUFF_STRING_VALUES;
-      }
-      shard_set->RunBriefInParallel([&](EngineShard* shard) {
-        if (!CompactObj::InitHuffmanThreadLocal(domain, raw)) {
-          succeed = false;
-        }
-      });
-    }
-    return succeed ? rb->SendOk() : cmd_cntx->SendError("Failed to set bintable");
-  }
-
-  if (parser.Check("EXPORT")) {
-    print_bintable = true;
-  } else if (parser.Check("IMPORT", &bintable)) {
-    RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
-
-    string raw;
-    bool succeed = absl::Base64Unescape(bintable, &raw);
-    if (succeed) {
-      bintable = raw;
-    }
-  }
-
-  if (parser.HasNext()) {
-    string_view type_str = parser.Next();
-    type = ObjTypeFromString(type_str);
-    if (type == kInvalidCompactObjType) {
-      return cmd_cntx->SendError(kSyntaxErr);
-    }
-  }
-
-  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
-
-  fb2::Mutex mu;
-  HufHist hist;
-  shard_set->RunBlockingInParallel([&](EngineShard* shard) {
-    HufHist local;
-    DoComputeHist(type, shard, cntx_, &local);
-    std::unique_lock lk(mu);
-    hist.Merge(local);
-  });
-
-  size_t num_bits = 0, compressed_size = 0, raw_size = 0;
-  if (hist.max_symbol) {
-    HuffmanEncoder huff_enc;
-    string err_msg;
-
-    raw_size = PostProcessHist(&hist);
-
-    if (bintable.empty()) {
-      if (!huff_enc.Build(hist.hist.data(), HufHist::kMaxSymbol, &err_msg)) {
-        return cmd_cntx->SendError(StrCat("Internal error: ", err_msg));
-      }
-    } else {
-      // Try to read the bintable and create a ctable from it.
-      if (!huff_enc.Load(bintable, &err_msg)) {
-        return cmd_cntx->SendError(StrCat("Internal error: ", err_msg));
-      }
-    }
-    num_bits = huff_enc.num_bits();
-    compressed_size = huff_enc.EstimateCompressedSize(hist.hist.data(), HufHist::kMaxSymbol);
-
-    if (print_bintable) {
-      auto exported = huff_enc.Export();
-      bintable = exported.value_or(string{});
-    } else {
-      bintable.clear();
-    }
-  }
-
-  unsigned map_len = print_bintable ? 6 : 5;
-
-  rb->StartCollection(map_len, CollectionType::MAP);
-  rb->SendSimpleString("max_symbol");
-  rb->SendLong(hist.max_symbol);
-
-  rb->SendSimpleString("max_bits");
-  rb->SendLong(num_bits);
-  rb->SendSimpleString("raw_size");
-  rb->SendLong(raw_size);
-  rb->SendSimpleString("compressed_size");
-  rb->SendLong(compressed_size);
-  rb->SendSimpleString("ratio");
-  double ratio = raw_size > 0 ? static_cast<double>(compressed_size) / raw_size : 0;
-  rb->SendDouble(ratio);
-  if (print_bintable) {
-    rb->SendSimpleString("bintable");
-    rb->SendBulkString(absl::Base64Escape(bintable));
-  }
 }
 
 void DebugCmd::IOStats(facade::CmdArgParser parser, CommandContext* cmd_cntx) {

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -62,7 +62,6 @@ class DebugCmd {
   void Topk(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void Keys(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void Values(facade::CmdArgParser parser, CommandContext* cmd_cntx);
-  void Compression(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void IOStats(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void Segments(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void CompactTable(facade::CmdArgParser parser, CommandContext* cmd_cntx);

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -1106,22 +1106,6 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
   EXPECT_EQ(metrics.facade_stats.conn_stats.num_conns_other, 0);
 }
 
-TEST_F(DflyEngineTest, Huffman) {
-  // enable compression for keys optimized for letter a.
-  auto resp = Run({"debug", "compression", "set", "GBDgCpXW/////7/pygS5t9x7792qU1trLQ=="});
-  EXPECT_EQ(resp, "OK");
-
-  // for string values optimized for letter x.
-  resp = Run({"debug", "compression", "set", "ChD4bAf/D/bPSwY=", "string"});
-  EXPECT_EQ(resp, "OK");
-  resp = Run({"debug", "populate", "200000", "aaaaaaaaaaaaaaaaaaaaaaaaaa", "32"});
-  EXPECT_EQ(resp, "OK");
-
-  auto metrics = GetMetrics();
-  EXPECT_EQ(metrics.events.huff_encode_success, 400000);  // each key and value
-  EXPECT_LT(metrics.heap_used_bytes, 14'000'000);         // less than 15mb
-}
-
 TEST_F(DflyEngineTest, MemoryKeys) {
   Run({"debug", "populate", "10000", "abcd_efgh_ijkl_mnop", "10"});
   auto metrics = GetMetrics();

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -4,14 +4,12 @@
 
 #include "server/engine_shard.h"
 
-#include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 
 #include <memory>
 
 #include "base/flags.h"
-#include "core/huff_coder.h"
 #include "core/page_usage/page_usage_stats.h"
 #include "core/qlist.h"
 #include "io/proc_reader.h"
@@ -132,90 +130,6 @@ size_t CalculateHowManyBytesToEvictOnShard(size_t global_memory_limit, size_t gl
   return shard_budget < shard_memory_threshold ? (shard_memory_threshold - shard_budget) : 0;
 }
 
-class HuffmanCheckTask {
- public:
-  HuffmanCheckTask() {
-    hist_.fill(0);
-  }
-
-  int32_t Run(DbSlice* db_slice);
-
- private:
-  PrimeTable::Cursor cursor_;
-
-  static constexpr unsigned kMaxSymbol = 255;
-  array<unsigned, kMaxSymbol + 1> hist_;  // histogram of symbols.
-  string scratch_;
-};
-
-int32_t HuffmanCheckTask::Run(DbSlice* db_slice) {
-  DbTable* db_table = db_slice->GetDBTable(0);  // we currently support only default db.
-  if (!db_table)
-    return -1;
-
-  // incrementally aggregate frequency histogram.
-  auto& prime = db_table->prime;
-
-  constexpr uint32_t kMaxTraverses = 512;
-  uint32_t traverses_count = 0;
-  do {
-    cursor_ = prime.Traverse(cursor_, [&](PrimeIterator it) {
-      if (!it->first.IsInline()) {
-        string_view val = it->first.GetSlice(&scratch_);
-        for (unsigned char c : val) {
-          hist_[c]++;
-        }
-
-        if (val.size() > 1024) {
-          traverses_count = kMaxTraverses;  // return early.
-          string{}.swap(scratch_);          // free memory.
-        }
-      }
-    });
-    traverses_count++;
-  } while (traverses_count < kMaxTraverses && cursor_);
-
-  if (cursor_)
-    return 4;  // priority to continue later.
-
-  // Finished scanning the table, now normalize the table.
-  constexpr unsigned kMaxFreqTotal = static_cast<unsigned>((1U << 31) * 0.9);
-  size_t total_freq = std::accumulate(hist_.begin(), hist_.end(), 0UL);
-  if (total_freq == 0)
-    return -1;
-
-  // to avoid overflow.
-  double scale = total_freq > kMaxFreqTotal ? static_cast<double>(total_freq) / kMaxFreqTotal : 1.0;
-  for (unsigned i = 0; i <= kMaxSymbol; i++) {
-    hist_[i] = static_cast<unsigned>(hist_[i] / scale);
-    if (hist_[i] == 0) {
-      hist_[i] = 1;  // Avoid zero frequency symbols.
-    }
-  }
-
-  // Build the huffman table. We currently output the table to logs and just increase
-  // the metric counter to signal that we built a table.
-
-  HuffmanEncoder huff_enc;
-  string error_msg;
-  if (huff_enc.Build(hist_.data(), kMaxSymbol, &error_msg)) {
-    size_t compressed_size = huff_enc.EstimateCompressedSize(hist_.data(), kMaxSymbol);
-    double ratio = double(compressed_size) / total_freq;
-    LOG(INFO) << "Huffman table built, reducing character count from " << total_freq << " to "
-              << compressed_size << ", compression ratio " << ratio;
-    if (ratio < 1.0) {
-      if (auto bintable = huff_enc.Export()) {
-        LOG(INFO) << "Huffman binary table: " << absl::Base64Escape(*bintable);
-        db_slice->shard_owner()->stats().huffman_tables_built++;
-      }
-    }
-  } else {
-    LOG(WARNING) << "Huffman build failed: " << error_msg;
-  }
-
-  return -1;  // task completed.
-}
-
 }  // namespace
 
 __thread EngineShard* EngineShard::shard_ = nullptr;
@@ -241,7 +155,7 @@ string EngineShard::TxQueueInfo::Format() const {
 }
 
 EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
-  static_assert(sizeof(Stats) == 144);
+  static_assert(sizeof(Stats) == 136);
 
 #define ADD(x) x += o.x
 
@@ -259,7 +173,6 @@ EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
   ADD(total_heartbeat_expired_bytes);
   ADD(total_heartbeat_expired_calls);
   ADD(total_migrated_keys);
-  ADD(huffman_tables_built);
   ADD(stream_sequential_accesses);
   ADD(stream_random_accesses);
   ADD(stream_fetch_all_accesses);
@@ -530,7 +443,6 @@ void EngineShard::Shutdown() {
 
 void EngineShard::StopPeriodicFiber() {
   ProactorBase::me()->RemoveOnIdleTask(defrag_task_id_);
-  ProactorBase::me()->RemoveOnIdleTask(huffman_check_task_id_);
 
   fiber_heartbeat_periodic_done_.Notify();
   if (fiber_heartbeat_periodic_.IsJoinable()) {
@@ -849,40 +761,6 @@ void EngineShard::Heartbeat() {
     return;
   }
   stalled_start_ns_ = 0;
-
-  thread_local bool check_huffman = (shard_id_ == 0);  // run it only on shard 0.
-  if (check_huffman) {
-    auto* ptr = db_slice.GetDBTable(0);
-    if (ptr) {
-      size_t key_usage = ptr->stats.memory_usage_by_type[OBJ_KEY];
-      size_t obj_usage = ptr->stats.obj_memory_usage;
-
-#ifdef NDEBUG
-#define MB_THRESHOLD (50 * 1024 * 1024)
-#else
-#define MB_THRESHOLD (5 * 1024 * 1024)
-#endif
-
-      if (key_usage > MB_THRESHOLD && key_usage > obj_usage / 8) {
-        VLOG(1) << "Scheduling huffman check task, key usage: " << key_usage
-                << ", obj usage: " << obj_usage;
-
-        check_huffman = false;  // trigger only once.
-
-        // launch the task
-        huffman_check_task_id_ = ProactorBase::me()->AddOnIdleTask(
-            [task = HuffmanCheckTask{}]() mutable {
-              if (!shard_ || !namespaces) {
-                return -1;
-              }
-
-              DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_->shard_id());
-              return task.Run(&db_slice);
-            },
-            "huffman_check");
-      }
-    }
-  }
 
   if (!IsReplica()) {  // Never run expiry/evictions on replica.
     RetireExpiredAndEvict();

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -46,9 +46,6 @@ class EngineShard {
     // cluster stats
     uint64_t total_migrated_keys = 0;
 
-    // how many huffman tables were built successfully in the background
-    uint32_t huffman_tables_built = 0;
-
     // Stream access pattern metrics (per-command, not per-entry).
     uint64_t stream_sequential_accesses = 0;  // head/tail: XADD, XREAD recent, XTRIM, etc.
     uint64_t stream_random_accesses = 0;      // arbitrary-ID lookups: XRANGE partial, XDEL, XCLAIM
@@ -352,7 +349,7 @@ class EngineShard {
 
   IntentLock shard_lock_;
 
-  uint32_t defrag_task_id_ = UINT32_MAX, huffman_check_task_id_ = UINT32_MAX;
+  uint32_t defrag_task_id_ = UINT32_MAX;
   EvictionTaskState eviction_state_;  // Used on eviction fiber
   util::fb2::Fiber fiber_heartbeat_periodic_;
   util::fb2::Done fiber_heartbeat_periodic_done_;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -116,11 +116,10 @@ ABSL_FLAG(strings::MemoryBytesFlag, maxmemory, strings::MemoryBytesFlag{},
 ABSL_FLAG(uint32_t, shard_thread_busy_polling_usec, 0,
           "If non-zero, overrides the busy polling parameter for shard threads.");
 
-ABSL_FLAG(string, huffman_table, "",
-          "a comma separated map: domain1:code1,domain2:code2,... where "
-          "domain can currently be only KEYS or STRINGS, code is a base64-encoded huffman table"
-          " exported via "
-          "DEBUG COMPRESSION EXPORT. if the flag is empty no huffman compression is applied.");
+// TODO: remove this retired flag after Jan 1, 2027.
+ABSL_RETIRED_FLAG(string, huffman_table, "",
+                  "Deprecated: huffman compression of keys and string values is no longer "
+                  "configurable and the flag is ignored.");
 
 ABSL_FLAG(bool, jsonpathv2, true,
           "If true uses Dragonfly jsonpath implementation, "
@@ -717,46 +716,6 @@ void UpdateSchedulerFlagsOnThread() {
                       GetFlag(FLAGS_scheduler_background_warrant));
 }
 
-void SetHuffmanTable(const std::string& huffman_table) {
-  if (huffman_table.empty())
-    return;
-  vector<string_view> parts = absl::StrSplit(huffman_table, ',');
-  for (const auto& part : parts) {
-    vector<string_view> kv = absl::StrSplit(part, ':');
-    if (kv.size() != 2 || kv[0].empty() || kv[1].empty()) {
-      LOG(ERROR) << "Invalid huffman table entry" << part;
-      continue;
-    }
-    string domain_str = absl::AsciiStrToUpper(kv[0]);
-    CompactObj::HuffmanDomain domain;
-
-    if (domain_str == "KEYS") {
-      domain = CompactObj::HUFF_KEYS;
-    } else if (domain_str == "STRINGS") {
-      domain = CompactObj::HUFF_STRING_VALUES;
-    } else {
-      LOG(ERROR) << "Unknown huffman domain: " << kv[0];
-      continue;
-    }
-
-    string unescaped;
-    if (!absl::Base64Unescape(kv[1], &unescaped)) {
-      LOG(ERROR) << "Failed to decode base64 huffman table for domain " << kv[0] << " with value "
-                 << kv[1];
-      continue;
-    }
-
-    atomic_bool success = true;
-    shard_set->RunBriefInParallel([&](auto* shard) {
-      if (!CompactObj::InitHuffmanThreadLocal(domain, unescaped)) {
-        success = false;
-      }
-    });
-    LOG_IF(ERROR, !success) << "Failed to set huffman table for domain " << kv[0] << " with value "
-                            << kv[1];
-  }
-}
-
 string_view CommandOptName(CO::CommandOpt opt, bool enabled) {
   using namespace CO;
   if (!enabled) {
@@ -1184,8 +1143,6 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
     UpdateFromFlagsOnThread();
     UpdateSchedulerFlagsOnThread();
   });
-  SetHuffmanTable(GetFlag(FLAGS_huffman_table));
-
   // Requires that shard_set will be initialized before because server_family_.Init might
   // load the snapshot.
   server_family_.Init(acceptor, std::move(listeners));

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -622,9 +622,6 @@ void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* d
   AppendMetricValue("defrag_skipped_total", m.shard_stats.defrag_skipped_not_enough_fragmentation,
                     {"reason"}, {"not_enough_fragmentation"}, &resp->body());
 
-  AppendMetricWithoutLabels("huffman_tables_built", "Huffman tables built",
-                            m.shard_stats.huffman_tables_built, MetricType::COUNTER, &resp->body());
-
   AppendMetricHeader("list_reads", "List Reads Patterns", MetricType::COUNTER, &resp->body());
   AppendMetricValue("list_reads", m.qlist_stats.total_node_reads, {"type"}, {"total"},
                     &resp->body());

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -307,20 +307,3 @@ async def test_metrics_sanity_check(df_server: DflyInstance):
         logging.error(f"found error: {error}")
 
     assert actual_errors == []
-
-
-@pytest.mark.opt_only
-@dfly_args({"proactor_threads": "2"})
-async def test_huffman_tables_built(df_server: DflyInstance):
-    async_client = df_server.client()
-    # Insert enough data to trigger background huffman table building
-    key_name = "keyfooobarrsoooooooooooooooooooooooooooooooooooooooooooooooo"
-    await async_client.execute_command("DEBUG", "POPULATE", "1000000", key_name, "14")
-
-    @assert_eventually(times=500)
-    async def check_metrics():
-        metrics = await df_server.metrics()
-        m = metrics["dragonfly_huffman_tables_built"]
-        assert m.samples[0].value > 0
-
-    await check_metrics()


### PR DESCRIPTION
Removes the huffman-sizing tooling and retires the flag that consumed its output.

## Changes

- **`debugcmd.{cc,h}`**: drop `DEBUG COMPRESSION`, its help text, and the `HufHist` / `DoComputeHist` / `PostProcessHist` helpers it exclusively used.
- **`engine_shard.{cc,h}`**: drop the background `HuffmanCheckTask`, the heartbeat hook that scheduled it on shard 0, and the now-always-zero `huffman_tables_built` stat (plus its `dragonfly_huffman_tables_built` metric in `metrics.cc`).
- **`main_service.cc`**: `--huffman_table` becomes `ABSL_RETIRED_FLAG` — accepted and ignored, so existing command lines keep working. Marked with a `TODO` to delete it after Jan 1, 2027. `SetHuffmanTable()` and its `Service::Init` call site are removed with it.
- **`dragonfly_test.cc`**: drop `DflyEngineTest.Huffman` — with both `DEBUG COMPRESSION SET` and the flag gone there is no server-side way to install a bintable. `CompactObj::InitHuffmanThreadLocal` and the encode path stay covered by `compact_object_test`.
- Drop `tests/dragonfly/server_family_test.py::test_huffman_tables_built` (metric no longer exists).

Note that this leaves huffman encoding unreachable at the server level; the `CompactObj` machinery and its `huffenc_success_total` / `huffenc_attempt_total` INFO fields are untouched.

## Testing

- `ninja dragonfly dragonfly_test` — clean, no warnings.
- `./dragonfly_test` — 50 passed, 1 skipped (`DefragDflyEngineTest.TestDefragOption`, pre-existing).
- `./dragonfly --huffman_table=KEYS:abc --version` starts fine, logging abseil's standard `Accessing retired flag` notice, matching the other retired flags in the tree.