### PR TITLE
fix(facade): cap inline requests at 64KB and stop eager bulk-length allocation

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -124,6 +124,17 @@ class BackedArguments {
     dest[arg.size()] = '\0';
   }
 
+  // Extends the last argument with a chunk, keeping the trailing '\0'.
+  void ExtendLastArg(const void* data, size_t len) {
+    assert(!offsets_.empty() && !storage_.empty());
+    size_t old_size = storage_.size();
+    if (old_size + len > storage_.capacity())
+      storage_.reserve(std::max(old_size + len, storage_.capacity() * 2));
+    storage_.resize(old_size + len);
+    memcpy(storage_.data() + old_size - 1, data, len);
+    storage_[old_size + len - 1] = '\0';
+  }
+
   void PopArg() {
     uint32_t last_offs = offsets_.back();
     offsets_.pop_back();

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -194,13 +194,15 @@ constexpr size_t kHttpProbeAppendBytes = 128;
 thread_local ProactorReadBuffer tl_shared_read_buf;
 
 void SendProtocolError(RespSrvParser::Result pres, SinkReplyBuilder* builder) {
-  constexpr string_view res = "-ERR Protocol error: "sv;
+  // The builder already prepends the protocol-error preamble.
   if (pres == RespSrvParser::BAD_BULKLEN) {
-    builder->SendProtocolError(absl::StrCat(res, "invalid bulk length"));
+    builder->SendProtocolError("invalid bulk length");
   } else if (pres == RespSrvParser::BAD_ARRAYLEN) {
-    builder->SendProtocolError(absl::StrCat(res, "invalid multibulk length"));
+    builder->SendProtocolError("invalid multibulk length");
+  } else if (pres == RespSrvParser::BAD_INLINE) {
+    builder->SendProtocolError("too big inline request");
   } else {
-    builder->SendProtocolError(absl::StrCat(res, "parse error"));
+    builder->SendProtocolError("parse error");
   }
 }
 

--- a/src/facade/resp_srv_parser.cc
+++ b/src/facade/resp_srv_parser.cc
@@ -12,6 +12,12 @@
 
 namespace facade {
 
+namespace {
+constexpr uint32_t kMaxInlineSize = 64 * 1024;
+// Above this declared bulk length the buffer grows as data arrives instead of upfront.
+constexpr size_t kBulkEagerLimit = 1u << 20;
+}  // namespace
+
 using namespace std;
 
 auto RespSrvParser::Parse(Buffer str, uint32_t* consumed, cmn::BackedArguments* args) -> Result {
@@ -23,6 +29,7 @@ auto RespSrvParser::Parse(Buffer str, uint32_t* consumed, cmn::BackedArguments* 
   if (state_ == CMD_COMPLETE_S) {
     args->clear();
     buf_stash_.clear();
+    inline_total_ = 0;
 
     if (str[0] == '*') {
       // We recognized a non-INLINE state, starting with '*'
@@ -113,6 +120,9 @@ auto RespSrvParser::ParseInline(Buffer str, cmn::BackedArguments* args) -> Resul
 
     buf_stash_.append(reinterpret_cast<const char*>(token_start), len);
     if (ptr == end) {
+      inline_total_ += len;
+      if (inline_total_ > kMaxInlineSize)
+        return {BAD_INLINE, uint32_t(len)};
       return {INPUT_PENDING, ptr - token_start};
     }
 
@@ -155,10 +165,16 @@ auto RespSrvParser::ParseInline(Buffer str, cmn::BackedArguments* args) -> Resul
     } else if (args->empty()) {
       state_ = CMD_COMPLETE_S;  // have not found anything besides whitespace.
     }
+    inline_total_ += last_consumed;
+    if (inline_total_ > kMaxInlineSize)
+      return {BAD_INLINE, last_consumed};
     return {INPUT_PENDING, last_consumed};
   }
 
   DCHECK_EQ('\n', *ptr);
+
+  if (inline_total_ + last_consumed > kMaxInlineSize)
+    return {BAD_INLINE, last_consumed};
 
   ++last_consumed;  // consume \n as well.
   state_ = CMD_COMPLETE_S;
@@ -259,7 +275,8 @@ auto RespSrvParser::ParseArg(Buffer str, cmn::BackedArguments* args) -> ResultCo
 
   bulk_len_ = len;
   state_ = BULK_STR_S;
-  args->PushArg(size_t(len));
+  bulk_append_ = size_t(len) > kBulkEagerLimit;
+  args->PushArg(bulk_append_ ? size_t(0) : size_t(len));
 
   return {OK, res.second};
 }
@@ -271,11 +288,16 @@ auto RespSrvParser::ConsumeBulk(Buffer str, cmn::BackedArguments* args) -> Resul
   if (str.size() >= bulk_len_) {
     consumed = bulk_len_;
     if (bulk_len_) {
-      char* last_arg = args->data(args->size() - 1);  // Get pointer to last argument.
-      DCHECK_GE(args->elem_len(args->size() - 1), bulk_len_);
-      char* start = last_arg + (args->elem_len(args->size() - 1) - bulk_len_);
-      memcpy(start, str.data(), bulk_len_);
-      str.remove_prefix(exchange(bulk_len_, 0));
+      if (bulk_append_) {
+        args->ExtendLastArg(str.data(), bulk_len_);
+        str.remove_prefix(exchange(bulk_len_, 0));
+      } else {
+        char* last_arg = args->data(args->size() - 1);  // Get pointer to last argument.
+        DCHECK_GE(args->elem_len(args->size() - 1), bulk_len_);
+        char* start = last_arg + (args->elem_len(args->size() - 1) - bulk_len_);
+        memcpy(start, str.data(), bulk_len_);
+        str.remove_prefix(exchange(bulk_len_, 0));
+      }
     }
 
     if (str.size() >= 2) {
@@ -297,11 +319,15 @@ auto RespSrvParser::ConsumeBulk(Buffer str, cmn::BackedArguments* args) -> Resul
   }
 
   DCHECK(bulk_len_);
-  DCHECK_GE(args->elem_len(args->size() - 1), bulk_len_);
   size_t len = std::min<size_t>(str.size(), bulk_len_);
-  char* last_arg = args->data(args->size() - 1);  // Get pointer to last argument.
-  char* start = last_arg + (args->elem_len(args->size() - 1) - bulk_len_);
-  memcpy(start, str.data(), len);
+  if (bulk_append_) {
+    args->ExtendLastArg(str.data(), len);
+  } else {
+    DCHECK_GE(args->elem_len(args->size() - 1), bulk_len_);
+    char* last_arg = args->data(args->size() - 1);  // Get pointer to last argument.
+    char* start = last_arg + (args->elem_len(args->size() - 1) - bulk_len_);
+    memcpy(start, str.data(), len);
+  }
   consumed = len;
   bulk_len_ -= len;
 

--- a/src/facade/resp_srv_parser.h
+++ b/src/facade/resp_srv_parser.h
@@ -24,6 +24,7 @@ class RespSrvParser {
     BAD_ARRAYLEN,
     BAD_BULKLEN,
     BAD_STRING,
+    BAD_INLINE,
   };
   using Buffer = absl::Span<const uint8_t>;
   explicit RespSrvParser(uint32_t max_arr_len = UINT32_MAX, uint32_t max_bulk_len = UINT32_MAX)
@@ -73,6 +74,8 @@ class RespSrvParser {
   uint8_t small_len_ = 0;
 
   uint32_t bulk_len_ = 0, arg_len_ = 0;
+  uint32_t inline_total_ = 0;  // accumulated length of the current inline line
+  bool bulk_append_ = false;   // current bulk grows incrementally instead of eager reserve
   uint32_t max_arr_len_;
   uint32_t max_bulk_len_;
 

--- a/src/facade/resp_srv_parser_test.cc
+++ b/src/facade/resp_srv_parser_test.cc
@@ -180,6 +180,65 @@ TEST_F(RespSrvParserTest, LargeBulk) {
   EXPECT_EQ(27000000u, args_[0].size());
 }
 
+TEST_F(RespSrvParserTest, InlineTooLong) {
+  // A single unterminated token.
+  string big(40000, 'A');
+  ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(big));
+  EXPECT_EQ(RespSrvParser::BAD_INLINE, Parse(big));  // 80000 > 64KB, still no EOL
+}
+
+TEST_F(RespSrvParserTest, InlineManyTokensTooLong) {
+  string chunk;
+  for (unsigned i = 0; i < 5000; ++i)
+    chunk += "aaaaaaa ";  // 40000 bytes of complete tokens
+  ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(chunk));
+  EXPECT_EQ(RespSrvParser::BAD_INLINE, Parse(chunk));
+}
+
+TEST_F(RespSrvParserTest, InlineCapFinalFragmentWithEol) {
+  // The cap must hold even when the crossing fragment carries the newline.
+  string big(63 * 1024, 'A');
+  ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(big));
+  EXPECT_EQ(RespSrvParser::BAD_INLINE, Parse(string(4096, 'A') + "\r\n"));
+}
+
+TEST_F(RespSrvParserTest, InlineCapSingleBufferWithEol) {
+  // An oversized line completed within one buffer must be rejected as well.
+  EXPECT_EQ(RespSrvParser::BAD_INLINE, Parse(string(70 * 1024, 'A') + "\r\n"));
+}
+
+TEST_F(RespSrvParserTest, InlineBelowCapOk) {
+  string ok_line(63 * 1024, 'B');
+  ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(ok_line));
+  ASSERT_EQ(RespSrvParser::OK, Parse("\r\n"));
+  EXPECT_THAT(Vec(), ElementsAre(ok_line));
+}
+
+TEST_F(RespSrvParserTest, HugeBulkNoEagerAlloc) {
+  // Declaring a huge bulk length must not allocate the full buffer upfront.
+  ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse("*1\r\n$200000000\r\n"));
+  EXPECT_LT(args_.HeapMemory() + parser_.UsedMemory(), 64u * 1024);
+}
+
+TEST_F(RespSrvParserTest, BulkOverEagerLimitAssembled) {
+  const size_t kLen = 2'000'000;
+  ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(absl::StrCat("*1\r\n$", kLen, "\r\n")));
+  EXPECT_LT(args_.HeapMemory() + parser_.UsedMemory(), 64u * 1024);
+
+  string chunk(100'000, 'x');
+  chunk.front() = 'F';
+  for (unsigned i = 0; i < kLen / chunk.size(); ++i) {
+    ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse(chunk));
+    ASSERT_EQ(chunk.size(), consumed_);
+  }
+  ASSERT_EQ(RespSrvParser::OK, Parse("\r\n"));
+  ASSERT_EQ(1u, args_.size());
+  ASSERT_EQ(kLen, args_[0].size());
+  EXPECT_EQ('F', args_[0][0]);
+  EXPECT_EQ('F', args_[0][kLen - chunk.size()]);
+  EXPECT_EQ('x', args_[0][kLen - 1]);
+}
+
 TEST_F(RespSrvParserTest, Eol) {
   ASSERT_EQ(RespSrvParser::INPUT_PENDING, Parse("*1\r"));
   EXPECT_EQ(3, consumed_);

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2586,7 +2586,9 @@ async def test_send_timeout(df_server, async_client: aioredis.Redis):
     clients = await async_client.client_list()
     assert len(clients) == 2
     size = 1024 * 1024
-    writer.write(f"SET a {'v'*size}\n".encode())
+    # RESP: an inline line this large would exceed the 64KB inline cap.
+    value = "v" * size
+    writer.write(f"*3\r\n$3\r\nSET\r\n$1\r\na\r\n${size}\r\n{value}\r\n".encode())
     await writer.drain()
 
     async def get_task():


### PR DESCRIPTION
An unterminated inline line grew the parser buffers without bound, and a declared bulk length was allocated upfront: an 18-byte "*1\r\n$2000000000\r\n" request took RSS from 35MB to over 1GB. Inline lines above 64KB now fail with "too big inline request"; bulks above 1MB grow incrementally as data arrives. Also drop the duplicated "-ERR Protocol error: " preamble from parser errors.