### PR TITLE
fix(sort): stop SORT LIMIT from overflowing the entries range

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1894,8 +1894,9 @@ template <typename C> auto GetSortRange(const C& entries, const optional<SortBou
   auto start_it = entries.begin();
   auto end_it = entries.end();
   if (bounds) {
-    start_it += std::min<uint32_t>(bounds->offset, entries.size());
-    end_it = entries.begin() + std::min<uint32_t>(bounds->offset + bounds->count, entries.size());
+    start_it += std::min<size_t>(bounds->offset, entries.size());
+    end_it =
+        entries.begin() + std::min<size_t>(size_t{bounds->offset} + bounds->count, entries.size());
   }
 
   return std::make_pair(start_it, end_it);
@@ -2003,7 +2004,7 @@ struct SortVisitor {
     if (params.bounds) {
       auto sort_it =
           entries.begin() +
-          std::min<uint32_t>(params.bounds->offset + params.bounds->count, entries.size());
+          std::min<size_t>(size_t{params.bounds->offset} + params.bounds->count, entries.size());
       std::partial_sort(entries.begin(), sort_it, entries.end(), cmp);
     } else {
       rng::sort(entries, cmp);

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1988,6 +1988,18 @@ TEST_F(GenericFamilyTest, SortNegativeLimit) {
   ASSERT_THAT(resp, ErrArg("value is not an integer"));
 }
 
+TEST_F(GenericFamilyTest, SortLimitOverflow) {
+  Run({"rpush", "l", "1", "2", "3", "4", "5"});
+
+  EXPECT_THAT(Run({"sort", "l", "LIMIT", "4294967295", "2"}), ArrLen(0));
+  EXPECT_THAT(Run({"sort", "l", "LIMIT", "2", "4294967295"}).GetVec(), ElementsAre("3", "4", "5"));
+
+  EXPECT_THAT(Run({"sort", "l", "LIMIT", "4294967295", "2", "STORE", "dst"}), IntArg(0));
+  EXPECT_THAT(Run({"exists", "dst"}), IntArg(0));
+
+  EXPECT_EQ(Run({"ping"}), "PONG");
+}
+
 TEST_F(GenericFamilyTest, SortBy) {
   Run({"del", "list-1"});
   Run({"lpush", "list-1", "1", "2", "3"});


### PR DESCRIPTION
SORT LIMIT offset and count are parsed as uint32, but offset + count was summed in 32 bits. A value near UINT32_MAX wraps to a small number, so start_it lands past end_it and the reply loop (and the STORE path) run off the entries vector, crashing the server with a SIGSEGV.

The sum is now widened to size_t, so the range stays valid and clamps to the collection size.

How to reproduce:

```
  RPUSH l 1 2 3 4 5
  SORT l ALPHA LIMIT 4294967295 2
```