### PR TITLE
fix(ci): disable GoogleTests by default

### DIFF
--- a/.github/REGRESSION-TESTS.md
+++ b/.github/REGRESSION-TESTS.md
@@ -7,9 +7,10 @@ or GoogleTest inputs. You can also choose your own branch.
 ## Execution Model
 
 - Scheduled runs execute Pytest once and do not build or run GoogleTests.
-- Manual runs execute the Pytest step first and then attempt the GoogleTest step,
-  even if Pytest fails. Set Pytest `iterations` to `0` to skip Pytest and run
-  GoogleTests only.
+- Manual runs execute the Pytest step first when `iterations` is positive.
+  GoogleTests are disabled when `gtest-iterations` is `0` and run when it is
+  positive. When both test families are enabled, they run one after another:
+  GoogleTests are attempted after Pytest even if Pytest fails.
 - Each workflow fans out across its configured matrix. Inputs apply to every
   matrix job; they cannot select an architecture, runner, or build type.
 
@@ -36,17 +37,19 @@ test-cases:  (^|/)connection_test\.py::(test_case_one|test_case_two)$|(^|/)eval_
 
 ## GoogleTest Inputs
 
-GoogleTests run only for manual dispatches of these two regression workflows. With default GoogleTest inputs, every
-target found by recursively scanning `CMakeLists.txt` files for `helio_cxx_test(...)`
-under `src/core`, `src/facade`, and `src/server` runs once. This includes tests in
-nested directories such as `src/core/json` and `src/server/cluster`; the available
-targets can still vary with the selected build configuration.
+GoogleTests run only for manual dispatches of these two regression workflows.
+`gtest-iterations=0` disables them, including when GoogleTest selectors are supplied.
+Set `gtest-iterations` to a positive value to enable them. With no selectors, every
+discovered target runs. Targets are found by recursively scanning `CMakeLists.txt`
+files for `helio_cxx_test(...)` under `src/core`, `src/facade`, and `src/server`. This
+includes tests in nested directories such as `src/core/json` and `src/server/cluster`;
+the available targets can still vary with the selected build configuration.
 
 | Input | Default | Description |
 | --- | --- | --- |
 | `gtest-suites` | empty | Comma- or space-separated GoogleTest target names. A target path and `.cc` suffix are accepted, but only the target name is used. Empty runs all discovered targets. Example: `set_family_test,generic_family_test`. |
 | `gtest-cases` | empty | Value passed directly as `--gtest_filter`. Empty runs all cases in each selected target. Example: `SetFamilyTest.*:HSetFamilyTest.*`. |
-| `gtest-iterations` | `1` | Positive GoogleTest run count. |
+| `gtest-iterations` | `0` | GoogleTest run count. `0` skips GoogleTests; a positive value enables and repeats them. |
 
 Specify `gtest-suites` when using `gtest-cases` for only a few binaries. Otherwise
 the workflow builds every target and evaluates the filter against each one. A

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -88,9 +88,9 @@ inputs:
     description: "Optional value forwarded to --gtest_filter"
   gtest-iterations:
     required: false
-    default: "1"
+    default: "0"
     type: string
-    description: "Optional number of times to run selected GoogleTest suites; defaults to 1"
+    description: "Number of times to run selected GoogleTest suites; default: 0 (skips GoogleTests)"
   run-gtests:
     required: false
     default: "false"

--- a/.github/scripts/run-regression-tests-helper.sh
+++ b/.github/scripts/run-regression-tests-helper.sh
@@ -90,9 +90,8 @@ ValidateInputs() {
   fi
   ITERATIONS_INPUT=$((10#${ITERATIONS_INPUT}))
 
-  if [[ -n "${GTEST_ITERATIONS_INPUT}" ]] && \
-     ! [[ "${GTEST_ITERATIONS_INPUT}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "gtest-iterations must be a positive integer, got: ${GTEST_ITERATIONS_INPUT}"
+  if [[ -n "${GTEST_ITERATIONS_INPUT}" ]] && ! [[ "${GTEST_ITERATIONS_INPUT}" =~ ^[0-9]+$ ]]; then
+    echo "gtest-iterations must be a non-negative integer, got: ${GTEST_ITERATIONS_INPUT}"
     exit 2
   fi
   if [[ -n "${GTEST_ITERATIONS_INPUT}" ]]; then
@@ -328,10 +327,14 @@ RunPytests() {
 
 RunGtests() {
   if [[ -z "${GTEST_ITERATIONS_INPUT}" ]]; then
-    GTEST_ITERATIONS_INPUT=1
+    GTEST_ITERATIONS_INPUT=0
   fi
   MAX_TESTS_RUN_TIME_INPUT="${MAX_TESTS_RUN_TIME_MINUTES}"
   ValidateInputs
+  if [[ "${GTEST_ITERATIONS_INPUT}" -eq 0 ]]; then
+    echo "Skipping GoogleTests: gtest-iterations is 0"
+    return
+  fi
   max_tests_run_time_minutes=${MAX_TESTS_RUN_TIME_INPUT}
   deadline_seconds=$(GetDeadlineSeconds "${max_tests_run_time_minutes}")
 

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -17,7 +17,7 @@ on:
         default: ""
         type: string
       iterations:
-        description: "Pytest: optional number of iterations. Default: 1. Example: 12"
+        description: "Pytest: optional number of iterations. Default: 1."
         required: false
         default: "1"
         type: string
@@ -34,9 +34,9 @@ on:
         default: ""
         type: string
       gtest-iterations:
-        description: "GoogleTest: optional number of iterations. Default: 1. Example: 12"
+        description: "GoogleTest: number of iterations; default: 0 (skips GoogleTests)."
         required: false
-        default: "1"
+        default: "0"
         type: string
 
       # Common inputs.

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -17,7 +17,7 @@ on:
         default: ""
         type: string
       iterations:
-        description: "Pytest: optional number of iterations. Default: 1. Example: 12"
+        description: "Pytest: optional number of iterations. Default: 1."
         required: false
         default: "1"
         type: string
@@ -34,9 +34,9 @@ on:
         default: ""
         type: string
       gtest-iterations:
-        description: "GoogleTest: optional number of iterations. Default: 1. Example: 12"
+        description: "GoogleTest: number of iterations; default: 0 (skips GoogleTests)."
         required: false
-        default: "1"
+        default: "0"
         type: string
 
       # Common inputs.


### PR DESCRIPTION
Default gtest-iterations to 0 so manual Pytest runs do not build or execute GoogleTests unless explicitly requested.

Use a positive gtest-iterations value to enable and repeat GoogleTest runs, and document the public controls and execution order.
