### PR TITLE
fix(server): regression fix: use O(1) methods for conn. metric

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -39,6 +39,7 @@ class BackedArguments {
     storage_.reserve(total_size);
   }
 
+  // Must remain O(1) for connection memory accounting.
   size_t HeapMemory() const {
     size_t s1 = offsets_.capacity() <= kLenCap ? 0 : offsets_.capacity() * sizeof(uint32_t);
     size_t s2 = storage_.capacity() <= kStorageCap ? 0 : storage_.capacity();

--- a/src/common/heap_size.h
+++ b/src/common/heap_size.h
@@ -33,9 +33,13 @@ template <typename Container>
 size_t AccumulateContainer(const Container& c);  // defined below to use HeapSize()
 }  // namespace detail
 
-inline size_t HeapSize(const std::string& s) {
+inline size_t ShallowHeapSize(const std::string& s) {
   constexpr size_t kSmallStringOptSize = 15;
   return s.capacity() > kSmallStringOptSize ? s.capacity() : 0UL;
+}
+
+inline size_t HeapSize(const std::string& s) {
+  return ShallowHeapSize(s);
 }
 
 // Overload for types that have defined UsedMemory

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -42,6 +42,10 @@ class ConnectionContext {
     return 0;
   }
 
+  virtual size_t UsedMemoryO1() const {
+    return 0;
+  }
+
   // Noop.
   virtual void Unsubscribe(std::string_view channel) {
   }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2882,6 +2882,24 @@ size_t Connection::GetMemoryUsage() const {
   return mem;
 }
 
+size_t Connection::GetMemoryUsageO1() const {
+  size_t mem = sizeof(*this) + cmn::ShallowHeapSize(name_);
+
+  if (memcache_parser_)
+    mem += sizeof(*memcache_parser_) + memcache_parser_->UsedMemory();
+  if (redis_parser_)
+    mem += sizeof(*redis_parser_) + redis_parser_->UsedMemory();
+  if (cc_)
+    mem += sizeof(*cc_) + cc_->UsedMemoryO1();
+  if (reply_builder_)
+    mem += sizeof(*reply_builder_) + reply_builder_->UsedMemory();
+
+  if (parsed_cmd_)
+    mem += parsed_cmd_->GetSize() + parsed_cmd_->HeapMemory();
+  mem += 9'000;
+  return mem;
+}
+
 std::shared_ptr<const TlsCertInfo> Connection::GetTlsCertInfo() const {
 #ifdef DFLY_USE_SSL
   auto* facade_listener = static_cast<facade::Listener*>(listener());
@@ -2898,7 +2916,7 @@ void Connection::RefreshConnectionMemoryUsage() {
   DCHECK(socket());
   DCHECK_EQ(socket()->proactor(), ProactorBase::me());
 
-  size_t current = account_connection_memory_ ? GetMemoryUsage() : 0;
+  size_t current = account_connection_memory_ ? GetMemoryUsageO1() : 0;
   ConnectionStats& conn_stats = GetLocalConnStats();
 
   if (current >= accounted_connection_memory_bytes_) {
@@ -2947,7 +2965,7 @@ void Connection::IncreaseConnStats() {
   }
 
   conn_stats_registered_ = true;
-  accounted_connection_memory_bytes_ = account_connection_memory_ ? GetMemoryUsage() : 0;
+  accounted_connection_memory_bytes_ = account_connection_memory_ ? GetMemoryUsageO1() : 0;
   conn_stats.connection_memory_bytes += accounted_connection_memory_bytes_;
 }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -264,6 +264,7 @@ class Connection : public util::Connection {
 
   // Returns memory usage of this connection's auxiliary members in bytes.
   size_t GetMemoryUsage() const;
+  size_t GetMemoryUsageO1() const;
 
   ConnectionContext* cntx();
 

--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -125,6 +125,7 @@ class MemcacheParser {
   // so that the memcache command name does not need to be duplicated in callers.
   static std::string_view CmdName(CmdType type);
 
+  // Must remain O(1) for connection memory accounting.
   size_t UsedMemory() const {
     return tmp_buf_.capacity();
   }

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -97,6 +97,7 @@ class SinkReplyBuilder {
     return ec_;
   }
 
+  // Must remain O(1) for connection memory accounting.
   size_t UsedMemory() const {
     return buffer_.Capacity();
   }

--- a/src/facade/resp_srv_parser.cc
+++ b/src/facade/resp_srv_parser.cc
@@ -341,7 +341,7 @@ void RespSrvParser::HandleFinishArg() {
 }
 
 size_t RespSrvParser::UsedMemory() const {
-  return cmn::HeapSize(buf_stash_);
+  return cmn::ShallowHeapSize(buf_stash_);
 }
 
 }  // namespace facade

--- a/src/facade/resp_srv_parser.h
+++ b/src/facade/resp_srv_parser.h
@@ -46,6 +46,7 @@ class RespSrvParser {
     return bulk_len_;
   }
 
+  // Must remain O(1) for connection memory accounting.
   size_t UsedMemory() const;
 
  private:

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -23,6 +23,7 @@ namespace dfly {
 using namespace std;
 using namespace facade;
 using cmn::HeapSize;
+using cmn::ShallowHeapSize;
 
 namespace {
 void SendSubscriptionChangedResponse(string_view action, std::optional<string_view> topic,
@@ -214,6 +215,32 @@ size_t ConnectionContext::UsedMemory() const {
   return facade::ConnectionContext::UsedMemory() + HeapSize(conn_state) +
          HeapSize(authed_username) + HeapSize(acl_commands) + HeapSize(keys.key_globs) +
          HeapSize(pub_sub.globs);
+}
+
+namespace {
+
+template <typename T> size_t CapBytes(const T& coll) {
+  return coll.capacity() * sizeof(typename T::value_type);
+}
+
+}  // namespace
+
+size_t ConnectionContext::UsedMemoryO1() const {
+  const auto& state = conn_state;
+  size_t mem = facade::ConnectionContext::UsedMemoryO1() + state.exec_info.GetStoredCmdBytes() +
+               CapBytes(state.exec_info.watched_keys) + CapBytes(authed_username) +
+               CapBytes(acl_commands) + CapBytes(keys.key_globs) + CapBytes(pub_sub.globs);
+
+  if (const auto* script = state.script_info.get())
+    mem += sizeof(*script) + CapBytes(script->lock_tags) + script->async_cmds_heap_mem +
+           CapBytes(script->acl_commands) + CapBytes(script->acl_keys.key_globs) +
+           CapBytes(script->acl_pub_sub.globs);
+
+  if (const auto* subscriptions = state.subscribe_info.get())
+    mem += sizeof(*subscriptions) + CapBytes(subscriptions->channels) +
+           CapBytes(subscriptions->patterns);
+
+  return mem;
 }
 
 void ConnectionContext::OnSocketError(uint32_t /* epoll_mask */) {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -350,6 +350,7 @@ class ConnectionContext : public facade::ConnectionContext {
   void ChangeMonitor(bool start);  // either start or stop monitor on a given connection
 
   size_t UsedMemory() const override;
+  size_t UsedMemoryO1() const override;
 
   void Unsubscribe(std::string_view channel) override;
   void OnSocketError(uint32_t epoll_mask) override;

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -4,7 +4,10 @@
 
 #include "server/server_family.h"
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/strings/match.h>
+
+#include <chrono>
 
 #include "absl/strings/str_cat.h"
 #include "base/flags.h"
@@ -764,6 +767,64 @@ TEST_F(ServerFamilyTest, DebugPopulateZeroValSize) {
   // val_size=0 with the default element count (1) must not crash the server.
   auto resp = Run({"DEBUG", "POPULATE", "1", "key", "0"});
   EXPECT_THAT(resp, ErrArg("val_size must be positive"));
+}
+
+TEST_F(ServerFamilyTest, ConnMemUseConstTime) {
+  if (!absl::GetFlag(FLAGS_cluster_mode).empty()) {
+    GTEST_SKIP() << "SUBSCRIBE requires non-cluster mode";
+  }
+
+  pp_->at(0)->Await([&] {
+    constexpr unsigned kSmallSubscriptions = 100;
+    constexpr unsigned kLargeSubscriptions = 30'000;
+    constexpr unsigned kIterations = 256;
+
+    single_response_ = false;
+    absl::Cleanup cleanup = [&] {
+      Run({"UNSUBSCRIBE"});
+      single_response_ = true;
+    };
+    auto subscribe = [&](unsigned first, unsigned end) {
+      vector<string> args{"SUBSCRIBE"};
+      args.reserve(1 + end - first);
+      const string prefix(64, 'x');
+      for (unsigned i = first; i < end; ++i) {
+        args.push_back(absl::StrCat(prefix, ":", i));
+      }
+      EXPECT_THAT(Run(absl::Span<const string>{args}),
+                  RespElementsAre("subscribe", args[1], first + 1));
+    };
+
+    auto thread_cpu_time = [] {
+      timespec ts{};
+      CHECK_EQ(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts), 0);
+      return chrono::seconds(ts.tv_sec) + chrono::nanoseconds(ts.tv_nsec);
+    };
+
+    subscribe(0, kSmallSubscriptions);
+    auto* conn = GetConnection(GetId());
+    ASSERT_NE(conn, nullptr);
+
+    auto measure = [&] {
+      const auto start = thread_cpu_time();
+      for (unsigned i = 0; i < kIterations; ++i) {
+        benchmark::DoNotOptimize(conn->GetMemoryUsageO1());
+      }
+      return thread_cpu_time() - start;
+    };
+
+    const size_t small_bytes = conn->GetMemoryUsageO1();
+    ASSERT_GT(small_bytes, 0u);
+    const auto small_time = measure();
+
+    subscribe(kSmallSubscriptions, kLargeSubscriptions);
+    const size_t large_bytes = conn->GetMemoryUsageO1();
+    EXPECT_GT(large_bytes, small_bytes);
+    const auto large_time = measure();
+
+    const auto budget = 10 * small_time + chrono::milliseconds(1);
+    EXPECT_LE(large_time.count(), budget.count());
+  });
 }
 
 TEST_F(ServerFamilyTest, MemoryArenaSummary) {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -746,6 +746,17 @@ auto BaseFamilyTest::AddFindConn(Protocol proto, std::string_view id) -> TestCon
   return it->second.get();
 }
 
+TestConnection* BaseFamilyTest::GetConnection(string_view conn_id) {
+  DCHECK(ProactorBase::IsProactorThread());
+  unique_lock lk(mu_);
+  auto it = connections_.find(conn_id);
+  if (it == connections_.end())
+    return nullptr;
+  auto* conn = it->second->conn();
+  DCHECK_EQ(conn->socket()->proactor(), ProactorBase::me());
+  return conn;
+}
+
 Transaction* BaseFamilyTest::GetTransaction(string_view conn_id) {
   unique_lock lk(mu_);
   auto it = connections_.find(conn_id);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -140,6 +140,8 @@ class BaseFamilyTest : public ::testing::Test {
   }
 
   TestConnWrapper* AddFindConn(Protocol proto, std::string_view id);
+  // Returns an existing connection, or nullptr. Call only on its owning proactor thread.
+  TestConnection* GetConnection(std::string_view conn_id);
   Transaction* GetTransaction(std::string_view conn_id);
   static std::vector<std::string> StrArray(const RespExpr& expr);
 


### PR DESCRIPTION
The metric for connection bytes previously used the method `HeapSize` in many places when getting the memory usage of a connection. `HeapSize` is overloaded which will delegate to `UsedMemory` in certain cases. For concrete example:

- `Connection::GetMemoryUsage` is called to refresh connection memory usage
- it calls `HeapSize` and then `UsedMemory` on the connection context
- that calls heap size function and then `UsedMemory` on the `ConnectionState` (and inside it subscriber info obj)
- which ends up calling `AccumulateContainer` on the channels and patterns hashset, which will iterate on every string

The combination of `HeapSize` + `UsedMemory` overloads is very useful to provide a generic interface to calculate byte sizes, but it can represent linear walk on collections, which is bad for hot path methods.

In the test added it is a large number of channels which can be seen to cause slowness in calculating memory usage (before this change).

---

- introduce constant time / shallow check methods
- do not use generic methods like HeapSize etc for the metric calculation for connection memory bytes which can hide deep walks on hot path
- add test which roughly checks that time taken does not scale with connection state subscriber info
- generic methods will reuse const-time methods where possible or use that plus non-const calculations

the `memory stats` command will still use the deep walk methods

some nested checks like subscription strings, watched keys etc are not possible in O(1) yet so skipped. so metric is not as close to the full conn. bytes usage as before. cached counters may be gradually added for this.