### PR TITLE
fix(rdb): bound RESTORE allocations to the remaining input to prevent a remote OOM

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -213,6 +213,8 @@ OpResult<DbSlice::ItAndUpdater> RdbRestoreValue::Add(string_view key, string_vie
                                                      const DbContext& cntx, const RestoreArgs& args,
                                                      DbSlice* db_slice) {
   InMemSource data_src(data);
+  // Bound declared lengths to the payload so a crafted element length can't force a huge resize.
+  source_limit_ = data.size();
   PrimeValue pv;
   bool first_parse = true;
   do {

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -7,6 +7,7 @@
 #include <absl/cleanup/cleanup.h>
 
 extern "C" {
+#include "redis/crc64.h"
 #include "redis/rdb.h"
 }
 
@@ -1443,6 +1444,52 @@ TEST_F(GenericFamilyTest, RestoreRejectsEmptyCollections) {
     EXPECT_THAT(Run({"restore", "e", "0", payload}), ErrArg("ERR Bad data format"));
     EXPECT_THAT(Run({"exists", "e"}), IntArg(0));
   }
+}
+
+// A collection element declaring a 64-bit length must be rejected, not resized (remote OOM).
+TEST_F(GenericFamilyTest, RestoreRejectsHugeElementLength) {
+  uint8_t set_huge[] = {0x02, 0x01, 0x81, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                        0x0b, 0x00, 0x10, 0xd6, 0x89, 0xeb, 0x19, 0x8f, 0x53, 0xc7};
+  uint8_t hash_huge[] = {0x04, 0x01, 0x81, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                         0x0b, 0x00, 0x03, 0x21, 0x50, 0xfd, 0xd3, 0x79, 0x3d, 0xcc};
+  uint8_t zset_huge[] = {0x05, 0x01, 0x81, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                         0x0b, 0x00, 0xce, 0x41, 0xc0, 0x57, 0xd9, 0xc3, 0xfc, 0x5a};
+  for (auto payload : {ToSV(set_huge), ToSV(hash_huge), ToSV(zset_huge)}) {
+    Run({"del", "e"});
+    EXPECT_THAT(Run({"restore", "e", "0", payload}), ErrArg("ERR Bad data format"));
+    EXPECT_THAT(Run({"exists", "e"}), IntArg(0));
+  }
+  EXPECT_EQ(Run({"ping"}), "PONG");  // server survived
+}
+
+// An LZF-encoded element declaring a 64-bit compressed length must be rejected before its buffer
+// is resized.
+TEST_F(GenericFamilyTest, RestoreRejectsHugeCompressedLength) {
+  uint8_t set_lzf[] = {0x02, 0x01, 0xc3, 0x81, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                       0x0a, 0x0b, 0x00, 0x18, 0x36, 0x24, 0x06, 0xd8, 0x88, 0x36, 0xdb};
+  EXPECT_THAT(Run({"restore", "e", "0", ToSV(set_lzf)}), ErrArg("ERR Bad data format"));
+  EXPECT_THAT(Run({"exists", "e"}), IntArg(0));
+  EXPECT_EQ(Run({"ping"}), "PONG");  // server survived
+}
+
+// A SET declaring a 64-bit member count but supplying a full first chunk of real members reaches
+// set->Reserve with the claimed count and crashes; the count must be rejected up front.
+TEST_F(GenericFamilyTest, RestoreRejectsHugeMemberCount) {
+  string payload;
+  payload.push_back(0x02);      // RDB_TYPE_SET
+  payload.push_back('\x81');    // RDB_64BITLEN
+  for (int i = 7; i >= 0; --i)  // count 0x7fffffffffffffff, big-endian
+    payload.push_back(static_cast<char>((0x7fffffffffffffffULL >> (i * 8)) & 0xff));
+  payload.append(4092, '\x00');  // a full chunk of empty-string members
+  payload.push_back(0x0b);       // rdb version, little-endian
+  payload.push_back(0x00);
+  uint64_t crc = crc64(0, reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+  for (int i = 0; i < 8; ++i)
+    payload.push_back(static_cast<char>((crc >> (i * 8)) & 0xff));
+
+  EXPECT_THAT(Run({"restore", "e", "0", payload}), ErrArg("ERR Bad data format"));
+  EXPECT_THAT(Run({"exists", "e"}), IntArg(0));
+  EXPECT_EQ(Run({"ping"}), "PONG");  // server survived
 }
 
 TEST_F(GenericFamilyTest, RestoreOobZsetListpack) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1481,6 +1481,12 @@ error_code RdbLoaderBase::ReadStringObj(RdbVariant* dest, bool big_string_split)
     }
   }
 
