### PR TITLE
fix(generic): run RM as a no-key transaction

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -775,125 +775,72 @@ uint64_t ScanGeneric(uint64_t cursor, const ScanOpts& scan_opts, StringVec* keys
   return cursor;
 }
 
-// A container walk (e.g. SORT_RO yielding inside container_utils::Iterate*) parks with raw pointers
-// into the value while its transaction stays as the shard's running_tx(). RM holds no key lock, so
-// freeing a value under that walk is a use-after-free. kDeferred leaves the key for a later pass.
-enum class DeleteScannedResult { kDeleted, kMissing, kDeferred };
-
-DeleteScannedResult DeleteScannedKey(const OpArgs& op_args, string_view key) {
-  auto& db_slice = op_args.GetDbSlice();
-  auto res = db_slice.FindMutable(op_args.db_cntx, key);
-  if (!IsValid(res.it))
-    return DeleteScannedResult::kMissing;
-
-  // FindMutable preempts (change callbacks), so a walk may have started on this shard meanwhile.
-  if (op_args.shard->running_tx() != nullptr) {
-    res.post_updater.Cancel();
-    return DeleteScannedResult::kDeferred;
-  }
-
-  db_slice.DelMutable(op_args.db_cntx, std::move(res));
-  if (op_args.shard->journal()) {
-    RecordDelete(op_args.db_cntx.db_index, key);
-  }
-  return DeleteScannedResult::kDeleted;
-}
-
-// Returns false if a key was deferred. *cursor is then left where this pass started, so the next
-// RM call revisits the key instead of losing it behind a cursor OpScan already advanced. Rescanning
-// is idempotent - whatever we did delete no longer matches.
-bool OpScanAndDelete(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor,
+void OpScanAndDelete(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor,
                      uint32_t* deleted) {
-  // A walk parked on this shard leaves its transaction as running_tx(). Defer the whole batch
-  // rather than scan and free under it; the cursor stays put and the client's next call retries.
-  if (op_args.shard->running_tx() != nullptr)
-    return false;
-
-  const uint64_t scan_start = *cursor;
   StringVec keys;
   OpScan(op_args, scan_opts, cursor, &keys);
 
+  auto& db_slice = op_args.GetDbSlice();
   uint32_t count = 0;
-  bool complete = true;
   for (const auto& key : keys) {
-    switch (DeleteScannedKey(op_args, key)) {
-      case DeleteScannedResult::kDeleted:
-        ++count;
-        break;
-      case DeleteScannedResult::kMissing:
-        break;
-      case DeleteScannedResult::kDeferred:
-        complete = false;
-        break;
+    auto it = db_slice.FindMutable(op_args.db_cntx, key).it;  // post_updater runs immediately
+    if (!IsValid(it))
+      continue;
+    db_slice.Del(op_args.db_cntx, it);
+    if (op_args.shard->journal()) {
+      RecordDelete(op_args.db_cntx.db_index, key);
     }
+    ++count;
   }
   *deleted += count;
-
-  if (!complete)
-    *cursor = scan_start;
-  return complete;
 }
 
-uint64_t RmGeneric(uint64_t cursor, const ScanOpts& scan_opts, uint32_t* deleted,
-                   ConnectionContext* cntx) {
-  // A returned cursor of 0 means the pass is over, so it cannot also mean "resume at shard 0,
-  // bucket 0" - which is what we must say when a key is deferred in shard 0's first batch. A dash
-  // token stays below 2^40 and we shift it by 10, so the high bits are ours to use as a flag.
-  constexpr uint64_t kResumeBit = 1ULL << 62;
-  cursor &= ~kResumeBit;
-
+uint64_t RmGeneric(uint64_t cursor, const ScanOpts& scan_opts, uint32_t* deleted, Transaction* tx) {
   ShardId sid = cursor % 1024;
 
-  EngineShardSet* ess = shard_set;
-  unsigned shard_count = ess->size();
+  unsigned shard_count = shard_set->size();
   constexpr uint64_t kMaxRmTimeMs = 100;
 
   CHECK_LT(shard_count, 1024u);
 
+  *deleted = 0;
+
   if (sid >= shard_count) {
+    tx->Conclude();
     return 0;
   }
 
   cursor >>= 10;
-  DbContext db_cntx{cntx->ns, cntx->conn_state.db_index, GetCurrentTimeMs()};
+  const uint64_t deadline_ms = GetCurrentTimeMs() + kMaxRmTimeMs;
 
-  *deleted = 0;
-  bool complete = true;
+  // RM runs as a no-key transaction spanning all shards, so each scan+delete hop executes as the
+  // shard's running_tx: no other transaction can walk or mutate the value while the callback runs,
+  // which is what makes deleting the key safe without a key lock. Between hops the shard is free.
+  while (sid < shard_count) {
+    uint64_t shard_cursor = cursor;
+    tx->Execute(
+        [sid, &scan_opts, &shard_cursor, deleted](Transaction* t, EngineShard* shard) {
+          if (shard->shard_id() == sid)
+            OpScanAndDelete(t->GetOpArgs(shard), scan_opts, &shard_cursor, deleted);
+          return OpStatus::OK;
+        },
+        /*conclude=*/false);
+    cursor = shard_cursor;
 
-  do {
-    auto cb = [&] {
-      OpArgs op_args{EngineShard::tlocal(), nullptr, db_cntx};
-      complete = OpScanAndDelete(op_args, scan_opts, &cursor, deleted);
-    };
-
-    if (EngineShard::tlocal() && EngineShard::tlocal()->shard_id() == sid) {
-      cb();
-      util::ThisFiber::Yield();
-    } else {
-      ess->Await(sid, cb);
-    }
-
-    if (!complete)  // cursor stayed put; hand it back so the deferred key is revisited
-      break;
-
-    if (cursor == 0) {
+    if (cursor == 0)  // this shard is exhausted, move to the next one
       ++sid;
-      if (unsigned(sid) == shard_count)
-        break;
-    }
 
-    uint64_t time_now_ms = GetCurrentTimeMs();
-    if (time_now_ms > db_cntx.time_now_ms + kMaxRmTimeMs) {
+    if (*deleted >= scan_opts.limit || GetCurrentTimeMs() >= deadline_ms)
       break;
-    }
-  } while (*deleted < scan_opts.limit);
+  }
+
+  tx->Conclude();
 
   if (sid < shard_count) {
     cursor = (cursor << 10) | sid;
-    if (cursor == 0)  // deferred in shard 0's first batch; a bare 0 would read as "done"
-      cursor = kResumeBit;
   } else {
     DCHECK_EQ(0u, cursor);
+    cursor = 0;
   }
 
   return cursor;
@@ -2814,7 +2761,7 @@ void GenericFamily::Rm(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   }
 
   uint32_t deleted = 0;
-  cursor = RmGeneric(cursor, ops.value(), &deleted, cmd_cntx->server_conn_cntx());
+  cursor = RmGeneric(cursor, ops.value(), &deleted, cmd_cntx->tx());
 
   auto replier = [cursor, deleted](RedisReplyBuilder* rb) {
     std::string cursor_str = absl::StrCat(cursor);
@@ -2963,7 +2910,13 @@ void GenericFamily::Register(CommandRegistry* registry) {
       << CI{"RENAMENX", CO::JOURNALED | CO::NO_AUTOJOURNAL, 3, 1, 2, acl::kRenamNX}.HFUNC(RenameNx)
       << CI{"SELECT", kSelectOpts, 2, 0, 0, acl::kSelect}.HFUNC(Select)
       << CI{"SCAN", CO::READONLY | CO::FAST | CO::LOADING, -2, 0, 0, acl::kScan}.HFUNC(Scan)
-      << CI{"RM", CO::JOURNALED | CO::NO_AUTOJOURNAL, -2, 0, 0, acl::kRm}.HFUNC(Rm)
+      << CI{"RM",
+            CO::NO_KEY_TRANSACTIONAL | CO::NO_KEY_TX_SPAN_ALL | CO::JOURNALED | CO::NO_AUTOJOURNAL,
+            -2,
+            0,
+            0,
+            acl::kRm}
+             .HFUNC(Rm)
       << CI{"TTL", CO::READONLY | CO::FAST, 2, 1, 1, acl::kTTL}.HFUNC(Ttl)
       << CI{"PTTL", CO::READONLY | CO::FAST, 2, 1, 1, acl::kPTTL}.HFUNC(Pttl)
       << CI{"FIELDTTL", CO::READONLY | CO::FAST, 3, 1, 1, acl::kFieldTtl}.HFUNC(FieldTtl)

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -2273,6 +2273,28 @@ TEST_F(GenericFamilyTest, RmDeletesMatchingKeys) {
   EXPECT_EQ(Run({"dbsize"}), 5);
 }
 
+// RM is a no-key transaction, so it must run correctly as one command inside MULTI/EXEC: it
+// concludes its own hops without ending the surrounding EXEC, and commands after it still run.
+TEST_F(GenericFamilyTest, RmInsideMulti) {
+  Run({"set", "x", "1"});
+  Run({"sadd", "y", "a", "b"});
+
+  Run({"multi"});
+  Run({"set", "x", "2"});
+  Run({"rm", "0", "match", "y", "count", "10"});
+  Run({"get", "x"});
+  auto exec = Run({"exec"});
+
+  ASSERT_THAT(exec, ArrLen(3));
+  EXPECT_EQ(exec.GetVec()[0], "OK");
+  EXPECT_THAT(exec.GetVec()[1], ArrLen(2));              // RM reply: [cursor, deleted]
+  EXPECT_THAT(exec.GetVec()[1].GetVec()[1], IntArg(1));  // y deleted
+  EXPECT_EQ(exec.GetVec()[2], "2");                      // GET x ran after RM
+
+  EXPECT_EQ(Run({"exists", "y"}), 0);
+  EXPECT_EQ(Run({"get", "x"}), "2");
+}
+
 // Verifies that long-running container iteration is yielding.
 // This test uses a sorted set iteration path, but the same yielding
 // behavior is expected for other containers (SET, HASH, LIST) with non
@@ -2399,12 +2421,12 @@ TEST_F(GenericFamilyTest, ConcurrentWritesDuringContainerYield) {
   }
 }
 
-// RM deletes without a key lock. While a fiber is parked inside container_utils::Iterate* its
-// transaction is the shard's running_tx(); RM must defer rather than free the value under it, and
-// must not lose the key behind the cursor either - the returned cursor keeps pointing at it until a
-// later pass, once the walk is gone, deletes it.
-TEST_F(GenericFamilyTest, RmDefersWhileContainerYields) {
-  // Put the list on shard 0 so the deferred cursor also exercises the shard-0/resume-token path.
+// RM runs as a no-key transaction, so a scan+delete hop executes as the shard's running_tx: it
+// cannot run while another transaction is parked mid-container-walk on that shard. It waits its
+// turn instead of freeing the value under the walk. This is the regression test for the fuzzer
+// use-after-free (SORT_RO walking a list while RM deletes it).
+TEST_F(GenericFamilyTest, RmWaitsForContainerYield) {
+  // Put the list on shard 0 so RM's first hop targets exactly the shard holding the parked walk.
   const unsigned shard_count = shard_set->size();
   string key;
   for (int i = 0; key.empty(); ++i) {
@@ -2438,7 +2460,7 @@ TEST_F(GenericFamilyTest, RmDefersWhileContainerYields) {
       size_t visited = 0;
       container_utils::IterateList(res.value()->second, [&](container_utils::ContainerEntry) {
         walk_started.store(true);
-        while (!release_walk.load())  // hold the walk parked so running_tx() stays set
+        while (!release_walk.load())  // hold the walk parked while RM tries to run
           ThisFiber::SleepFor(std::chrono::milliseconds(1));
         ++visited;
         return true;
@@ -2451,35 +2473,41 @@ TEST_F(GenericFamilyTest, RmDefersWhileContainerYields) {
 
   RespExpr rm_resp;
   auto remover = pp_->at(1)->LaunchFiber([&] {
-    Run("remover", {"ping"});  // pay the connection setup before the window opens
     for (int spin = 0; spin < 100'000 && !walk_started.load(); ++spin)
       ThisFiber::Yield();
+    // Blocks behind the parked walk on shard 0 until it is released, then deletes.
     rm_resp = Run("remover", {"rm", "0", "match", key, "count", "10"});
   });
+
+  // Release the walk only once RM has actually queued its transaction behind the running walk on
+  // shard 0. The parked read ran optimistically and is not itself in the queue, so a non-empty
+  // queue means RM is waiting. A fixed sleep could let the walk finish before RM even schedules
+  // and never exercise the overlap.
+  bool rm_queued = false;
+  for (int spin = 0; spin < 5'000 && !rm_queued; ++spin) {
+    shard_set->Await(0, [&] { rm_queued = !EngineShard::tlocal()->txq()->Empty(); });
+    if (!rm_queued)
+      ThisFiber::SleepFor(std::chrono::milliseconds(1));
+  }
+  release_walk.store(true);
+
+  reader.Join();
   remover.Join();
 
-  // Deferred: nothing freed under the walk, and the pass did not report itself finished. A
-  // transactional EXISTS here would deadlock behind the parked read tx, so the key's survival is
-  // confirmed below instead, once the walk is gone.
+  EXPECT_TRUE(rm_queued) << "RM did not queue behind the parked walk; overlap not exercised";
+
+  // RM waited the walk out rather than crashing or deferring, and deleted the key. Drain to the
+  // final cursor instead of assuming one pass: RM's time budget may split the pass across calls.
   ASSERT_THAT(rm_resp, ArrLen(2));
-  EXPECT_THAT(rm_resp.GetVec()[1], IntArg(0));
+  uint32_t total = rm_resp.GetVec()[1].GetInt().value_or(0);
   string cursor = rm_resp.GetVec()[0].GetString();
-  EXPECT_NE(cursor, "0");
-
-  release_walk.store(true);
-  reader.Join();
-
-  // The walk is gone; resuming from the deferred cursor deletes the key and drains to completion.
-  // total == 1 proves the key survived the deferred pass.
-  uint32_t total = 0;
-  for (int call = 0; call < 100; ++call) {
+  for (int call = 0; cursor != "0" && call < 100; ++call) {
     RespExpr resp = Run({"rm", cursor, "match", key, "count", "10"});
     ASSERT_THAT(resp, ArrLen(2)) << call;
     total += resp.GetVec()[1].GetInt().value_or(0);
     cursor = resp.GetVec()[0].GetString();
-    if (cursor == "0")
-      break;
   }
+  EXPECT_EQ(cursor, "0");
   EXPECT_EQ(total, 1u);
   EXPECT_THAT(Run({"exists", key}), IntArg(0));
 }


### PR DESCRIPTION
Follow-up to #8210, which stopped the RM use-after-free with a running_tx() check. That was a heuristic: it deferred whenever any transaction was mid-flight on the shard, which under replication is almost always, and it did not close the window where a key is mutated or retyped between the scan that collects it and the delete that frees it.

RM now runs as a no-key transaction spanning all shards (NO_KEY_TRANSACTIONAL | NO_KEY_TX_SPAN_ALL). Each scan+delete hop executes as the shard's running_tx, so no other transaction can walk or mutate the value while the callback runs. That makes deleting a key safe without a key lock, without any running_tx() check, and lets RM make progress instead of deferring. The running_tx defer, cursor rewind and resume-token added in #8210 are gone.

Behavior change: like other no-key-transactional commands, RM is now rejected inside atomic scripts. It previously ran there scanning undeclared keys, which already broke the script key-declaration contract.

How to reproduce the original crash:
```
  RPUSH mylist <20000+ elements>
  SORT_RO mylist ALPHA   (do not read the reply)
  RM 0 MATCH mylist COUNT 10
```