### PR TITLE
fix(stream): stop XREAD/XREADGROUP inside a script from aborting the server

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3316,6 +3316,9 @@ void XReadGeneric2(ParsedArgs args, bool read_group, CommandContext* cmd_cntx) {
             JournalConsumerCreationIfNeeded(op_args, *opts, key);
           }
         }
+        // A squashed stub can't block, and AVOID_CONCLUDING would abort the squash.
+        if (tx->IsSquashedStub())
+          return OpStatus::OK;
         return {OpStatus::OK, Transaction::RunnableResult::AVOID_CONCLUDING};
       }
     }

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -317,6 +317,21 @@ TEST_F(StreamFamilyTest, XReadGroup) {
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 }
 
+TEST_F(StreamFamilyTest, XReadInsideScriptNoEntries) {
+  // Nothing to serve inside a script must reply nil, not abort on AVOID_CONCLUDING.
+  Run({"xadd", "s", "1-0", "k", "v"});
+  Run({"xgroup", "create", "s", "g", "$"});
+
+  auto resp =
+      Run({"eval", "return redis.call('xreadgroup','group','g','c','STREAMS','s','>')", "1", "s"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_EQ(Run({"ping"}), "PONG");
+
+  resp = Run({"eval", "return redis.call('xread','STREAMS','s','$')", "1", "s"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_EQ(Run({"ping"}), "PONG");
+}
+
 // A multi-stream XREADGROUP where one stream is valid and another has no matching key/group
 // must return NOGROUP without mutating any state on the valid stream: no PEL insertion, no new
 // consumer, and no advance of last-delivered-id. Both single shard and cross shard are tested.


### PR DESCRIPTION
`XREAD`/`XREADGROUP` with nothing to serve requests `AVOID_CONCLUDING` so it can block, but inside a script the command runs as a squashed transaction stub whose result flags are asserted to be zero, so any `EVAL` reading an empty or missing stream aborted the server.

A squashed stub cannot sit in the transaction queue to block, so the no-entries branch now concludes instead of requesting `AVOID_CONCLUDING`; `XReadBlock` already replies nil for a non-blockable transaction.

Found by valkey `unit/scripting` (`EVAL - Scripts do not block on XREAD[GROUP]`).