+  // Reject a length beyond the remaining input before allocating or reserving it.
+  if (len > RemainingBytes()) {
+    LOG(ERROR) << "Bad string length " << len;
+    return RdbError(errc::rdb_file_corrupted);
+  }
+
   if (big_string_split && len > kMaxStringSize) {
     pending_read_.remaining = len - kMaxStringSize;
     pending_read_.reserve = len;
@@ -1528,6 +1534,12 @@ auto RdbLoaderBase::ReadLzf() -> io::Result<LzfString> {
     return Unexpected(errc::rdb_file_corrupted);
   }
 
+  // Reject a compressed length beyond the remaining input before allocating it.
+  if (clen > RemainingBytes()) {
+    LOG(ERROR) << "Bad compressed length " << clen;
+    return Unexpected(errc::rdb_file_corrupted);
+  }
+
   res.compressed_blob.resize(clen);
   /* Load the compressed representation and uncompress it to target. */
   error_code ec = FetchBuf(clen, res.compressed_blob.data());
@@ -1546,6 +1558,9 @@ auto RdbLoaderBase::ReadSet(int rdbtype) -> io::Result<OpaqueObj> {
     SET_OR_UNEXPECT(LoadLen(NULL), len);
     if (len == 0 && !RdbTypeAllowedEmpty(rdbtype))
       return Unexpected(errc::empty_key);
+    // Reject a member count beyond the remaining input before it is reserved.
+    if (len > RemainingBytes())
+      return Unexpected(errc::rdb_file_corrupted);
     if (rdbtype == RDB_TYPE_SET_WITH_EXPIRY) {
       len *= 2;
     }
@@ -1627,6 +1642,9 @@ auto RdbLoaderBase::ReadHMap(int rdbtype) -> io::Result<OpaqueObj> {
     SET_OR_UNEXPECT(LoadLen(NULL), len);
     if (len == 0 && !RdbTypeAllowedEmpty(rdbtype))
       return Unexpected(errc::empty_key);
+    // Reject a field count beyond the remaining input before it is reserved.
+    if (len > RemainingBytes())
+      return Unexpected(errc::rdb_file_corrupted);
 
     if (rdbtype == RDB_TYPE_HASH) {
       len *= 2;
@@ -1667,6 +1685,9 @@ auto RdbLoaderBase::ReadZSet(int rdbtype) -> io::Result<OpaqueObj> {
     zsetlen = pending_read_.remaining;
   } else {
     SET_OR_UNEXPECT(LoadLen(nullptr), zsetlen);
+    // Reject a member count beyond the remaining input before it is reserved.
+    if (zsetlen > RemainingBytes())
+      return Unexpected(errc::rdb_file_corrupted);
     pending_read_.reserve = zsetlen;
   }
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -246,6 +246,15 @@ class RdbLoaderBase {
 
   std::error_code EnsureReadInternal(size_t min_to_read);
 
+  // Upper bound on bytes a bounded source can still supply; SIZE_MAX when unbounded (file load).
+  // Used to reject a declared length/count before allocating for it (a crafted RESTORE OOM).
+  size_t RemainingBytes() const {
+    if (source_limit_ == SIZE_MAX)
+      return SIZE_MAX;
+    size_t from_source = bytes_read_ < source_limit_ ? source_limit_ - bytes_read_ : 0;
+    return (mem_buf_ ? mem_buf_->InputLen() : 0) + from_source;
+  }
+
   // Wrapper to consume n bytes from mem buf, and also decrement remaining_payload_bytes if a chunk
   // read is in progress
   std::error_code ConsumeInput(size_t n);


### PR DESCRIPTION
A crafted `RESTORE` payload could make the loader allocate a buffer from an attacker-declared length before any bound was checked, so a tiny (~12KB or less) CRC-valid payload aborted the server (`mimalloc: out of memory in 'new'` -> SIGABRT, or SIGSEGV). The top-level string path is capped via `big_string_split`, but element strings, LZF compressed lengths, and collection member counts were not, and `RESTORE` never bounded the loader source — so the existing out-of-bound check in `FetchBuf` never fired. The CRC64 footer is the only cost to an attacker.

`RESTORE` now bounds the loader source to the payload size, and every pre-allocation is rejected up front when its declared length or count exceeds the bytes the source can still supply (`RemainingBytes()`):

- element/top-level string byte length, before `resize()` and before the deferred `ReserveString()`
- LZF compressed length, before resizing the compressed buffer (the decompressed length is already capped)
- SET / HASH / ZSET member counts, before they are reserved

The guard is inert for unbounded file loads, so normal RDB loading and replication are unchanged. Verified: large collections (member count above the chunk size) and multi-hundred-KB strings still round-trip through `DUMP`/`RESTORE`.

Found by valkey `integration/corrupt-dump` (`OOM in rdbGenericLoadStringObject`).