### PR TITLE
perf(facade): batch parser memory refreshes

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1689,6 +1689,8 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
                                                 bool enqueue_only) {
   DCHECK_EQ(enqueue_only, ioloop_v2_)
       << "enqueue_only==true should only be used for ioloop_v2_ and vice versa";
+  // Account memory once after parsing completes, including every terminal parser status.
+  absl::Cleanup refresh_memory_usage = [this] { RefreshConnectionMemoryUsage(); };
   uint32_t consumed = 0;
   RespSrvParser::Result result = RespSrvParser::OK;
 
@@ -1754,7 +1756,6 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
           << CONN_ID << "Redis parser error: " << static_cast<unsigned int>(result)
           << " during parse: " << io::View(read_buffer);
     }
-    RefreshConnectionMemoryUsage();
     if (stop_parsing)
       break;
 


### PR DESCRIPTION
Refresh connection-memory telemetry once when ParseRedis exits rather than after each parsed command. The refresh uses net-delta accounting, so the final value remains correct for V1 and V2.

Pipeline backpressure is unaffected: EnqueueParsedCommand updates pipeline_queue_bytes for every command before limits are checked.
