### PR TITLE
chore: move watchdog after shard destruction

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1169,12 +1169,12 @@ void Service::Shutdown() {
   cluster_family_.Shutdown();
   server_family_.Shutdown();
 
-  shutdown_watchdog.emplace(pp_);
-
   engine_varz.reset();
 
   shard_set->PreShutdown();
   shard_set->Shutdown();
+
+  shutdown_watchdog.emplace(pp_);
 
   delete channel_store;
   channel_store = nullptr;


### PR DESCRIPTION
Move the watchdog after the shard destruction because it can take a lot of time. 