### PR TITLE
fix(deb): Change export syntax for DEB_BUILD_OPTIONS

### DIFF
--- a/tools/packaging/debian/rules
+++ b/tools/packaging/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_BUILD_OPTIONS="noopt nostrip nocheck"
+export DEB_BUILD_OPTIONS := noopt nostrip nocheck
 
 %:
 	dh $@


### PR DESCRIPTION
Fixes warning corresponding to rules files syntax.