### PR TITLE
fix(protocol): detect RESP commands after empty inline lines

### DIFF
--- a/src/facade/resp_srv_parser.cc
+++ b/src/facade/resp_srv_parser.cc
@@ -26,25 +26,25 @@ auto RespSrvParser::Parse(Buffer str, uint32_t* consumed, cmn::BackedArguments* 
   DVLOG(2) << "Parsing: "
            << absl::CHexEscape(string_view{reinterpret_cast<const char*>(str.data()), str.size()});
 
-  if (state_ == CMD_COMPLETE_S) {
-    args->clear();
-    buf_stash_.clear();
-    inline_total_ = 0;
-
-    if (str[0] == '*') {
-      // We recognized a non-INLINE state, starting with '*'
-      str.remove_prefix(1);
-      *consumed += 1;
-      state_ = ARRAY_LEN_S;
-      if (str.empty())
-        return INPUT_PENDING;
-    } else {  // INLINE mode, aka PING\n
-      state_ = INLINE_S;
-    }
-  }
-
   ResultConsumed resultc{OK, 0};
   do {
+    if (state_ == CMD_COMPLETE_S) {
+      args->clear();
+      buf_stash_.clear();
+      inline_total_ = 0;
+
+      if (str[0] == '*') {
+        // We recognized a non-INLINE state, starting with '*'
+        str.remove_prefix(1);
+        *consumed += 1;
+        state_ = ARRAY_LEN_S;
+        if (str.empty())
+          return INPUT_PENDING;
+      } else {  // INLINE mode, aka PING\n
+        state_ = INLINE_S;
+      }
+    }
+
     switch (state_) {
       case ARRAY_LEN_S:
         resultc = ConsumeArrayLen(str, args);
@@ -78,7 +78,9 @@ auto RespSrvParser::Parse(Buffer str, uint32_t* consumed, cmn::BackedArguments* 
 
     *consumed += resultc.second;
     str.remove_prefix(exchange(resultc.second, 0));
-  } while (state_ != CMD_COMPLETE_S && resultc.first == OK && !str.empty());
+    // Empty inline lines end a command too. Detect the next command's protocol again,
+    // even when it is already in this buffer (e.g. the redis-cli --pipe ECHO sentinel).
+  } while ((state_ != CMD_COMPLETE_S || args->empty()) && resultc.first == OK && !str.empty());
 
   if (state_ != CMD_COMPLETE_S) {
     if (resultc.first == OK) {
@@ -98,7 +100,7 @@ auto RespSrvParser::Parse(Buffer str, uint32_t* consumed, cmn::BackedArguments* 
   }
 
   args->MaybeShrink();
-  return resultc.first;
+  return resultc.first == OK && args->empty() ? INPUT_PENDING : resultc.first;
 }
 
 auto RespSrvParser::ParseInline(Buffer str, cmn::BackedArguments* args) -> ResultConsumed {
@@ -133,10 +135,6 @@ auto RespSrvParser::ParseInline(Buffer str, cmn::BackedArguments* args) -> Resul
   while (ptr != end) {
     // For inline input we only require \n.
     if (*ptr == '\n') {
-      if (args->empty()) {
-        ++ptr;
-        continue;  // skip empty line
-      }
       break;
     }
 

--- a/src/facade/resp_srv_parser_test.cc
+++ b/src/facade/resp_srv_parser_test.cc
@@ -270,6 +270,50 @@ TEST_F(RespSrvParserTest, InlineReset) {
   EXPECT_EQ(13, consumed_);
 }
 
+TEST_F(RespSrvParserTest, EmptyLinesBeforeMultibulk) {
+  // redis-cli --pipe prefixes its final ECHO with CRLF. The sentinel is binary data.
+  const string sentinel("0123\r\n\0*2\r\nabcdefghi", 20);
+  const string echo = absl::StrCat("*2\r\n$4\r\nECHO\r\n$20\r\n", sentinel, "\r\n");
+  for (string_view prefix : {"\r\n", "\n", "\r\n\r\n", "\t \r\n\n"}) {
+    const string input = absl::StrCat(prefix, echo);
+    // Include every two-buffer split, including CRLF and the multibulk marker.
+    for (size_t split = 1; split <= input.size(); ++split) {
+      SCOPED_TRACE(absl::StrCat("prefix size: ", prefix.size(), ", split: ", split));
+      ASSERT_EQ(split == input.size() ? RespSrvParser::OK : RespSrvParser::INPUT_PENDING,
+                Parse(string_view(input).substr(0, split)));
+      ASSERT_EQ(split, consumed_);
+      if (split < input.size()) {
+        ASSERT_EQ(RespSrvParser::OK, Parse(string_view(input).substr(split)));
+        ASSERT_EQ(input.size() - split, consumed_);
+      }
+      EXPECT_THAT(Vec(), ElementsAre("ECHO", sentinel));
+    }
+  }
+}
+
+TEST_F(RespSrvParserTest, EmptyLineTooLong) {
+  // An empty argument list must not hide a size-limit error.
+  EXPECT_EQ(RespSrvParser::BAD_INLINE, Parse(string(70 * 1024, ' ')));
+}
+
+TEST_F(RespSrvParserTest, EmptyLinesBetweenPipelinedCommands) {
+  const string input = "*1\r\n$4\r\nPING\r\n\r\n*2\r\n$4\r\nECHO\r\n$3\r\nfoo\r\n\nPING\r\n";
+  string_view remaining(input);
+  ASSERT_EQ(RespSrvParser::OK, Parse(remaining));
+  EXPECT_THAT(Vec(), ElementsAre("PING"));
+  ASSERT_EQ(14, consumed_);
+  remaining.remove_prefix(consumed_);
+
+  ASSERT_EQ(RespSrvParser::OK, Parse(remaining));
+  EXPECT_THAT(Vec(), ElementsAre("ECHO", "foo"));
+  ASSERT_EQ(25, consumed_);
+  remaining.remove_prefix(consumed_);
+
+  ASSERT_EQ(RespSrvParser::OK, Parse(remaining));
+  EXPECT_THAT(Vec(), ElementsAre("PING"));
+  EXPECT_EQ(remaining.size(), consumed_);
+}
+
 static string SetCmd(size_t val_size) {
   const string val(val_size, 'x');
   return absl::StrCat("*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$", val_size, "\r\n", val, "\r\n");


### PR DESCRIPTION
`redis-cli --pipe` prefixes its final RESP ECHO with CRLF. When both arrive in one buffer,
Dragonfly stays in inline mode and parses `*2` as a command, causing errors and a timeout.

- Restart protocol detection after empty inline lines without dispatching empty commands.
- Cover every two-buffer split of a binary ECHO sentinel, pipelined commands, and inline size errors.

Validation: Debug server build, all 23 `resp_srv_parser_test` tests, and pre-commit checks pass.
The issue's `redis-cli --pipe` reproduction returns `errors: 0, replies: 5` with both V1 and V2
I/O loops; all five stored values are correct.

Fixes #8243.
