### PR TITLE
ci: enable Epoll regression tests with RESP V2

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -135,6 +135,8 @@ runs:
     - name: Prepare regression JUnit environment
       if: always()
       shell: bash
+      env:
+        DF_RUNTIME_FLAGS_INPUT: ${{ inputs.df-runtime-flags }}
       run: |
         JUNIT_DIR="${GITHUB_WORKSPACE}/test-results/junit/regression"
         mkdir -p "${JUNIT_DIR}"
@@ -150,26 +152,42 @@ runs:
         fi
 
         SAFE_FILTER=$("${GITHUB_WORKSPACE}/.github/scripts/sanitize-token.sh" "${FILTER}" all)
+        SAFE_RUNTIME_FLAGS=$("${GITHUB_WORKSPACE}/.github/scripts/sanitize-token.sh" "${DF_RUNTIME_FLAGS_INPUT}" default)
 
         UNIQUE_SUFFIX="$(date +%s%N)-${RANDOM}"
         {
           echo "REGRESSION_JUNIT_DIR=${JUNIT_DIR}"
           echo "REGRESSION_JUNIT_KIND=${KIND}"
-          echo "REGRESSION_JUNIT_S3_SUFFIX=${RUNNER_OS}-${RUNNER_ARCH}-${KIND}-${FILTER}"
-          echo "REGRESSION_JUNIT_ARTIFACT=junit-regression-${GITHUB_JOB}-${RUNNER_OS}-${RUNNER_ARCH}-${KIND}-${SAFE_FILTER}-${UNIQUE_SUFFIX}"
+          echo "REGRESSION_JUNIT_S3_SUFFIX=${RUNNER_OS}-${RUNNER_ARCH}-${KIND}-${SAFE_FILTER}-${SAFE_RUNTIME_FLAGS}"
+          echo "REGRESSION_JUNIT_ARTIFACT=junit-regression-${GITHUB_JOB}-${RUNNER_OS}-${RUNNER_ARCH}-${KIND}-${SAFE_FILTER}-${SAFE_RUNTIME_FLAGS}-${UNIQUE_SUFFIX}"
         } >> "${GITHUB_ENV}"
 
     - name: Run S3 snapshot tests with MinIO
       if: inputs.s3-bucket != '' && inputs.test-suites == '' && inputs.test-cases == '' && inputs.iterations == '1'
       shell: bash
+      env:
+        DF_RUNTIME_FLAGS_INPUT: ${{ inputs.df-runtime-flags }}
       run: |
         echo "=== Running S3 snapshot tests with local MinIO ==="
         cd ${GITHUB_WORKSPACE}/tests
 
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
 
+        # Match the Dragonfly I/O loop configuration selected by the surrounding workflow matrix.
+        df_runtime_args=()
+        if [[ -n "${DF_RUNTIME_FLAGS_INPUT}" ]]; then
+          set -f
+          for flag in ${DF_RUNTIME_FLAGS_INPUT}; do
+            df_runtime_args+=(--df "$flag")
+          done
+          set +f
+        fi
+        if [[ "${{ inputs.epoll }}" == 'epoll' ]]; then
+          df_runtime_args+=(--df force_epoll=true)
+        fi
+
         # MinIO binary is downloaded and started by conftest.py when MINIO_S3_ENDPOINT is set
-        MINIO_S3_ENDPOINT=http://localhost:9000 timeout 10m pytest -k "s3" --timeout=300 --color=yes dragonfly/snapshot_test.py --log-cli-level=INFO -v
+        MINIO_S3_ENDPOINT=http://localhost:9000 timeout 10m pytest -k "s3" --timeout=300 --color=yes dragonfly/snapshot_test.py "${df_runtime_args[@]}" --log-cli-level=INFO -v
 
     - name: Run PyTests
       id: main

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -62,6 +62,7 @@ jobs:
         proactor: [Epoll]
         build-type: [Debug]
         runner: [ubuntu-latest, [self-hosted, linux, ARM64]]
+        enable_resp_io_loop_v2: [false, true]
 
     runs-on: ${{ matrix.runner }}
 
@@ -137,6 +138,7 @@ jobs:
           gtest-iterations: ${{ inputs['gtest-iterations'] || '' }}
           run-gtests: 'true'
           continue-on-test-failure: ${{ inputs['continue-on-test-failure'] || 'false' }}
+          df-runtime-flags: enable_resp_io_loop_v2=${{ matrix.enable_resp_io_loop_v2 }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}


### PR DESCRIPTION
Run the Epoll regression suite with both RESP I/O loop versions. Match the existing Uring workflow by forwarding the selected matrix value through the regression test action. The existing regression tests now run once with V1 and once with V2 under Epoll.
