### PR TITLE
feat(ci): add manual regression tests controls

### DIFF
--- a/.github/REGRESSION-TESTS.md
+++ b/.github/REGRESSION-TESTS.md
@@ -1,0 +1,103 @@
+# Manual Regression Tests
+
+`Regression Tests` and `Epoll Regression Tests` run Pytest automatically on a
+schedule. To run them manually, use **Actions** > select one of the two workflow > **Run workflow** to choose Pytest
+or GoogleTest inputs. You can also choose your own branch.
+
+## Execution Model
+
+- Scheduled runs execute Pytest once and do not build or run GoogleTests.
+- Manual runs execute the Pytest step first and then attempt the GoogleTest step,
+  even if Pytest fails. Set Pytest `iterations` to `0` to skip Pytest and run
+  GoogleTests only.
+- Each workflow fans out across its configured matrix. Inputs apply to every
+  matrix job; they cannot select an architecture, runner, or build type.
+
+## Pytest Inputs
+
+With default inputs, Pytest runs the full `tests/dragonfly` suite once.
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `test-suites` | empty | Comma- or space-separated Python filenames relative to `tests/dragonfly/`. A name without a path is resolved there. Empty runs all suites. Example: `connection_test,eval_test`. |
+| `test-cases` | empty | Extended regular expression matched against collected Pytest node IDs. Empty runs all cases in the selected suites. Example: `test_timeout\|test_eval`. |
+| `iterations` | `1` | Non-negative Pytest run count. Set `0` to skip Pytest for a GoogleTest-only manual run. |
+
+
+
+`test-cases` applies globally to all selected suites; there is no per-suite filter
+input. The selected node IDs are passed to Pytest explicitly. To select two cases
+from `connection_test` and all cases from `eval_test`, use:
+
+```text
+test-suites: connection_test,eval_test
+test-cases:  (^|/)connection_test\.py::(test_case_one|test_case_two)$|(^|/)eval_test\.py::
+```
+
+## GoogleTest Inputs
+
+GoogleTests run only for manual dispatches of these two regression workflows. With default GoogleTest inputs, every
+target found by recursively scanning `CMakeLists.txt` files for `helio_cxx_test(...)`
+under `src/core`, `src/facade`, and `src/server` runs once. This includes tests in
+nested directories such as `src/core/json` and `src/server/cluster`; the available
+targets can still vary with the selected build configuration.
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `gtest-suites` | empty | Comma- or space-separated GoogleTest target names. A target path and `.cc` suffix are accepted, but only the target name is used. Empty runs all discovered targets. Example: `set_family_test,generic_family_test`. |
+| `gtest-cases` | empty | Value passed directly as `--gtest_filter`. Empty runs all cases in each selected target. Example: `SetFamilyTest.*:HSetFamilyTest.*`. |
+| `gtest-iterations` | `1` | Positive GoogleTest run count. |
+
+Specify `gtest-suites` when using `gtest-cases` for only a few binaries. Otherwise
+the workflow builds every target and evaluates the filter against each one. A
+selected target whose filter matches no tests is skipped.
+
+## Common Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `max-tests-run-time` | `360` manual; not used for scheduled runs | Positive shared budget from 1 through 360 minutes. For manual runs, the deadline starts immediately before the main Pytest step and covers Pytest and GoogleTest steps. Scheduled runs retain their existing timeout behavior. |
+| `continue-on-test-failure` | `false` | When `true`, Pytest and GoogleTest each complete all selected iterations and report failure afterward. When `false`, the first failed iteration stops that test system. |
+
+The iteration count and `max-tests-run-time` are concurrent limits: each test system ends
+when either is reached. Budget expiry stops the active test command and is
+treated as a controlled successful completion. A job cannot exceed GitHub Actions'
+six-hour timeout.
+
+## Continuation Mode
+
+Set `continue-on-test-failure` to `true` when results from the entire run matter
+more than stopping at the first failure. Common uses include measuring how often one
+test fails across thousands of repetitions, collecting a complete six-hour CI
+stability result, and future scheduled stress tests.
+
+For a manual run with this option enabled, matrix `fail-fast` is disabled: a failed
+matrix job does not cancel its siblings, so every selected configuration reaches its
+own result. GitHub Actions cannot distinguish a test result failure from a build or
+infrastructure failure for this setting, so siblings also continue after those
+failures. Scheduled runs and manual runs with the option disabled keep fail-fast
+matrix behavior.
+
+For manual runs, Pytest keeps `/tmp/failed/` between processes and the helper
+clears it once before the run begins. With continuation enabled, every failed
+iteration archives the complete `/tmp/dragonfly_logs/` directory as
+`/tmp/failed/iteration_<n>_logs.tar.gz`. Clean iteration logs are deleted. The
+failed matrix job uploads its `logs` artifact from `/tmp/failed/*`, containing all
+failed-iteration archives and `pytest-failures-by-iteration.txt`. The report lists
+failed cases from every failed Pytest iteration. Archives are standard gzip tar
+files. Scheduled runs retain the existing cleanup behavior.
+
+## Validation And Scale
+
+Manual inputs are validated after checkout and before the Dragonfly build. Invalid
+counts, suite names, targets, and regular expressions fail early. GoogleTest targets
+are checked after CMake configuration because target availability can vary by build
+configuration.
+
+Iteration counts apply per matrix job. For example, three Pytest iterations in the
+regular Uring workflow run across eight matrix jobs, producing 24 Pytest runs. The
+lint job does not add test iterations.
+
+Before every Pytest or GoogleTest iteration, the regression action logs an iteration
+banner and the exact shell-escaped command. Expand `Run regression tests action` in
+the job log to inspect them.

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -59,6 +59,53 @@ inputs:
     required: false
     type: string
     description: "Runtime flags to pass to the dragonfly process via --df, e.g. 'enable_resp_io_loop_v2=true'"
