### PR TITLE
fix(set): restore StringSet as the default SET implementation for 2.0

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -30,7 +30,7 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/transaction.h"
 
-ABSL_FLAG(bool, use_oah_set, true, "If true, store SET values in OAHSet instead of StringSet.");
+ABSL_FLAG(bool, use_oah_set, false, "If true, store SET values in OAHSet instead of StringSet.");
 
 namespace rng = std::ranges;
 


### PR DESCRIPTION
Flip use_oah_set back to false. OAHSet stays available behind the flag; the default reverts to the implementation that has production mileage in v1.40.x until OAHSet has been exercised in real deployments.
