### PR TITLE
fix(cluster): advertise the master's announced address on replicas in emulated mode

### DIFF
--- a/docs/cluster-mode.md
+++ b/docs/cluster-mode.md
@@ -593,14 +593,15 @@ mechanism, the state transition each side undergoes, and the recovery action.
 | Value | Behavior |
 |-------|----------|
 | unset / `""` | No cluster commands; `DFLYCLUSTER` rejected. |
-| `emulated` | Single-node owner of slots `0..16383`. `CLUSTER *` answers from a synthetic topology built from the local replication summary. `DFLYCLUSTER` is not exposed. |
+| `emulated` | Single-node owner of slots `0..16383`. `CLUSTER *` answers from a synthetic topology built from the local replication summary. A replica advertises its master at the address the master announces to clients (learned during the replication handshake, so both sides must run a version that has it), not at the address it replicates from. `DFLYCLUSTER` is not exposed. |
 | `yes` | Full cluster mode. Topology must be installed via `DFLYCLUSTER CONFIG` before the node serves any data-plane traffic. |
 
 | Flag | Default | Effect |
 |------|---------|--------|
 | `--admin_port` | `0` (off) | Required in real-cluster mode. `DFLYCLUSTER` and `DFLYMIGRATE` only accept connections on this listener; client-facing listeners reject them. |
 | `--cluster_node_id` | `""` (uses the master replication id) | Node identity in the config; must match what the cluster manager embeds in `master.id`, `replicas[].id`, and `migrations[].node_id`. Disallowed in `emulated` mode. |
-| `--cluster_announce_ip` | `""` (uses the local bind) | IP returned to clients in `CLUSTER SLOTS/SHARDS/NODES` and embedded in MOVED replies. |
+| `--cluster_announce_ip` | `""` (uses the local bind) | IP returned to clients in `CLUSTER SLOTS/SHARDS/NODES` and embedded in MOVED replies. Also sent to replicas during the replication handshake, so a runtime change reaches them on their next connection. |
+| `--announce_port` | `0` (uses `--port`) | Port announced to cluster clients and to the replication master; propagated to replicas like `--cluster_announce_ip`. |
 | `--experimental_cluster_shard_by_slot` | `false` | When `true`, thread-shard selection uses the slot id modulo shard count instead of a tag-hash modulo shard count. |
 | `--slot_migration_throttle_us` | `0` (off) | Target-side throttle: sleep this many microseconds after every 100 µs of migration processing. A starting value of `20` is reasonable if migrations starve user traffic. |
 | `--slot_migration_connection_timeout_ms` | `2000` | Source-side TCP connect timeout for the migration's INIT, FLOW, and ACK reconnects. |

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -123,6 +123,19 @@ std::optional<ClusterShardInfos> ClusterFamily::GetShardInfos(ConnectionContext*
   return nullopt;
 }
 
