### PR TITLE
fix(tests): download the S3 fixture server from silo instead of dl.min.io

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -3,6 +3,7 @@ Pytest fixtures to be provided for all tests without import
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import random
@@ -45,6 +46,17 @@ FAILED_PATH = "/tmp/failed/"
 LAST_LOGS = "/tmp/last_test_log_dir.txt"
 
 
+# dl.min.io returns HTTP 410 for every OSS build since MinIO archived the project, so the
+# pinned release assets on GitHub are the download source now.
+MINIO_RELEASE = "RELEASE.2025-09-07T16-13-09Z"
+MINIO_SHA256 = {
+    "linux-amd64": "7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f",
+    "linux-arm64": "5c83cd2cf151717ba0243f73e1c7802ff36e272b67144bdd7f1f7d684fd6f03d",
+    "darwin-amd64": "4759080aeef7385aaceaac1131c30aaeb99605921553967dc6d3ef4e16ac64f9",
+    "darwin-arm64": "7c3b3039b76e55a1b80935848ed83998d5e8d317374f87851f46a019ff5c0aa4",
+}
+
+
 def _download_minio_binary(dest: Path):
     """Download MinIO binary to dest if not already cached.
 
@@ -57,11 +69,25 @@ def _download_minio_binary(dest: Path):
     arch = platform.machine()
     arch_map = {"x86_64": "amd64", "aarch64": "arm64", "arm64": "arm64"}
     arch = arch_map.get(arch, arch)
-    url = f"https://dl.min.io/server/minio/release/{system}-{arch}/minio"
+    platform_key = f"{system}-{arch}"
+    expected_sha256 = MINIO_SHA256.get(platform_key)
+    if expected_sha256 is None:
+        raise RuntimeError(f"No pinned MinIO build for {platform_key}")
+
+    url = (
+        f"https://github.com/minio/minio/releases/download/{MINIO_RELEASE}"
+        f"/minio.{platform_key}.{MINIO_RELEASE}"
+    )
     logging.info(f"Downloading MinIO binary from {url}")
-    tmp_dest = dest.with_suffix(".tmp")
+    tmp_dest = dest.with_name(dest.name + ".tmp")
     try:
         download_with_retries(url, tmp_dest)
+        actual_sha256 = hashlib.sha256(tmp_dest.read_bytes()).hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise RuntimeError(
+                f"MinIO checksum mismatch for {url}: got {actual_sha256}, "
+                f"expected {expected_sha256}"
+            )
         tmp_dest.chmod(0o755)
         tmp_dest.rename(dest)
     except Exception:
@@ -77,7 +103,7 @@ def _start_minio_server(endpoint):
 
     cache_dir = Path.home() / ".cache" / "dragonfly-tests"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    minio_bin = cache_dir / "minio"
+    minio_bin = cache_dir / f"minio-{MINIO_RELEASE}"
 
     if not minio_bin.exists():
         _download_minio_binary(minio_bin)

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -10,6 +10,7 @@ import random
 import shutil
 import subprocess
 import sys
+import tarfile
 import time
 import typing
 from contextlib import AsyncExitStack
@@ -46,64 +47,73 @@ FAILED_PATH = "/tmp/failed/"
 LAST_LOGS = "/tmp/last_test_log_dir.txt"
 
 
-# dl.min.io returns HTTP 410 for every OSS build since MinIO archived the project, so the
-# pinned release assets on GitHub are the download source now.
-MINIO_RELEASE = "RELEASE.2025-09-07T16-13-09Z"
+# MinIO archived its OSS server and dl.min.io returns HTTP 410 for every build, so the
+# binary comes from silo, a maintained fork that is CLI- and API-compatible with it.
+MINIO_RELEASE = "RELEASE.2026-09-03T13-18-01Z"
+MINIO_VERSION = "20260903131801.0.0"
 MINIO_SHA256 = {
-    "linux-amd64": "7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f",
-    "linux-arm64": "5c83cd2cf151717ba0243f73e1c7802ff36e272b67144bdd7f1f7d684fd6f03d",
-    "darwin-amd64": "4759080aeef7385aaceaac1131c30aaeb99605921553967dc6d3ef4e16ac64f9",
-    "darwin-arm64": "7c3b3039b76e55a1b80935848ed83998d5e8d317374f87851f46a019ff5c0aa4",
+    "linux-amd64": "cbe5c01eac0a97ccb22fa252eafa432e8608bfde7e3ea27a324cb5ed625a1e96",
+    "linux-arm64": "311846ca9387de36f8e34daa8bf1a130684cc7b8c61aa39581264249eb8df0cf",
+    "darwin-amd64": "35b4121f6ca2ba79514c3536e5f7f79ae8f7fe6fb88288efbdfa2ae8d5283131",
+    "darwin-arm64": "bcfd90d51ab6dffc34193aac260464097bb1d2decdd2598538e618bc02ada668",
 }
 
 
-def _download_minio_binary(dest: Path):
-    """Download MinIO binary to dest if not already cached.
-
-    Downloads to a temporary file first, then renames atomically to avoid
-    leaving a corrupt binary on interrupted downloads.
-    """
+def _minio_platform_key() -> str:
     import platform
 
     system = platform.system().lower()
     arch = platform.machine()
     arch_map = {"x86_64": "amd64", "aarch64": "arm64", "arm64": "arm64"}
-    arch = arch_map.get(arch, arch)
-    platform_key = f"{system}-{arch}"
+    return f"{system}-{arch_map.get(arch, arch)}"
+
+
+def _download_minio_binary(dest: Path):
+    """Download the MinIO-compatible server to dest if not already cached.
+
+    The checksum is verified against the published one before the binary is
+    extracted, and the result is renamed atomically so an interrupted download
+    never leaves a usable but corrupt binary behind.
+    """
+    platform_key = _minio_platform_key()
     expected_sha256 = MINIO_SHA256.get(platform_key)
     if expected_sha256 is None:
         raise RuntimeError(f"No pinned MinIO build for {platform_key}")
 
     url = (
-        f"https://github.com/minio/minio/releases/download/{MINIO_RELEASE}"
-        f"/minio.{platform_key}.{MINIO_RELEASE}"
+        f"https://github.com/pgsty/silo/releases/download/{MINIO_RELEASE}"
+        f"/silo_{MINIO_VERSION}_{platform_key.replace('-', '_')}.tar.gz"
     )
     logging.info(f"Downloading MinIO binary from {url}")
+    tmp_archive = dest.with_name(dest.name + ".tar.gz")
     tmp_dest = dest.with_name(dest.name + ".tmp")
     try:
-        download_with_retries(url, tmp_dest)
-        actual_sha256 = hashlib.sha256(tmp_dest.read_bytes()).hexdigest()
+        download_with_retries(url, tmp_archive)
+        actual_sha256 = hashlib.sha256(tmp_archive.read_bytes()).hexdigest()
         if actual_sha256 != expected_sha256:
             raise RuntimeError(
                 f"MinIO checksum mismatch for {url}: got {actual_sha256}, "
                 f"expected {expected_sha256}"
             )
+        with tarfile.open(tmp_archive) as tar:
+            with tar.extractfile("silo") as src, open(tmp_dest, "wb") as dst:
+                shutil.copyfileobj(src, dst)
         tmp_dest.chmod(0o755)
         tmp_dest.rename(dest)
-    except Exception:
+    finally:
+        tmp_archive.unlink(missing_ok=True)
         tmp_dest.unlink(missing_ok=True)
-        raise
 
 
 def _start_minio_server(endpoint):
-    """Start MinIO subprocess and configure env vars for S3 tests."""
+    """Start the MinIO-compatible server and configure env vars for S3 tests."""
     from urllib.parse import urlparse
 
     import boto3
 
     cache_dir = Path.home() / ".cache" / "dragonfly-tests"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    minio_bin = cache_dir / f"minio-{MINIO_RELEASE}"
+    minio_bin = cache_dir / f"minio-{MINIO_RELEASE}-{_minio_platform_key()}"
 
     if not minio_bin.exists():
         _download_minio_binary(minio_bin)


### PR DESCRIPTION
MinIO archived its OSS server and `dl.min.io` now returns HTTP 410 for every architecture and every release. The download happens in `pytest_configure`, so it aborts the session with INTERNALERROR before collection - and because `Run PyTests` is gated on `if: success()`, that skips the **entire** regression suite, not just the S3 tests. Regression, Epoll and Heavy Tests have been red on main since 2026-09-11 21:05Z, and the failure alert posts with an empty failed-test list because no `report.json` is ever produced.

The binary now comes from [silo](https://github.com/pgsty/silo), a maintained AGPL-3.0 fork of MinIO that is CLI- and API-compatible, so nothing outside the download changes: same `server <dir> --address :PORT` invocation, same `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`, same `/minio/health/live`. The MinIO-flavoured names in the fixture are kept for that reason.

`helio` fetches the same binary in its own CI: romange/helio#647
