### PR TITLE
fix: allocate sorted map pointers on data heap

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -6,6 +6,7 @@
 
 #include <absl/base/internal/endian.h>
 
+#include <memory>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -508,16 +509,16 @@ class CompactObj {
   static MemoryResource* memory_resource();  // thread-local.
 
   template <typename T, typename... Args> static T* AllocateMR(Args&&... args) {
-    void* ptr = memory_resource()->allocate(sizeof(T), alignof(T));
+    T* ptr = static_cast<T*>(memory_resource()->allocate(sizeof(T), alignof(T)));
     if constexpr (std::is_constructible_v<T, decltype(memory_resource())> && sizeof...(args) == 0)
-      return new (ptr) T{memory_resource()};
+      return std::construct_at(ptr, memory_resource());
     else
-      return new (ptr) T{std::forward<Args>(args)...};
+      return std::construct_at(ptr, std::forward<Args>(args)...);
   }
 
   template <typename T> static void DeleteMR(void* ptr) {
     T* t = (T*)ptr;
-    t->~T();
+    std::destroy_at(t);
     memory_resource()->deallocate(ptr, sizeof(T), alignof(T));
   }
 

--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <stack>
 #include <type_traits>
 #include <vector>
@@ -914,8 +915,7 @@ auto DenseSet::NewLink(void* data, DensePtr next) -> DenseLinkKey* {
   using LinkAllocator = StatelessAllocator<DenseLinkKey>;
 
   LinkAllocator la;
-  DenseLinkKey* lk = la.allocate(1);
-  la.construct(lk);
+  DenseLinkKey* lk = std::construct_at(la.allocate(1));
 
   lk->next = next;
   lk->SetObject(data);

--- a/src/core/detail/stateless_allocator.h
+++ b/src/core/detail/stateless_allocator.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cassert>
+#include <memory>
 
 #include "base/pmr/memory_resource.h"
 
@@ -19,6 +20,11 @@ template <typename T, typename Impl> class StatelessAllocatorBase {
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
   using is_always_equal = std::true_type;
+
+  // TODO: redundant with the std::allocator_traits fallback to std::construct_at; remove.
+  template <typename U, typename... _Args> void construct(U* __p, _Args&&... __args) {
+    std::construct_at(__p, std::forward<_Args>(__args)...);
+  }
 
   static value_type* allocate(size_type n) {
     static_assert(

--- a/src/core/detail/stateless_allocator.h
+++ b/src/core/detail/stateless_allocator.h
@@ -20,10 +20,6 @@ template <typename T, typename Impl> class StatelessAllocatorBase {
   using difference_type = std::ptrdiff_t;
   using is_always_equal = std::true_type;
 
-  template <typename U, typename... _Args> void construct(U* __p, _Args&&... __args) {
-    ::new (static_cast<void*>(__p)) U(std::forward<_Args>(__args)...);
-  }
-
   static value_type* allocate(size_type n) {
     static_assert(
         std::is_empty_v<Impl>,

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -7,6 +7,7 @@
 #include <absl/strings/str_cat.h>
 
 #include <cmath>
+#include <memory>
 
 extern "C" {
 #include "redis/listpack.h"
@@ -629,15 +630,17 @@ unsigned char* ZzlFind(unsigned char* lp, std::string_view ele, double* score) {
 
 SortedMap::SortedMap() {
   PMR_NS::memory_resource* mr = StatelessAllocator<char>::resource();
-  score_map = new (mr->allocate(sizeof(ScoreMap), alignof(ScoreMap))) ScoreMap();
-  score_tree = new (mr->allocate(sizeof(ScoreTree), alignof(ScoreTree))) ScoreTree(mr);
+  score_map =
+      std::construct_at(static_cast<ScoreMap*>(mr->allocate(sizeof(ScoreMap), alignof(ScoreMap))));
+  score_tree = std::construct_at(
+      static_cast<ScoreTree*>(mr->allocate(sizeof(ScoreTree), alignof(ScoreTree))), mr);
 }
 
 SortedMap::~SortedMap() {
   PMR_NS::memory_resource* mr = StatelessAllocator<char>::resource();
-  score_tree->~ScoreTree();
+  std::destroy_at(score_tree);
   mr->deallocate(score_tree, sizeof(ScoreTree), alignof(ScoreTree));
-  score_map->~ScoreMap();
+  std::destroy_at(score_map);
   mr->deallocate(score_map, sizeof(ScoreMap), alignof(ScoreMap));
 }
 
@@ -1164,8 +1167,8 @@ SortedMap* SortedMap::FromListPack(PMR_NS::memory_resource* res, const uint8_t* 
   unsigned int vlen;
   long long vlong;
 
-  void* ptr = res->allocate(sizeof(SortedMap), alignof(SortedMap));
-  SortedMap* zs = new (ptr) SortedMap;
+  SortedMap* zs = std::construct_at(
+      static_cast<SortedMap*>(res->allocate(sizeof(SortedMap), alignof(SortedMap))));
 
   eptr = lpSeek(zl, 0);
   if (eptr != NULL) {

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -627,13 +627,18 @@ unsigned char* ZzlFind(unsigned char* lp, std::string_view ele, double* score) {
   return nullptr;
 }
 
-SortedMap::SortedMap()
-    : score_map(new ScoreMap), score_tree(new ScoreTree(StatelessAllocator<char>::resource())) {
+SortedMap::SortedMap() {
+  PMR_NS::memory_resource* mr = StatelessAllocator<char>::resource();
+  score_map = new (mr->allocate(sizeof(ScoreMap), alignof(ScoreMap))) ScoreMap();
+  score_tree = new (mr->allocate(sizeof(ScoreTree), alignof(ScoreTree))) ScoreTree(mr);
 }
 
 SortedMap::~SortedMap() {
-  delete score_tree;
-  delete score_map;
+  PMR_NS::memory_resource* mr = StatelessAllocator<char>::resource();
+  score_tree->~ScoreTree();
+  mr->deallocate(score_tree, sizeof(ScoreTree), alignof(ScoreTree));
+  score_map->~ScoreMap();
+  mr->deallocate(score_map, sizeof(ScoreMap), alignof(ScoreMap));
 }
 
 // Three way comparison of q and key.

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -630,10 +630,10 @@ unsigned char* ZzlFind(unsigned char* lp, std::string_view ele, double* score) {
 
 SortedMap::SortedMap() {
   PMR_NS::memory_resource* mr = StatelessAllocator<char>::resource();
-  score_map =
-      std::construct_at(static_cast<ScoreMap*>(mr->allocate(sizeof(ScoreMap), alignof(ScoreMap))));
-  score_tree = std::construct_at(
-      static_cast<ScoreTree*>(mr->allocate(sizeof(ScoreTree), alignof(ScoreTree))), mr);
+  auto* map_mem = static_cast<ScoreMap*>(mr->allocate(sizeof(ScoreMap), alignof(ScoreMap)));
+  score_map = std::construct_at(map_mem);
+  auto* tree_mem = static_cast<ScoreTree*>(mr->allocate(sizeof(ScoreTree), alignof(ScoreTree)));
+  score_tree = std::construct_at(tree_mem, mr);
 }
 
 SortedMap::~SortedMap() {
@@ -1167,8 +1167,8 @@ SortedMap* SortedMap::FromListPack(PMR_NS::memory_resource* res, const uint8_t* 
   unsigned int vlen;
   long long vlong;
 
-  SortedMap* zs = std::construct_at(
-      static_cast<SortedMap*>(res->allocate(sizeof(SortedMap), alignof(SortedMap))));
+  auto* zs_mem = static_cast<SortedMap*>(res->allocate(sizeof(SortedMap), alignof(SortedMap)));
+  SortedMap* zs = std::construct_at(zs_mem);
 
   eptr = lpSeek(zl, 0);
   if (eptr != NULL) {


### PR DESCRIPTION
Core data structures should allocate on data heap and not the backing heap. The issue is that we allocated the internal pointers of the sorted map via `new` which used the backing instead of the data heap.

Small refactor: use the idiom where possible (std::construct_at + std::desruct_at)