### PR TITLE
fix(multi): refuse denyoom commands and EXEC at queue time under maxmemory

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1422,6 +1422,20 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid,
       return ErrorReply{absl::StrCat("'", cmd_name, "' not allowed inside a transaction")};
   }
 
+  // Refused before queueing so that EXEC is all-or-nothing under maxmemory.
+  if (const auto& exec_info = dfly_cntx.conn_state.exec_info; exec_info.IsCollecting()) {
+    bool denyoom = cid.opt_mask() & CO::DENYOOM;
+    if (cid.IsExec())
+      denyoom = any_of(exec_info.body.begin(), exec_info.body.end(),
+                       [](const StoredCmd& cmd) { return cmd.Cid()->opt_mask() & CO::DENYOOM; });
+    if (denyoom && etl.ShouldDenyOnOOM(base::CycleClock::ToUsec(base::CycleClock::Now()))) {
+      if (cid.IsExec())
+        return ErrorReply{
+            absl::StrCat("-EXECABORT Transaction discarded because of: ", kOutOfMemory)};
+      return ErrorReply{kOutOfMemory};
+    }
+  }
+
   if (IsClusterEnabled()) {
     if (auto err = CheckKeysOwnership(cid, tail_args, dfly_cntx); err)
       return err;

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -142,6 +142,32 @@ TEST_F(MultiTest, RejectedExecDiscards) {
   EXPECT_EQ(Run({"get", "x"}), "2");
 }
 
+TEST_F(MultiTest, ExecDeniedOnOom) {
+  const uint64_t old_limit = max_memory_limit;
+  used_mem_current = 1000000;
+  max_memory_limit = 100000;
+
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "x", "1"}), ErrArg("Out of memory"));
+  EXPECT_THAT(Run({"get", "x"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXECABORT"));
+
+  // Memory runs out only after the write was queued: EXEC itself is refused.
+  max_memory_limit = old_limit;
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "y", "1"}), "QUEUED");
+  max_memory_limit = 100000;
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXECABORT Transaction discarded because of: Out of memory"));
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXEC without MULTI"));
+  EXPECT_THAT(Run({"get", "y"}), ArgType(RespExpr::NIL));
+
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"get", "x"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre(ArgType(RespExpr::NIL))));
+
+  max_memory_limit = old_limit;
+}
+
 TEST_F(MultiTest, Multi) {
   RespExpr resp = Run({"multi"});
   ASSERT_EQ(resp, "OK");


### PR DESCRIPTION
With maxmemory reached, a denyoom command inside MULTI was QUEUED and only failed at EXEC time, while the other queued writes applied. Found by the Valkey unit/multi tests.

- VerifyCommandState refuses a denyoom command while collecting (the transaction keeps collecting and EXEC aborts), and refuses EXEC when any queued command is denyoom and memory ran out after queueing (the transaction is discarded, EXECABORT reply)
- Regression test covers queue-time refusal, EXEC-time refusal and a read-only transaction that still runs

Fixes #8275