### PR TITLE
fix(debug): do not flush when the snapshot cannot be loaded

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -744,6 +744,12 @@ void DebugCmd::Reload(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
   string last_save_file = sf_.GetLastSaveInfo().file_name;
 
+  // Validate before FlushAll so an unloadable snapshot does not destroy the dataset.
+  if (GenericError load_check = sf_.CheckSnapshotLoadable(last_save_file); load_check) {
+    LOG(WARNING) << "Cannot reload snapshot '" << last_save_file << "': " << load_check.Format();
+    return cmd_cntx->SendError(load_check.Format());
+  }
+
   sf_.FlushAll(cntx_->ns);
 
   if (auto fut_ec = sf_.Load(last_save_file, ServerFamily::LoadExistingKeys::kFail); fut_ec) {

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -373,7 +373,15 @@ io::Result<vector<string>, GenericError> FileSnapshotStorage::ExpandFromPath(con
 
 error_code FileSnapshotStorage::CheckPath(const string& path) {
   error_code ec;
-  std::ignore = fs::canonical(path, ec);
+  fs::path canonical = fs::canonical(path, ec);
+  if (ec)
+    return ec;
+  // A directory (or other non-regular file) shadowing a .rdb path passes canonical() but fails
+  // to load; reject it before the caller flushes the dataset.
+  error_code type_ec;
+  if (!fs::is_regular_file(canonical, ec) && !ec)
+    ec = fs::is_directory(canonical, type_ec) ? make_error_code(errc::is_a_directory)
+                                              : make_error_code(errc::invalid_argument);
   return ec;
 }
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -14,6 +14,8 @@ extern "C" {
 #include <absl/flags/reflection.h>
 #include <mimalloc.h>
 
+#include <filesystem>
+
 #include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
@@ -29,6 +31,7 @@ extern "C" {
 #include "server/rdb_load.h"
 #include "server/rdb_save.h"
 #include "server/serializer_commons.h"
+#include "server/server_state.h"
 #include "server/test_utils.h"
 #include "strings/human_readable.h"
 
@@ -1020,6 +1023,50 @@ TEST_F(RdbTest, DebugReloadRdbFormat) {
   EXPECT_EQ(Run({"debug", "reload"}), "OK");
   EXPECT_THAT(service_->server_family().GetLastSaveInfo().file_name, EndsWith(".rdb"));
   EXPECT_EQ(Run({"get", "k1"}), "v1");
+}
+
+TEST_F(RdbTest, DebugReloadNoSnapshotKeepsData) {
+  // Nothing was ever saved; RELOAD NOSAVE must fail without flushing the dataset.
+  Run({"set", "k1", "v1"});
+  EXPECT_THAT(Run({"debug", "reload", "nosave"}), ErrArg("no snapshot"));
+  EXPECT_EQ(Run({"get", "k1"}), "v1");
+}
+
+TEST_F(RdbTest, DebugReloadMissingSnapshotKeepsData) {
+  Run({"set", "k1", "v1"});
+  EXPECT_EQ(Run({"debug", "reload"}), "OK");
+  CleanupSnapshots();  // the snapshot disappears out from under the server
+  EXPECT_THAT(Run({"debug", "reload", "nosave"}), ErrArg("not found"));
+  EXPECT_EQ(Run({"get", "k1"}), "v1");
+}
+
+TEST_F(RdbTest, DebugReloadOnReplicaKeepsData) {
+  Run({"set", "k1", "v1"});
+  EXPECT_EQ(Run({"debug", "reload"}), "OK");
+  pp_->AwaitFiberOnAll([](auto*) { ServerState::tlocal()->is_master = false; });
+  EXPECT_THAT(Run({"debug", "reload", "nosave"}), ErrArg("replica"));
+  EXPECT_EQ(Run({"get", "k1"}), "v1");
+  pp_->AwaitFiberOnAll([](auto*) { ServerState::tlocal()->is_master = true; });
+}
+
+TEST_F(RdbTest, DebugReloadSnapshotDirectoryKeepsData) {
+  // Single-file .rdb: a directory shadowing the path passes fs::canonical, so it must be
+  // rejected as a non-regular file before the flush.
+  absl::FlagSaver fs;
+  ShutdownService();  // clears dbfilename; set it afterwards, as InitWithDbFilename does
+  absl::SetFlag(&FLAGS_df_snapshot_format, false);
+  absl::SetFlag(&FLAGS_dbfilename, absl::StrCat("rdbtestdump_", getpid(), ".rdb"));
+  ResetService();
+
+  Run({"set", "k1", "v1"});
+  EXPECT_EQ(Run({"debug", "reload"}), "OK");
+  std::string path = service_->server_family().GetLastSaveInfo().file_name;
+  ASSERT_THAT(path, EndsWith(".rdb"));
+  CleanupSnapshots();
+  std::filesystem::create_directory(path);  // a directory now shadows the snapshot path
+  EXPECT_THAT(Run({"debug", "reload", "nosave"}), ErrArg("directory"));
+  EXPECT_EQ(Run({"get", "k1"}), "v1");
+  std::filesystem::remove(path);
 }
 
 // Tests loading a huge stream, where the stream is loaded in multiple partial

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1440,6 +1440,17 @@ void ServerFamily::FlushAll(Namespace* ns) {
   Drakarys(flush_trans.get(), DbSlice::kDbAll, false);
 }
 
+GenericError ServerFamily::CheckSnapshotLoadable(const std::string& path) {
+  if (!IsMaster())
+    return {std::make_error_code(std::errc::operation_not_permitted), "replica cannot load data"};
+  if (path.empty())
+    return {std::make_error_code(std::errc::invalid_argument), "no snapshot found to load"};
+  auto storage = detail::IsCloudPath(path) ? CreateCloudSnapshotStorage(path) : snapshot_storage_;
+  if (auto res = storage->ExpandSnapshot(path); !res)
+    return res.error();
+  return {};
+}
+
 // Load starts as many fibers as there are files to load each one separately.
 // It starts one more fiber that waits for all load fibers to finish and returns the first
 // error (if any occurred) with a future.

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -195,6 +195,9 @@ class ServerFamily {
 
   void FlushAll(Namespace* ns);
 
+  // Returns an error if the snapshot at `path` cannot be loaded (empty/bad name, missing files).
+  GenericError CheckSnapshotLoadable(const std::string& path);
+
   // Load snapshot from file (.rdb file or summary.dfs file) and return
   // future with error_code.
   enum class LoadExistingKeys : uint8_t { kFail, kOverride };


### PR DESCRIPTION
DEBUG RELOAD flushed the dataset before checking that the last snapshot was even loadable, so a bad or missing file left the server empty. Validate the path (extension, existence) before FlushAll. This also fixes an abort on DEBUG RELOAD NOSAVE when nothing was ever saved (empty path hit Load).