+  # Pytest - manual trigger inputs
+  test-suites:
+    required: false
+    default: ""
+    type: string
+    description: "Optional pytest filenames relative to tests/dragonfly; empty runs all suites once"
+  test-cases:
+    required: false
+    default: ""
+    type: string
+    description: "Optional extended regular expression matched against collected pytest node IDs; empty runs all cases"
+  iterations:
+    required: false
+    default: "1"
+    type: string
+    description: "Optional number of times to run selected pytest tests; defaults to 1"
+  # GoogleTest - manual trigger inputs
+  gtest-suites:
+    required: false
+    default: ""
+    type: string
+    description: "Optional GoogleTest target names for manually dispatched workflows; empty runs all suites once"
+  gtest-cases:
+    required: false
+    default: ""
+    type: string
+    description: "Optional value forwarded to --gtest_filter"
+  gtest-iterations:
+    required: false
+    default: "1"
+    type: string
+    description: "Optional number of times to run selected GoogleTest suites; defaults to 1"
+  run-gtests:
+    required: false
+    default: "false"
+    type: string
+    description: "Enable GoogleTest execution for workflows that expose GoogleTest controls"
+  max-tests-run-time:
+    required: false
+    default: ""
+    type: string
+    description: "Optional shared Pytest and GoogleTest budget in minutes for manual workflows"
+  continue-on-test-failure:
+    required: false
+    default: "false"
+    type: string
+    description: "When true, both test families continue selected iterations after failures and fail after all runs complete"
 
 runs:
   using: "composite"
@@ -113,7 +160,7 @@ runs:
         } >> "${GITHUB_ENV}"
 
     - name: Run S3 snapshot tests with MinIO
-      if: inputs.s3-bucket != ''
+      if: inputs.s3-bucket != '' && inputs.test-suites == '' && inputs.test-cases == '' && inputs.iterations == '1'
       shell: bash
       run: |
         echo "=== Running S3 snapshot tests with local MinIO ==="
@@ -126,76 +173,29 @@ runs:
 
     - name: Run PyTests
       id: main
+      if: success()
       shell: bash
+      # Start the manual test budget with Pytest; GoogleTest uses the same deadline.
       run: |
