### PR TITLE
perf(facade): simplify connection memory refreshes

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2046,7 +2046,6 @@ bool Connection::ShouldEndAsyncFiber(const MessageHandle& msg) {
 void Connection::SquashPipeline() {
   DCHECK_EQ(GetPendingMessageCount(), parsed_cmd_q_len_);
   DCHECK_EQ(reply_builder_->GetProtocol(), Protocol::REDIS);  // Only Redis is supported.
-  ConnectionMemoryTracker memory_tracker(this);
   unsigned pipeline_count = std::min<uint32_t>(parsed_cmd_q_len_, pipeline_squash_limit_cached);
   auto& conn_stats = tl_facade_stats->conn_stats;
 
@@ -2069,6 +2068,8 @@ void Connection::SquashPipeline() {
     skip_next_squashing_ = true;
     return;
   }
+
+  ConnectionMemoryTracker memory_tracker(this);
 
   // Send all replies under a ReplyScope before releasing the commands.
   // This allows the reply builder to flush without copies
@@ -2895,16 +2896,20 @@ void Connection::RefreshConnectionMemoryUsage() {
   if (!conn_stats_registered_)
     return;
 
+  SetMemoryContribution(account_connection_memory_ ? GetMemoryUsage() : 0);
+}
+
+void Connection::SetMemoryContribution(size_t bytes) {
+  DCHECK(conn_stats_registered_);
   DCHECK(socket());
   DCHECK_EQ(socket()->proactor(), ProactorBase::me());
 
-  size_t current = account_connection_memory_ ? GetMemoryUsage() : 0;
   ConnectionStats& conn_stats = GetLocalConnStats();
 
-  if (current >= accounted_connection_memory_bytes_) {
-    conn_stats.connection_memory_bytes += current - accounted_connection_memory_bytes_;
+  if (bytes >= accounted_connection_memory_bytes_) {
+    conn_stats.connection_memory_bytes += bytes - accounted_connection_memory_bytes_;
   } else {
-    const size_t delta = accounted_connection_memory_bytes_ - current;
+    const size_t delta = accounted_connection_memory_bytes_ - bytes;
     if (ABSL_PREDICT_FALSE(delta > conn_stats.connection_memory_bytes)) {
       LOG(DFATAL) << CONN_ID << "Connection memory accounting underflow: total="
                   << conn_stats.connection_memory_bytes << " delta=" << delta;
@@ -2914,7 +2919,7 @@ void Connection::RefreshConnectionMemoryUsage() {
     }
   }
 
-  accounted_connection_memory_bytes_ = current;
+  accounted_connection_memory_bytes_ = bytes;
 }
 
 void Connection::SetConnectionMemoryAccounting(bool enabled) {
@@ -2922,13 +2927,13 @@ void Connection::SetConnectionMemoryAccounting(bool enabled) {
     return;
 
   account_connection_memory_ = enabled;
-  // reduce memory to 0 and tl stat contribution to 0 on enabled=false
   RefreshConnectionMemoryUsage();
 }
 
 void Connection::IncreaseConnStats() {
   DCHECK(tl_facade_stats);
   DCHECK(!conn_stats_registered_);
+  DCHECK_EQ(accounted_connection_memory_bytes_, 0u);
   DCHECK(socket());
   DCHECK_EQ(socket()->proactor(), ProactorBase::me());
   auto& conn_stats = tl_facade_stats->conn_stats;
@@ -2947,24 +2952,15 @@ void Connection::IncreaseConnStats() {
   }
 
   conn_stats_registered_ = true;
-  accounted_connection_memory_bytes_ = account_connection_memory_ ? GetMemoryUsage() : 0;
-  conn_stats.connection_memory_bytes += accounted_connection_memory_bytes_;
+  RefreshConnectionMemoryUsage();
 }
 
 void Connection::DecreaseConnStats() {
   DCHECK(tl_facade_stats);
   DCHECK(conn_stats_registered_);
   auto& conn_stats = tl_facade_stats->conn_stats;
-  RefreshConnectionMemoryUsage();
-  if (ABSL_PREDICT_FALSE(accounted_connection_memory_bytes_ > conn_stats.connection_memory_bytes)) {
-    LOG(DFATAL) << CONN_ID << "Connection memory accounting underflow on unregister: total="
-                << conn_stats.connection_memory_bytes
-                << " delta=" << accounted_connection_memory_bytes_;
-    conn_stats.connection_memory_bytes = 0;
-  } else {
-    conn_stats.connection_memory_bytes -= accounted_connection_memory_bytes_;
-  }
-  accounted_connection_memory_bytes_ = 0;
+  // Remove the last reported contribution, not a fresh estimate of memory being discarded.
+  SetMemoryContribution(0);
   conn_stats_registered_ = false;
 
   if (IsMainOrMemcache()) {
@@ -3053,6 +3049,7 @@ Connection::ParserStatus Connection::ParseRedisBatch(base::IoBuf& buf) {
 
 Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
   CHECK(io_buf.InputLen() > 0);
+  ConnectionMemoryTracker memory_tracker(this);
 
   do {
     if (parsed_cmd_ == nullptr) {
@@ -3069,7 +3066,6 @@ Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
     DVLOG(2) << CONN_ID << "mc_result " << unsigned(result) << " consumed: " << consumed << " type "
              << unsigned(parsed_cmd_->mc_command()->type);
     if (result == MemcacheParser::INPUT_PENDING) {
-      RefreshConnectionMemoryUsage();
       return NEED_MORE;
     }
 
@@ -3108,7 +3104,6 @@ Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
           break;
       }
     }
-    RefreshConnectionMemoryUsage();
   } while (parsed_cmd_q_len_ < 128 && io_buf.InputLen() > 0);
   // Memcache parse errors are turned into deferred replies above, so we never return ERROR here.
   return OK;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -552,6 +552,9 @@ class Connection : public util::Connection {
   void IncreaseConnStats();
   void DecreaseConnStats();
 
+  // Replaces this connection's last reported contribution to the owning thread's total.
+  void SetMemoryContribution(size_t bytes);
+
   // Registers or unregisters the two connection-owned read buffers: io_buf_ and overflow_buf_.
   // The shared per-proactor buffer capacity is registered separately and is not this connection's
   // responsibility. GetReadBufCapacity is a helper.

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1347,15 +1347,28 @@ async def test_large_cmd(async_client: aioredis.Redis):
     assert len(res) == MAX_ARR_SIZE
 
 
-@dfly_args({"proactor_threads": 1})
-async def test_parser_memory_stats(df_server, async_client: aioredis.Redis):
-    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port, limit=10)
-    writer.write(b"*1000\r\n")
-    writer.write(b"$4\r\nmget\r\n")
-    val = (b"a" * 100) + b"\r\n"
-    for i in range(900):
-        writer.write(b"$100\r\n" + val)
-    await writer.drain()  # writer is pending because the request is not finished.
+@dfly_multi_test_args(
+    {
+        "proactor_threads": 1,
+        "memcached_port": 11212,
+        "enable_resp_io_loop_v2": "false",
+        "enable_memcache_io_loop_v2": "false",
+    },
+    {
+        "proactor_threads": 1,
+        "memcached_port": 11212,
+        "enable_resp_io_loop_v2": "true",
+        "enable_memcache_io_loop_v2": "true",
+    },
+)
+@pytest.mark.parametrize("protocol", ["redis", "memcache"])
+async def test_parser_memory_stats(df_server, async_client: aioredis.Redis, protocol):
+    await async_client.ping()
+    metrics = await df_server.metrics()
+    baseline = metrics["dragonfly_connection_memory_bytes"].samples[0].value
+
+    port = df_server.port if protocol == "redis" else df_server.mc_port
+    reader, writer = await asyncio.open_connection("127.0.0.1", port, limit=10)
 
     @assert_eventually
     async def check_stats():
@@ -1364,13 +1377,34 @@ async def test_parser_memory_stats(df_server, async_client: aioredis.Redis):
 
         metrics = await df_server.metrics()
         connection_memory_bytes = metrics["dragonfly_connection_memory_bytes"].samples[0].value
-        assert connection_memory_bytes > 130000
+        assert connection_memory_bytes > baseline + 130000
         assert any(
             sample.labels["class"] == "connection" and sample.value == connection_memory_bytes
             for sample in metrics["dragonfly_memory_by_class_bytes"].samples
         )
 
-    await check_stats()
+    try:
+        if protocol == "redis":
+            writer.write(b"*1000\r\n")
+            writer.write(b"$4\r\nmget\r\n")
+            val = (b"a" * 100) + b"\r\n"
+            for i in range(900):
+                writer.write(b"$100\r\n" + val)
+        else:
+            writer.write(b"set key 0 0 200000\r\n" + b"a" * 150000)
+        await writer.drain()  # Leave the request incomplete and the connection idle.
+        await check_stats()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    @assert_eventually
+    async def check_cleanup():
+        metrics = await df_server.metrics()
+        current = metrics["dragonfly_connection_memory_bytes"].samples[0].value
+        assert baseline <= current < baseline + 4096
+
+    await check_cleanup()
 
 
 async def test_reject_non_tls_connections_on_tls(with_tls_server_args, df_factory):
@@ -3266,7 +3300,7 @@ async def test_client_migrate(df_server: DflyInstance):
     Test that we can migrate a client with "CLIENT MIGRATE" command.
     """
     client1 = df_server.client()
-    await client1.client_setname("test_migrate")
+    await client1.client_setname("test_migrate" + "x" * 65536)
     resp = await client1.execute_command("DFLY THREAD")
     client_id = await client1.client_id()
     assert resp[1] == 4
@@ -3277,8 +3311,19 @@ async def test_client_migrate(df_server: DflyInstance):
     dest_tid = (current_tid + 1) % 4
     resp = await client2.execute_command("CLIENT", "MIGRATE", client_id + 999, dest_tid)
     assert resp == 0  # Not migrated as the client does not exist
+    metrics = await df_server.metrics()
+    memory_before = metrics["dragonfly_connection_memory_bytes"].samples[0].value
     resp = await client2.execute_command("CLIENT", "MIGRATE", client_id, dest_tid)
     assert resp == 1  # migrated successfully
+
+    @assert_eventually
+    async def check_migrated():
+        assert (await client1.execute_command("DFLY THREAD"))[0] == dest_tid
+        metrics = await df_server.metrics()
+        memory_after = metrics["dragonfly_connection_memory_bytes"].samples[0].value
+        assert abs(memory_after - memory_before) < 4096
+
+    await check_migrated()
 
 
 @dfly_multi_test_args(


### PR DESCRIPTION
Simplify the per-thread connection-memory accounting introduced in #7550 and remove redundant measurements. Based directly on `main`; independent of #8245, which makes each estimate O(1).

- Centralize contribution replacement, delta accounting, and underflow diagnostics. On close or migration departure, subtract the last reported contribution without measuring again.
- Refresh Memcached parser memory once per batch, including incomplete-input and error exits, matching the existing Redis parser batching.
- Skip refreshes for V1 squash attempts that execute no commands; the subsequent regular dispatch still refreshes.
- Preserve successful execution/reply checkpoints and replication exclusion. No timers, pending-refresh queues, or connection scans in `GetMetrics()`.
- Extend telemetry coverage to Redis/Memcached under both IO loops, connection cleanup, and completed thread migrations.

Coalescing is deliberately conservative: this does not impose a time-based refresh rate or defer updates across potentially blocking commands.