### PR TITLE
fix: potential livelock in FinalizeMigration

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -339,9 +339,16 @@ void OutgoingMigration::SyncFb() {
     }
 
     long attempt = 0;
+    constexpr long kMaxFinalizeAttempts = 30;  // bound retries so finalize can't loop forever
     while (GetState() != MigrationState::C_FINISHED && !FinalizeMigration(++attempt)) {
       // Break loop and don't sleep in case of C_FATAL, or a reported error (e.g. OOM on ACK).
       if (GetState() == MigrationState::C_FATAL || !exec_st_.IsRunning()) {
+        break;
+      }
+      if (attempt >= kMaxFinalizeAttempts) {
+        exec_st_.ReportError(absl::StrCat("Migration finalization failed after ", attempt,
+                                          " attempts for ", cf_->MyID(), " : ",
+                                          migration_info_.node_info.id));
         break;
       }
       // Process commands that were on pause and try again

--- a/tests/dragonfly/cluster_migration_resilience_test.py
+++ b/tests/dragonfly/cluster_migration_resilience_test.py
@@ -95,7 +95,7 @@ async def test_network_disconnect_during_migration(df_factory, proxy_factory):
         ),
     ],
 )
-@dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "pause_wait_timeout": 10})
 async def test_cluster_fuzzymigration(
     df_factory: DflyInstanceFactory,
     df_seeder_factory,


### PR DESCRIPTION
This https://github.com/dragonflydb/dragonfly/commit/85ca2698d7ff6f6134510bbf58572a4650ed3bea PR introduced a regression: if the `Pause` does not work the datastore can livelock because `FinalizeMigration` is never actually bound.

Since the test failed only for ioloopv2 my original hypothesis was that it had a corner case that ignored the CheckPoint messages sent by the DispatchTracker. I think this is unlikely. So:

* I increased the pause wait time
* bound the FinalizeLoop to 30 attempts (incremental total sleeps of 15 seconds)