### PR TITLE
fix(server): default SLOWLOG GET to 10 entries

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1037,7 +1037,7 @@ bool ValidateSnapshotFilenameFlags() {
 
 void SlowLogGet(facade::ParsedArgs args, std::string_view sub_cmd, util::ProactorPool* pp,
                 CommandContext* cmd_cntx) {
-  size_t requested_slow_log_length = UINT32_MAX;
+  size_t requested_slow_log_length = 10;
   size_t argc = args.size();
   if (argc >= 3) {
     return cmd_cntx->SendError(facade::UnknownSubCmd(sub_cmd, "SLOWLOG"), facade::kSyntaxErrType);
@@ -1048,9 +1048,7 @@ void SlowLogGet(facade::ParsedArgs args, std::string_view sub_cmd, util::Proacto
       return cmd_cntx->SendError("count should be greater than or equal to -1",
                                  facade::kSyntaxErrType);
     }
-    if (num >= 0) {
-      requested_slow_log_length = num;
-    }
+    requested_slow_log_length = num == -1 ? UINT32_MAX : static_cast<size_t>(num);
   }
 
   // gather all the individual slowlogs from all the fibers and sort them by their timestamp

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -165,15 +165,27 @@ TEST_F(ServerFamilyTest, SlowLogMaxLengthZero) {
 }
 
 TEST_F(ServerFamilyTest, SlowLogGetLen) {
-  auto resp = Run({"config", "set", "slowlog_max_len", "3"});
+  auto resp = Run({"config", "set", "slowlog_max_len", "20"});
   EXPECT_THAT(resp.GetString(), "OK");
   resp = Run({"config", "set", "slowlog_log_slower_than", "0"});
   EXPECT_THAT(resp.GetString(), "OK");
+  Run({"slowlog", "reset"});
 
-  for (int i = 1; i <= 3; ++i) {
+  for (int i = 1; i <= 15; ++i) {
     resp = Run({"lpush", "mykey", std::to_string(i)});
     EXPECT_THAT(resp.GetInt(), i);
   }
+  Run({"config", "set", "slowlog_log_slower_than", "-1"});
+  const auto slowlog_length = Run({"slowlog", "len"}).GetInt();
+  EXPECT_GT(slowlog_length, 10);
+
+  // Test GET without a count - returns 10 entries by default
+  resp = Run({"slowlog", "get"});
+  EXPECT_THAT(resp.GetVec().size(), 10);
+
+  // Test GET with a positive count - returns the requested number of entries
+  resp = Run({"slowlog", "get", "3"});
+  EXPECT_THAT(resp.GetVec().size(), 3);
 
   // Test GET 0 - returns empty
   resp = Run({"slowlog", "get", "0"});
@@ -181,7 +193,7 @@ TEST_F(ServerFamilyTest, SlowLogGetLen) {
 
   // Test GET -1 - returns all entries
   resp = Run({"slowlog", "get", "-1"});
-  EXPECT_THAT(resp.GetVec().size(), 3);
+  EXPECT_THAT(resp.GetVec().size(), slowlog_length);
 
   // Test GET < -1 - returns error
   resp = Run({"slowlog", "get", "-2"});


### PR DESCRIPTION


Make `SLOWLOG GET` return 10 entries by default, matching Redis behavior, while preserving `SLOWLOG GET -1` as the way to return all entries.