+ClusterNodeInfo ClusterFamily::AnnouncedNodeInfo(const facade::Connection* conn, string_view id) {
+  std::string ip = absl::GetFlag(FLAGS_cluster_announce_ip);
+  if (ip.empty()) {
+    ip = conn->LocalBindAddress();
+  }
+  return {.id = string(id), .ip = std::move(ip), .port = AnnouncedPort()};
+}
+
+uint16_t ClusterFamily::AnnouncedPort() {
+  uint16_t port = absl::GetFlag(FLAGS_announce_port);
+  return port == 0 ? static_cast<uint16_t>(absl::GetFlag(FLAGS_port)) : port;
+}
+
 ClusterShardInfo ClusterFamily::GetEmulatedShardInfo(ConnectionContext* cntx) const {
   ClusterShardInfo info{.slot_ranges = SlotRanges({{.start = 0, .end = kMaxSlotNum}}),
                         .master = {},
@@ -133,16 +146,7 @@ ClusterShardInfo ClusterFamily::GetEmulatedShardInfo(ConnectionContext* cntx) co
   ServerState& etl = *ServerState::tlocal();
   if (!repl_info) {
     DCHECK(etl.is_master);
-    std::string cluster_announce_ip = absl::GetFlag(FLAGS_cluster_announce_ip);
-    std::string preferred_endpoint =
-        cluster_announce_ip.empty() ? cntx->conn()->LocalBindAddress() : cluster_announce_ip;
-    uint16_t cluster_announce_port = absl::GetFlag(FLAGS_announce_port);
-    uint16_t preferred_port = cluster_announce_port == 0
-                                  ? static_cast<uint16_t>(absl::GetFlag(FLAGS_port))
-                                  : cluster_announce_port;
-
-    info.master = {{.id = id_, .ip = preferred_endpoint, .port = preferred_port},
-                   NodeHealth::ONLINE};
+    info.master = {AnnouncedNodeInfo(cntx->conn(), id_), NodeHealth::ONLINE};
 
     if (cntx->conn()->IsPrivileged() || !absl::GetFlag(FLAGS_managed_service_info)) {
       for (const auto& replica : server_family_->GetDflyCmd()->GetReplicasRoleInfo()) {
@@ -153,9 +157,14 @@ ClusterShardInfo ClusterFamily::GetEmulatedShardInfo(ConnectionContext* cntx) co
       }
     }
   } else {
-    // TODO: We currently don't save the master's ID in the replica
-    info.master = {{.id = "", .ip = repl_info->summary.host, .port = repl_info->summary.port},
-                   NodeHealth::ONLINE};
+    // The master's announced address, not the one we replicate from (e.g. its admin port).
+    const ReplicaSummary& master = repl_info->summary;
+    ClusterNodeInfo master_node{.id = master.master_id, .ip = master.host, .port = master.port};
+    if (master.announced) {
+      master_node.ip = master.announced->ip;
+      master_node.port = master.announced->port;
+    }
+    info.master = {std::move(master_node), NodeHealth::ONLINE};
     info.replicas.push_back({{.id = id_,
                               .ip = cntx->conn()->LocalBindAddress(),
                               .port = static_cast<uint16_t>(absl::GetFlag(FLAGS_port))},

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "facade/cmd_arg_parser.h"
 #include "facade/conn_context.h"
@@ -41,6 +42,12 @@ class ClusterFamily {
   const std::string& MyID() const {
     return id_;
   }
+
+  // Address this node advertises to cluster clients: cluster_announce_ip, else the address `conn`
+  // was accepted on, and announce_port, else --port.
+  static ClusterNodeInfo AnnouncedNodeInfo(const facade::Connection* conn,
+                                           std::string_view id = {});
+  static uint16_t AnnouncedPort();
 
   // Only for debug purpose. Pause/Resume all incoming migrations
   void PauseAllIncomingMigrations(bool pause) ABSL_LOCKS_EXCLUDED(migration_mu_);

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -64,8 +64,6 @@ ABSL_FLAG(bool, break_replication_on_master_restart, false,
 ABSL_FLAG(std::string, replica_announce_ip, "",
           "IP address that Dragonfly announces to replication master");
 ABSL_FLAG(bool, experimental_cascaded_partial_sync, false, "Experimental cascaded psync");
-ABSL_DECLARE_FLAG(int32_t, port);
-ABSL_DECLARE_FLAG(uint16_t, announce_port);
 ABSL_FLAG(
     int, replica_priority, 100,
     "Published by info command for sentinel to pick replica based on score during a failover");
@@ -335,10 +333,7 @@ error_code Replica::Greet() {
   PC_RETURN_ON_BAD_RESPONSE(CheckRespIsSimpleReply("PONG"));
 
   // Corresponds to server.repl_state == REPL_STATE_SEND_HANDSHAKE condition in replication.c
-  uint16_t port = absl::GetFlag(FLAGS_announce_port);
-  if (port == 0) {
-    port = static_cast<uint16_t>(absl::GetFlag(FLAGS_port));
-  }
+  uint16_t port = cluster::ClusterFamily::AnnouncedPort();
   RETURN_ON_ERR(SendCommandAndReadResponse(StrCat("REPLCONF listening-port ", port)));
   PC_RETURN_ON_BAD_RESPONSE(CheckRespIsSimpleReply("OK"));
 
@@ -358,6 +353,9 @@ error_code Replica::Greet() {
   RETURN_ON_ERR(SendCommandAndReadResponse("REPLCONF capa dragonfly"));
   PC_RETURN_ON_BAD_RESPONSE(CheckRespFirstTypes({RespExpr::STRING}));
 
+  // The address belongs to the master we are greeting now, which may be a different server.
+  master_context_.announced.reset();
+
   if (LastResponseArgs().size() == 1) {  // Redis
     PC_RETURN_ON_BAD_RESPONSE(CheckRespIsSimpleReply("OK"));
   } else if (LastResponseArgs().size() >= 3) {  // it's dragonfly master.
@@ -373,7 +371,8 @@ error_code Replica::Greet() {
 }
 
 std::error_code Replica::HandleCapaDflyResp() {
-  // Response is: <master_repl_id, syncid, num_shards [, version]>
+  // Response is: <master_repl_id> <syncid> <num_shards> [<version> [<lineage_id>
+  //   [<announced_ip> <announced_port>]]]
   if (!CheckRespFirstTypes({RespExpr::STRING, RespExpr::STRING, RespExpr::INT64}) ||
       LastResponseArgs()[0].GetBuf().size() != CONFIG_RUN_ID_SIZE)
     return make_error_code(errc::bad_message);
@@ -425,11 +424,23 @@ std::error_code Replica::HandleCapaDflyResp() {
     master_context_.lineage_id = master_context_.master_repl_id;
   }
 
+  if (LastResponseArgs().size() >= 7) {
+    PC_RETURN_ON_BAD_RESPONSE(LastResponseArgs()[5].type == RespExpr::STRING &&
+                              LastResponseArgs()[6].type == RespExpr::INT64);
+    int64_t announced_port = get<int64_t>(LastResponseArgs()[6].u);
+    PC_RETURN_ON_BAD_RESPONSE(announced_port >= 0 && announced_port <= UINT16_MAX);
+    master_context_.announced = {string(ToSV(LastResponseArgs()[5].GetBuf())),
+                                 static_cast<uint16_t>(announced_port)};
+  }
+
   VLOG(1) << "Master id: " << master_context_.master_repl_id
           << ", sync id: " << master_context_.dfly_session_id
           << ", num journals: " << param_num_flows
           << ", version: " << unsigned(master_context_.version)
-          << ", lineage: " << master_context_.lineage_id;
+          << ", lineage: " << master_context_.lineage_id << ", announced address: "
+          << (master_context_.announced
+                  ? StrCat(master_context_.announced->ip, ":", master_context_.announced->port)
+                  : "none");
 
   return error_code{};
 }
@@ -1391,6 +1402,7 @@ auto Replica::GetSummary() const -> Summary {
     Summary res;
     res.host = server().host;
     res.port = server().port;
+    res.announced = master_context_.announced;
     res.master_link_established = (state_mask_ & R_TCP_CONNECTED);
     res.full_sync_in_progress = (state_mask_ & R_SYNCING);
     res.full_sync_done = (state_mask_ & R_SYNC_OK);

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -36,7 +36,8 @@ struct MasterContext {
   std::string dfly_session_id;  // Sync session id for dfly sync.
   unsigned num_flows = 0;
   DflyVersion version = DflyVersion::VER1;
-  std::string lineage_id;  // lineage id of master
+  std::string lineage_id;                     // lineage id of master
+  std::optional<AnnouncedAddress> announced;  // from the capa reply, absent on older masters
 };
 
 // This class manages replication from both Dragonfly and Redis masters.

--- a/src/server/replica_types.h
+++ b/src/server/replica_types.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -11,9 +12,16 @@
 
 namespace dfly {
 
+// The client address a master announces during the replication handshake.
+struct AnnouncedAddress {
+  std::string ip;
+  uint16_t port;
+};
+
 struct ReplicaSummary {
   std::string host;
   uint16_t port;
+  std::optional<AnnouncedAddress> announced;  // absent when the master does not send it
   bool master_link_established;
   bool full_sync_in_progress;
   bool full_sync_done;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3620,17 +3620,21 @@ void ServerFamily::ReplConf(CmdArgParser parser, CommandContext* cmd_cntx) {
 
         cntx->replica_conn = true;
 
-        // The response for 'capa dragonfly' is:
-        //   <masterid> <syncid> <numthreads> <version> <lineage_id>
+        // The response for 'capa dragonfly' is <master_repl_id> <syncid> <num_shards> <version>
+        // <lineage_id> <announced_ip> <announced_port>. It may only grow at the end, and the ip
+        // is a bulk string because it is operator-supplied.
         std::string lineage_id = GetLineageId();
+        auto announced = cluster::ClusterFamily::AnnouncedNodeInfo(cntx->conn());
 
         auto* rb = static_cast<RedisReplyBuilder*>(builder);
-        rb->StartArray(5);
+        rb->StartArray(7);
         rb->SendSimpleString(master_replid_);
         rb->SendSimpleString(sync_id);
         rb->SendLong(flow_count);
         rb->SendLong(unsigned(DflyVersion::CURRENT_VER));
         rb->SendSimpleString(lineage_id);
+        rb->SendBulkString(announced.ip);
+        rb->SendLong(announced.port);
         return;
       }
     } else if (cmd == "LISTENING-PORT") {

--- a/tests/dragonfly/cluster_config_test.py
+++ b/tests/dragonfly/cluster_config_test.py
@@ -81,7 +81,7 @@ class ReplicaInfo:
     port: int
 
 
-def verify_slots_result(port: int, answer: list, replicas) -> bool:
+def verify_slots_result(port: int, answer: list, replicas, master_id: str | None = None) -> bool:
     def is_local_host(ip: str) -> bool:
         return ip == "127.0.0.1" or ip == "localhost"
 
@@ -93,10 +93,12 @@ def verify_slots_result(port: int, answer: list, replicas) -> bool:
     ip_addr = info[0]
     assert is_local_host(ip_addr)
     assert info[1] == port
+    if master_id is not None:
+        assert info[2] == master_id
 
     # Replicas
     assert len(answer) == 3 + len(replicas)
-    for i in range(3, len(replicas)):
+    for i in range(3, len(answer)):
         replica = replicas[i - 3]
         rep_info = answer[i]
         assert len(rep_info) == 3
@@ -132,18 +134,48 @@ async def test_emulated_cluster_with_replicas(df_factory):
     res = await c_master.execute_command("CLUSTER SLOTS")
     assert verify_slots_result(port=master.port, answer=res[0], replicas=[])
 
-    # Connect replicas to master
-    for replica, c_replica in zip(replicas, c_replicas):
-        rc = await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    # One replica uses the admin port, as the operator does; both must advertise the client port.
+    for c_replica, master_port in zip(c_replicas, [master.admin_port, master.port]):
+        rc = await c_replica.execute_command(f"REPLICAOF localhost {master_port}")
         assert rc == "OK"
 
-    await asyncio.sleep(0.5)
+    await wait_available_async(c_replicas)
 
-    for replica, c_replica in zip(replicas, c_replicas):
+    for replica, replica_id, c_replica in zip(replicas, replica_ids, c_replicas):
         res = await c_replica.execute_command("CLUSTER SLOTS")
         assert verify_slots_result(
-            port=master.port, answer=res[0], replicas=[ReplicaInfo(replica.port, id)]
+            port=master.port,
+            answer=res[0],
+            replicas=[ReplicaInfo(replica_id, replica.port)],
+            master_id=master_id,
         )
+
+        assert await c_replica.execute_command("CLUSTER NODES") == {
+            f"127.0.0.1:{master.port}": {
+                "connected": True,
+                "epoch": "0",
+                "flags": "master",
+                "hostname": "",
+                "last_ping_sent": "0",
+                "last_pong_rcvd": "0",
+                "master_id": "-",
+                "migrations": [],
+                "node_id": master_id,
+                "slots": [["0", "16383"]],
+            },
+            f"127.0.0.1:{replica.port}": {
+                "connected": True,
+                "epoch": "0",
+                "flags": "myself,slave",
+                "hostname": "",
+                "last_ping_sent": "0",
+                "last_pong_rcvd": "0",
+                "master_id": master_id,
+                "migrations": [],
+                "node_id": replica_id,
+                "slots": [],
+            },
+        }
 
     res = await c_master.execute_command("CLUSTER SLOTS")
     assert verify_slots_result(
@@ -212,6 +244,59 @@ async def test_emulated_cluster_with_replicas(df_factory):
             "slots": [],
         },
     }
+
+
+@dfly_args({"proactor_threads": 2, "cluster_mode": "emulated"})
+async def test_emulated_cluster_replica_advertises_announced_addresses(df_factory):
+    # The replica advertises the master's announced address, not the one it replicates from.
+    master = df_factory.create(
+        port=next(next_port),
+        admin_port=next(next_port),
+        cluster_announce_ip="127.0.0.2",
+        announce_port=1337,
+    )
+    replica = df_factory.create(port=next(next_port))
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+    master_id = await c_master.execute_command("CLUSTER MYID")
+    replica_id = await c_replica.execute_command("CLUSTER MYID")
+
+    # The handshake reply may only grow at the end; elements 6-7 carry the announced address.
+    probe = master.client(socket_timeout=5)
+    res = await probe.execute_command("REPLCONF", "capa", "dragonfly")
+    assert len(res) >= 7 and res[5:7] == ["127.0.0.2", 1337]
+    await probe.aclose()
+
+    assert await c_replica.execute_command(f"REPLICAOF localhost {master.admin_port}") == "OK"
+    await wait_available_async(c_replica)
+
+    expected = [[0, 16383, ["127.0.0.2", 1337, master_id], ["127.0.0.1", replica.port, replica_id]]]
+    assert await c_replica.execute_command("CLUSTER SLOTS") == expected
+
+    # The announced address is captured at handshake time: a runtime change on the master reaches
+    # the replica on its next connection.
+    assert await c_master.execute_command("CONFIG SET cluster_announce_ip 127.0.0.4") == "OK"
+    assert await c_master.execute_command("CONFIG SET announce_port 1339") == "OK"
+    assert await c_replica.execute_command("CLUSTER SLOTS") == expected
+
+    assert await c_replica.execute_command("REPLICAOF NO ONE") == "OK"
+    assert await c_replica.execute_command(f"REPLICAOF localhost {master.admin_port}") == "OK"
+    await wait_available_async(c_replica)
+    expected[0][2][:2] = ["127.0.0.4", 1339]
+    assert await c_replica.execute_command("CLUSTER SLOTS") == expected
+
+    # An automatic reconnect re-reads the announced address (the restart drops the CONFIG SETs).
+    master.stop()
+    master.start()
+    expected[0][2] = ["127.0.0.2", 1337, await c_master.execute_command("CLUSTER MYID")]
+
+    @assert_eventually(times=200)
+    async def replica_follows_restarted_master():
+        assert await c_replica.execute_command("CLUSTER SLOTS") == expected
+
+    await replica_follows_restarted_master()
 
 
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})

--- a/tests/dragonfly/replication_config_test.py
+++ b/tests/dragonfly/replication_config_test.py
@@ -89,6 +89,7 @@ async def test_no_tls_on_admin_port(
         **with_tls_server_args,
         requirepass="XXX",
         proactor_threads=t_master,
+        cluster_mode="emulated",
     )
     master.start()
     c_master = master.admin_client(password="XXX")
@@ -104,6 +105,7 @@ async def test_no_tls_on_admin_port(
         proactor_threads=t_replica,
         requirepass="XXX",
         masterauth="XXX",
+        cluster_mode="emulated",
     )
     replica.start()
     c_replica = replica.admin_client(password="XXX")
@@ -112,6 +114,10 @@ async def test_no_tls_on_admin_port(
 
     # 3. Verify that replica dbsize == debug populate key size -- replication works
     await assert_debug_populate_synced(c_master, c_replica, 100, populate=False)
+
+    # 4. The replica advertises the master's client port, not the admin port it replicates over
+    res = await c_replica.execute_command("CLUSTER SLOTS")
+    assert res[0][2][1] == master.port
 
 
 # 1. Number of master threads
@@ -419,9 +425,9 @@ def download_dragonfly_release(version):
 async def test_replicate_old_master(
     df_factory: DflyInstanceFactory, cluster_mode, announce_ip, announce_port
 ):
-    cpu = platform.processor()
-    if cpu != "x86_64":
-        pytest.skip(f"Supported only on x64, running on {cpu}")
+    cpu = platform.machine()
+    if cpu not in ("x86_64", "aarch64"):
+        pytest.skip(f"No release binaries for {cpu}")
 
     dfly_version = "v1.19.2"
     released_dfly_path = download_dragonfly_release(dfly_version)
@@ -453,6 +459,49 @@ async def test_replicate_old_master(
     await wait_available_async(c_replica)
 
     assert await c_replica.execute_command("get", "k1") == "v1"
+
+    if cluster_mode == "emulated":
+        # An old master sends no announced address: fall back to the one we replicate from.
+        res = await c_replica.execute_command("CLUSTER SLOTS")
+        master_replid = (await c_replica.execute_command("INFO", "REPLICATION"))["master_replid"]
+        assert res[0][2] == ["localhost", master.port, master_replid]
+        assert res[0][3][1] == replica.port
+
+
+async def test_replicate_to_old_replica(df_factory: DflyInstanceFactory):
+    cpu = platform.machine()
+    if cpu not in ("x86_64", "aarch64"):
+        pytest.skip(f"No release binaries for {cpu}")
+
+    dfly_version = "v1.19.2"
+    released_dfly_path = download_dragonfly_release(dfly_version)
+    master = df_factory.create(cluster_mode="emulated", admin_port=ADMIN_PORT)
+    replica = df_factory.create(version=1.19, path=released_dfly_path, cluster_mode="emulated")
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+    assert (
+        f"df-{dfly_version}"
+        == (await c_replica.execute_command("info", "server"))["dragonfly_version"]
+    )
+    await c_master.execute_command("set", "k1", "v1")
+
+    # An old replica must tolerate the longer handshake reply of a new master.
+    assert await c_replica.execute_command(f"REPLICAOF localhost {master.admin_port}") == "OK"
+
+    @assert_eventually(times=200)
+    async def old_replica_synced():
+        # The old version has no slave_repl_offset, which wait_available_async relies on.
+        info = await c_replica.execute_command("INFO", "REPLICATION")
+        assert info["master_link_status"] == "up" and info["master_sync_in_progress"] == 0
+        assert await c_replica.execute_command("get", "k1") == "v1"
+
+    await old_replica_synced()
+
+    # It keeps advertising the address it replicates from until it is upgraded.
+    res = await c_replica.execute_command("CLUSTER SLOTS")
+    assert res[0][2][:2] == ["localhost", master.admin_port]
 
 
 # This Test was intorduced in response to a bug when replicating empty hashmaps (encoded as


### PR DESCRIPTION
In emulated cluster mode a replica built the master row of CLUSTER NODES/SLOTS/SHARDS
from the host:port given to REPLICAOF. The operator replicates over the admin port, so
replicas advertised <master>:9999 and cluster-aware clients connected to the admin
listener or failed on AUTH. Nothing in the handshake carried the master's client port,
so --announce_port on the master could not fix it.

The master now appends its announced address (cluster_announce_ip or the address the
connection was accepted on, announce_port or --port) to the REPLCONF capa dragonfly
reply. The reply only grows at the end: replicas since v1.12 ignore trailing elements,
and a replica of an older master falls back to the REPLICAOF address. The replica also
fills the master node id from the same handshake instead of leaving it empty.

Fixes #7771