### PR TITLE
fix(facade): Reject unbounded memcached keys

### DIFF
--- a/src/facade/memcache_parser.cc
+++ b/src/facade/memcache_parser.cc
@@ -21,6 +21,9 @@ using MP = MemcacheParser;
 
 namespace {
 
+// Max allowed key length by memcached protocol
+constexpr size_t kMaxKeyLen = 250;
+
 int64_t ToAbsolute(uint32_t ts, uint64_t now) {
   // if expire_ts is greater than month it's a unix timestamp
   // https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L139
@@ -149,6 +152,8 @@ MP::Result ParseValueless(ArgSlice tokens, int64_t now, MP::Command* res) {
   res->cmd_flags.return_value = true;
   res->cmd_flags.return_flags = true;
 
+  if (tokens[key_pos].size() > kMaxKeyLen)
+    return MP::PARSE_ERROR;
   res->backed_args->PushArg(tokens[key_pos++]);
 
   if (key_pos < num_tokens && res->type == MP::STATS)
@@ -164,6 +169,8 @@ MP::Result ParseValueless(ArgSlice tokens, int64_t now, MP::Command* res) {
   }
 
   while (key_pos < num_tokens) {
+    if (tokens[key_pos].size() > kMaxKeyLen)
+      return MP::PARSE_ERROR;
     res->backed_args->PushArg(tokens[key_pos++]);
   }
 
@@ -226,7 +233,7 @@ MP::Result ParseMeta(ArgSlice tokens, int64_t now, MP::Command* res, uint32_t ma
     return MP::PARSE_ERROR;
   }
 
-  if (tokens[0].size() > 250)
+  if (tokens[0].size() > kMaxKeyLen)
     return MP::PARSE_ERROR;
 
   res->cmd_flags.meta = true;
@@ -400,8 +407,8 @@ auto MP::ParseInternal(ArgSlice tokens_view, Command* cmd) -> Result {
   tokens_view.remove_prefix(1);
   cmd->backed_args->clear();
 
-  if (cmd->type <= CAS) {                                         // Store command
-    if (tokens_view.size() < 4 || tokens_view[0].size() > 250) {  // key length limit
+  if (cmd->type <= CAS) {                                                // Store command
+    if (tokens_view.size() < 4 || tokens_view[0].size() > kMaxKeyLen) {  // key length limit
       return MP::PARSE_ERROR;
     }
 

--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -314,4 +314,23 @@ TEST_F(MCParserNoreplyTest, LargeGetRequest) {
   }));
 }
 
+// Keys longer than 250 bytes must be rejected on the get/gets/gat/gats path, matching the
+// store and meta paths. Otherwise the oversized echoed key overflows the reply buffer.
+TEST_F(MCParserTest, OversizedKeyRejected) {
+  std::string long_key(251, 'k');
+
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, Parse(absl::StrCat("get ", long_key, "\r\n")));
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, Parse(absl::StrCat("gets ", long_key, "\r\n")));
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, Parse(absl::StrCat("gat 10 ", long_key, "\r\n")));
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, Parse(absl::StrCat("delete ", long_key, "\r\n")));
+
+  // A second oversized key in a multi-key get is rejected too.
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, Parse(absl::StrCat("get ok ", long_key, "\r\n")));
+
+  // A 250-byte key is still accepted.
+  std::string max_key(250, 'k');
+  EXPECT_EQ(MemcacheParser::OK, Parse(absl::StrCat("get ", max_key, "\r\n")));
+  EXPECT_EQ(max_key, cmd_.key());
+}
+
 }  // namespace facade

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -102,7 +102,10 @@ void SinkReplyBuilder::CloseConnection() {
 }
 
 template <typename... Ts> void SinkReplyBuilder::WritePieces(Ts&&... pieces) {
-  if (size_t required = (piece_size(pieces) + ...); buffer_.AppendLen() <= required)
+  size_t required = (piece_size(pieces) + ...);
+  CHECK_LE(required, kMaxBufferSize);
+
+  if (buffer_.AppendLen() <= required)
     Flush(required);
 
   auto iovec_end = [](const iovec& v) { return reinterpret_cast<char*>(v.iov_base) + v.iov_len; };
@@ -275,6 +278,7 @@ void MCReplyBuilder::SendValue(MemcacheCmdFlags cmd_flags, std::string_view key,
       WritePieces("HD ", flags, kCRLF);
     }
   } else {
+    DCHECK_LE(key.size(), kMaxBufferSize);  // Memcached key bounds to 250 by hard protocol
     WritePieces("VALUE ", key, " ", mc_flag, " ", value.size());
     if (cmd_flags.return_cas)
       WritePieces(" ", mc_token);

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -366,13 +366,14 @@ async def test_read_huge_redis_key_over_memcached(
                 break
             resp += chunk
     except socket.timeout:
-        pass
+        pytest.fail(f"Timed out waiting for memcached reply, got: {resp!r}")
     sock.close()
 
     # The oversized key must be rejected, never echoed back in a VALUE line.
+    assert resp.endswith(b"\r\n")
+    assert resp.startswith((b"CLIENT_ERROR", b"ERROR", b"SERVER_ERROR"))
     assert big_key.encode() not in resp
     assert b"VALUE" not in resp
-
     # The server must still be alive and serving memcached traffic.
     assert memcached_client.set("alive", "1")
     assert memcached_client.get("alive") == b"1"

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -334,3 +334,45 @@ def test_memcached_half_close(df_server: DflyInstance):
     sock.close()
 
     assert response == b"STORED\r\nVALUE hc 0 3\r\nfoo\r\nEND\r\n"
+
+
+@dfly_args(DEFAULT_ARGS)
+async def test_read_huge_redis_key_over_memcached(
+    df_server: DflyInstance, memcached_client: MCClient
+):
+    """
+    Memcached keys have a hard 250 limit. Ensure we never exceed it even with an open Redis port on the side.
+    """
+    big_key = "k" * 20000  # > 8192 reply-buffer limit, < 32768 default client iobuf limit
+
+    # Create key with Redis
+    redis_client = df_server.client()
+    assert await redis_client.set(big_key, "some-value")
+
+    # Compliant python client rejects it
+    with pytest.raises(Exception):
+        memcached_client.get(big_key)
+
+    # Try with a raw socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5)
+    sock.connect(("127.0.0.1", df_server.mc_port))
+    sock.sendall(b"get " + big_key.encode() + b"\r\n")
+    resp = b""
+    try:
+        while not resp.endswith(b"\r\n"):
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            resp += chunk
+    except socket.timeout:
+        pass
+    sock.close()
+
+    # The oversized key must be rejected, never echoed back in a VALUE line.
+    assert big_key.encode() not in resp
+    assert b"VALUE" not in resp
+
+    # The server must still be alive and serving memcached traffic.
+    assert memcached_client.set("alive", "1")
+    assert memcached_client.get("alive") == b"1"


### PR DESCRIPTION
Fix possible buffer overflow bug. Memcached keys are limited to 250 by the protocol, however not all parser paths verify it correctly. Later this fixed size string is threated as a "piece" by the memcached reply builder assuming fixed size. However if it is unbounded, it overflows the internal buffer

Memcached commands never return keys that were not mentioned (i.e. there is no SCAN-like command), so requesting a large key requires mentioning it, which will be rejected by the parser. This is why it is safe to run alonside an open redis port that does not have this limitation