### PR TITLE
chore: log error if migration does not finalize

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -339,10 +339,20 @@ void OutgoingMigration::SyncFb() {
     }
 
     long attempt = 0;
+    // Attempts are spaced 500ms apart, so this is ~15s of failed finalize attempts.
+    constexpr long kStalledFinalizeAttempts = 30;
     while (GetState() != MigrationState::C_FINISHED && !FinalizeMigration(++attempt)) {
       // Break loop and don't sleep in case of C_FATAL, or a reported error (e.g. OOM on ACK).
       if (GetState() == MigrationState::C_FATAL || !exec_st_.IsRunning()) {
         break;
+      }
+      if (attempt >= kStalledFinalizeAttempts) {
+        auto err = absl::StrCat("Migration finalization stuck after ", attempt, " attempts for ",
+                                cf_->MyID(), " : ", migration_info_.node_info.id);
+        LOG_EVERY_T(ERROR, 1) << err;
+        if (attempt == kStalledFinalizeAttempts) {
+          SetLastError(std::move(err));
+        }
       }
       // Process commands that were on pause and try again
       VLOG(1) << "Waiting for migration to finalize...";


### PR DESCRIPTION
This https://github.com/dragonflydb/dragonfly/commit/85ca2698d7ff6f6134510bbf58572a4650ed3bea PR introduced a regression: if the Pause does not work the datastore can livelock because FinalizeMigration is never actually bound.

So what we traded here is:

A minor data loss vs a potential livelock. It's correct in nature but we also need to address the livelock.

Then I tried to introduce https://github.com/dragonflydb/dragonfly/pull/8250 but this is also `pathogenic`. 

As I wrote there cancelling the context is not enough as it trades a small retry loop into a full resync. 

Then I thought maybe we can `Finish` the migration. This doesn't work either. It leaves the target nodes slots `unflushed` and the target not reports ongoing migration as syncing. This relies on the operator to become aware and send a cluster config. This is not good either.

So what I did instead is a middle ground for now. If for some rare event/reason we can't finalize the migration within `15seconds` we set the last error + log(error) such that we become aware and either wait or send a new cluster config which will properly clean up the migrations on both target and source.