### PR TITLE
fix: script load interpreter wait

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -16,10 +16,12 @@
 #include "facade/resp_expr.h"
 #include "server/conn_context.h"
 #include "server/main_service.h"
+#include "server/server_state.h"
 #include "server/test_utils.h"
 #include "server/transaction.h"
 
 ABSL_DECLARE_FLAG(uint32_t, num_shards);
+ABSL_DECLARE_FLAG(uint32_t, interpreter_per_thread);
 ABSL_DECLARE_FLAG(bool, multi_exec_squash);
 ABSL_DECLARE_FLAG(bool, lua_auto_async);
 ABSL_DECLARE_FLAG(bool, lua_allow_undeclared_auto_correct);
@@ -58,6 +60,15 @@ class MultiTest : public BaseFamilyTest {
   MultiTest() : BaseFamilyTest() {
     num_threads_ = kPoolThreadCount;
   }
+};
+
+class ScriptLoadTest : public MultiTest {
+ protected:
+  ScriptLoadTest() {
+    absl::SetFlag(&FLAGS_interpreter_per_thread, 1);
+  }
+
+  absl::FlagSaver saver_;
 };
 
 class SingleShardMultiTest : public BaseFamilyTest {
@@ -989,6 +1000,67 @@ TEST_F(MultiTest, ExecGlobalFallback) {
   Run({"move", "a", "1"});
   Run({"exec"});
   EXPECT_EQ(1, GetMetrics().coordinator_stats.tx_global_cnt);
+}
+
+TEST_F(ScriptLoadTest, CachedScriptDoesNotWaitForInterpreter) {
+  constexpr string_view kScript = "return 5";
+  string sha = Run({"script", "load", kScript}).GetString();
+
+  // Load on a different thread whose only interpreter is unavailable and has no compiled copy.
+  pp_->at(1)->Await([&] {
+    auto* ss = ServerState::tlocal();
+    auto* interpreter = ss->BorrowInterpreter();
+    EXPECT_FALSE(interpreter->Exists(sha));
+
+    bool loaded = false;
+    Fiber load_fb([&] {
+      EXPECT_EQ(Run({"script", "load", kScript}), sha);
+      loaded = true;
+    });
+
+    ExpectConditionWithinTimeout([&] { return loaded || ss->stats.blocked_on_interpreter != 0; });
+    EXPECT_TRUE(loaded) << "Cached SCRIPT LOAD waited for an interpreter";
+
+    // Release the interpreter even on failure so the load can finish and the test can clean up.
+    ss->ReturnInterpreter(interpreter);
+    load_fb.Join();
+    EXPECT_THAT(Run({"evalsha", sha, "0"}), IntArg(5));
+  });
+}
+
+TEST_F(ScriptLoadTest, ReleasesInterpreterBeforeJournaling) {
+  pp_->at(1)->Await([&] {
+    // Prevent journaling from finishing while we test interpreter reuse.
+    TransactionSuspension suspension;
+    suspension.Start();
+
+    auto is_scheduled = [&](string_view id) {
+      auto* tx = GetTransaction(id);
+      return tx != nullptr && tx->IsScheduled();
+    };
+
+    Fiber first_load([&] {
+      EXPECT_THAT(Run("first_load", {"script", "load", "return 1"}), ArgType(RespExpr::STRING));
+    });
+    ExpectConditionWithinTimeout([&] { return is_scheduled("first_load"); });
+
+    // This thread has one interpreter. Use a different script so the second load must borrow it
+    // and compile. Reaching journaling while the first is still waiting proves the interpreter
+    // was returned. If the first retains it, the second blocks in Get() and the assertion fails.
+    Fiber second_load([&] {
+      EXPECT_THAT(Run("second_load", {"script", "load", "return 2"}), ArgType(RespExpr::STRING));
+    });
+    ExpectConditionWithinTimeout([&] {
+      return is_scheduled("second_load") ||
+             ServerState::tlocal()->stats.blocked_on_interpreter != 0;
+    });
+    EXPECT_TRUE(is_scheduled("second_load"))
+        << "First load retained the interpreter while journaling";
+
+    suspension.Terminate();
+    first_load.Join();
+    second_load.Join();
+  });
 }
 
 TEST_F(MultiTest, ScriptFlagsCommand) {

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -152,22 +152,27 @@ void ScriptMgr::LoadCmd(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* 
                         ConnectionContext* cntx) {
   string_view body = parser.Next<string_view>();
   auto rb = static_cast<RedisReplyBuilder*>(builder);
+
+  char sha_buf[41];
+  Interpreter::FuncSha1(body, sha_buf);
+  string_view sha{sha_buf, 40};
   if (body.empty()) {
-    char sha[41];
-    Interpreter::FuncSha1(body, sha);
     return rb->SendBulkString(sha);
   }
 
-  BorrowedInterpreter interpreter{tx, &cntx->conn_state};
+  // The per-thread params cache only contains loaded scripts. EVALSHA lazily loads them into
+  // its interpreter, so cached loads do not need to borrow one here.
+  if (!ServerState::tlocal()->GetScriptParams(sha)) {
+    BorrowedInterpreter interpreter{tx, &cntx->conn_state};
+    auto res = InsertWithSha(sha, body, interpreter);
+    if (!res)
+      return builder->SendError(res.error().Format());
+  }
 
-  auto res = Insert(body, interpreter);
-  if (!res)
-    return builder->SendError(res.error().Format());
-
-  // Schedule empty callback inorder to journal command via transaction framework.
+  // Journal cached loads too, but return any owned interpreter before waiting on the transaction.
   tx->ScheduleSingleHop([](auto* t, auto* shard) { return OpStatus::OK; });
 
-  return rb->SendBulkString(res.value());
+  return rb->SendBulkString(sha);
 }
 
 void ScriptMgr::ConfigCmd(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* builder) {
@@ -276,6 +281,11 @@ nonstd::expected<string, GenericError> ScriptMgr::Insert(string_view body,
   Interpreter::FuncSha1(body, sha_buf);
   string_view sha{sha_buf, std::strlen(sha_buf)};
 
+  return InsertWithSha(sha, body, interpreter);
+}
+
+nonstd::expected<string, GenericError> ScriptMgr::InsertWithSha(string_view sha, string_view body,
+                                                                Interpreter* interpreter) {
   if (interpreter->Exists(sha)) {
     return string{sha};
   }

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -76,6 +76,11 @@ class ScriptMgr {
   void OnScriptError(std::string_view sha, std::string_view error);
 
  private:
+  // Insert using the precomputed SHA of the original script body.
+  nonstd::expected<std::string, GenericError> InsertWithSha(std::string_view sha,
+                                                            std::string_view body,
+                                                            Interpreter* interpreter);
+
   void ExistsCmd(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* builder) const;
   void FlushCmd(Transaction* tx, SinkReplyBuilder* builder);
   void LoadCmd(CmdArgParser parser, Transaction* tx, SinkReplyBuilder* builder,

--- a/tools/script_load_benchmark.py
+++ b/tools/script_load_benchmark.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+r"""Measure SCRIPT LOAD latency while idle and during HGET-heavy Lua contention.
+
+Use fresh local servers for each before/after run (requires redis>=5.2.1):
+  build-opt/dragonfly --port=6380 --proactor_threads=4 --num_shards=1 \
+      --interpreter_per_thread=50 --default_lua_flags=allow-undeclared-keys --dbfilename=
+  python3 tools/script_load_benchmark.py
+
+Adjust the constants below; COLD forces cache misses. Probes arrive at fixed intervals;
+background EVAL traffic then stops and requests drain. Latencies include that drain.
+"""
+
+import asyncio
+import hashlib
+import time
+
+from redis import asyncio as redis
+
+
+PORT = 6380
+EVAL_WORKERS = 512
+HGETS_PER_EVAL = 2000
+PROBES = 40
+PROBE_INTERVAL = 0.25
+WARMUP = 3
+COLD = False
+SCRIPT_BODY = b"return 1\n--".ljust(311005, b"x")
+
+WORKLOAD = """
+local value
+for i = 1, tonumber(ARGV[1]) do
+    value = redis.call('HGET', ARGV[2], 'field')
+end
+return value
+"""
+
+
+async def main():
+    key = f"script_load_benchmark:{time.time_ns()}"
+    connections = [
+        redis.Redis(
+            host="127.0.0.1",
+            port=PORT,
+            decode_responses=True,
+            single_connection_client=True,
+            socket_timeout=60,
+            socket_connect_timeout=5,
+        )
+        for _ in range(1 + EVAL_WORKERS + PROBES)
+    ]
+    admin = connections[0]
+    stop = asyncio.Event()
+    workers, probes = [], []
+
+    async def load(connection, index):
+        script = SCRIPT_BODY + f"\n-- {key}:{index}".encode() if COLD else SCRIPT_BODY
+        expected = hashlib.sha1(script).hexdigest()
+        started = time.monotonic()
+        if await connection.script_load(script) != expected:
+            raise RuntimeError("Unexpected SCRIPT LOAD SHA")
+        return (time.monotonic() - started) * 1000
+
+    async def worker(connection, sha):
+        while not stop.is_set():
+            if await connection.evalsha(sha, 0, HGETS_PER_EVAL, key) != "value":
+                raise RuntimeError("Unexpected HGET workload result")
+
+    try:
+        # Establish sockets before timing so connection setup is excluded.
+        await asyncio.gather(*(connection.ping() for connection in connections))
+        await admin.hset(key, "field", "value")
+        sha = await admin.script_load(WORKLOAD)
+        if not COLD:
+            await admin.script_load(SCRIPT_BODY)
+        idle = [await load(admin, i) for i in range(20)]
+        blocked_before = (await admin.info("stats"))["lua_blocked_total"]
+        workers = [
+            asyncio.create_task(worker(connection, sha))
+            for connection in connections[1 : 1 + EVAL_WORKERS]
+        ]
+        await asyncio.sleep(WARMUP)
+        if (await admin.info("stats"))["lua_blocked_total"] <= blocked_before:
+            raise RuntimeError("No interpreter contention; increase EVAL_WORKERS or HGETS_PER_EVAL")
+
+        started = time.monotonic()
+        for i, connection in enumerate(connections[1 + EVAL_WORKERS :]):
+            await asyncio.sleep(max(0, started + i * PROBE_INTERVAL - time.monotonic()))
+            probes.append(asyncio.create_task(load(connection, i + 20)))
+        await asyncio.sleep(max(0, started + PROBES * PROBE_INTERVAL - time.monotonic()))
+        stop.set()
+        contended = await asyncio.wait_for(asyncio.gather(*probes), 60)
+        await asyncio.wait_for(asyncio.gather(*workers), 60)
+        await admin.delete(key)
+        for name, values in (("idle", idle), ("contended", contended)):
+            print(f"{name}: mean {sum(values) / len(values):.2f} ms, max {max(values):.2f} ms")
+    finally:
+        stop.set()
+        for task in workers + probes:
+            task.cancel()
+        await asyncio.gather(*workers, *probes, return_exceptions=True)
+        await asyncio.gather(*(connection.aclose() for connection in connections))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Summary: Improves SCRIPT LOAD behavior when Lua interpreters are contended.

Changes:

- Computes the script SHA once at the start of the load path.
- Skips borrowing an interpreter when the local script-parameter cache already has the script.
- Extracts SHA-aware insertion so uncached loads reuse the precomputed digest.
- Limits the owned interpreter lifetime to compilation, before the journaling transaction hop.
- Keeps cached SCRIPT LOAD commands journaled and returns the SHA directly.
- Adds multithreaded regressions for contention and interpreter release before journaling.
- Adds a Python benchmark for idle versus contended script-load latency.

Technical Notes: Cached scripts remain lazily compiled into an interpreter by EVALSHA; script metadata continues to be published across thread-local caches.

| Latency | Before  | After  |
|---|---:|---:|
| Idle mean | 0.44 ms | 0.38 ms |
| Idle maximum | 1.87 ms | 0.50 ms |
| Contended mean | 620.78 ms | 259.90 ms |
| Contended maximum | 1,818.46 ms | 998.94 ms |
