### PR TITLE
fix(generic): stop RM from freeing a container under a yielding iteration

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -775,28 +775,73 @@ uint64_t ScanGeneric(uint64_t cursor, const ScanOpts& scan_opts, StringVec* keys
   return cursor;
 }
 
-void OpScanAndDelete(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor,
+// A container walk (e.g. SORT_RO yielding inside container_utils::Iterate*) parks with raw pointers
+// into the value while its transaction stays as the shard's running_tx(). RM holds no key lock, so
+// freeing a value under that walk is a use-after-free. kDeferred leaves the key for a later pass.
+enum class DeleteScannedResult { kDeleted, kMissing, kDeferred };
+
+DeleteScannedResult DeleteScannedKey(const OpArgs& op_args, string_view key) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto res = db_slice.FindMutable(op_args.db_cntx, key);
+  if (!IsValid(res.it))
+    return DeleteScannedResult::kMissing;
+
+  // FindMutable preempts (change callbacks), so a walk may have started on this shard meanwhile.
+  if (op_args.shard->running_tx() != nullptr) {
+    res.post_updater.Cancel();
+    return DeleteScannedResult::kDeferred;
+  }
+
+  db_slice.DelMutable(op_args.db_cntx, std::move(res));
+  if (op_args.shard->journal()) {
+    RecordDelete(op_args.db_cntx.db_index, key);
+  }
+  return DeleteScannedResult::kDeleted;
+}
+
+// Returns false if a key was deferred. *cursor is then left where this pass started, so the next
+// RM call revisits the key instead of losing it behind a cursor OpScan already advanced. Rescanning
+// is idempotent - whatever we did delete no longer matches.
+bool OpScanAndDelete(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor,
                      uint32_t* deleted) {
+  // A walk parked on this shard leaves its transaction as running_tx(). Defer the whole batch
+  // rather than scan and free under it; the cursor stays put and the client's next call retries.
+  if (op_args.shard->running_tx() != nullptr)
+    return false;
+
+  const uint64_t scan_start = *cursor;
   StringVec keys;
   OpScan(op_args, scan_opts, cursor, &keys);
 
-  auto& db_slice = op_args.GetDbSlice();
   uint32_t count = 0;
+  bool complete = true;
   for (const auto& key : keys) {
-    auto it = db_slice.FindMutable(op_args.db_cntx, key).it;
-    if (!IsValid(it))
-      continue;
-    db_slice.Del(op_args.db_cntx, it);
-    if (op_args.shard->journal()) {
-      RecordDelete(op_args.db_cntx.db_index, key);
+    switch (DeleteScannedKey(op_args, key)) {
+      case DeleteScannedResult::kDeleted:
+        ++count;
+        break;
+      case DeleteScannedResult::kMissing:
+        break;
+      case DeleteScannedResult::kDeferred:
+        complete = false;
+        break;
     }
-    ++count;
   }
   *deleted += count;
+
+  if (!complete)
+    *cursor = scan_start;
+  return complete;
 }
 
 uint64_t RmGeneric(uint64_t cursor, const ScanOpts& scan_opts, uint32_t* deleted,
                    ConnectionContext* cntx) {
+  // A returned cursor of 0 means the pass is over, so it cannot also mean "resume at shard 0,
+  // bucket 0" - which is what we must say when a key is deferred in shard 0's first batch. A dash
+  // token stays below 2^40 and we shift it by 10, so the high bits are ours to use as a flag.
+  constexpr uint64_t kResumeBit = 1ULL << 62;
+  cursor &= ~kResumeBit;
+
   ShardId sid = cursor % 1024;
 
   EngineShardSet* ess = shard_set;
@@ -813,11 +858,12 @@ uint64_t RmGeneric(uint64_t cursor, const ScanOpts& scan_opts, uint32_t* deleted
   DbContext db_cntx{cntx->ns, cntx->conn_state.db_index, GetCurrentTimeMs()};
 
   *deleted = 0;
+  bool complete = true;
 
   do {
     auto cb = [&] {
       OpArgs op_args{EngineShard::tlocal(), nullptr, db_cntx};
-      OpScanAndDelete(op_args, scan_opts, &cursor, deleted);
+      complete = OpScanAndDelete(op_args, scan_opts, &cursor, deleted);
     };
 
     if (EngineShard::tlocal() && EngineShard::tlocal()->shard_id() == sid) {
@@ -826,6 +872,9 @@ uint64_t RmGeneric(uint64_t cursor, const ScanOpts& scan_opts, uint32_t* deleted
     } else {
       ess->Await(sid, cb);
     }
+
+    if (!complete)  // cursor stayed put; hand it back so the deferred key is revisited
+      break;
 
     if (cursor == 0) {
       ++sid;
@@ -841,6 +890,8 @@ uint64_t RmGeneric(uint64_t cursor, const ScanOpts& scan_opts, uint32_t* deleted
 
   if (sid < shard_count) {
     cursor = (cursor << 10) | sid;
+    if (cursor == 0)  // deferred in shard 0's first batch; a bare 0 would read as "done"
+      cursor = kResumeBit;
   } else {
     DCHECK_EQ(0u, cursor);
   }

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -2357,6 +2357,91 @@ TEST_F(GenericFamilyTest, ConcurrentWritesDuringContainerYield) {
   }
 }
 
+// RM deletes without a key lock. While a fiber is parked inside container_utils::Iterate* its
+// transaction is the shard's running_tx(); RM must defer rather than free the value under it, and
+// must not lose the key behind the cursor either - the returned cursor keeps pointing at it until a
+// later pass, once the walk is gone, deletes it.
+TEST_F(GenericFamilyTest, RmDefersWhileContainerYields) {
+  // Put the list on shard 0 so the deferred cursor also exercises the shard-0/resume-token path.
+  const unsigned shard_count = shard_set->size();
+  string key;
+  for (int i = 0; key.empty(); ++i) {
+    string candidate = absl::StrCat("list", i);
+    if (Shard(candidate, shard_count) == 0)
+      key = candidate;
+  }
+
+  constexpr int kListSize = 20'000;
+  constexpr int kBatch = 1'000;
+  vector<string> batch_args = {"rpush", key};
+  batch_args.insert(batch_args.end(), kBatch, "v");
+  for (int pushed = 0; pushed < kListSize; pushed += kBatch) {
+    Run(absl::Span<const string>(batch_args));
+  }
+
+  atomic_bool walk_started{false};
+  atomic_bool release_walk{false};
+  auto reader = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    static CommandId cid{"RM_ITERATION", CO::READONLY, 1, 1, 1};
+    boost::intrusive_ptr<Transaction> tx(new Transaction{&cid});
+    CmdArgVec args{key};
+    ASSERT_EQ(tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, CmdArgList{args}),
+              OpStatus::OK);
+
+    auto cb = [&](Transaction* tx, EngineShard* shard) -> OpResult<void> {
+      auto op_args = tx->GetOpArgs(shard);
+      auto res = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_LIST);
+      CHECK(res);
+
+      size_t visited = 0;
+      container_utils::IterateList(res.value()->second, [&](container_utils::ContainerEntry) {
+        walk_started.store(true);
+        while (!release_walk.load())  // hold the walk parked so running_tx() stays set
+          ThisFiber::SleepFor(std::chrono::milliseconds(1));
+        ++visited;
+        return true;
+      });
+      EXPECT_EQ(visited, kListSize);  // the value stayed live for the whole walk
+      return OpStatus::OK;
+    };
+    EXPECT_EQ(tx->ScheduleSingleHopT(std::move(cb)).status(), OpStatus::OK);
+  });
+
+  RespExpr rm_resp;
+  auto remover = pp_->at(1)->LaunchFiber([&] {
+    Run("remover", {"ping"});  // pay the connection setup before the window opens
+    for (int spin = 0; spin < 100'000 && !walk_started.load(); ++spin)
+      ThisFiber::Yield();
+    rm_resp = Run("remover", {"rm", "0", "match", key, "count", "10"});
+  });
+  remover.Join();
+
+  // Deferred: nothing freed under the walk, and the pass did not report itself finished. A
+  // transactional EXISTS here would deadlock behind the parked read tx, so the key's survival is
+  // confirmed below instead, once the walk is gone.
+  ASSERT_THAT(rm_resp, ArrLen(2));
+  EXPECT_THAT(rm_resp.GetVec()[1], IntArg(0));
+  string cursor = rm_resp.GetVec()[0].GetString();
+  EXPECT_NE(cursor, "0");
+
+  release_walk.store(true);
+  reader.Join();
+
+  // The walk is gone; resuming from the deferred cursor deletes the key and drains to completion.
+  // total == 1 proves the key survived the deferred pass.
+  uint32_t total = 0;
+  for (int call = 0; call < 100; ++call) {
+    RespExpr resp = Run({"rm", cursor, "match", key, "count", "10"});
+    ASSERT_THAT(resp, ArrLen(2)) << call;
+    total += resp.GetVec()[1].GetInt().value_or(0);
+    cursor = resp.GetVec()[0].GetString();
+    if (cursor == "0")
+      break;
+  }
+  EXPECT_EQ(total, 1u);
+  EXPECT_THAT(Run({"exists", key}), IntArg(0));
+}
+
 // Regression test for SORT BY nosort STORE inside MULTI/EXEC does a
 // non-concluding Execute() hop to fetch elements, then falls through to the
 // unsorted reply path without a concluding hop or Conclude().


### PR DESCRIPTION
RM deletes keys outside the transaction framework, so nothing serializes it against a command that is suspended mid-iteration. Container iteration yields every --container_iteration_yield_interval_usec (500 usec by default) while holding raw pointers into the value, so RM can free the container under the running iterator: an lpAssertValidEntry abort in debug builds, a silent use-after-free in release.

Reproducible example:

Plain main, one proactor thread, no special flags:

```
conn A:  RPUSH mylist <20000 elements>
conn B:  SORT mylist ALPHA            # long enough to yield; do not read the reply
conn C:  RM 0 MATCH mylist COUNT 10   # while B is still iterating
```

```
SIGABRT: __assert_fail <- lpAssertValidEntry <- lpNext <- QList::Iterator::Next
         <- QList::Iterate <- container_utils::IterateList <- OpFetchSortEntries <- SortGeneric
```

LRANGE and SORT_RO work as the reader too, so the victim side needs no write permission.

Found here:
https://github.com/dragonflydb/dragonfly/actions/runs/33478201692/job/99761833826
and
https://github.com/dragonflydb/dragonfly/actions/runs/33416302935/job/99567646361
