### PR TITLE
fix(server): Fix sort .. store replication

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -2943,7 +2943,8 @@ void GenericFamily::Register(CommandRegistry* registry) {
       << CI{"UNLINK", CO::JOURNALED | CO::NO_AUTOJOURNAL, -2, 1, -1, acl::kUnlink}.SetAsyncHandler(
              CmdDel)
       << CI{"STICK", CO::JOURNALED, -2, 1, -1, acl::kStick}.HFUNC(Stick)
-      << CI{"SORT", CO::JOURNALED | CO::STORE_LAST_KEY, -2, 1, 1, acl::kSort}.HFUNC(Sort)
+      << CI{"SORT", CO::JOURNALED | CO::STORE_LAST_KEY | CO::NO_AUTOJOURNAL, -2, 1, 1, acl::kSort}
+             .HFUNC(Sort)
       << CI{"SORT_RO", CO::READONLY, -2, 1, 1, acl::kSortRO}.HFUNC(Sort_RO)
       << CI{"MOVE", CO::JOURNALED | CO::GLOBAL_TRANS | CO::NO_AUTOJOURNAL, 3, 1, 1, acl::kMove}
              .HFUNC(Move)

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -47,7 +47,6 @@ extern "C" {
 #include "server/transaction.h"
 #include "util/fibers/fibers.h"
 #include "util/fibers/future.h"
-#include "util/varz.h"
 
 namespace rng = std::ranges;
 
@@ -1836,15 +1835,22 @@ OpResult<uint32_t> OpStore(const OpArgs& op_args, std::string_view key, Iterator
 
   QList* ql_v2 = CompactObj::AllocateMR<QList>();
   QList::Where where = QList::TAIL;
+  std::vector rpush_args{key};
+
+  auto add_item = [&](const auto& value) {
+    ql_v2->Push(value, where);
+    if (op_args.shard->journal())
+      rpush_args.push_back(value);
+  };
+
   for (auto it = start_it; it != end_it; ++it) {
     if (has_get_patterns) {
       // Store all GET pattern values for this entry
-      for (const auto& value : it->get_values) {
-        ql_v2->Push(value, where);
-      }
+      for (const auto& value : it->get_values)
+        add_item(value);
     } else {
       // No GET patterns - store the element itself
-      ql_v2->Push(it->ResultKey(), where);
+      add_item(it->ResultKey());
     }
   }
   len = ql_v2->Size();
@@ -1854,6 +1860,8 @@ OpResult<uint32_t> OpStore(const OpArgs& op_args, std::string_view key, Iterator
     auto it_res = op_args.GetDbSlice().FindMutable(op_args.db_cntx, key);
     if (IsValid(it_res.it)) {
       op_args.GetDbSlice().DelMutable(op_args.db_cntx, std::move(it_res));
+      if (op_args.shard->journal())
+        RecordJournal(op_args, "DEL", {key});
     }
     return 0;
   }
@@ -1864,6 +1872,13 @@ OpResult<uint32_t> OpStore(const OpArgs& op_args, std::string_view key, Iterator
   // This would overwrite existing value if any with new list.
   auto op_res = op_args.GetDbSlice().AddOrUpdate(op_args.db_cntx, key, std::move(pv), 0);
   RETURN_ON_BAD_STATUS(op_res);
+
+  if (op_args.shard->journal()) {
+    RecordJournal(op_args, "DEL", {key});
+    RecordJournal(op_args, "RPUSH", rpush_args);
+    if (op_res->it->first.IsSticky())
+      RecordJournal(op_args, "STICK", {key});
+  }
 
   return len;
 }

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -27,6 +27,7 @@ from redis import asyncio as aioredis
 from . import PortPicker
 from .instance import DflyInstance, DflyInstanceFactory, DflyParams, RedisServer
 from .proxy import Proxy
+from .replication_utils import ReplicationSetup
 from .utility import (
     DflySeederFactory,
     download_with_retries,
@@ -453,7 +454,7 @@ async def async_client(async_pool):
 
 
 @pytest_asyncio.fixture
-async def replication(df_factory, request):
+async def replication(df_factory, request) -> ReplicationSetup:
     """Decomposable, marker-annotated replication fixture.
 
     Configure the topology with ``@pytest.mark.replication(...)`` whose keyword

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -19,6 +19,7 @@ from .replication_utils import (
     replica_role_reply,
     setup_replication,
     start_replication,
+    ReplicationSetup,
 )
 from .seeder import DebugPopulateSeeder
 from .seeder import Seeder as SeederV2
@@ -621,8 +622,8 @@ async def test_georadius_store_cross_shard_precision(replication):
 @pytest.mark.replication(
     master_args={"proactor_threads": 4, "num_shards": 3}, replica_args={"proactor_threads": 3}
 )
-async def test_sort_store_x_shard(replication):
-    _, _, cm, [cr] = replication
+async def test_sort_store_x_shard(replication: ReplicationSetup):
+    cm, cr = replication.c_master, replication.c_replica
     await cm.rpush("x", 3, 1, 2)
     assert (await cm.sort("x", alpha=True, store="z")) == 3
 
@@ -638,12 +639,56 @@ async def test_sort_store_x_shard(replication):
     assert (await cm.lrange("z", 0, -1)) == ["1", "2", "3"]
     assert (await cr.lrange("z", 0, -1)) == ["1", "2", "3"]
 
+    # test empty collection is deleted
     await cm.delete("x")
     assert (await cm.sort("x", alpha=True, store="z")) == 0
     await check_all_replicas_finished([cr], cm)
 
     assert not (await cm.exists("z"))
     assert not (await cr.exists("z"))
+
+    # test no auto journal
+    await cm.rpush("x", 3, 1, 2)
+    assert (await cm.sort("x", start=1, num=2, store="x")) == 2
+    await check_all_replicas_finished([cr], cm)
+
+    assert (await cm.lrange("x", start=0, end=-1)) == ["2", "3"]
+    assert (await cr.lrange("x", start=0, end=-1)) == ["2", "3"]
+
+    await cm.rpush("z", "stale", "values")
+    assert await cm.execute_command("STICK", "z") == 1
+    await check_all_replicas_finished([cr], cm)
+    assert await cr.lrange("z", 0, -1) == ["stale", "values"]
+
+    assert await cm.sort("x", store="z") == 2
+    await check_all_replicas_finished([cr], cm)
+    assert await cm.lrange("z", 0, -1) == ["2", "3"]
+    assert await cr.lrange("z", 0, -1) == ["2", "3"]
+
+    # BY nosort maintains order on replication
+    await cm.delete("x")
+    await cm.sadd("x", "charlie", "alpha", "bravo")
+    assert await cm.sort("x", by="nosort", store="z") == 3
+    stored = await cm.lrange("z", 0, -1)
+    assert len(stored) == 3
+    assert set(stored) == {"alpha", "bravo", "charlie"}
+
+    await check_all_replicas_finished([cr], cm)
+    assert await cr.lrange("z", 0, -1) == stored
+
+    await cm.mset(
+        {"sort-value:alpha": "first", "sort-value:bravo": "second", "sort-value:charlie": "third"}
+    )
+    assert await cm.sort("x", alpha=True, get=["#", "sort-value:*"], store="z") == 6
+    await check_all_replicas_finished([cr], cm)
+    expected = ["alpha", "first", "bravo", "second", "charlie", "third"]
+    assert await cm.lrange("z", 0, -1) == expected
+    assert await cr.lrange("z", 0, -1) == expected
+
+    # Promote so we can run the STICK command
+    await cr.execute_command("REPLICAOF", "NO", "ONE")
+    assert await cr.execute_command("STICK", "z") == 0
+    assert await cm.execute_command("STICK", "z") == 0
 
 
 """

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -6,7 +6,6 @@ import time
 
 import async_timeout
 import pytest
-
 import redis
 from redis import asyncio as aioredis
 
@@ -617,6 +616,34 @@ async def test_georadius_store_cross_shard_precision(replication):
         replica_scores = await c_replica.zrange(key, 0, -1, withscores=True)
         assert len(master_scores) == 2
         assert master_scores == replica_scores
+
+
+@pytest.mark.replication(
+    master_args={"proactor_threads": 4, "num_shards": 3}, replica_args={"proactor_threads": 3}
+)
+async def test_sort_store_x_shard(replication):
+    _, _, cm, [cr] = replication
+    await cm.rpush("x", 3, 1, 2)
+    assert (await cm.sort("x", alpha=True, store="z")) == 3
+
+    async def shard_for(k: str):
+        info = await cm.execute_command(f"DEBUG OBJECT {k}")
+        return int(info.split("shard:", 1)[1].split()[0])
+
+    assert (await shard_for("x")) != (await shard_for("z"))
+
+    await check_all_replicas_finished([cr], cm)
+    assert (await cr.lrange("x", 0, -1)) == ["3", "1", "2"]
+
+    assert (await cm.lrange("z", 0, -1)) == ["1", "2", "3"]
+    assert (await cr.lrange("z", 0, -1)) == ["1", "2", "3"]
+
+    await cm.delete("x")
+    assert (await cm.sort("x", alpha=True, store="z")) == 0
+    await check_all_replicas_finished([cr], cm)
+
+    assert not (await cm.exists("z"))
+    assert not (await cr.exists("z"))
 
 
 """

--- a/tests/dragonfly/replication_utils.py
+++ b/tests/dragonfly/replication_utils.py
@@ -190,8 +190,8 @@ class ReplicationSetup:
 
     master: DflyInstance
     replicas: list[DflyInstance]
-    c_master: "object"
-    c_replicas: list["object"]
+    c_master: "aioredis.Redis"
+    c_replicas: list["aioredis.Redis"]
 
     def __iter__(self):
         return iter((self.master, self.replicas, self.c_master, self.c_replicas))


### PR DESCRIPTION
During replication of a command like `SORT key STORE dest`, in case key and dest are on different shards, the `dest` journal does not receive a store command, only sort, so the value of dest is lost.

To fix this:

- sort is marked `NO_AUTOJOURNAL`, the command handler will do the journal operations manually
- in the opstore helper, the args list is prepared during iteration
- the journal sends delete of the key if exists
- journal uses `RPUSH` with the key and arg list to send the list explicitly
- if key exists and result was empty then journal sends delete to wipe the key

fixes https://github.com/dragonflydb/dragonfly/issues/8271