### PR TITLE
fix(script): restore the caller's database after a script that runs SELECT

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -283,6 +283,18 @@ TEST_F(DflyEngineTest, EvalShaNegativeZeroNumKeys) {
   EXPECT_THAT(Run({"eval", "return 1", "-0"}), ErrArg(facade::kInvalidIntErr));
 }
 
+TEST_F(DflyEngineTest, EvalSelectDoesNotLeak) {
+  Run({"select", "2"});
+  Run({"set", "k2", "v"});
+  Run({"select", "1"});
+  Run({"set", "canary", "hi"});
+  Run({"set", "k1b", "v"});
+  // SELECT applies to the rest of the script (db 2 holds one key) ...
+  EXPECT_THAT(Run({"eval", "redis.call('select', 2) return redis.call('dbsize')", "0"}), IntArg(1));
+  // ... but must not move the connection off db 1.
+  EXPECT_EQ(Run({"get", "canary"}), "hi");
+}
+
 TEST_F(DflyEngineTest, ScriptFlush) {
   auto resp = Run({"script", "load", "return 5"});
   EXPECT_THAT(resp, ArgType(RespExpr::STRING));

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2360,8 +2360,11 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, 
     }
   }
 
-  // Reset cid to EVAL[] as the context is reused during command dispatch
-  absl::Cleanup clean = [interpreter, cmd_cntx, cid = cmd_cntx->cid()]() {
+  // Reset cid to EVAL[] as the context is reused during command dispatch. A SELECT inside the
+  // script must not outlive it, so the caller's db is restored as well.
+  absl::Cleanup clean = [interpreter, cmd_cntx, conn_cntx, caller_db = conn_cntx->db_index(),
+                         cid = cmd_cntx->cid()]() {
+    conn_cntx->conn_state.db_index = caller_db;
     interpreter->ResetStack();
     cmd_cntx->SetupTx(cid, cmd_cntx->tx());
   };


### PR DESCRIPTION
A `SELECT` inside a keyless script changed the calling connection's database and the change outlived the script, so subsequent commands on that connection ran against the wrong database. Scripts with declared keys were already rejected by the LOCK_AHEAD guard; the keyless path was not.

`EvalInternal` now restores the caller's `db_index` when the script finishes (on error too). A `SELECT` still applies to the rest of the script, matching upstream semantics.

Fixes #8276