### PR TITLE
fix(cluster): don't crash when migration finalize pause times out

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -384,13 +384,14 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
       dfly::Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
                   nullptr, ClientPause::ALL, is_pause_in_progress);
 
-  DCHECK(pause_fb_opt);
+  // Pause can legitimately time out under load; retry rather than finalize unpaused.
   if (!pause_fb_opt) {
     auto err = absl::StrCat("Migration finalization time out ", cf_->MyID(), " : ",
                             migration_info_.node_info.id, " attempt ", attempt);
 
     LOG(WARNING) << err;
     SetLastError(std::move(err));
+    return false;
   }
 
   absl::Cleanup cleanup([&is_block_active, &pause_fb_opt]() {

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -384,7 +384,6 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
       dfly::Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
                   nullptr, ClientPause::ALL, is_pause_in_progress);
 
-  // Pause can legitimately time out under load; retry rather than finalize unpaused.
   if (!pause_fb_opt) {
     auto err = absl::StrCat("Migration finalization time out ", cf_->MyID(), " : ",
                             migration_info_.node_info.id, " attempt ", attempt);


### PR DESCRIPTION
`OutgoingMigration::FinalizeMigration` pauses clients before finalizing so no transaction gets scheduled with stale slot ownership. `dfly::Pause()` can legitimately return `nullopt` if it times out waiting for busy commands to finish dispatching under load, the code right after it already logs a warning and records the error for that exact case, but a `DCHECK(pause_fb_opt)` placed just before it aborts the process instead of letting execution fall through to the handling that already exists.

Under load the timeout fires for real and the process SIGABRTs:

```
Check failed: pause_fb_opt
outgoing_slot_migration.cc:387
```

Seen recurring in the fuzz-migration test (3 nodes, 20000 keys):
https://github.com/dragonflydb/dragonfly/actions/runs/33821266998

Fixes #8137.