### PR TITLE
fix(facade): limit queue wakeup to V1 in EnqueueParsedCommand

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -3442,7 +3442,7 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
 
   // AsyncFiber for Memcache only wakes up on dispatch_q_, notify only redis as this is the parse
   // commands queue.
-  if ((!cc_->sync_dispatch) && (protocol_ == Protocol::REDIS)) {
+  if (!ioloop_v2_ && (!cc_->sync_dispatch) && (protocol_ == Protocol::REDIS)) {
     cnd_.notify_one();
   }
 }


### PR DESCRIPTION
Restrict parsed-command condition-variable notifications to V1's AsyncFiber consumer. V2 dispatches through its single connection fiber, which does not wait on cnd_.
