### PR TITLE
fix(multi): keep collecting after a queue-time error so EXEC aborts the whole transaction

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -317,6 +317,7 @@ vector<unsigned> ConnectionContext::ChangeSubscriptions(facade::ParsedArgs chann
 void ConnectionState::ExecInfo::Clear() {
   DCHECK(!preborrowed_interpreter);  // Must have been released properly
   state = EXEC_INACTIVE;
+  error = false;
   const size_t cleared_size = ClearStoredCmds();
   ServerState::tlocal()->stats.stored_cmd_bytes -= cleared_size;
   is_write = false;

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -86,7 +86,7 @@ class StoredCmd {
 struct ConnectionState {
   // MULTI-EXEC transaction related data.
   struct ExecInfo {
-    enum ExecState : uint8_t { EXEC_INACTIVE, EXEC_COLLECT, EXEC_RUNNING, EXEC_ERROR };
+    enum ExecState : uint8_t { EXEC_INACTIVE, EXEC_COLLECT, EXEC_RUNNING };
 
     ExecInfo() = default;
     // ExecInfo is immovable due to being referenced from DbSlice.
@@ -122,6 +122,7 @@ struct ConnectionState {
     ExecState state = EXEC_INACTIVE;
     std::vector<StoredCmd> body;
     bool is_write = false;
+    bool error = false;  // a queue-time error: keep collecting, but EXEC must abort
 
     std::vector<std::pair<DbIndex, std::string>> watched_keys;  // List of keys registered by WATCH
     std::atomic_bool watched_dirty = false;  // Set if a watched key was changed before EXEC

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1492,6 +1492,11 @@ DispatchResult Service::DispatchCommand(
     } else {
       parsed_cmd->SendError(ReportUnknownCmd(absl::AsciiStrToUpper(args.Front())));
     }
+    // A collecting MULTI must abort at EXEC, as with any other queue-time error.
+    auto& exec_info =
+        static_cast<CommandContext*>(parsed_cmd)->server_conn_cntx()->conn_state.exec_info;
+    if (exec_info.IsCollecting())
+      exec_info.error = true;
     return DispatchResult::ERROR;
   }
 
@@ -1539,8 +1544,11 @@ DispatchResult Service::DispatchCommand(
   if (auto err = VerifyCommandState(*cid, args_no_cmd, *dfly_cntx); err) {
     LOG_IF(WARNING, dfly_cntx->replica_conn || !dfly_cntx->conn() /* no owner in replica context */)
         << "VerifyCommandState error: " << err->ToSv();
-    if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
-      exec_info.state = ConnectionState::ExecInfo::EXEC_ERROR;
+    // A rejected EXEC discards the transaction, a rejected queued command only marks it.
+    if (cid->IsExec())
+      MultiCleanup(dfly_cntx);
+    else if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
+      exec_info.error = true;
 
     // We need to skip this because ACK's should not be replied to
     // Bonus points because this allows to continue replication with ACL users who got
@@ -2546,7 +2554,7 @@ void Service::Exec(CmdArgParser, CommandContext* cmd_cntx) {
   auto* cntx = cmd_cntx->server_conn_cntx();
   auto& exec_info = cntx->conn_state.exec_info;
 
-  if (exec_info.state == ConnectionState::ExecInfo::EXEC_ERROR) {
+  if (exec_info.error) {
     return rb->SendError("-EXECABORT Transaction discarded because of previous errors");
   }
 

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -103,6 +103,45 @@ TEST_F(MultiTest, MultiWithError) {
   EXPECT_THAT(Run({"get", "z"}), "y");
 }
 
+TEST_F(MultiTest, MultiWithUnknownCommand) {
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"nosuchcmd"}), ErrArg("unknown command"));
+  EXPECT_THAT(Run({"set", "x", "y"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXECABORT Transaction discarded because of previous errors"));
+  EXPECT_THAT(Run({"get", "x"}), ArgType(RespExpr::NIL));
+}
+
+// Commands after a queue-time error are still queued, never executed outside the transaction.
+TEST_F(MultiTest, MultiQueueErrorStillQueues) {
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "x", "y"}), "QUEUED");
+  EXPECT_THAT(Run({"set", "x"}), ErrArg("wrong number of arguments"));
+  EXPECT_THAT(Run({"set", "w", "v"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXECABORT Transaction discarded because of previous errors"));
+  EXPECT_THAT(Run({"get", "x"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"get", "w"}), ArgType(RespExpr::NIL));
+}
+
+TEST_F(MultiTest, MultiQueueErrorDiscard) {
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"nosuchcmd"}), ErrArg("unknown command"));
+  EXPECT_THAT(Run({"multi"}), ErrArg("MULTI calls can not be nested"));
+  EXPECT_THAT(Run({"discard"}), "OK");
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXEC without MULTI"));
+  EXPECT_THAT(Run({"set", "after", "1"}), "OK");
+}
+
+TEST_F(MultiTest, RejectedExecDiscards) {
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "x", "1"}), "QUEUED");
+  EXPECT_THAT(Run({"exec", "blahblah"}), ErrArg("EXECABORT"));
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXEC without MULTI"));
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "x", "2"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre("OK")));
+  EXPECT_EQ(Run({"get", "x"}), "2");
+}
+
 TEST_F(MultiTest, Multi) {
   RespExpr resp = Run({"multi"});
   ASSERT_EQ(resp, "OK");

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -169,7 +169,7 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
     client = aioredis.Redis(port=df.port, decode_responses=True)
 
     # NOPERM while executing multi
-    await client.execute_command("ACL SETUSER kk -@string")
+    await client.execute_command("ACL SETUSER kk -@string +@list")
     assert res == "OK"
     await client.execute_command("AUTH kk kk")
     assert res == "OK"
@@ -178,6 +178,11 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
 
     with pytest.raises(redis.exceptions.NoPermissionError):
         await client.execute_command("SET x bar")
+    # The transaction keeps collecting after the queue-time error and EXEC aborts all of it.
+    assert await client.execute_command("RPUSH l a") == "QUEUED"
+    with pytest.raises(redis.exceptions.ExecAbortError):
+        await client.execute_command("EXEC")
+    assert await client.execute_command("LLEN l") == 0
     await client.aclose()
 
     # NOPERM between multi and exec


### PR DESCRIPTION
A command that failed while a MULTI was collecting (unknown command, wrong arity, NOAUTH) moved the transaction out of the collecting state, so every later command ran immediately outside the transaction and replied OK, DISCARD reported "without MULTI", and a nested MULTI was accepted; EXEC then returned EXECABORT for a transaction that had already partially applied. An unknown command did not even mark the transaction.

The error is now a flag on the collecting transaction: later commands keep being queued, DISCARD and the nested-MULTI check keep working, and EXEC discards everything with EXECABORT.

Fixes #8274