-        ls -l ${GITHUB_WORKSPACE}/
-        cd ${GITHUB_WORKSPACE}/tests
-        echo "Current commit is ${{github.sha}}"
-        # used by PyTests
-        export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
-        export ROOT_DIR="${GITHUB_WORKSPACE}/tests/dragonfly/valkey_search"
-        export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
-        export FILTER="${{inputs.filter}}"
-        JUNIT_DIR="${REGRESSION_JUNIT_DIR}"
-
-        # Runtime flags forwarded to the dragonfly process via --df.
-        # Globbing is disabled while splitting so values like vmodule=*=1 are preserved,
-        # and the flags are collected into an array to avoid re-splitting/globbing
-        # when expanded on the pytest command line.
-        DF_RUNTIME_ARGS=()
-        if [[ -n "${DF_RUNTIME_FLAGS_INPUT}" ]]; then
-          set -f # disables filename expansion (globbing)
-          for flag in ${DF_RUNTIME_FLAGS_INPUT}; do
-            DF_RUNTIME_ARGS+=(--df "$flag")
-          done
-          set +f
+        if [[ -n "${MAX_TESTS_RUN_TIME_MINUTES}" ]]; then
+          echo "Shared regression test time budget: ${MAX_TESTS_RUN_TIME_MINUTES} minutes (Pytest and GoogleTest)"
+          export REGRESSION_DEADLINE_EPOCH=$(( $(date +%s) + 10#${MAX_TESTS_RUN_TIME_MINUTES} * 60 ))
+          echo "REGRESSION_DEADLINE_EPOCH=${REGRESSION_DEADLINE_EPOCH}" >> "$GITHUB_ENV"
         fi
-
-        # Exclude large tests unless explicitly requested
-        if [[ "$FILTER" == "large" ]]; then
-          : # keep as-is, run only large tests
-        elif [[ -n "$FILTER" ]]; then
-          FILTER="(not large) and ($FILTER)"
-        else
-          FILTER="not large"
-        fi
-
-        if [[ "${REGRESSION_JUNIT_KIND}" == 'epoll' ]]; then
-          FILTER="$FILTER and not exclude_epoll"
-          # Run only replication tests with epoll
-          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
-            --json-report --json-report-file=report.json \
-            --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
-            dragonfly --df force_epoll=true "${DF_RUNTIME_ARGS[@]}" --log-cli-level=INFO || code=$?
-        else
-          # Run only replication tests with iouring
-          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
-            --json-report --json-report-file=report.json \
-            --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
-            dragonfly "${DF_RUNTIME_ARGS[@]}" --log-cli-level=INFO || code=$?
-        fi
-
-        # timeout returns 124 if we exceeded the timeout duration
-        if [[ $code -eq 124 ]]; then
-          # Add an extra new line here because when tests timeout the first line below continues from the test failure name
-          echo "\n"
-          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 TESTS TIMEDOUT 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-          # Copy the last log file because we timedout and pytest did not copy it over
-          # the /tmp/failed/ folder
-          cat /tmp/last_test_log_dir.txt | xargs -I {} mv {}/ /tmp/failed/
-          exit 1
-        fi
-
-        # when a test fails in pytest it returns 1 but there are other return codes as well so we just check if the code is non zero
-        if [[ $code -ne 0 ]]; then
-          exit 1
-        fi
+        "${GITHUB_WORKSPACE}/.github/scripts/run-regression-tests-helper.sh" pytest
       env:
+        BUILD_FOLDER_NAME: ${{ inputs.build-folder-name }}
+        REGRESSION_DFLY_EXECUTABLE: ${{ inputs.dfly-executable }}
+        TEST_FILTER: ${{ inputs.filter }}
         # Pass the raw runtime-flags input through the environment so the value is never
         # embedded directly in the shell script (avoids shell injection).
         DF_RUNTIME_FLAGS_INPUT: ${{ inputs.df-runtime-flags }}
+        TEST_SUITES_INPUT: ${{ inputs.test-suites }}
+        TEST_CASES_INPUT: ${{ inputs.test-cases }}
+        ITERATIONS_INPUT: ${{ inputs.iterations }}
+        MAX_TESTS_RUN_TIME_MINUTES: ${{ inputs.max-tests-run-time }}
+        CONTINUE_ON_TEST_FAILURE_INPUT: ${{ inputs.continue-on-test-failure }}
+        DELETE_FAILED_LOGS: ${{ github.event_name == 'workflow_dispatch' && 'false' || 'true' }}
         # Add environment variables to enable the S3 snapshot test.
         # AWS credentials: if inputs provided, use them; otherwise rely on workflow OIDC auth
         DRAGONFLY_S3_BUCKET: ${{ inputs.s3-bucket }}
@@ -206,6 +206,18 @@ runs:
         # Azure credentials for snapshot tests (optional)
         DRAGONFLY_AZURE_CONTAINER: ${{ inputs.azure-container }}
         AZURE_STORAGE_CONNECTION_STRING: ${{ inputs.azure-storage-connection-string }}
+
+    - name: Build and run GoogleTests
+      if: always() && github.event_name == 'workflow_dispatch' && inputs.run-gtests == 'true'
+      shell: bash
+      run: "${GITHUB_WORKSPACE}/.github/scripts/run-regression-tests-helper.sh gtest"
+      env:
+        BUILD_FOLDER_NAME: ${{ inputs.build-folder-name }}
+        GTEST_SUITES_INPUT: ${{ inputs.gtest-suites }}
+        GTEST_CASES_INPUT: ${{ inputs.gtest-cases }}
+        GTEST_ITERATIONS_INPUT: ${{ inputs.gtest-iterations }}
+        MAX_TESTS_RUN_TIME_MINUTES: ${{ inputs.max-tests-run-time }}
+        CONTINUE_ON_TEST_FAILURE_INPUT: ${{ inputs.continue-on-test-failure }}
 
     - name: Upload regression JUnit results
       if: always()

--- a/.github/scripts/run-regression-tests-helper.sh
+++ b/.github/scripts/run-regression-tests-helper.sh
@@ -1,0 +1,459 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# This helper supports scheduled and manually triggered regression runs:
+# 1. Input validation for manual workflow dispatches.
+# 2. Pytest execution for scheduled and manual runs.
+# 3. GoogleTest execution for manual runs only.
+
+PrintCommand() {
+  printf 'Command: '
+  printf '%q ' "$@"
+  printf '\n'
+}
+
+PrintIteration() {
+  printf '\033[32m=== %s iteration %s/%s ===\033[0m\n' "$1" "$2" "$3"
+}
+
+GetDeadlineSeconds() {
+  local max_tests_run_time_minutes=$1
+
+  if [[ -n "${REGRESSION_DEADLINE_EPOCH:-}" ]]; then
+    printf '%s\n' "${REGRESSION_DEADLINE_EPOCH}"
+  elif [[ -z "${max_tests_run_time_minutes}" ]]; then
+    printf '%s\n' ""
+  else
+    printf '%s\n' "$(( $(date +%s) + max_tests_run_time_minutes * 60 ))"
+  fi
+}
+
+PrintBudgetExhausted() {
+  echo "Shared regression time budget of $1 minutes exhausted; this is not an error: test input requested aborting the run"
+}
+
+ExitOnTimeout() {
+  local test_failed=$1
+  local max_tests_run_time_minutes=$2
+
+  if [[ -n "${REGRESSION_DEADLINE_EPOCH:-}" ]]; then
+    PrintBudgetExhausted "${max_tests_run_time_minutes}"
+    [[ "${test_failed}" == true ]] && exit 1
+    exit 0
+  fi
+
+  echo "Scheduled regression test timeout exhausted"
+  exit 1
+}
+
+ArchiveAndCleanPytestLogs() {
+  local iteration=$1
+  local test_failed=$2
+  local junit_file=$3
+  local log_root=/tmp/dragonfly_logs
+
+  if [[ "${test_failed}" == true ]]; then
+    local archive_dir=/tmp/failed
+    local archive_path="${archive_dir}/iteration_${iteration}_logs.tar.gz"
+    local start_seconds=$SECONDS
+
+    mkdir -p "${archive_dir}"
+    if ! python3 "${GITHUB_WORKSPACE}/.github/scripts/write-pytest-failure-report.py" \
+      "${junit_file}" "${iteration}" "${archive_dir}/pytest-failures-by-iteration.txt"; then
+      echo "Failed to write Pytest failure report for iteration ${iteration} (continuing)"
+    fi
+    if [[ ! -d "${log_root}" ]]; then
+      echo "No Pytest logs found for failed iteration ${iteration}"
+      return
+    fi
+    echo "Archiving Pytest logs from iteration ${iteration}: ${archive_path}"
+    if ! tar -czf "${archive_path}" -C /tmp dragonfly_logs; then
+      echo "Failed to archive Pytest logs from iteration ${iteration}"
+      return 1
+    fi
+    echo "Archived Pytest logs from iteration ${iteration} in $((SECONDS - start_seconds)) seconds"
+  elif [[ ! -d "${log_root}" ]]; then
+    return
+  fi
+
+  rm -rf "${log_root}"
+  echo "Removed Pytest logs from iteration ${iteration}"
+}
+
+ValidateInputs() {
+  ITERATIONS_INPUT=${ITERATIONS_INPUT:-1}
+
+  if ! [[ "${ITERATIONS_INPUT}" =~ ^[0-9]+$ ]]; then
+    echo "iterations must be a non-negative integer, got: ${ITERATIONS_INPUT}"
+    exit 2
+  fi
+  ITERATIONS_INPUT=$((10#${ITERATIONS_INPUT}))
+
+  if [[ -n "${GTEST_ITERATIONS_INPUT}" ]] && \
+     ! [[ "${GTEST_ITERATIONS_INPUT}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "gtest-iterations must be a positive integer, got: ${GTEST_ITERATIONS_INPUT}"
+    exit 2
+  fi
+  if [[ -n "${GTEST_ITERATIONS_INPUT}" ]]; then
+    GTEST_ITERATIONS_INPUT=$((10#${GTEST_ITERATIONS_INPUT}))
+  fi
+
+  if [[ -n "${MAX_TESTS_RUN_TIME_INPUT}" ]] && ! [[ "${MAX_TESTS_RUN_TIME_INPUT}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "max-tests-run-time must be a positive integer, got: ${MAX_TESTS_RUN_TIME_INPUT}"
+    exit 2
+  fi
+
+  if [[ -n "${MAX_TESTS_RUN_TIME_INPUT}" ]] && ((10#${MAX_TESTS_RUN_TIME_INPUT} > 360)); then
+    echo "max-tests-run-time must be between 1 and 360 minutes, got: ${MAX_TESTS_RUN_TIME_INPUT}"
+    exit 2
+  fi
+  if [[ -n "${MAX_TESTS_RUN_TIME_INPUT}" ]]; then
+    MAX_TESTS_RUN_TIME_INPUT=$((10#${MAX_TESTS_RUN_TIME_INPUT}))
+  fi
+
+  case "${CONTINUE_ON_TEST_FAILURE_INPUT}" in
+    true|false) ;;
+    *)
+      echo "continue-on-test-failure must be true or false, got: ${CONTINUE_ON_TEST_FAILURE_INPUT}"
+      exit 2
+      ;;
+  esac
+
+  if [[ -n "${TEST_CASES_INPUT}" ]]; then
+    regex_status=0
+    grep -E -q -- "${TEST_CASES_INPUT}" /dev/null || regex_status=$?
+    if [[ "${regex_status}" -eq 2 ]]; then
+      echo "test-cases is not a valid extended regular expression: ${TEST_CASES_INPUT}"
+      exit 2
+    fi
+  fi
+
+  NormalizePytestSuites
+}
+
+NormalizePytestSuites() {
+  NORMALIZED_TEST_PATHS=()
+  [[ -z "${TEST_SUITES_INPUT}" ]] && return
+
+  normalized_suites="${TEST_SUITES_INPUT//,/ }"
+  for suite in ${normalized_suites}; do
+    suite="${suite#tests/dragonfly/}"
+    suite="${suite%.py}.py"
+    if [[ "${suite}" == /* || "${suite}" == .. || "${suite}" == ../* || \
+          "${suite}" == */../* || "${suite}" == */.. ]]; then
+      echo "Test suite must be relative to tests/dragonfly: ${suite}"
+      exit 2
+    fi
+    suite="dragonfly/${suite}"
+    if [[ ! -f "${GITHUB_WORKSPACE}/tests/${suite}" ]]; then
+      echo "Test suite not found: ${suite}"
+      exit 2
+    fi
+    NORMALIZED_TEST_PATHS+=("${suite}")
+  done
+}
+
+RunPytests() {
+  MAX_TESTS_RUN_TIME_INPUT="${MAX_TESTS_RUN_TIME_MINUTES}"
+  ValidateInputs
+  if [[ "${ITERATIONS_INPUT}" -eq 0 ]]; then
+    echo "Pytest iterations set to 0; skipping Pytest"
+    return 0
+  fi
+  max_tests_run_time_minutes=${MAX_TESTS_RUN_TIME_INPUT}
+  deadline_seconds=$(GetDeadlineSeconds "${max_tests_run_time_minutes}")
+
+  if [[ "${DELETE_FAILED_LOGS:-true}" == false ]]; then
+    rm -rf /tmp/failed
+    mkdir -p /tmp/failed
+  fi
+
+  ls -l ${GITHUB_WORKSPACE}/
+  cd ${GITHUB_WORKSPACE}/tests || exit 2
+  echo "Current commit is ${GITHUB_SHA}"
+  # used by PyTests
+  export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${BUILD_FOLDER_NAME}/${REGRESSION_DFLY_EXECUTABLE}"
+  export ROOT_DIR="${GITHUB_WORKSPACE}/tests/dragonfly/valkey_search"
+  export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
+  export FILTER="${TEST_FILTER}"
+  JUNIT_DIR="${REGRESSION_JUNIT_DIR}"
+
+  # Runtime flags forwarded to the dragonfly process via --df.
+  # Globbing is disabled while splitting so values like vmodule=*=1 are preserved,
+  # and the flags are collected into an array to avoid re-splitting/globbing
+  # when expanded on the pytest command line.
+  DF_RUNTIME_ARGS=()
+  if [[ -n "${DF_RUNTIME_FLAGS_INPUT}" ]]; then
+    set -f # disables filename expansion (globbing)
+    for flag in ${DF_RUNTIME_FLAGS_INPUT}; do
+      DF_RUNTIME_ARGS+=(--df "$flag")
+    done
+    set +f
+  fi
+
+  # Exclude large tests unless explicitly requested
+  if [[ "$FILTER" == "large" ]]; then
+    : # keep as-is, run only large tests
+  elif [[ -n "$FILTER" ]]; then
+    FILTER="(not large) and ($FILTER)"
+  else
+    FILTER="not large"
+  fi
+
+  if [[ "${REGRESSION_JUNIT_KIND}" == 'epoll' ]]; then
+    FILTER="$FILTER and not exclude_epoll"
+  fi
+
+  test_paths=()
+  if [[ -n "${TEST_SUITES_INPUT}" ]]; then
+    test_paths=("${NORMALIZED_TEST_PATHS[@]}")
+  else
+    test_paths=(dragonfly)
+  fi
+
+  selected_tests=()
+  if [[ -n "${TEST_CASES_INPUT}" ]]; then
+    if [[ -n "${deadline_seconds}" ]]; then
+      remaining_seconds=$((deadline_seconds - $(date +%s)))
+      if [[ "${remaining_seconds}" -le 0 ]]; then
+        ExitOnTimeout false "${max_tests_run_time_minutes}"
+      fi
+    else
+      remaining_seconds=""
+    fi
+    pytest_collect_command=(pytest -m "${FILTER}" --collect-only -q --color=no "${test_paths[@]}")
+    if [[ -n "${remaining_seconds}" ]]; then
+      pytest_collect_command=(timeout "${remaining_seconds}s" "${pytest_collect_command[@]}")
+    fi
+    collection_output_file=$(mktemp)
+    collection_code=0
+    "${pytest_collect_command[@]}" >"${collection_output_file}" 2>/dev/null || collection_code=$?
+    if [[ "${collection_code}" -eq 124 ]]; then
+      rm -f "${collection_output_file}"
+      ExitOnTimeout false "${max_tests_run_time_minutes}"
+    fi
+    if [[ "${collection_code}" -ne 0 ]]; then
+      cat "${collection_output_file}"
+      rm -f "${collection_output_file}"
+      exit "${collection_code}"
+    fi
+    mapfile -t selected_tests < <(
+      grep -E '^dragonfly/.*\.py::' "${collection_output_file}" | grep -E -- "${TEST_CASES_INPUT}" || true
+    )
+    rm -f "${collection_output_file}"
+    if [[ "${#selected_tests[@]}" -eq 0 ]]; then
+      echo "No tests matched test-cases regex: ${TEST_CASES_INPUT}"
+      exit 2
+    fi
+  else
+    selected_tests=("${test_paths[@]}")
+  fi
+
+  pytest_failed=false
+  for iteration in $(seq 1 "${ITERATIONS_INPUT}"); do
+    PrintIteration "Regression test" "${iteration}" "${ITERATIONS_INPUT}"
+    junit_file="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}-${iteration}.xml"
+    if [[ -n "${deadline_seconds}" ]]; then
+      remaining_seconds=$((deadline_seconds - $(date +%s)))
+      if [[ "${remaining_seconds}" -le 0 ]]; then
+        ExitOnTimeout "${pytest_failed}" "${max_tests_run_time_minutes}"
+      fi
+    else
+      remaining_seconds=""
+    fi
+    code=0
+    if [[ "${REGRESSION_JUNIT_KIND}" == "epoll" ]]; then
+      # Run only replication tests with epoll
+      pytest_command=(pytest -m "${FILTER}" --durations=10
+        --timeout=300 --color=yes --json-report --json-report-file=report.json
+        --junitxml="${junit_file}" "${selected_tests[@]}" --df force_epoll=true
+        "${DF_RUNTIME_ARGS[@]}" --log-cli-level=INFO)
+    else
+      # Run only replication tests with iouring
+      pytest_command=(pytest -m "${FILTER}" --durations=10
+        --timeout=300 --color=yes --json-report --json-report-file=report.json
+        --junitxml="${junit_file}" "${selected_tests[@]}" "${DF_RUNTIME_ARGS[@]}"
+        --log-cli-level=INFO)
+    fi
+    if [[ -n "${remaining_seconds}" ]]; then
+      pytest_command=(timeout "${remaining_seconds}s" "${pytest_command[@]}")
+    else
+      pytest_command=(timeout 80m "${pytest_command[@]}")
+    fi
+    PrintCommand "${pytest_command[@]}"
+    "${pytest_command[@]}" || code=$?
+
+    # timeout returns 124 if we exceeded the timeout duration
+    if [[ "${code}" -eq 124 ]]; then
+      # Add an extra new line here because when tests timeout the first line below continues from the test failure name
+      echo "\n"
+      echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
+      echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 TESTS TIMEDOUT 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
+      echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
+      # Copy the last log file because we timed out and pytest did not copy it
+      # to the /tmp/failed/ folder.
+      if [[ -f /tmp/last_test_log_dir.txt ]]; then
+        while IFS= read -r log_dir; do
+          if [[ -d "${log_dir}" ]]; then
+            mkdir -p /tmp/failed
+            mv "${log_dir}" /tmp/failed/
+          fi
+        done </tmp/last_test_log_dir.txt
+      fi
+      ExitOnTimeout "${pytest_failed}" "${max_tests_run_time_minutes}"
+    fi
+
+    if [[ "${code}" -eq 0 ]]; then
+      if [[ "${CONTINUE_ON_TEST_FAILURE_INPUT}" == true ]]; then
+        ArchiveAndCleanPytestLogs "${iteration}" false "${junit_file}" || exit 1
+      fi
+      continue
+    fi
+    if [[ "${code}" -eq 1 ]]; then
+      pytest_failed=true
+      if [[ "${CONTINUE_ON_TEST_FAILURE_INPUT}" == true ]]; then
+        ArchiveAndCleanPytestLogs "${iteration}" true "${junit_file}" || exit 1
+        continue
+      fi
+    fi
+    # when a test fails in pytest it returns 1 but there are other return codes as well so we just check if the code is non zero
+    exit "${code}"
+  done
+
+  if [[ "${pytest_failed}" == true ]]; then
+    exit 1
+  fi
+}
+
+RunGtests() {
+  if [[ -z "${GTEST_ITERATIONS_INPUT}" ]]; then
+    GTEST_ITERATIONS_INPUT=1
+  fi
+  MAX_TESTS_RUN_TIME_INPUT="${MAX_TESTS_RUN_TIME_MINUTES}"
+  ValidateInputs
+  max_tests_run_time_minutes=${MAX_TESTS_RUN_TIME_INPUT}
+  deadline_seconds=$(GetDeadlineSeconds "${max_tests_run_time_minutes}")
+
+  cd "${GITHUB_WORKSPACE}" || exit 2
+  mapfile -t available_gtest_suites < <(
+    find src/core src/facade src/server -name CMakeLists.txt -print0 |
+      xargs -0 grep -hE '^[[:space:]]*helio_cxx_test\(' |
+      sed -E 's/^[[:space:]]*helio_cxx_test\(([[:alnum:]_/-]+).*/\1/' |
+      awk -F/ '{print $NF}' | sort -u
+  )
+  if [[ "${#available_gtest_suites[@]}" -eq 0 ]]; then
+    echo "No GoogleTest suites were discovered under src/core, src/facade, or src/server"
+    exit 2
+  fi
+
+  selected_gtest_suites=()
+  if [[ -n "${GTEST_SUITES_INPUT}" ]]; then
+    normalized_suites="${GTEST_SUITES_INPUT//,/ }"
+    for suite in ${normalized_suites}; do
+      suite="${suite##*/}"
+      suite="${suite%.cc}"
+      if ! printf '%s\n' "${available_gtest_suites[@]}" | grep -Fxq -- "${suite}"; then
+        echo "GoogleTest suite not found: ${suite}"
+        exit 2
+      fi
+      selected_gtest_suites+=("${suite}")
+    done
+  else
+    selected_gtest_suites=("${available_gtest_suites[@]}")
+  fi
+
+  echo "Building GoogleTest suites: ${selected_gtest_suites[*]}"
+  cd "${GITHUB_WORKSPACE}/${BUILD_FOLDER_NAME}" || exit 2
+  if [[ -n "${deadline_seconds}" ]]; then
+    remaining_seconds=$((deadline_seconds - $(date +%s)))
+    if [[ "${remaining_seconds}" -le 0 ]]; then
+      ExitOnTimeout false "${max_tests_run_time_minutes}"
+    fi
+  else
+    remaining_seconds=""
+  fi
+  gtest_build_code=0
+  gtest_build_command=(ninja "${selected_gtest_suites[@]}")
+  if [[ -n "${remaining_seconds}" ]]; then
+    gtest_build_command=(timeout "${remaining_seconds}s" "${gtest_build_command[@]}")
+  fi
+  PrintCommand "${gtest_build_command[@]}"
+  "${gtest_build_command[@]}" || gtest_build_code=$?
+  if [[ "${gtest_build_code}" -eq 124 ]]; then
+    ExitOnTimeout false "${max_tests_run_time_minutes}"
+  fi
+  if [[ "${gtest_build_code}" -ne 0 ]]; then
+    exit "${gtest_build_code}"
+  fi
+
+  gtest_failed=false
+  for iteration in $(seq 1 "${GTEST_ITERATIONS_INPUT}"); do
+    PrintIteration "GoogleTest" "${iteration}" "${GTEST_ITERATIONS_INPUT}"
+    for suite in "${selected_gtest_suites[@]}"; do
+      if [[ -n "${deadline_seconds}" ]]; then
+        remaining_seconds=$((deadline_seconds - $(date +%s)))
+        if [[ "${remaining_seconds}" -le 0 ]]; then
+          ExitOnTimeout "${gtest_failed}" "${max_tests_run_time_minutes}"
+        fi
+      else
+        remaining_seconds=""
+      fi
+      binary_path=$(find "${GITHUB_WORKSPACE}/${BUILD_FOLDER_NAME}" -type f -name "${suite}" \
+        -executable -print -quit)
+      if [[ -z "${binary_path}" ]]; then
+        echo "Built GoogleTest executable not found: ${suite}"
+        exit 2
+      fi
+
+      gtest_args=()
+      if [[ -n "${GTEST_CASES_INPUT}" ]]; then
+        gtest_args+=("--gtest_filter=${GTEST_CASES_INPUT}")
+      fi
+      code=0
+      gtest_command=("${binary_path}" "${gtest_args[@]}")
+      if [[ -n "${remaining_seconds}" ]]; then
+        gtest_command=(timeout "${remaining_seconds}s" "${gtest_command[@]}")
+      fi
+      PrintCommand "${gtest_command[@]}"
+      gtest_output_file=$(mktemp)
+      "${gtest_command[@]}" >"${gtest_output_file}" 2>&1 || code=$?
+      cat "${gtest_output_file}"
+      if [[ -n "${GTEST_CASES_INPUT}" ]] && \
+        (grep -Eq 'filter ".*" did not match any test; no tests were run' "${gtest_output_file}" || \
+         grep -Eq '\[ *PASSED *\] 0 tests\.' "${gtest_output_file}"); then
+        echo "Skipping ${suite}: GoogleTest filter matched no tests: ${GTEST_CASES_INPUT}"
+        rm -f "${gtest_output_file}"
+        continue
+      fi
+      rm -f "${gtest_output_file}"
+      if [[ "${code}" -eq 124 ]]; then
+        ExitOnTimeout "${gtest_failed}" "${max_tests_run_time_minutes}"
+      fi
+      if [[ "${code}" -eq 0 ]]; then
+        continue
+      fi
+      if [[ "${code}" -eq 1 ]]; then
+        gtest_failed=true
+        if [[ "${CONTINUE_ON_TEST_FAILURE_INPUT}" == true ]]; then
+          continue
+        fi
+      fi
+      exit "${code}"
+    done
+  done
+
+  if [[ "${gtest_failed}" == true ]]; then
+    exit 1
+  fi
+}
+
+case "${1:-}" in
+  validate) ValidateInputs ;;
+  pytest) RunPytests ;;
+  gtest) RunGtests ;;
+  *)
+    echo "Usage: $0 {validate|pytest|gtest}"
+    exit 2
+    ;;
+esac

--- a/.github/scripts/write-pytest-failure-report.py
+++ b/.github/scripts/write-pytest-failure-report.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Append failed Pytest cases for manual regression workflow artifacts.
+
+The utility is used for failed iterations when manual regression runs are
+enabled; it is not part of the scheduled regression workflow.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} JUNIT_XML ITERATION OUTPUT_FILE", file=sys.stderr)
+        return 2
+
+    junit_file = Path(sys.argv[1])
+    iteration = sys.argv[2]
+    output_file = Path(sys.argv[3])
+
+    if not junit_file.is_file():
+        print(f"JUnit XML not found: {junit_file}", file=sys.stderr)
+        return 1
+
+    try:
+        root = ET.parse(junit_file).getroot()
+    except ET.ParseError as error:
+        print(f"Could not parse JUnit XML {junit_file}: {error}", file=sys.stderr)
+        return 1
+
+    failed_tests = []
+    for testcase in root.iter():
+        if local_name(testcase.tag) != "testcase":
+            continue
+        if any(local_name(child.tag) in {"failure", "error"} for child in testcase):
+            classname = testcase.attrib.get("classname", "")
+            name = testcase.attrib.get("name", "unknown")
+            failed_tests.append(f"{classname}::{name}" if classname else name)
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with output_file.open("a", encoding="utf-8") as output:
+        output.write(f"Pytest iteration {iteration}\n")
+        if failed_tests:
+            output.writelines(f"  {test_name}\n" for test_name in failed_tests)
+        else:
+            output.write("  No failed test cases were recorded in the JUnit XML.\n")
+        output.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -4,11 +4,58 @@ on:
   schedule:
     - cron: "0 0/3 * * *"
   workflow_dispatch:
+    inputs:
+      # Pytest - manual trigger inputs
+      test-suites:
+        description: "Pytest: optional filenames; empty runs all Pytest suites. See .github/REGRESSION-TESTS.md for details. Example: connection_test,eval_test"
+        required: false
+        default: ""
+        type: string
+      test-cases:
+        description: "Pytest: optional node ID regex. Example: test_golang_asynq_script|test_shared_read_buffer_overflow_copy_metric"
+        required: false
+        default: ""
+        type: string
+      iterations:
+        description: "Pytest: optional number of iterations. Default: 1. Example: 12"
+        required: false
+        default: "1"
+        type: string
+
+      # GoogleTest - manual trigger inputs.
+      gtest-suites:
+        description: "GoogleTest: manual runs only; optional targets, empty runs every target. Example: dfly_core_test,redis_parser_test"
+        required: false
+        default: ""
+        type: string
+      gtest-cases:
+        description: "GoogleTest: optional --gtest_filter. Example: StringMapTest.*:DashTest.*"
+        required: false
+        default: ""
+        type: string
+      gtest-iterations:
+        description: "GoogleTest: optional number of iterations. Default: 1. Example: 12"
+        required: false
+        default: "1"
+        type: string
+
+      # Common inputs.
+      max-tests-run-time:
+        description: "Common: combined time limit (minutes) for Pytest and GoogleTest runs; Default: 360"
+        required: false
+        default: "360"
+        type: string
+      continue-on-test-failure:
+        description: "Common: failure handling for Pytest and GoogleTest; true completes iterations, archives failed Pytest logs, and deletes clean logs."
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
     if: github.repository == 'dragonflydb/dragonfly'
     strategy:
+      fail-fast: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs['continue-on-test-failure'] != 'true' }}
       matrix:
         # Test of these containers
         container: ["ubuntu-dev:24"]
@@ -34,6 +81,20 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+
+      - name: Init Manual runs
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          ITERATIONS_INPUT: ${{ inputs.iterations || '1' }}
+          TEST_SUITES_INPUT: ${{ inputs['test-suites'] || '' }}
+          TEST_CASES_INPUT: ${{ inputs['test-cases'] || '' }}
+          GTEST_SUITES_INPUT: ${{ inputs['gtest-suites'] || '' }}
+          GTEST_ITERATIONS_INPUT: ${{ inputs['gtest-iterations'] || '' }}
+          MAX_TESTS_RUN_TIME_INPUT: ${{ inputs['max-tests-run-time'] || '' }}
+          CONTINUE_ON_TEST_FAILURE_INPUT: ${{ inputs['continue-on-test-failure'] || 'false' }}
+        run: |
+          .github/scripts/run-regression-tests-helper.sh validate
 
       - name: Print environment info
         run: |
@@ -67,6 +128,15 @@ jobs:
           gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not empty' || 'not opt_only' }}
+          test-suites: ${{ inputs['test-suites'] || '' }}
+          test-cases: ${{ inputs['test-cases'] || '' }}
+          iterations: ${{ inputs.iterations || '1' }}
+          max-tests-run-time: ${{ inputs['max-tests-run-time'] || '' }}
+          gtest-suites: ${{ inputs['gtest-suites'] || '' }}
+          gtest-cases: ${{ inputs['gtest-cases'] || '' }}
+          gtest-iterations: ${{ inputs['gtest-iterations'] || '' }}
+          run-gtests: 'true'
+          continue-on-test-failure: ${{ inputs['continue-on-test-failure'] || 'false' }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -4,11 +4,58 @@ on:
   schedule:
     - cron: "0 0/3 * * *"
   workflow_dispatch:
+    inputs:
+      # Pytest - manual trigger inpu
+      test-suites:
+        description: "Pytest: optional filenames; empty runs all Pytest suites. See .github/REGRESSION-TESTS.md for details. Example: connection_test,eval_test"
+        required: false
+        default: ""
+        type: string
+      test-cases:
+        description: "Pytest: optional node ID regex. Example: test_golang_asynq_script|test_shared_read_buffer_overflow_copy_metric"
+        required: false
+        default: ""
+        type: string
+      iterations:
+        description: "Pytest: optional number of iterations. Default: 1. Example: 12"
+        required: false
+        default: "1"
+        type: string
+
+      # GoogleTest - manual trigger inputs.
+      gtest-suites:
+        description: "GoogleTest: manual runs only; optional targets, empty runs every target. Example: dfly_core_test,redis_parser_test"
+        required: false
+        default: ""
+        type: string
+      gtest-cases:
+        description: "GoogleTest: optional --gtest_filter. Example: StringMapTest.*:DashTest.*"
+        required: false
+        default: ""
+        type: string
+      gtest-iterations:
+        description: "GoogleTest: optional number of iterations. Default: 1. Example: 12"
+        required: false
+        default: "1"
+        type: string
+
+      # Common inputs.
+      max-tests-run-time:
+        description: "Common: combined time limit (minutes) for Pytest and GoogleTest runs; Default: 360"
+        required: false
+        default: "360"
+        type: string
+      continue-on-test-failure:
+        description: "Common: failure handling for Pytest and GoogleTest; true completes iterations, archives failed Pytest logs, and deletes clean logs."
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
     if: github.repository == 'dragonflydb/dragonfly'
     strategy:
+      fail-fast: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs['continue-on-test-failure'] != 'true' }}
       matrix:
         # Test of these containers
         container: ["ubuntu-dev:24"]
@@ -35,6 +82,20 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+
+      - name: Init Manual runs
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          ITERATIONS_INPUT: ${{ inputs.iterations || '1' }}
+          TEST_SUITES_INPUT: ${{ inputs['test-suites'] || '' }}
+          TEST_CASES_INPUT: ${{ inputs['test-cases'] || '' }}
+          GTEST_SUITES_INPUT: ${{ inputs['gtest-suites'] || '' }}
+          GTEST_ITERATIONS_INPUT: ${{ inputs['gtest-iterations'] || '' }}
+          MAX_TESTS_RUN_TIME_INPUT: ${{ inputs['max-tests-run-time'] || '' }}
+          CONTINUE_ON_TEST_FAILURE_INPUT: ${{ inputs['continue-on-test-failure'] || 'false' }}
+        run: |
+          .github/scripts/run-regression-tests-helper.sh validate
 
       - name: Print environment info
         run: |
@@ -69,6 +130,15 @@ jobs:
           gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only' || 'not opt_only' }}
+          test-suites: ${{ inputs['test-suites'] || '' }}
+          test-cases: ${{ inputs['test-cases'] || '' }}
+          iterations: ${{ inputs.iterations || '1' }}
+          max-tests-run-time: ${{ inputs['max-tests-run-time'] || '' }}
+          gtest-suites: ${{ inputs['gtest-suites'] || '' }}
+          gtest-cases: ${{ inputs['gtest-cases'] || '' }}
+          gtest-iterations: ${{ inputs['gtest-iterations'] || '' }}
+          run-gtests: 'true'
+          continue-on-test-failure: ${{ inputs['continue-on-test-failure'] || 'false' }}
           df-runtime-flags: enable_resp_io_loop_v2=${{ matrix.enable_resp_io_loop_v2 }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -148,8 +148,10 @@ _minio_data_dir = None
 def pytest_configure(config):
     global _minio_proc, _minio_data_dir
 
-    # clean everything
-    if os.path.exists(FAILED_PATH):
+    # Clean everything - unless  explicitly requested not to
+    if os.environ.get("DELETE_FAILED_LOGS", "true").lower() == "true" and os.path.exists(
+        FAILED_PATH
+    ):
         shutil.rmtree(FAILED_PATH)
     if os.path.exists(BASE_LOG_DIR):
         shutil.rmtree(BASE_LOG_DIR)


### PR DESCRIPTION
Allow targeted, repeated Pytest and GoogleTest runs to reproduce intermittent regressions without affecting scheduled workflows.

Add validation, a shared manual time budget, failure continuation, and per-iteration Pytest log archives and failure reports.

Update Pytest setup to retain failed logs across manual iterations.

See .github/REGRESSION-TESTS.md for workflow inputs and details.

**Note**: As large part of this PR is due to documentation, workflow refactoring, and boilerplate code.

<img width="481" height="934" alt="image" src="https://github.com/user-attachments/assets/cb77a884-d8bf-4c1b-8322-7ef3a53fe011" />
<img width="591" height="996" alt="image" src="https://github.com/user-attachments/assets/9fabd780-9aef-4caa-b549-54181ef26e06" />

Examples:
https://github.com/dragonflydb/dragonfly/actions/runs/33369764132/job/99417940390
<img width="2107" height="1373" alt="image" src="https://github.com/user-attachments/assets/6acf31b4-2628-4eb4-b8e4-3fc81b1432a6" />

