### PR TITLE
feat(server): Turn off journal after a bound

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -14,6 +14,7 @@
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
+#include "server/journal/journal.h"
 #include "server/journal/streamer.h"
 #include "server/main_service.h"
 #include "server/namespaces.h"
@@ -36,6 +37,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   SliceSlotMigration(DbSlice* slice, ServerContext server_context, SlotSet slots,
                      OutgoingMigration* om)
       : ProtocolClient(server_context), streamer_(slice, std::move(slots), &exec_st_) {
+    journal::AcquireUser();
     // Flows only report errors; teardown is owned by the migration-level handler
     // (OutgoingMigration::OnAttemptError), which ResetError() joins at every attempt boundary.
     // A forwarder that fires late (after the boundary) injects an error into the new attempt
@@ -44,6 +46,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   }
 
   ~SliceSlotMigration() {
+    DCHECK(cancel_done_->IsCompleted());
     CloseSocket();
     // it should already be unregistered, this cancel was added to avoid race condition that we
     // possibly have.
@@ -94,9 +97,18 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   }
 
   void Cancel() {
+    auto done = cancel_done_;
+    if (cancel_started_) {
+      done->Wait();
+      return;
+    }
+
+    cancel_started_ = true;
     // Shutdown socket and allow IO loops to return.
     ShutdownSocket();
     streamer_.Cancel();
+    journal::ReleaseUser();
+    done->Dec();
   }
 
   void Finalize(long attempt) {
@@ -112,6 +124,8 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
  private:
   ExecutionState exec_st_;
   RestoreStreamer streamer_;
+  bool cancel_started_ = false;
+  fb2::BlockingCounter cancel_done_{1};
 };
 
 OutgoingMigration::OutgoingMigration(MigrationInfo info, ClusterFamily* cf, ServerFamily* sf)
@@ -132,6 +146,7 @@ OutgoingMigration::~OutgoingMigration() {
   // owner of the db tables
   OnAllShards([](auto& migration) {
     if (migration) {
+      migration->Cancel();
       migration.reset();
     }
   });
@@ -307,7 +322,6 @@ void OutgoingMigration::SyncFb() {
         migration->Cancel();
       }
       DbSlice& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
-      journal::StartInThread();
       migration = std::make_unique<SliceSlotMigration>(&db_slice, server(),
                                                        migration_info_.slot_ranges, this);
     });

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -176,6 +176,10 @@ void DflyCmd::ReplicaInfo::Cancel() {
     }
     VLOG(2) << "After flow cleanup " << shard->shard_id();
     flow->conn = nullptr;
+    if (flow->journal_held) {
+      journal::ReleaseUser();
+      flow->journal_held = false;
+    }
   });
   // Wait for error handler to quit.
   exec_st_.JoinErrorHandler();
@@ -336,7 +340,10 @@ void DflyCmd::Flow(CmdArgParser parser, CommandContext* cmd_cntx) {
       return;
     }
 
-    journal::StartInThread();
+    if (!flow.journal_held) {
+      journal::AcquireUser();
+      flow.journal_held = true;
+    }
 
     std::optional<Replica::LastMasterSyncData> my_last_master = sf_->GetLastMasterData();
 
