### PR TITLE
fix: replace broken awesome-prometheus-alerts link

### DIFF
--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -63,7 +63,7 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 | probes.readinessProbe.successThreshold | int | `1` |  |
 | probes.readinessProbe.timeoutSeconds | int | `5` |  |
 | prometheusRule.enabled | bool | `false` | Deploy a PrometheusRule |
-| prometheusRule.spec | list | `[]` | PrometheusRule.Spec https://awesome-prometheus-alerts.grep.to/rules |
+| prometheusRule.spec | list | `[]` | PrometheusRule.Spec https://samber.github.io/awesome-prometheus-alerts/rules |
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources.limits | object | `{}` | The resource limits for the containers |
 | resources.requests | object | `{}` | The requested resources for the containers |

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -90,7 +90,7 @@ prometheusRule:
   # -- Deploy a PrometheusRule
   enabled: false
   # -- PrometheusRule.Spec
-  # https://awesome-prometheus-alerts.grep.to/rules
+  # https://samber.github.io/awesome-prometheus-alerts/rules
   spec: []
 
 storage:


### PR DESCRIPTION
Hi!

The awesome-prometheus-alerts.grep.to domain is no longer maintained: the site is gone and the domain now shows a parking page, so the link in this repo is broken.

This PR replaces it with the current home of the project:

https://samber.github.io/awesome-prometheus-alerts

No other changes. Thanks!