### PR TITLE
fix: restore shard_repl_backlog_len for compatibility

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -489,8 +489,8 @@ bool DflyCmd::IsLSNInPartialSyncBuffer(LSN lsn) const {
     LOG(INFO) << "Partial sync requested from stale LSN=" << lsn
               << " that the replication buffer doesn't contain this anymore (current_lsn="
               << journal::GetLsn() << "). Will perform a full sync of the data.";
-    LOG(INFO) << "If this happens often, increase --shard_repl_backlog_time_ms or "
-                 "--shard_repl_backlog_max_bytes.";
+    LOG(INFO) << "If this happens often, increase --shard_repl_backlog_len in legacy mode, or "
+                 "--shard_repl_backlog_time_ms/--shard_repl_backlog_max_bytes otherwise.";
   }
   return exists;
 }

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -5,11 +5,14 @@
 #include "server/journal/journal_slice.h"
 
 #include <absl/flags/flag.h>
+#include <absl/flags/parse.h>
+#include <absl/flags/reflection.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
 #include <fcntl.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <filesystem>
 
 #include "base/function2.hpp"
@@ -20,15 +23,17 @@
 #include "strings/human_readable.h"
 #include "util/fibers/fibers.h"
 
-ABSL_RETIRED_FLAG(uint32_t, shard_repl_backlog_len, 0,
-                  "Deprecated. Use --shard_repl_backlog_time_ms and "
-                  "--shard_repl_backlog_max_bytes instead.");
+ABSL_FLAG(uint32_t, shard_repl_backlog_len, 0,
+          "Legacy maximum number of entries retained by each shard's replication backlog. "
+          "A nonzero value disables time- and byte-based eviction unless either new backlog "
+          "limit flag is explicitly configured.");
 ABSL_FLAG(uint32_t, shard_repl_backlog_time_ms, 5000,
           "Target retention age in milliseconds of entries in the per-shard replication backlog. "
           "Entries older than this are evicted on later journal writes. 0 disables time-based "
           "eviction.");
 ABSL_FLAG(strings::MemoryBytesFlag, shard_repl_backlog_max_bytes, 0,
-          "Total bytes retained by replication backlog. 0 (the default) uses 0.5% of maxmemory.");
+          "Maximum bytes retained by each shard's replication backlog. 0 (the default) uses "
+          "maxmemory / shard count / 200.");
 
 namespace dfly {
 namespace journal {
@@ -38,15 +43,29 @@ using namespace util;
 namespace {
 constexpr size_t kMaxTimeEvictionsPerCall = 100;
 
+bool IsFlagConfigured(const absl::CommandLineFlag& handle) {
+  // DFLY_ environment flags are parsed programmatically (see ParseFlagsFromEnv) and do not set
+  // Abseil's command-line marker. Check their presence separately so an explicitly configured
+  // flag selects the new mode even when its value equals the default one.
+  return absl::flags_internal::WasPresentOnCommandLine(handle.Name()) ||
+         handle.CurrentValue() != handle.DefaultValue() ||
+         std::getenv(absl::StrCat("DFLY_", handle.Name()).c_str()) != nullptr;
+}
+
+bool AreNewBacklogLimitsConfigured() {
+  return IsFlagConfigured(absl::GetFlagReflectionHandle(FLAGS_shard_repl_backlog_time_ms)) ||
+         IsFlagConfigured(absl::GetFlagReflectionHandle(FLAGS_shard_repl_backlog_max_bytes));
+}
+
 size_t GetPerShardBacklogMaxBytes() {
-  size_t total_max_bytes = absl::GetFlag(FLAGS_shard_repl_backlog_max_bytes).value;
-  if (total_max_bytes == 0) {
-    constexpr size_t kBacklogMemoryFraction = 200;
-    total_max_bytes = max_memory_limit.load(memory_order_relaxed) / kBacklogMemoryFraction;
+  const size_t per_shard_max_bytes = absl::GetFlag(FLAGS_shard_repl_backlog_max_bytes).value;
+  if (per_shard_max_bytes != 0) {
+    return per_shard_max_bytes;
   }
 
+  constexpr size_t kBacklogMemoryFraction = 200;
   const size_t shard_count = shard_set ? max<size_t>(1, shard_set->size()) : 1;
-  return total_max_bytes / shard_count;
+  return max_memory_limit.load(memory_order_relaxed) / shard_count / kBacklogMemoryFraction;
 }
 
 }  // namespace
@@ -62,8 +81,17 @@ void JournalSlice::Init() {
   if (ring_buffer_.capacity() > 0)
     return;
 
-  constexpr size_t kDefaultBacklogCapacity = 8192;
-  ring_buffer_.set_capacity(kDefaultBacklogCapacity);
+  const uint32_t legacy_entry_limit = absl::GetFlag(FLAGS_shard_repl_backlog_len);
+  if (legacy_entry_limit != 0 && !AreNewBacklogLimitsConfigured()) {
+    LOG_FIRST_N(WARNING, 1) << "Using deprecated --shard_repl_backlog_len=" << legacy_entry_limit
+                            << ". Time- and byte-based backlog eviction is disabled. Prefer "
+                               "--shard_repl_backlog_time_ms/--shard_repl_backlog_max_bytes.";
+    use_legacy_entry_limit_ = true;
+    ring_buffer_.set_capacity(legacy_entry_limit);
+    return;
+  }
+
+  ring_buffer_.set_capacity(8192);
   max_age_ms_ = absl::GetFlag(FLAGS_shard_repl_backlog_time_ms);
   max_bytes_ = GetPerShardBacklogMaxBytes();
 }
@@ -174,6 +202,15 @@ size_t JournalSlice::ItemBytes(const JournalItem& item) {
 }
 
 void JournalSlice::CleanEntries(size_t next_item_bytes, uint64_t now_ms) {
+  if (use_legacy_entry_limit_) {
+    if (ring_buffer_.full()) {
+      const size_t evicted_item_bytes = ItemBytes(ring_buffer_.front());
+      DCHECK_GE(ring_buffer_bytes_, evicted_item_bytes);
+      ring_buffer_bytes_ -= evicted_item_bytes;
+    }
+    return;
+  }
+
   size_t retained_bytes = ring_buffer_bytes_;
   size_t time_evictions = 0;
   size_t bytes_to_free = 0;

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -90,6 +90,7 @@ class JournalSlice {
   uint32_t next_cb_id_ = 1;
   std::error_code status_ec_;
   bool enable_journal_flush_ = true;
+  bool use_legacy_entry_limit_ = false;
 
   uint32_t max_age_ms_ = 0;
   size_t max_bytes_ = 0;

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -22,6 +22,7 @@
 
 ABSL_DECLARE_FLAG(uint32_t, shard_repl_backlog_time_ms);
 ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, shard_repl_backlog_max_bytes);
+ABSL_DECLARE_FLAG(uint32_t, shard_repl_backlog_len);
 
 using namespace testing;
 using namespace std;
@@ -211,6 +212,68 @@ void AddSetRecord(JournalSlice* slice, string_view value) {
   array<string_view, 2> args{"key", value};
   slice->AddLogRecord(
       Entry{0, Op::COMMAND, 0, nullopt, Entry::Payload{"SET", ArgSlice{args.data(), args.size()}}});
+}
+
+TEST(Journal, BacklogSupportsLegacyEntryLimit) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_len, 2u);
+
+  JournalSlice slice;
+  slice.Init();
+
+  AddSetRecord(&slice, "value");
+  AddSetRecord(&slice, "value");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 2u);
+  EXPECT_TRUE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+  EXPECT_GT(slice.GetRingBufferBytes(), 1u);
+  const size_t retained_bytes = slice.GetRingBufferBytes();
+
+  AddSetRecord(&slice, "value");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 2u);
+  EXPECT_EQ(slice.GetRingBufferBytes(), retained_bytes);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+  EXPECT_TRUE(slice.IsLSNInBuffer(3));
+}
+
+TEST(Journal, BacklogByteLimitOverridesLegacyEntryLimit) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_len, 2u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_max_bytes, strings::MemoryBytesFlag{1});
+
+  JournalSlice slice;
+  slice.Init();
+
+  AddSetRecord(&slice, "value");
+  AddSetRecord(&slice, "value");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
+}
+
+TEST(Journal, BacklogTimeLimitOverridesLegacyEntryLimit) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_len, 2u);
+  absl::SetFlag(&FLAGS_shard_repl_backlog_time_ms, 1u);
+
+  const uint64_t original_time = TEST_current_time_ms;
+  auto restore_time = absl::MakeCleanup([original_time] { TEST_current_time_ms = original_time; });
+
+  JournalSlice slice;
+  slice.Init();
+
+  TEST_current_time_ms = 1000;
+  AddSetRecord(&slice, "value");
+  TEST_current_time_ms = 1001;
+  AddSetRecord(&slice, "value");
+
+  EXPECT_EQ(slice.GetRingBufferSize(), 1u);
+  EXPECT_FALSE(slice.IsLSNInBuffer(1));
+  EXPECT_TRUE(slice.IsLSNInBuffer(2));
 }
 
 TEST(Journal, BacklogHonorsByteLimitAndReplacesOversizedRecord) {


### PR DESCRIPTION
Address comments from #8039

Summary: Restores shard_repl_backlog_len as a supported legacy replication-backlog setting for compatibility.

Changes:

- Selects entry-count retention when the legacy flag is nonzero and neither modern limit is configured.
- Detects explicit command-line and `DFLY_` environment configuration so modern limits take precedence.
- Tracks overwritten entry bytes correctly in legacy circular-buffer mode and updates backlog limit documentation.
- Adds unit coverage for legacy retention and precedence of byte- and time-based limits.