@@ -1048,6 +1055,7 @@ void FlowInfo::TryShutdownSocket() {
 }
 
 FlowInfo::~FlowInfo() {
+  DCHECK(!journal_held);
 }
 
 FlowInfo::FlowInfo() {

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -54,6 +54,8 @@ struct FlowInfo {
   // Written by REPLCONF ACK on the owner-shard proactor; all readers also run there.
   uint64_t last_acked_lsn = 0;
 
+  bool journal_held = false;
+
   std::function<void()> cleanup;  // Optional cleanup for cancellation.
 };
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -762,6 +762,8 @@ void EngineShard::Heartbeat() {
   }
   stalled_start_ns_ = 0;
 
+  journal::MaybeStop();
+
   if (!IsReplica()) {  // Never run expiry/evictions on replica.
     RetireExpiredAndEvict();
   }

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -56,6 +56,28 @@ error_code Close() {
   return {};
 }
 
+void AcquireUser(bool start_journal) {
+  if (start_journal) {
+    StartInThread();
+  }
+  journal_slice.AcquireUser();
+}
+
+void ReleaseUser() {
+  journal_slice.ReleaseUser();
+}
+
+void MaybeStop() {
+  EngineShard* shard = EngineShard::tlocal();
+  if (shard->journal() && journal_slice.CanStop()) {
+    const LSN resume_bound = journal_slice.resume_bound();
+    ClearBuffer();
+    shard->set_journal(false);
+    LOG_EVERY_T(INFO, 1) << "Stopped unused journal on shard " << shard->shard_id()
+                         << ": resume boundary " << resume_bound << " evicted";
+  }
+}
+
 unsigned GetCallbackCount() {
   return journal_slice.OnChangeCbCount();
 }

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -24,6 +24,11 @@ std::error_code Close();
 
 //******* The following functions must be called in the context of the owning shard *********//
 
+void AcquireUser(bool start_journal = true);
+void ReleaseUser();
+
+void MaybeStop();
+
 unsigned GetCallbackCount();
 inline bool HasRegisteredCallbacks() {
   return GetCallbackCount() > 0;

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -110,6 +110,25 @@ bool JournalSlice::IsLSNInBuffer(LSN lsn) const {
   return ring_buffer_.front().lsn <= lsn && lsn <= ring_buffer_.back().lsn;
 }
 
+bool JournalSlice::IsLSNBeforeBuffer(LSN lsn) const {
+  DCHECK(ring_buffer_.capacity() > 0);
+  return lsn < (ring_buffer_.empty() ? cur_lsn() : ring_buffer_.front().lsn);
+}
+
+void JournalSlice::AcquireUser() {
+  ++user_count_;
+}
+
+void JournalSlice::ReleaseUser() {
+  CHECK_GT(user_count_, 0u);
+  if (--user_count_ == 0)
+    RefreshResumeBound();
+}
+
+bool JournalSlice::CanStop() const {
+  return user_count_ == 0 && IsLSNBeforeBuffer(resume_bound_);
+}
+
 std::string_view JournalSlice::GetEntry(LSN lsn) const {
   DCHECK(ring_buffer_.capacity() > 0 && IsLSNInBuffer(lsn));
 
@@ -266,6 +285,7 @@ uint32_t JournalSlice::RegisterOnChange(JournalConsumerInterface* consumer) {
   // mutex lock isn't needed due to iterators are not invalidated
   uint32_t id = next_cb_id_++;
   journal_consumers_arr_.emplace_back(id, consumer);
+  AcquireUser();
   return id;
 }
 
@@ -276,6 +296,7 @@ void JournalSlice::UnregisterOnChange(uint32_t id) {
                     [id](const auto& e) { return e.first == id; });
   CHECK(it != journal_consumers_arr_.end());
   journal_consumers_arr_.erase(it);
+  ReleaseUser();
 }
 
 }  // namespace journal

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -35,6 +35,19 @@ class JournalSlice {
 
   void AddLogRecord(const Entry& entry);
 
+  void AcquireUser();
+  void ReleaseUser();
+
+  void RefreshResumeBound() {
+    resume_bound_ = cur_lsn();
+  }
+
+  LSN resume_bound() const {
+    return resume_bound_;
+  }
+
+  bool CanStop() const;
+
   // Register a callback that will be called every time a new entry is
   // added to the journal.
   // The callback receives the entry and a boolean that indicates whether
@@ -49,6 +62,8 @@ class JournalSlice {
   /// Returns whether the journal entry with this LSN is available
   /// from the buffer.
   bool IsLSNInBuffer(LSN lsn) const;
+  bool IsLSNBeforeBuffer(LSN lsn) const;
+
   std::string_view GetEntry(LSN lsn) const;
   // SetFlushMode with allow_flush=false is used to disable preemptions during
   // subsequent calls to AddLogRecord.
@@ -73,6 +88,7 @@ class JournalSlice {
 
   void SetStartingLSN(LSN lsn) {
     lsn_ = lsn;
+    RefreshResumeBound();
   }
 
  private:
@@ -86,6 +102,9 @@ class JournalSlice {
   std::list<std::pair<uint32_t, JournalConsumerInterface*>> journal_consumers_arr_;
 
   LSN lsn_ = 1;
+
+  LSN resume_bound_ = 1;
+  uint32_t user_count_ = 0;
 
   uint32_t next_cb_id_ = 1;
   std::error_code status_ec_;

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -214,6 +214,54 @@ void AddSetRecord(JournalSlice* slice, string_view value) {
       Entry{0, Op::COMMAND, 0, nullopt, Entry::Payload{"SET", ArgSlice{args.data(), args.size()}}});
 }
 
+TEST(Journal, LastUserFreezesResumeBoundary) {
+  absl::FlagSaver flag_saver;
+  absl::SetFlag(&FLAGS_shard_repl_backlog_len, 1u);
+  JournalSlice slice;
+  slice.Init();
+
+  struct Consumer : JournalConsumerInterface {
+    void ConsumeJournalChange(const JournalChangeItem&) override {
+    }
+    void ThrottleIfNeeded() override {
+    }
+  } consumer;
+  auto id = slice.RegisterOnChange(&consumer);
+  AddSetRecord(&slice, "first");
+  AddSetRecord(&slice, "second");
+  // user count != 0 due to register
+  EXPECT_FALSE(slice.CanStop());
+
+  slice.AcquireUser();
+  slice.UnregisterOnChange(id);
+  AddSetRecord(&slice, "third");
+  EXPECT_FALSE(slice.CanStop());
+
+  // last user gone sets resume-lsn=4
+  slice.ReleaseUser();
+  AddSetRecord(&slice, "fourth");
+  EXPECT_FALSE(slice.CanStop());
+  AddSetRecord(&slice, "fifth");
+  EXPECT_TRUE(slice.CanStop());
+
+  slice.AcquireUser();
+  EXPECT_FALSE(slice.CanStop());
+  // resume-lsn updated to 6
+  slice.ReleaseUser();
+  AddSetRecord(&slice, "sixth");
+  EXPECT_FALSE(slice.CanStop());
+  AddSetRecord(&slice, "seventh");
+  EXPECT_TRUE(slice.CanStop());
+
+  slice.RefreshResumeBound();
+  EXPECT_TRUE(slice.IsLSNInBuffer(7));
+  EXPECT_FALSE(slice.CanStop());
+  AddSetRecord(&slice, "eighth");
+  EXPECT_FALSE(slice.CanStop());
+  AddSetRecord(&slice, "ninth");
+  EXPECT_TRUE(slice.CanStop());
+}
+
 TEST(Journal, BacklogSupportsLegacyEntryLimit) {
   absl::FlagSaver flag_saver;
   absl::SetFlag(&FLAGS_shard_repl_backlog_len, 2u);

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -950,7 +950,13 @@ void Replica::JoinDflyFlows() {
 }
 
 void Replica::SetShardStates(bool replica) {
-  shard_set->RunBriefInParallel([replica](EngineShard* shard) { shard->SetReplica(replica); });
+  shard_set->RunBriefInParallel([replica](EngineShard* shard) {
+    if (replica)
+      journal::AcquireUser(/*start_journal=*/false);
+    else
+      journal::ReleaseUser();
+    shard->SetReplica(replica);
+  });
 }
 
 error_code Replica::SendNextPhaseRequest(string_view kind) {

--- a/tests/dragonfly/replication_resilience_test.py
+++ b/tests/dragonfly/replication_resilience_test.py
@@ -1361,6 +1361,65 @@ async def test_partial_sync(df_factory, proactors, proxy_factory):
     assert len(lines) == 1
 
 
+async def test_unused_journal_stops_and_restarts(df_factory, proxy_factory):
+    master = df_factory.create(
+        proactor_threads=2,
+        shard_repl_backlog_time_ms=0,
+        shard_repl_backlog_max_bytes="1b",
+    )
+    replica = df_factory.create(proactor_threads=2)
+    df_factory.start_all([master, replica])
+    cm, cr = master.client(), replica.client()
+    proxy = await proxy_factory(master.port)
+
+    await cr.execute_command(f"REPLICAOF localhost {proxy.port}")
+    await wait_for_replicas_state(cr)
+    # key acts like a log collecting all phases
+    await cm.append("key", "base")
+    await check_all_replicas_finished([cr], cm)
+    assert await cr.execute_command("DFLY REPLICAOFFSET") == [0]
+
+    await proxy.close()
+
+    @assert_eventually
+    async def replica_disconnected():
+        assert (await cm.info("replication"))["connected_slaves"] == 0
+
+    await replica_disconnected()
+    last_offset = (await cm.execute_command("DFLY REPLICAOFFSET"))[0]
+    # backlog retains just one item. second write evicts resume boundary.
+    await cm.append("key", "_first")
+    await cm.append("key", "_second")
+
+    @assert_eventually
+    async def journal_stopped():
+        assert await cm.execute_command("DFLY REPLICAOFFSET") == [0]
+        info = await cm.info("memory")
+        assert info["psync_buffer_size"] == info["psync_buffer_bytes"] == 0
+
+    await journal_stopped()
+    await cm.append("key", "_unjournaled")
+    await journal_stopped()
+
+    await proxy.start_serving()
+    await check_all_replicas_finished([cr], cm)
+    assert await cr.get("key") == "base_first_second_unjournaled"
+    assert (await cm.execute_command("DFLY REPLICAOFFSET"))[0] > last_offset
+    await cm.append("key", "_streamed")
+    await check_all_replicas_finished([cr], cm)
+    assert await cr.get("key") == "base_first_second_unjournaled_streamed"
+
+    await cm.aclose()
+    await cr.aclose()
+    master.stop()
+    replica.stop()
+    lines = master.find_in_logs(
+        f"Stopped unused journal on shard 0: resume boundary {last_offset} evicted"
+    )
+    assert len(lines) == 1
+    assert len(master.find_in_logs("Partial sync requested from stale LSN")) == 1
+
+
 async def test_partial_sync_keeps_oversized_backlog_record(df_factory, proxy_factory):
     master = df_factory.create(
         proactor_threads=2,


### PR DESCRIPTION
The journal behavior is that even if a master has no replicas the journal buffer is kept around in case a replica might reconnect. But there are cases where the replica will never reconnect, eg if the replication was a means for upgrade.

In this case the journal wastefully collects serialized commands which are sent nowhere (these are not kept indefinitely, they are discarded from the ring buffer after time/size/count, but still take up memory for no reason)

To fix, here a heuristic based decision is added

- journal maintains a count of its users (replication, slot migration, journal consumers etc)
- when the last user goes away (count == 0) the curr. journal LSN is stored in a field
- a heartbeat method checks if that LSN is fallen behind / outside the journal
- __iff__ there are no users still and that lsn is fallen behind the entire journal, then the journal is cleared and turned off (set to false)
