### PR TITLE
refactor: improve SCAN iterator/expiration performance

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -681,6 +681,10 @@ struct CompactKey : public CompactObj {
     return taglen_ == SDS_TTL_TAG;
   }
 
+  bool IsExpired(uint64_t now_ms) const {
+    return taglen_ == SDS_TTL_TAG && int64_t(now_ms) >= int64_t(u_.sds_ttl.exp_ms);
+  }
+
   // Embed expire time directly in the key by converting to SDS_TTL_TAG.
   void SetExpireTime(uint64_t abs_ms);
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1472,13 +1472,20 @@ PrimeIterator DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterator it,
     return it;
   }
 
-  int64_t expire_time = it->first.GetExpireTime();
+  if (!it->first.IsExpired(cntx.time_now_ms) || !Expire(cntx, it, events)) {
+    return it;
+  }
+
+  return PrimeIterator{};
+}
+
+bool DbSlice::Expire(const Context& cntx, PrimeIterator it, vector<string>* events) const {
+  DCHECK(it->first.IsExpired(cntx.time_now_ms));
 
   // Never do expiration if expiration is disabled, or on replicas unless replica_delete_expired
   // is enabled (which allows replicas to proactively delete expired keys on the read path).
-  if (int64_t(cntx.time_now_ms) < expire_time || !expire_allowed_ ||
-      (owner_->IsReplica() && !absl::GetFlag(FLAGS_replica_delete_expired))) {
-    return it;
+  if (!expire_allowed_ || (owner_->IsReplica() && !absl::GetFlag(FLAGS_replica_delete_expired))) {
+    return false;
   }
 
   string scratch;
@@ -1506,7 +1513,7 @@ PrimeIterator DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterator it,
   ++events_.expired_keys;
   db->stats.events.expired_keys++;
 
-  return PrimeIterator{};
+  return true;
 }
 
 void DbSlice::ExpireAllIfNeeded() {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -421,6 +421,14 @@ class DbSlice {
   // and returns Iterator{}.
   Iterator ExpireIfNeeded(const Context& cntx, Iterator it) const;
 
+  // Attempts to expire a valid entry and returns true only when it was erased.
+  // The caller must prevent preemption while using the raw iterator.
+  bool TryExpire(const Context& cntx, PrimeIterator it) const {
+    if (!it->first.IsExpired(cntx.time_now_ms))
+      return false;
+    return Expire(cntx, it, nullptr);
+  }
+
   // Iterate over all expire table entries and delete expired.
   void ExpireAllIfNeeded();
 
@@ -612,6 +620,7 @@ class DbSlice {
   // will send notifications later). If null, the notification is sent immediately (read path).
   PrimeIterator ExpireIfNeeded(const Context& cntx, PrimeIterator it,
                                std::vector<std::string>* events = nullptr) const;
+  bool Expire(const Context& cntx, PrimeIterator it, std::vector<std::string>* events) const;
 
   OpResult<ItAndUpdater> AddOrFindInternal(const Context& cntx, std::string_view key,
                                            std::optional<unsigned> req_obj_type);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -646,45 +646,52 @@ OpStatus OpRestore(const OpArgs& op_args, std::string_view key, std::string_view
   return add_res.status();
 }
 
+bool AppendScanKey(const CompactKey& key, const ScanOpts& opts, StringVec* res) {
+  if (opts.matcher) {
+    string str;
+    key.GetString(&str);
+    if (!opts.matcher->Matches(str))
+      return false;
+    res->emplace_back(std::move(str));
+    return true;
+  }
+
+  res->emplace_back();
+  key.GetString(&res->back());
+  return true;
+}
+
 bool ScanCb(const OpArgs& op_args, PrimeIterator prime_it, const ScanOpts& opts, StringVec* res) {
   auto& db_slice = op_args.GetDbSlice();
 
-  DbSlice::Iterator it = DbSlice::Iterator::FromPrime(prime_it);
-  if (prime_it->first.HasExpire()) {
-    it = db_slice.ExpireIfNeeded(op_args.db_cntx, it);
-    if (!IsValid(it))
-      return false;
-  }
+  // OpScan holds a DisableFlushGuard while traversing, so a raw iterator is sufficient.
+  if (db_slice.TryExpire(op_args.db_cntx, prime_it)) [[unlikely]]
+    return false;
 
-  bool matches = !opts.type_filter || it->second.ObjType() == opts.type_filter;
+  bool matches = !opts.type_filter || prime_it->second.ObjType() == opts.type_filter;
   if (opts.mask.has_value()) {
     if (opts.mask == ScanOpts::Mask::Volatile) {
-      matches &= it->first.HasExpire();
+      matches &= prime_it->first.HasExpire();
     } else if (opts.mask == ScanOpts::Mask::Permanent) {
-      matches &= !it->first.HasExpire();
+      matches &= !prime_it->first.HasExpire();
     } else if (opts.mask == ScanOpts::Mask::Accessed) {
-      matches &= it->first.WasTouched();
+      matches &= prime_it->first.WasTouched();
     } else if (opts.mask == ScanOpts::Mask::Untouched) {
-      matches &= !it->first.WasTouched();
+      matches &= !prime_it->first.WasTouched();
     }
   }
   if (!matches)
     return false;
 
-  if (opts.min_malloc_size > 0 && it->second.MallocUsed() < opts.min_malloc_size) {
+  if (opts.min_malloc_size > 0 && prime_it->second.MallocUsed() < opts.min_malloc_size) {
     return false;
   }
 
-  if (opts.bucket_id != UINT_MAX && opts.bucket_id != it.GetInnerIt().bucket_id()) {
+  if (opts.bucket_id != UINT_MAX && opts.bucket_id != prime_it.bucket_id()) {
     return false;
   }
 
-  if (!opts.Matches(it.key())) {
-    return false;
-  }
-  res->emplace_back(it.key());
-
-  return true;
+  return AppendScanKey(prime_it->first, opts, res);
 }
 
 void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, StringVec* vec) {


### PR DESCRIPTION
Summary: This PR streamlines SCAN’s key iteration and lazy expiration path to reduce overhead during traversal.

Changes:

- Adds CompactKey::IsExpired for a direct TTL-tagged expiration check.
- Extracts the deletion portion of lazy expiry into DbSlice::Expire and exposes TryExpire for raw iterators.
- Updates SCAN to avoid constructing an auto-laundering iterator when traversal is protected from preemption.
- Defers key-string materialization until after type, attribute, size, bucket, and pattern filters pass.

Technical Notes: The existing journal flush guard maintains raw-iterator safety while expired entries are removed during SCAN.

| COUNT | TTL | MATCH | Before ms/DB | After ms/DB |
|---:|:---|:---|---:|---:|
| 10 | None | `*` | 359.90 | 320.85 |
| 10 | Live | `*` | 430.18 | 336.99 |
| 100 | None | `*` | 291.60 | 252.80 |
| 100 | Live | `*` | 349.08 | 266.83 |
| 1000 | None | `*` | 279.65 | 241.91 |
| 1000 | Live | `*` | 330.25 | 255.68 |
| 1000 | Live | `k*` | 333.36 | 262.81 |

I've asked AI to generate a call stack picture to show the difference in approaches for better understanding

<img width="1151" height="638" alt="scan-perf-before-after" src="https://github.com/user-attachments/assets/26f5ced5-81fa-41d3-82a1-1dcd2c171ee5" />

