### PR TITLE
fix(cluster): reject DFLYMIGRATE without cluster mode

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -831,6 +831,11 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgParser parser, CommandContext*
 }
 
 void ClusterFamily::DflyMigrate(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto* cntx = cmd_cntx->server_conn_cntx();
+  if (!(IsClusterEnabled() || (IsClusterEmulated() && cntx->journal_emulated))) {
+    return cmd_cntx->SendError("Cluster is disabled. Use --cluster_mode=yes to enable.");
+  }
+
   string sub_cmd = absl::AsciiStrToUpper(parser.Next());
 
   if (sub_cmd == "INIT") {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -72,6 +72,11 @@ constexpr char kIdNotFound[] = "syncid not found";
 constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
 
+// Sent to clients that use cluster management commands with cluster mode off or emulated:
+// modes that never have a cluster config, where migrations and slot management do not exist.
+constexpr string_view kClusterDisabledNoConfig =
+    "Cluster is disabled. Use --cluster_mode=yes to enable.";
+
 }  // namespace
 
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
@@ -471,7 +476,7 @@ void ClusterFamily::DflyCluster(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* builder = cmd_cntx->rb();
   auto* cntx = cmd_cntx->server_conn_cntx();
   if (!(IsClusterEnabled() || (IsClusterEmulated() && cntx->journal_emulated))) {
-    return builder->SendError("Cluster is disabled. Use --cluster_mode=yes to enable.");
+    return builder->SendError(kClusterDisabledNoConfig);
   }
 
   string sub_cmd = absl::AsciiStrToUpper(parser.Next());  // remove subcommand name
@@ -831,9 +836,11 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgParser parser, CommandContext*
 }
 
 void ClusterFamily::DflyMigrate(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto* cntx = cmd_cntx->server_conn_cntx();
-  if (!(IsClusterEnabled() || (IsClusterEmulated() && cntx->journal_emulated))) {
-    return cmd_cntx->SendError("Cluster is disabled. Use --cluster_mode=yes to enable.");
+  // Migrations can not exist without an applied cluster config, which off and emulated modes
+  // never have. Real mode without a config keeps the migration protocol replies below: the
+  // source relies on UNKNOWN_MIGRATION for its config-propagation grace period.
+  if (!IsClusterEnabled()) {
+    return cmd_cntx->SendError(kClusterDisabledNoConfig);
   }
 
   string sub_cmd = absl::AsciiStrToUpper(parser.Next());
@@ -1090,7 +1097,13 @@ void ClusterFamily::DflyMigrateAck(CmdArgParser parser, CommandContext* cmd_cntx
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   VLOG(1) << "DFLYMIGRATE ACK" << ack_args;
-  auto in_migrations = ClusterConfig::Current()->GetIncomingMigrations();
+  auto config = ClusterConfig::Current();
+  if (!config) {
+    // Reply like the unknown-migration path below: the source polls ACK while the config
+    // propagates and grants a quiet grace period on UNKNOWN_MIGRATION.
+    return cmd_cntx->SendSimpleString(kUnknownMigration);
+  }
+  auto in_migrations = config->GetIncomingMigrations();
   auto m_it = rng::find_if(in_migrations, [source_id = source_id](const auto& m) {
     return m.node_info.id == source_id;
   });

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -1539,29 +1539,40 @@ TEST_F(ClusterFamilyEmulatedTest, ForbidenCommands) {
   EXPECT_THAT(res, ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
 }
 
-class ClusterFamilyDisabledTest : public ClusterFamilyTest {
+// Migrations can not exist in modes without a cluster config: off and emulated reject at the
+// gate, while real mode without an applied config keeps the migration protocol replies.
+class DflyMigrateNoConfigTest : public ClusterFamilyTest,
+                                public testing::WithParamInterface<string_view> {
  protected:
-  void ConfigureClusterFlags() override {
-    SetTestFlag("cluster_mode", "");
+  void SetUp() override {
+    flag_saver_.emplace();
+    ClusterFamilyTest::SetUp();
   }
+
+  void ConfigureClusterFlags() override {
+    SetTestFlag("cluster_mode", GetParam());
+  }
+
+  std::optional<absl::FlagSaver> flag_saver_;
 };
 
-TEST_F(ClusterFamilyDisabledTest, DflyMigrateWithoutClusterMode) {
-  EXPECT_THAT(Run({"DFLYMIGRATE", "ACK", "src", "1"}),
-              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
-  EXPECT_THAT(Run({"DFLYMIGRATE", "INIT", "src", "1", "0-1"}),
-              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
-  EXPECT_THAT(Run({"DFLYMIGRATE", "FLOW", "src", "1", "0", "0"}),
-              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+TEST_P(DflyMigrateNoConfigTest, RejectsSubcommands) {
+  const auto expected = ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable.");
+  EXPECT_THAT(Run({"DFLYMIGRATE", "ACK", "src", "1"}), expected);
+  EXPECT_THAT(Run({"DFLYMIGRATE", "INIT", "src", "1", "0", "1"}), expected);
+  EXPECT_THAT(Run({"DFLYMIGRATE", "FLOW", "src", "1"}), expected);
 }
 
-TEST_F(ClusterFamilyEmulatedTest, DflyMigrateEmulatedMode) {
-  EXPECT_THAT(Run({"DFLYMIGRATE", "ACK", "src", "1"}),
-              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
-  EXPECT_THAT(Run({"DFLYMIGRATE", "INIT", "src", "1", "0-1"}),
-              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
-  EXPECT_THAT(Run({"DFLYMIGRATE", "FLOW", "src", "1", "0", "0"}),
-              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+INSTANTIATE_TEST_SUITE_P(ModesWithoutConfig, DflyMigrateNoConfigTest,
+                         testing::Values(""sv, "emulated"sv));
+
+// The config can reach a real-mode migration target after the source starts polling. The
+// handlers must not dereference the absent ClusterConfig and must keep the replies the
+// source's 30-second UNKNOWN_MIGRATION grace period depends on.
+TEST_F(ClusterFamilyTest, DflyMigrateRealModeWithoutConfig) {
+  EXPECT_EQ(Run({"DFLYMIGRATE", "INIT", "src", "1", "0", "1"}), "UNKNOWN_MIGRATION");
+  EXPECT_EQ(Run({"DFLYMIGRATE", "ACK", "src", "1"}), "UNKNOWN_MIGRATION");
+  EXPECT_THAT(Run({"DFLYMIGRATE", "FLOW", "src", "1"}), ErrArg("syncid not found"));
 }
 
 }  // namespace

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -1539,5 +1539,30 @@ TEST_F(ClusterFamilyEmulatedTest, ForbidenCommands) {
   EXPECT_THAT(res, ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
 }
 
+class ClusterFamilyDisabledTest : public ClusterFamilyTest {
+ protected:
+  void ConfigureClusterFlags() override {
+    SetTestFlag("cluster_mode", "");
+  }
+};
+
+TEST_F(ClusterFamilyDisabledTest, DflyMigrateWithoutClusterMode) {
+  EXPECT_THAT(Run({"DFLYMIGRATE", "ACK", "src", "1"}),
+              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+  EXPECT_THAT(Run({"DFLYMIGRATE", "INIT", "src", "1", "0-1"}),
+              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+  EXPECT_THAT(Run({"DFLYMIGRATE", "FLOW", "src", "1", "0", "0"}),
+              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+}
+
+TEST_F(ClusterFamilyEmulatedTest, DflyMigrateEmulatedMode) {
+  EXPECT_THAT(Run({"DFLYMIGRATE", "ACK", "src", "1"}),
+              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+  EXPECT_THAT(Run({"DFLYMIGRATE", "INIT", "src", "1", "0-1"}),
+              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+  EXPECT_THAT(Run({"DFLYMIGRATE", "FLOW", "src", "1", "0", "0"}),
+              ErrArg("Cluster is disabled. Use --cluster_mode=yes to enable."));
+}
+
 }  // namespace
 }  // namespace dfly::cluster


### PR DESCRIPTION
DFLYMIGRATE dereferenced a null `ClusterConfig::Current()` on non-cluster deployments: any client could crash the server (SIGSEGV). Gate the dispatcher like DFLYCLUSTER so all subcommands reply with the standard "Cluster is disabled" error.

Regression test: `DFLYMIGRATE ACK/INIT/FLOW` without cluster mode previously segfaulted; now returns the error.