### PR TITLE
test(acl): cover expired JWT authentication

### DIFF
--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -202,6 +202,34 @@ TEST_F(AclFamilyTest, AclAuth) {
   EXPECT_THAT(resp, "OK");
 }
 
+TEST_F(AclFamilyTest, AuthRejectedAfterJwtExpiry) {
+  TestInitAclFam();
+  auto resp = Run("ACL SETUSER shahar ON >mypass +@fast");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("AUTH shahar mypass");
+  EXPECT_THAT(resp, "OK");
+
+  // A command works right after a normal (non-JWT) AUTH, since auth_expires_at defaults
+  // to "never expires".
+  resp = Run("GET foo");
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+
+  // Simulate a JWT-derived auth whose token has already expired (as if the connection had
+  // authenticated with a JWT carrying an "exp" claim in the past).
+  SetAuthExpiresAt("IO0", std::chrono::steady_clock::now() - std::chrono::seconds(1));
+
+  resp = Run("GET foo");
+  EXPECT_THAT(resp, ErrArg("NOAUTH JWT token expired, please re-authenticate."));
+
+  // Re-authenticating resets auth_expires_at back to "never expires" and unblocks commands.
+  resp = Run("AUTH shahar mypass");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("GET foo");
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+}
+
 TEST_F(AclFamilyTest, AclWhoAmI) {
   TestInitAclFam();
   auto resp = Run("ACL WHOAMI WHO");

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -754,6 +754,13 @@ Transaction* BaseFamilyTest::GetTransaction(string_view conn_id) {
   return it->second->cmd_cntx()->transaction;
 }
 
+void BaseFamilyTest::SetAuthExpiresAt(string_view conn_id, chrono::steady_clock::time_point at) {
+  unique_lock lk(mu_);
+  auto it = connections_.find(conn_id);
+  CHECK(it != connections_.end()) << conn_id;
+  it->second->cmd_cntx()->auth_expires_at = at;
+}
+
 vector<string> BaseFamilyTest::StrArray(const RespExpr& expr) {
   CHECK(expr.type == RespExpr::ARRAY || expr.type == RespExpr::NIL_ARRAY);
   if (expr.type == RespExpr::NIL_ARRAY)

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -143,6 +143,8 @@ class BaseFamilyTest : public ::testing::Test {
   Transaction* GetTransaction(std::string_view conn_id);
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
+  void SetAuthExpiresAt(std::string_view conn_id, std::chrono::steady_clock::time_point at);
+
   Metrics GetMetrics() const {
     return service_->server_family().GetMetrics(&namespaces->GetDefaultNamespace(),
                                                 MetricsCollectOpts{});


### PR DESCRIPTION
Follow up on https://github.com/dragonflydb/dragonfly/pull/8171

