### PR TITLE
fix: compatibility RDB_TYPE_SET_LISTPACK with RedisShake

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1332,6 +1332,22 @@ TEST_F(GenericFamilyTest, Restore) {
   EXPECT_THAT(resp, ErrArg("ERR Bad data format"));
 }
 
+// Redis 7.2+ encodes small sets as listpacks under rdb type 20, the id Dragonfly used for JSON
+// before rdb version 10. Migration tools rebuild RESTORE payloads with their own footer version
+// (RedisShake hard codes 6), so type 20 must be read as a set listpack regardless of the version.
+TEST_F(GenericFamilyTest, RestoreSetListpackOldRdbVersion) {
+  // sadd set:strs alpha beta gamma, dumped by Redis 7.4 and re-footered by RedisShake with
+  // rdb version 6. Taken verbatim from a failing migration.
+  uint8_t SET_LISTPACK_DUMP_V6[] = {0x14, 0x1b, 0x1b, 0x00, 0x00, 0x00, 0x03, 0x00, 0x85, 0x61,
+                                    0x6c, 0x70, 0x68, 0x61, 0x06, 0x84, 0x62, 0x65, 0x74, 0x61,
+                                    0x05, 0x85, 0x67, 0x61, 0x6d, 0x6d, 0x61, 0x06, 0xff, 0x06,
+                                    0x00, 0xc7, 0xe8, 0x19, 0x08, 0x6c, 0x7e, 0x1a, 0x33};
+  EXPECT_THAT(Run({"restore", "set:strs", "0", ToSV(SET_LISTPACK_DUMP_V6)}), "OK");
+  EXPECT_THAT(Run({"type", "set:strs"}), "set");
+  EXPECT_THAT(Run({"smembers", "set:strs"}),
+              RespArray(UnorderedElementsAre("alpha", "beta", "gamma")));
+}
+
 // A crafted RESTORE payload with a valid listpack header but an interior 32-bit string entry
 // of declared length 0x7fffffff must be rejected. The trailing read triggers the deferred
 // crash for types that store the listpack as-is.

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1389,10 +1389,6 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_ZSET_ZIPLIST:
     case RDB_TYPE_STRING:
     case RDB_TYPE_JSON:
-    // Dragonfly used id 20 for JSON before rdb version 10, which collides with Redis'
-    // RDB_TYPE_SET_LISTPACK. We no longer support loading these legacy payloads, so id 20
-    // is always a set listpack. Do not reintroduce a rdb_version_ based branch here:
-    // tools such as RedisShake stamp RESTORE payloads with an unrelated footer version.
     case RDB_TYPE_SET_LISTPACK:
       iores = ReadGeneric(rdbtype);
       break;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1389,6 +1389,11 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_ZSET_ZIPLIST:
     case RDB_TYPE_STRING:
     case RDB_TYPE_JSON:
+    // Dragonfly used id 20 for JSON before rdb version 10, which collides with Redis'
+    // RDB_TYPE_SET_LISTPACK. We no longer support loading these legacy payloads, so id 20
+    // is always a set listpack. Do not reintroduce a rdb_version_ based branch here:
+    // tools such as RedisShake stamp RESTORE payloads with an unrelated footer version.
+    case RDB_TYPE_SET_LISTPACK:
       iores = ReadGeneric(rdbtype);
       break;
     case RDB_TYPE_HASH:
@@ -1407,17 +1412,6 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_STREAM_LISTPACKS_2:
     case RDB_TYPE_STREAM_LISTPACKS_3:
       iores = ReadStreams(rdbtype);
-      break;
-    case RDB_TYPE_SET_LISTPACK:
-      // We need to deal with protocol versions 9 and older because in these
-      // RDB_TYPE_JSON == 20. On newer versions > 9 we bumped up RDB_TYPE_JSON to 30
-      // because it overlapped with the new type RDB_TYPE_SET_LISTPACK
-      if (rdb_version_ < 10) {
-        // consider it RDB_TYPE_JSON_OLD (20)
-        iores = ReadGeneric(RDB_TYPE_JSON);
-      } else {
-        iores = ReadGeneric(rdbtype);
-      }
       break;
     case RDB_TYPE_MODULE_2:
       iores = ReadRedisModule2();


### PR DESCRIPTION
Summary: Restore compatibility with RedisShake payloads that preserve Redis's set-listpack object bytes but replace the RDB footer version.

Changes:

- Interpret RDB type 20 as RDB_TYPE_SET_LISTPACK regardless of the RDB version.
- Remove the prior version-based interpretation of type 20 as legacy Dragonfly JSON.
- Add a regression test using a Redis 7.4 small-set payload re-footered as RDB version 6 by RedisShake.

Technical note: The loader continues to route the object through generic blob parsing and set-listpack integrity validation.

Problem:

RedisShake uses the following approach to serialize data: it keeps the Redis object bytes and substitutes the version in the newly constructed RESTORE footer.

redis RDB: [type 0x14][listpack value], where 0x14 is RDB_TYPE_SET_LISTPACK

RedisShake RESTORE payload: [type 0x14][same listpack value][06 00][new CRC64], where 06 00 is rdb_version  forcefully set by RedisShake
In RedisShake 4.6.2, createValueDump() does exactly this:

  1. Writes the original object type.
  2. Writes the original serialized value.
  3. Hardcodes uint16(6) in little-endian format.
  4. Calculates a new CRC64 including that version.
  5. Sends the result with RESTORE.

 [See RedisShake v4.6.2 createValueDump()](https://github.com/tair-opensource/RedisShake/blob/v4.6.2/internal/rdb/rdb.go#L277-L285)

Dragonfly interpreted 0x14 type as JSON for rdb_version < 10. This behavior was added in v1.14.2 (February 2024). Because we don't support such an old version, we can drop this backward compatibility.
