### PR TITLE
﻿feat(server): add DEBUG PINGALL liveness probe

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -13,12 +13,15 @@ extern "C" {
 #include <absl/random/random.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_join.h>
 #include <lz4.h>
 #include <zdict.h>
 #include <zstd.h>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
+#include <memory>
 #include <numeric>
 
 #include "base/flags.h"
@@ -580,6 +583,10 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
         "    Prints histogram of object sizes.",
         "STACKTRACE",
         "    Prints the stacktraces of all current fibers to the logs.",
+        "PINGALL [timeout_ms]",
+        "    Liveness probe that checks every proactor thread and shard queue, not just the",
+        "    one handling this connection. Replies OK if all respond within <timeout_ms>",
+        "    (default 1000), or an error naming the ones that didn't.",
         "REPLDIAG",
         "    Investigation-only: like STACKTRACE, plus (if this instance is a redis-"
         "    stream replica) the unread byte count in the master socket's kernel recv buffer.",
@@ -667,6 +674,10 @@ void DebugCmd::Run(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
 
   if (subcmd == "STACKTRACE") {
     return Stacktrace(cmd_cntx);
+  }
+
+  if (subcmd == "PINGALL") {
+    return PingAll(parser, cmd_cntx);
   }
 
   if (subcmd == "REPLDIAG") {
@@ -1252,6 +1263,70 @@ void DebugCmd::Stacktrace(CommandContext* cmd_cntx) {
   });
   base::FlushLogs();
   rb->SendOk();
+}
+
+namespace {
+struct PingAllState {
+  PingAllState(unsigned num_fibers, unsigned num_shards)
+      : fiber_done(num_fibers), shard_done(num_shards) {
+  }
+
+  std::vector<std::atomic_bool> fiber_done;
+  std::vector<std::atomic_bool> shard_done;
+};
+}  // namespace
+
+// Unlike PING, checks that every proactor and shard queue is still making progress.
+void DebugCmd::PingAll(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  uint32_t timeout_ms = parser.NextOrDefault<uint32_t>(1000);
+  if (auto err = parser.TakeError(); err)
+    return rb->SendError("Invalid timeout value");
+
+  unsigned num_fibers = shard_set->pool()->size();
+  unsigned num_shards = shard_set->size();
+
+  fb2::BlockingCounter bc(num_fibers + num_shards);
+  // Heap-owned: a wedged callback may still run long after this function returns.
+  auto state = std::make_shared<PingAllState>(num_fibers, num_shards);
+
+  for (unsigned i = 0; i < num_fibers; ++i) {
+    ProactorBase* proactor = shard_set->pool()->at(i);
+    // Skip a full queue rather than risk DispatchBrief blocking on a stalled proactor.
+    if (!proactor->IsTaskQueueFull()) {
+      proactor->DispatchBrief([bc, state, i]() mutable {
+        state->fiber_done[i].store(true, std::memory_order_relaxed);
+        bc->Dec();
+      });
+    }
+    // Not decremented on failure, so WaitFor() below reports it as unresponsive.
+  }
+
+  for (unsigned i = 0; i < num_shards; ++i) {
+    shard_set->TryAdd(i, [bc, state, i]() mutable {
+      state->shard_done[i].store(true, std::memory_order_relaxed);
+      bc->Dec();
+    });
+  }
+
+  if (bc->WaitFor(std::chrono::milliseconds(timeout_ms))) {
+    return rb->SendOk();
+  }
+
+  std::vector<unsigned> late_fibers, late_shards;
+  for (unsigned i = 0; i < num_fibers; ++i) {
+    if (!state->fiber_done[i].load(std::memory_order_relaxed))
+      late_fibers.push_back(i);
+  }
+  for (unsigned i = 0; i < num_shards; ++i) {
+    if (!state->shard_done[i].load(std::memory_order_relaxed))
+      late_shards.push_back(i);
+  }
+
+  return rb->SendError(absl::StrCat("pingall timed out after ", timeout_ms, "ms: fiber=[",
+                                    absl::StrJoin(late_fibers, ","), "] shard_queue=[",
+                                    absl::StrJoin(late_shards, ","), "]"));
 }
 
 // Investigation-only: dumps everything Stacktrace() does, plus (on a redis-stream

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -54,6 +54,7 @@ class DebugCmd {
   void TxAnalysis(CommandContext* cmd_cntx);
   void ObjHist(CommandContext* cmd_cntx);
   void Stacktrace(CommandContext* cmd_cntx);
+  void PingAll(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   // Investigation-only. Remove once closed.
   void ReplDiag(CommandContext* cmd_cntx);
   void Shards(CommandContext* cmd_cntx);

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -7,6 +7,7 @@ extern "C" {
 #include "redis/zmalloc.h"
 }
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_join.h>
@@ -716,6 +717,26 @@ TEST_F(DflyEngineTest, Bug468) {
   ASSERT_THAT(resp, ErrArg("not an integer"));
 
   ASSERT_FALSE(IsLocked(0, "foo"));
+}
+
+TEST_F(DflyEngineTest, PingAll) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  // Wedge shard 1's task queue behind a task that never completes on its own.
+  fb2::Done gate;
+  absl::Cleanup release_gate = [&] { gate.Notify(); };  // survives a failed ASSERT below
+  shard_set->Add(1, [&] { gate.Wait(); });
+
+  // A wedged shard queue doesn't stop a plain PING from a different connection.
+  ASSERT_EQ(Run({"ping"}), "PONG");
+
+  RespExpr resp = Run({"debug", "pingall", "200"});
+  EXPECT_THAT(resp, ErrArg("shard_queue=[1]"));
+
+  gate.Notify();
+
+  resp = Run({"debug", "pingall", "200"});
+  ASSERT_EQ(resp, "OK");
 }
 
 struct CountingConsumer : public DbSlice::ChangeConsumerInterface {

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -57,6 +57,12 @@ class EngineShardSet {
     return shards_[sid]->GetFiberQueue()->Add(std::forward<F>(f));
   }
 
+  // Non-blocking: returns false immediately if the shard's queue is full instead of waiting.
+  template <typename F> bool TryAdd(ShardId sid, F&& f) {
+    assert(sid < size_);
+    return shards_[sid]->GetFiberQueue()->TryAdd(std::forward<F>(f));
+  }
+
   template <typename F> auto AddL2(ShardId sid, F&& f) {
     return shards_[sid]->GetSecondaryQueue()->Add(std::forward<F>(f));
   }


### PR DESCRIPTION
`PING` only proves the connection's own thread is alive, it never touches a shard queue, so a server with one wedged shard still answers `PING` (and passes healthcheck.sh/healthz) while `SET`/`GET` on that shard hangs forever. See #2191 ("does respond to PING but SET x y waits forever") and the `SCRIPT FLUSH` deadlock fixed in #8110 ("even GET hangs and only PING answers").

`DEBUG PINGALL [timeout_ms]` closes that gap: it dispatches a no-op to every proactor's fiber scheduler and pushes a no-op through every shard's task queue (via a new non-blocking `EngineShardSet::TryAdd`, never the blocking `Add`), then waits once on a deadline (default 1000ms, never blocking inside a proactor loop). It replies `+OK` if everything responded in time, or an error naming exactly which fiber/shard indices didn't, e.g. `pingall timed out after 1000ms: fiber=[] shard_queue=[1]`.

Per-callback state is heap-owned (`shared_ptr`) rather than stack-captured, since a genuinely wedged shard's callback may still run long after the command has already replied with a timeout error.

This catches a dead/livelocked proactor and a parked shard-queue fiber. It does not catch a wedged transaction-queue head or a permanently held global lock (#7272, #8110 class) — that needs a real transaction hop and can be a follow-up.

Added `DflyEngineTest.PingAll`: wedges shard 1 behind a task blocked on a gate, confirms plain `PING` is unaffected, confirms `DEBUG PINGALL 200` times out naming `shard_queue=[1]`, then confirms it succeeds once the gate is released.

Ran the full `dragonfly_test` suite (51 passed, 1 pre-existing unrelated skip) and `pre-commit` clang-format on the changed files.

Fixes #8200