### PR TITLE
fix(server): free hll sds when PFADD rejects a corrupt sparse HLL

### DIFF
--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -6,6 +6,8 @@ extern "C" {
 #include "redis/hyperloglog.h"
 }
 
+#include <absl/cleanup/cleanup.h>
+
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "facade/error.h"
@@ -115,10 +117,8 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
 
   int updated = 0;
   bool is_sparse = isValidHLL(StringToHllPtr(hll)) == HLL_VALID_SPARSE;
-  sds hll_sds;
-  if (is_sparse) {
-    hll_sds = sdsnewlen(hll.data(), hll.size());
-  }
+  sds hll_sds = is_sparse ? sdsnewlen(hll.data(), hll.size()) : nullptr;
+  absl::Cleanup sds_free = [&hll_sds] { sdsfree(hll_sds); };
 
   for (const auto& value : values) {
     int added;
@@ -131,7 +131,6 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
       if (promoted == 1) {
         is_sparse = false;
         hll = string{hll_sds, sdslen(hll_sds)};
-        sdsfree(hll_sds);
         DCHECK_EQ(isValidHLL(StringToHllPtr(hll)), HLL_VALID_DENSE);
       }
     } else {
@@ -145,7 +144,6 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
 
   if (is_sparse) {
     hll = string{hll_sds, sdslen(hll_sds)};
-    sdsfree(hll_sds);
   }
   res.post_updater.ReduceHeapUsage();
   if (res.it->second.IsExternal()) {

--- a/src/server/hll_family_test.cc
+++ b/src/server/hll_family_test.cc
@@ -332,6 +332,36 @@ TEST_F(HllFamilyTest, CorruptedSparseTruncatedRun) {
   EXPECT_THAT(Run({"pfcount", "truncated"}), ErrArg(kCorruptedHllError));
 }
 
+// Corrupt sparse HLL: passes isValidHLL(), rejected by hllSparseSet().
+// Each PFADD used to leak the sds copy of the value on that error path.
+TEST_F(HllFamilyTest, PfAddCorruptSparseDoesNotLeak) {
+  string hll("HYLL", 4);
+  hll.push_back(1);
+  hll.append(3, '\0');
+  hll.append(8, '\0');
+  for (int i = 0; i < 2048; ++i) {
+    hll.push_back('\x7f');
+    hll.push_back('\xff');
+  }
+  ASSERT_EQ(Run({"set", "leak", hll}), "OK");
+
+  auto used_memory = [this] {
+    const string info = Run({"info", "memory"}).GetString();
+    const auto pos = info.find("used_memory:") + strlen("used_memory:");
+    return strtoll(info.c_str() + pos, nullptr, 10);
+  };
+
+  EXPECT_THAT(Run({"pfadd", "leak", "x"}), ErrArg(kInvalidHllError));
+  const int64_t before = used_memory();
+
+  for (int i = 0; i < 50; ++i) {
+    EXPECT_THAT(Run({"pfadd", "leak", "x"}), ErrArg(kInvalidHllError));
+  }
+
+  const int64_t after = used_memory();
+  EXPECT_LE(after - before, int64_t(20 * hll.size()));
+}
+
 // PFCOUNT over several keys merges into a raw register array; it used to write
 // that array HLL_HDR_SIZE bytes too low, so the estimate silently dropped the
 // first 16 registers and counted 16 zeroed ones instead. The union estimate has


### PR DESCRIPTION
AddToHll copies the stored value into an `sds` before parsing it. When `hllSparseSet()` rejects a corrupt sparse body, the `added < 0` early return skipped `sdsfree()`, so every `PFADD` leaked a copy of the value (up to the 512MB proto max) until the process was OOM-killed.

Own the working `sds` with `absl::Cleanup` so all exits free it (success, promotion, parse error, OOM unwind).

Regression test: 50 PFADDs on a corrupt sparse HLL previously grew memory ~256KB; stays at baseline now.