### PR TITLE
refactor: use RESPParser for Redis replication

### DIFF
--- a/src/facade/resp_parser.cc
+++ b/src/facade/resp_parser.cc
@@ -14,8 +14,23 @@ extern "C" {
 
 namespace facade {
 
-RESPParser::RESPParser() {
+RESPParser::RESPParser() : RESPParser(Limits{}) {
+}
+
+RESPParser::RESPParser(Limits limits) {
+  Reset(limits);
+}
+
+void RESPParser::Reset() {
+  Reset(Limits{});
+}
+
+void RESPParser::Reset(Limits limits) {
+  redisReaderFree(reader_);
   reader_ = redisReaderCreate();
+  CHECK(reader_);
+
+  reader_->maxelements = limits.max_array_len;
 }
 
 RESPObj::RESPObj(RESPObj&& other) noexcept
@@ -47,21 +62,37 @@ size_t RESPObj::Size() const {
   return (type == Type::ARRAY || type == Type::MAP || type == Type::SET) ? reply_->elements : 1;
 }
 
-std::optional<RESPObj> RESPParser::Feed(const char* data, size_t len) {
+std::optional<RESPObj> RESPParser::Feed(const char* data, size_t len, size_t* consumed) {
+  if (consumed) {
+    *consumed = 0;
+  }
+
+  // The peer controls this data, so only log a bounded prefix of it.
+  auto log_error = [this, data, len](int status) {
+    constexpr size_t kMaxLoggedData = 256;
+    std::string_view sv = data ? std::string_view{data, len} : std::string_view{};
+    LOG(ERROR) << "RESP parser error: " << status << " description: " << reader_->errstr
+               << " data: " << sv.substr(0, kMaxLoggedData);
+  };
+
+  const size_t buffered_before = reader_->len - reader_->pos;
   int status = REDIS_OK;
   if (len != 0) {  // if no new data we check is previoud data produced a reply
     status = redisReaderFeed(reader_, data, len);
     if (status != REDIS_OK) {
-      LOG(ERROR) << "RESP parser error: " << status << " description: " << reader_->errstr
-                 << " data: " << std::string_view{data, len};
+      log_error(status);
       return std::nullopt;
     }
   }
   void* reply_obj = nullptr;
   status = redisReaderGetReply(reader_, &reply_obj);
+  if (consumed) {
+    const size_t buffered_after = reader_->len - reader_->pos;
+    DCHECK_LE(buffered_after, buffered_before + len);
+    *consumed = buffered_before + len - buffered_after;
+  }
   if (status != REDIS_OK) {
-    LOG(ERROR) << "RESP parser error: " << status << " description: " << reader_->errstr
-               << " data: " << data;
+    log_error(status);
     return std::nullopt;
   }
 

--- a/src/facade/resp_parser.h
+++ b/src/facade/resp_parser.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <tuple>
@@ -83,19 +84,36 @@ class RESPArray {
 
 class RESPParser {
  public:
+  struct Limits {
+    uint32_t max_array_len = UINT32_MAX;
+  };
+
   RESPParser();
+  explicit RESPParser(Limits limits);
+  RESPParser(const RESPParser&) = delete;
+  RESPParser& operator=(const RESPParser&) = delete;
+
   ~RESPParser() {
     redisReaderFree(reader_);
   }
 
-  std::optional<RESPObj> Feed(const char* data, size_t len);
+  // If consumed is provided, it receives the number of buffered wire bytes processed by this
+  // call. Summing it across calls gives the exact size of a fragmented reply.
+  std::optional<RESPObj> Feed(const char* data, size_t len, size_t* consumed = nullptr);
+
+  void Reset();
+  void Reset(Limits limits);
+
+  bool HasBufferedInput() const {
+    return reader_->pos < reader_->len;
+  }
 
   size_t BufferPos() const {
     return reader_->pos;
   }
 
  private:
-  redisReader* reader_;
+  redisReader* reader_ = nullptr;
 };
 
 std::ostream& operator<<(std::ostream& os, const RESPObj& obj);

--- a/src/facade/resp_parser_test.cc
+++ b/src/facade/resp_parser_test.cc
@@ -74,6 +74,51 @@ TEST_F(RESPParserTest, BaseRespTypesTest) {
   EXPECT_EQ(search_results["s9"]["title"], "test 9");
 }
 
+TEST_F(RESPParserTest, StreamingState) {
+  RESPParser reader;
+  size_t consumed = 0;
+
+  auto reply = reader.Feed("*1\r\n", 4, &consumed);
+  ASSERT_TRUE(reply.has_value());
+  EXPECT_TRUE(reply->Empty());
+  EXPECT_EQ(consumed, 4u);
+  EXPECT_FALSE(reader.HasBufferedInput());
+
+  constexpr std::string_view kReplies = "$4\r\nPING\r\n+OK\r\n";
+  reply = reader.Feed(kReplies.data(), kReplies.size(), &consumed);
+  ASSERT_TRUE(reply.has_value());
+  EXPECT_FALSE(reply->Empty());
+  EXPECT_EQ(consumed, 10u);
+  EXPECT_TRUE(reader.HasBufferedInput());
+
+  reply = reader.Feed(nullptr, 0, &consumed);
+  ASSERT_TRUE(reply.has_value());
+  EXPECT_FALSE(reply->Empty());
+  EXPECT_EQ(consumed, 5u);
+  EXPECT_FALSE(reader.HasBufferedInput());
+
+  reader.Reset();
+  std::string payload(2048, 'x');
+  std::string large_reply = "$" + std::to_string(payload.size()) + "\r\n" + payload + "\r\n";
+  std::string combined = large_reply + "+QUEUED\r\n";
+
+  reply = reader.Feed(combined.data(), combined.size(), &consumed);
+  ASSERT_TRUE(reply.has_value());
+  EXPECT_FALSE(reply->Empty());
+  EXPECT_EQ(consumed, large_reply.size());
+  EXPECT_TRUE(reader.HasBufferedInput());
+
+  reply = reader.Feed(nullptr, 0, &consumed);
+  ASSERT_TRUE(reply.has_value());
+  EXPECT_FALSE(reply->Empty());
+  EXPECT_EQ(consumed, 9u);
+  EXPECT_FALSE(reader.HasBufferedInput());
+}
+
+TEST_F(RESPParserTest, ArrayLimit) {
+  EXPECT_FALSE(RESPParser({.max_array_len = 2}).Feed("*3\r\n", 4).has_value());
+}
+
 TEST_F(RESPParserTest, RESPIteratorTest) {
   using Fields = std::map<std::string, std::string>;
   using Docs = std::map<std::string, Fields>;

--- a/src/server/cluster/coordinator.cc
+++ b/src/server/cluster/coordinator.cc
@@ -79,7 +79,7 @@ class Coordinator::CrossShardClient : public ProtocolClient {
       return false;
     }
 
-    ResetParser(RedisParser::Mode::CLIENT);
+    ResetParser();
     send_fb_ = util::fb2::Fiber("CSS_SendFb", &CrossShardClient::SendFb, this);
     resp_fb_ = util::fb2::Fiber("CSS_RespFb", &CrossShardClient::RespFb, this);
     return true;

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -66,7 +66,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
       return;
     }
 
-    ResetParser(RedisParser::Mode::CLIENT);
+    ResetParser();
 
     std::string cmd = absl::StrCat("DFLYMIGRATE FLOW ", node_id, " ", shard_id);
     VLOG(1) << "cmd: " << cmd;
@@ -261,7 +261,7 @@ void OutgoingMigration::SyncFb() {
     }
 
     VLOG(1) << "Migration initiating";
-    ResetParser(RedisParser::Mode::CLIENT);
+    ResetParser();
     auto cmd = absl::StrCat("DFLYMIGRATE INIT ", cf_->MyID(), " ", slot_migrations_.size());
     for (const auto& s : migration_info_.slot_ranges) {
       absl::StrAppend(&cmd, " ", s.start, " ", s.end);

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -17,6 +17,7 @@ extern "C" {
 #include <sys/ioctl.h>
 
 #include <boost/asio/ip/tcp.hpp>
+#include <limits>
 #include <string>
 
 #include "base/flags.h"
@@ -56,6 +57,43 @@ using namespace boost::asio;
 using namespace facade;
 using absl::GetFlag;
 using absl::StrCat;
+
+namespace {
+
+// Leaves dest empty if the reply is not a flat array of strings.
+bool CopyCommandArgs(const RESPObj& reply, cmn::BackedArguments* dest) {
+  dest->clear();
+
+  if (reply.GetType() != RESPObj::Type::ARRAY)
+    return false;
+
+  auto array = reply.As<RESPArray>();
+  if (!array || array->Empty())
+    return false;
+
+  size_t total_size = 0;
+  for (size_t i = 0; i < array->Size(); ++i) {
+    RESPObj arg = (*array)[i];
+    if (arg.GetType() != RESPObj::Type::STRING)
+      return false;
+
+    auto value = arg.As<string_view>();
+    DCHECK(value);
+    total_size += value->size() + 1;
+  }
+
+  // BackedArguments indexes its storage with uint32 offsets.
+  if (total_size > numeric_limits<uint32_t>::max())
+    return false;
+
+  dest->Reserve(array->Size(), total_size);
+  for (size_t i = 0; i < array->Size(); ++i) {
+    dest->PushArg(*(*array)[i].As<string_view>());
+  }
+  return true;
+}
+
+}  // namespace
 
 error_code ProtocolClient::Recv(FiberSocketBase* input, base::IoBuf* dest) {
   auto buf = dest->AppendBuffer();
@@ -225,7 +263,7 @@ error_code ProtocolClient::ConnectAndAuth(std::chrono::milliseconds connect_time
 
   auto masterauth = GetFlag(FLAGS_masterauth);
   auto masteruser = GetFlag(FLAGS_masteruser);
-  ResetParser(RedisParser::Mode::CLIENT);
+  ResetParser();
   if (!masterauth.empty()) {
     auto cmd = masteruser.empty() ? StrCat("AUTH ", masterauth)
                                   : StrCat("AUTH ", masteruser, " ", masterauth);
@@ -338,6 +376,48 @@ io::Result<ProtocolClient::ReadRespRes> ProtocolClient::ReadRespReply(uint32_t t
   auto res = ReadRespReply();
   sock_->set_timeout(prev_timeout);
   return res;
+}
+
+io::Result<ProtocolClient::ReadCommandRes> ProtocolClient::ReadRespCommand(
+    base::IoBuf* buffer, cmn::BackedArguments* dest) {
+  DCHECK(!parser_);
+  DCHECK(buffer);
+  DCHECK(dest);
+
+  size_t total_read = 0, consumed = 0;
+
+  // The parser may already hold a complete command left over from an earlier read.
+  auto response = resp_parser_.Feed(nullptr, 0, &consumed);
+  total_read += consumed;
+
+  while (response && response->Empty()) {
+    if (buffer->InputLen() == 0) {
+      DCHECK_GT(buffer->AppendLen(), 0u);
+      if (auto ec = Recv(sock_.get(), buffer); ec) {
+        return nonstd::make_unexpected(ec);
+      }
+    }
+
+    auto input = buffer->InputBuffer();
+    response =
+        resp_parser_.Feed(reinterpret_cast<const char*>(input.data()), input.size(), &consumed);
+    // Feed copies everything it is given, so the buffer can be released right away.
+    buffer->ConsumeInput(input.size());
+    total_read += consumed;
+  }
+
+  // Keep the wire-size representation in ReadCommandRes bounded.
+  if (!response || total_read > numeric_limits<uint32_t>::max()) {
+    return nonstd::make_unexpected(make_error_code(errc::bad_message));
+  }
+
+  if (!CopyCommandArgs(*response, dest)) {
+    LOG(ERROR) << "Invalid Redis replication command, reply type: "
+               << static_cast<int>(response->GetType()) << ", elements: " << response->Size();
+    return nonstd::make_unexpected(make_error_code(errc::bad_message));
+  }
+
+  return ReadCommandRes{static_cast<uint32_t>(total_read), resp_parser_.HasBufferedInput()};
 }
 
 io::Result<dfly::RESPObj> ProtocolClient::TakeRespReply(uint32_t timeout, base::IoBuf* buffer,
@@ -469,13 +549,19 @@ error_code ProtocolClient::SendCommandAndReadResponse(string_view command) {
   return response_res.has_value() ? error_code{} : response_res.error();
 }
 
-void ProtocolClient::ResetParser(RedisParser::Mode mode) {
-  // Bound the parser so a peer cannot force a huge allocation. SERVER mode mirrors an
-  // upstream master's commands, whose arg count can exceed our client cap.
-  uint32_t max_arr_len = GetFlag(FLAGS_max_multi_bulk_len);
-  if (mode == RedisParser::Mode::SERVER && max_arr_len < (1u << 20))
-    max_arr_len = 1u << 20;
-  parser_.reset(new RedisParser(mode, max_arr_len, GetFlag(FLAGS_max_bulk_len)));
+void ProtocolClient::ResetParser() {
+  parser_ = make_unique<RedisParser>(RedisParser::Mode::CLIENT, GetFlag(FLAGS_max_multi_bulk_len),
+                                     GetFlag(FLAGS_max_bulk_len));
+  resp_parser_.Reset();
+}
+
+void ProtocolClient::ResetCommandParser() {
+  parser_.reset();
+
+  // An upstream master's commands may contain more arguments than regular client requests.
+  uint32_t max_array_len = max(GetFlag(FLAGS_max_multi_bulk_len), 1u << 20);
+  // TODO: Add bulk-length, line-length, and nesting-depth limits to RESPParser.
+  resp_parser_.Reset({.max_array_len = max_array_len});
 }
 
 uint64_t ProtocolClient::LastIoTime() const {

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -88,16 +88,26 @@ class ProtocolClient {
     uint32_t left_in_buffer;
   };
 
-  // This function uses parser_ and cmd_args_ in order to consume a single response
+  struct ReadCommandRes {
+    uint32_t total_read = 0;     // wire bytes this command occupied
+    bool has_more_data = false;  // parser still holds buffered input
+  };
+
+  // TODO: Remove ReadRespReply, parser_, resp_args_, and their RespExpr-based helpers once all
+  // ProtocolClient response paths have migrated to RESPParser.
+  // This function uses parser_ and resp_args_ in order to consume a single response
   // from the sock_. The output will reside in resp_args_.
   // For error reporting purposes, the parsed command would be in last_resp_ if copy_msg is true.
   // If io_buf is not given, a internal temporary buffer will be used.
   // It is the responsibility of the caller to call buffer->ConsumeInput(rv.left_in_buffer) when it
   // is done with the result of the call; Calling ConsumeInput may invalidate the data in the result
   // if the buffer relocates.
-  // TODO these functions contains bugs related to partial reads and parser state management.
   io::Result<ReadRespRes> ReadRespReply(base::IoBuf* buffer = nullptr, bool copy_msg = true);
   io::Result<ReadRespRes> ReadRespReply(uint32_t timeout);
+
+  // Reads one flat RESP array into dest. buffer is only a staging area - the parser copies
+  // everything it is fed, so this drains buffer completely and the caller must not consume it.
+  io::Result<ReadCommandRes> ReadRespCommand(base::IoBuf* buffer, cmn::BackedArguments* dest);
 
   io::Result<facade::RESPObj> TakeRespReply(uint32_t timeout, base::IoBuf* buffer = nullptr,
                                             bool copy_msg = true);
@@ -122,7 +132,8 @@ class ProtocolClient {
     return server_context_;
   }
 
-  void ResetParser(facade::RedisParser::Mode mode);
+  void ResetParser();
+  void ResetCommandParser();
 
   // TODO can return invalid results if response answer was bigger than provided buffer into
   // ReadRespReply

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -328,7 +328,7 @@ void Replica::MainReplicationFb(std::optional<LastMasterSyncData> last_master_sy
 }
 
 error_code Replica::Greet() {
-  ResetParser(RedisParser::Mode::CLIENT);
+  ResetParser();
   VLOG(1) << "greeting message handling";
   // Corresponds to server.repl_state == REPL_STATE_CONNECTING state in redis
   RETURN_ON_ERR(SendCommandAndReadResponse("PING"));  // optional.
@@ -732,7 +732,7 @@ error_code Replica::ConsumeRedisStream() {
 
   // we never reply back on the commands.
   facade::CapturingReplyBuilder null_builder{facade::ReplyMode::NONE};
-  ResetParser(RedisParser::Mode::SERVER);
+  ResetCommandParser();
 
   // Master waits for this command in order to start sending replication stream.
   RETURN_ON_ERR(SendCommand("REPLCONF ACK 0"));
@@ -780,7 +780,11 @@ error_code Replica::ConsumeRedisStream() {
       ThisFiber::Yield();
     }
 
-    auto response = ReadRespReply(&io_buf, /*copy_msg=*/false);
+    CommandContext* ctx = &ctx_pool[batch.size()];
+    ctx->ResetForReuse();
+    ctx->Init(&null_builder, &conn_context);
+
+    auto response = ReadRespCommand(&io_buf, ctx);
 
     if (!response.has_value()) {
       LOG_REPL_ERROR("Error in Redis Stream at phase "
@@ -791,11 +795,11 @@ error_code Replica::ConsumeRedisStream() {
       return response.error();
     }
 
-    const auto& last_args = LastResponseArgs();
+    const auto& last_args = *ctx;
     bool queued = false;
 
     if (!last_args.empty()) {
-      auto cmd = last_args[0].GetView();
+      auto cmd = last_args.Front();
 
       // Valkey and Redis may send MULTI and EXEC as part of their replication commands.
       // Dragonfly disallows some commands, such as SELECT, inside of MULTI/EXEC, so here we
@@ -804,22 +808,10 @@ error_code Replica::ConsumeRedisStream() {
         VLOG(2) << "Got command " << absl::CHexEscape(cmd)
                 << "\n consumed: " << response->total_read;
 
-        if (LastResponseArgs()[0].GetBuf()[0] == '\r') {
-          for (const auto& arg : LastResponseArgs()) {
-            LOG(INFO) << absl::CHexEscape(ToSV(arg.GetBuf()));
-          }
-        }
-
-        CommandContext* ctx = &ctx_pool[batch.size()];
-        ctx->ResetForReuse();
-        ctx->Init(&null_builder, &conn_context);
-        FillBackedArgs(last_args, ctx);
         batch.push_back(BatchEntry{ctx, response->total_read});
         queued = true;
       }
     }
-
-    io_buf.ConsumeInput(response->left_in_buffer);
 
     if (!queued) {
       // Skipped commands can be ACKed immediately only if there are no earlier queued commands
@@ -835,7 +827,7 @@ error_code Replica::ConsumeRedisStream() {
 
     // Dispatch when the read buffer is drained or the batch is full, and drain the whole
     // batch before reading from the socket again.
-    if ((io_buf.InputLen() == 0 || batch.size() >= max_batch) && !batch.empty()) {
+    if ((!response->has_more_data || batch.size() >= max_batch) && !batch.empty()) {
       // Chain the commands together so that the squasher can process them in one go.
       for (size_t i = 0; i + 1 < batch.size(); ++i) {
         batch[i].cmd->next = batch[i + 1].cmd;
@@ -993,7 +985,7 @@ io::Result<bool> DflyShardReplica::StartSyncFlow(
     VLOG(1) << "Sending last master sync flow " << last_master_data.value().id << " " << lsn_str;
   }
 
-  ResetParser(RedisParser::Mode::CLIENT);
+  ResetParser();
   leftover_buf_.emplace(128);
   RETURN_ON_ERR_T(make_unexpected, SendCommand(cmd));
   auto read_resp = ReadRespReply(&*leftover_buf_);


### PR DESCRIPTION
Related to: #8196
Summary: Refactors Redis upstream-replication command parsing around RESPParser.

Changes:

- Adds resettable parser limits plus consumed-byte and buffered-input reporting.
- Bounds protocol-error payload logging to a small peer-controlled data prefix.
- Adds ReadRespCommand to parse and copy flat command arrays into CommandContext.
- Allows the staging I/O buffer to be drained immediately after parser input is copied.
- Migrates Redis stable-stream consumption away from server-mode RedisParser.
- Preserves per-command wire-byte counts used to advance replication ACK offsets.
- Simplifies parser reset calls across protocol-client users and adds a command-parser reset path.
- Adds unit coverage for streaming state, parser reset behavior, and array-size limits.

Technical Notes: Redis replication retains its higher array-count allowance; bulk, line, and nesting limits remain documented follow-up work.